### PR TITLE
fix: restore React and UI dependencies to CLI package

### DIFF
--- a/.changeset/fix-cli-dependencies.md
+++ b/.changeset/fix-cli-dependencies.md
@@ -1,0 +1,16 @@
+---
+"@lightfastai/cli": patch
+---
+
+fix: restore React and UI dependencies to CLI package for npm publishing
+
+Previously removed in PR #134, these dependencies are required when the CLI package is published to npm. The dev-server output references these packages but they weren't available in the published package, causing runtime errors.
+
+Restored dependencies:
+- React, React DOM, and related types
+- TanStack Query and Router
+- AI SDK packages
+- UI component libraries (Radix UI, lucide-react, etc.)
+- Build utilities (class-variance-authority, clsx, tailwind-merge)
+
+This ensures the dev-server UI works correctly when the CLI is installed from npm.

--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -38,10 +38,24 @@
 		"clean": "rm -rf dist .turbo node_modules .output .lightfast .nitro .tanstack"
 	},
 	"dependencies": {
+		"@ai-sdk/react": "2.0.15",
+		"@radix-ui/react-dialog": "^1.1.14",
+		"@radix-ui/react-slot": "^1.2.3",
+		"@radix-ui/react-tooltip": "^1.2.7",
+		"@tanstack/react-query": "^5.80.7",
+		"@tanstack/react-router": "^1.131.28",
+		"ai": "5.0.15",
 		"chalk": "^5.6.0",
 		"chokidar": "^4.0.3",
+		"class-variance-authority": "^0.7.1",
+		"clsx": "^2.1.1",
 		"commander": "^12.1.0",
 		"esbuild": "^0.25.9",
+		"geist": "^1.3.1",
+		"lucide-react": "^0.468.0",
+		"react": "^19.1.1",
+		"react-dom": "^19.1.1",
+		"tailwind-merge": "^3.3.1",
 		"zod": "^3.25.76"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,21 +1075,63 @@ importers:
 
   core/cli:
     dependencies:
+      '@ai-sdk/react':
+        specifier: 2.0.15
+        version: 2.0.15(react@19.1.1)(zod@3.25.76)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.8(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@19.1.11)(react@19.1.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.7
+        version: 1.2.7(@types/react-dom@19.1.8(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tanstack/react-query':
+        specifier: ^5.80.7
+        version: 5.84.0(react@19.1.1)
+      '@tanstack/react-router':
+        specifier: ^1.131.28
+        version: 1.131.28(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      ai:
+        specifier: 5.0.15
+        version: 5.0.15(zod@3.25.76)
       chalk:
         specifier: ^5.6.0
         version: 5.6.0
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       commander:
         specifier: ^12.1.0
         version: 12.1.0
       esbuild:
         specifier: ^0.25.9
         version: 0.25.9
+      geist:
+        specifier: ^1.3.1
+        version: 1.4.2(next@15.4.5(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       lightfast:
         specifier: '>=0.1.0'
         version: link:../lightfast
+      lucide-react:
+        specifier: ^0.468.0
+        version: 0.468.0(react@19.1.1)
+      react:
+        specifier: ^19.1.1
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.1.1(react@19.1.1)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1361,7 +1403,7 @@ importers:
         version: 1.0.15(zod@3.25.76)
       '@lightfastai/cli':
         specifier: file:../../core/cli
-        version: file:core/cli(lightfast@file:core/lightfast(typescript@5.9.2))
+        version: file:core/cli(@types/react-dom@19.1.8(@types/react@19.1.11))(@types/react@19.1.11)(lightfast@file:core/lightfast(typescript@5.9.2))(next@15.4.5(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       ai:
         specifier: 5.0.15
         version: 5.0.15(zod@3.25.76)
@@ -16382,15 +16424,33 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lightfastai/cli@file:core/cli(lightfast@file:core/lightfast(typescript@5.9.2))':
+  '@lightfastai/cli@file:core/cli(@types/react-dom@19.1.8(@types/react@19.1.11))(@types/react@19.1.11)(lightfast@file:core/lightfast(typescript@5.9.2))(next@15.4.5(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))':
     dependencies:
+      '@ai-sdk/react': 2.0.15(react@19.1.1)(zod@3.25.76)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.8(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.11)(react@19.1.1)
+      '@radix-ui/react-tooltip': 1.2.7(@types/react-dom@19.1.8(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tanstack/react-query': 5.84.0(react@19.1.1)
+      '@tanstack/react-router': 1.131.28(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      ai: 5.0.15(zod@3.25.76)
       chalk: 5.6.0
       chokidar: 4.0.3
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
       commander: 12.1.0
       esbuild: 0.25.9
+      geist: 1.4.2(next@15.4.5(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      lucide-react: 0.468.0(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tailwind-merge: 3.3.1
       zod: 3.25.76
     optionalDependencies:
       lightfast: file:core/lightfast(typescript@5.9.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - next
 
   '@logtail/next@0.2.1(next@15.4.5(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
     dependencies:


### PR DESCRIPTION
## Summary
- Restores React, TanStack, and UI dependencies that were removed in PR #134
- Fixes runtime errors when CLI is installed from npm
- Ensures dev-server UI works correctly in published package

## Problem
In PR #134, React and UI dependencies were removed from the CLI's package.json with the assumption that the dev-server would bundle everything. However, the dev-server's vite config only bundles specific modules, not all dependencies. This caused runtime errors when users installed the CLI from npm because required dependencies weren't available.

## Solution
Restored the following dependencies to the CLI package.json:
- React & React DOM (^19.1.1)
- @tanstack/react-query (^5.80.7) & @tanstack/react-router (^1.131.28)
- @ai-sdk/react (2.0.15) & ai (5.0.15)
- UI libraries: @radix-ui components, lucide-react, geist
- Build utilities: class-variance-authority, clsx, tailwind-merge

## Testing
- ✅ Built CLI package successfully
- ✅ Tested dev server starts and runs correctly
- ✅ API endpoints return expected data
- ✅ Package size increased to ~702KB (expected with React dependencies)

## Impact
This change ensures the dev-server UI works correctly when the CLI is installed from npm, restoring functionality that was broken after PR #134.

🤖 Generated with Claude Code