### PR TITLE
refactor: use specific ChatRouterOutputs/Inputs instead of generic RouterOutputs/Inputs

### DIFF
--- a/api/chat/src/index.ts
+++ b/api/chat/src/index.ts
@@ -16,10 +16,6 @@ import type { ChatAppRouter } from "./root";
 export type ChatRouterInputs = inferRouterInputs<ChatAppRouter>;
 export type ChatRouterOutputs = inferRouterOutputs<ChatAppRouter>;
 
-// For backward compatibility during migration
-export type RouterOutputs = ChatRouterOutputs;
-export type RouterInputs = ChatRouterInputs;
-export { chatAppRouter as appRouter } from "./root";
 
 // Export TRPC utilities
 export { createCallerFactory } from "./trpc";

--- a/apps/chat/src/app/(chat)/_components/chat-interface.tsx
+++ b/apps/chat/src/app/(chat)/_components/chat-interface.tsx
@@ -14,7 +14,7 @@ import { useErrorBoundaryHandler } from "~/hooks/use-error-boundary-handler";
 import { ChatErrorHandler } from "~/lib/errors/chat-error-handler";
 import { ChatErrorType } from "~/lib/errors/types";
 import type { LightfastAppChatUIMessage } from "~/ai/lightfast-app-chat-ui-messages";
-import type { RouterOutputs } from "@api/chat";
+import type { ChatRouterOutputs } from "@api/chat";
 
 // Dynamic imports for components that are conditionally rendered
 const ProviderModelSelector = dynamic(
@@ -40,7 +40,7 @@ const RateLimitDialog = dynamic(
 	{ ssr: false },
 );
 
-type UserInfo = RouterOutputs["user"]["getUser"];
+type UserInfo = ChatRouterOutputs["user"]["getUser"];
 
 interface ChatInterfaceProps {
 	agentId: string;

--- a/apps/chat/src/components/sidebar/types.ts
+++ b/apps/chat/src/components/sidebar/types.ts
@@ -1,7 +1,7 @@
-import type { RouterOutputs } from "@api/chat";
+import type { ChatRouterOutputs } from "@api/chat";
 
 // Core session type from API
-export type Session = RouterOutputs["session"]["list"][number];
+export type Session = ChatRouterOutputs["session"]["list"][number];
 
 // Props types
 export interface SidebarProps {

--- a/apps/chat/src/hooks/sidebar/use-pin-session.ts
+++ b/apps/chat/src/hooks/sidebar/use-pin-session.ts
@@ -3,9 +3,9 @@ import type { InfiniteData } from "@tanstack/react-query";
 import { produce } from "immer";
 import { useTRPC } from "~/trpc/react";
 import { showTRPCErrorToast } from "~/lib/trpc-errors";
-import type { RouterOutputs } from "@api/chat";
+import type { ChatRouterOutputs } from "@api/chat";
 
-type Session = RouterOutputs["session"]["list"][number];
+type Session = ChatRouterOutputs["session"]["list"][number];
 type SessionsInfiniteData = InfiniteData<Session[]>;
 
 export function usePinSession() {

--- a/apps/chat/src/hooks/use-create-session.ts
+++ b/apps/chat/src/hooks/use-create-session.ts
@@ -3,10 +3,10 @@ import type { InfiniteData } from "@tanstack/react-query";
 import { produce } from "immer";
 import { useTRPC } from "~/trpc/react";
 import { showTRPCErrorToast } from "~/lib/trpc-errors";
-import type { RouterOutputs } from "@api/chat";
+import type { ChatRouterOutputs } from "@api/chat";
 import { DEFAULT_SESSION_TITLE } from "@db/chat";
 
-type Session = RouterOutputs["session"]["list"][number];
+type Session = ChatRouterOutputs["session"]["list"][number];
 type SessionsInfiniteData = InfiniteData<Session[]>;
 
 interface CreateSessionInput {


### PR DESCRIPTION
## Summary
- Replaced all usage of generic `RouterOutputs`/`RouterInputs` with specific `ChatRouterOutputs`/`ChatRouterInputs` throughout the chat app
- Removed backward compatibility exports from `@api/chat` package
- Clean up API exports to use only chat-specific type names

## Changes
- **Type imports**: Updated all files to import `ChatRouterOutputs` instead of `RouterOutputs`
- **Type definitions**: Updated all type definitions to use chat-specific router types
- **API exports**: Removed generic `RouterOutputs`, `RouterInputs`, and `appRouter` exports
- **Consistency**: Ensures all chat app code uses consistent, descriptive type names

## Files Modified
- `apps/chat/src/hooks/use-create-session.ts`
- `apps/chat/src/hooks/sidebar/use-pin-session.ts` 
- `apps/chat/src/components/sidebar/types.ts`
- `apps/chat/src/app/(chat)/_components/chat-interface.tsx`
- `api/chat/src/index.ts`

## Test plan
- [x] Chat app typechecks without errors
- [x] API package builds successfully
- [x] All type references updated consistently

This provides better type clarity and removes potential confusion when multiple API packages exist.

🤖 Generated with [Claude Code](https://claude.ai/code)