### PR TITLE
refactor: update chat auth header to match unauthenticated layout

### DIFF
--- a/apps/chat/src/app/(auth)/layout.tsx
+++ b/apps/chat/src/app/(auth)/layout.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Button } from "@repo/ui/components/ui/button";
 import { Icons } from "@repo/ui/components/icons";
-import { getAppUrl } from "@repo/url-utils";
 
 export default function AuthLayout({
 	children,
@@ -14,21 +13,23 @@ export default function AuthLayout({
 }) {
 	const pathname = usePathname();
 	const isSignUpPage = pathname.includes("/sign-up");
-	const wwwUrl = getAppUrl("www");
 
 	return (
-		<div className="min-h-screen bg-background flex flex-col">
-			{/* Header - Fixed height matching apps/chat */}
-			<header className="h-14 flex items-center justify-between app-container bg-background">
-				<div className="flex items-center gap-2">
-					<Button variant="ghost" size="lg" asChild>
-						<Link href={wwwUrl} className="flex items-center">
-							<Icons.logoShort className="text-foreground size-7" />
+		<div className="min-h-screen bg-background flex flex-col relative">
+			{/* Mobile/Tablet header - relative positioning */}
+			<header className="lg:hidden relative h-14 flex items-center justify-between px-4 bg-background border-b border-border/50 z-10">
+				{/* Left side - Logo */}
+				<div className="flex items-center">
+					<Button variant="ghost" size="xs" asChild>
+						<Link href="/">
+							<Icons.logoShort className="h-4 w-auto text-foreground" />
 						</Link>
 					</Button>
 				</div>
+
+				{/* Right side - Sign in/up button */}
 				<div className="flex items-center gap-2">
-					<Button variant="outline" size="lg" asChild>
+					<Button variant="outline" size="xs" asChild>
 						<Link href={isSignUpPage ? "/sign-in" : "/sign-up"}>
 							{isSignUpPage ? "Sign In" : "Sign Up"}
 						</Link>
@@ -36,8 +37,29 @@ export default function AuthLayout({
 				</div>
 			</header>
 
+			{/* Desktop header - absolute positioning */}
+			{/* Left side - Logo only */}
+			<div className="hidden lg:flex absolute top-0 left-0 h-14 items-center pl-2 z-10 w-fit">
+				<Button variant="ghost" size="lg" asChild>
+					<Link href="/">
+						<Icons.logo className="size-22 text-foreground" />
+					</Link>
+				</Button>
+			</div>
+
+			{/* Desktop Right side - Sign in/up button */}
+			<div className="hidden lg:flex absolute top-0 right-0 h-14 items-center pr-2 z-10 w-fit">
+				<Button variant="ghost" size="lg" asChild>
+					<Link href={isSignUpPage ? "/sign-in" : "/sign-up"}>
+						<span className="text-md font-semibold">
+							{isSignUpPage ? "Sign In" : "Sign Up"}
+						</span>
+					</Link>
+				</Button>
+			</div>
+
 			{/* Main Content - Flex grow to fill remaining space */}
-			<main className="flex-1 flex items-center justify-center p-4">
+			<main className="flex-1 flex items-center justify-center p-4 lg:pt-14">
 				<div className="w-full max-w-xs">{children}</div>
 			</main>
 		</div>


### PR DESCRIPTION
## Summary
- Updated the chat app auth layout header to match the style of the unauthenticated header
- Replaced `Icons.logoShort` with `Icons.logo` on desktop for consistent branding
- Changed logo links to use root route ("/") instead of external www URL
- Implemented absolute positioning on desktop (0vw, 0vh concept) with minimal padding
- Maintained responsive mobile header with relative positioning

## Changes
- Desktop: Full logo with absolute positioning at viewport edges
- Mobile: Short logo with relative positioning and border
- Removed `app-container` class for cleaner absolute positioning
- Logo now navigates to chat app root instead of external site

## Test plan
- [x] Built chat app successfully (`pnpm --filter @lightfast/chat build`)
- [ ] Test sign-in/sign-up page header on desktop
- [ ] Test sign-in/sign-up page header on mobile
- [ ] Verify logo links navigate to correct route
- [ ] Confirm visual consistency with unauthenticated pages

🤖 Generated with [Claude Code](https://claude.ai/code)