### PR TITLE
fix(cloud): update tRPC client to use correct API endpoint

### DIFF
--- a/apps/cloud/src/trpc/react.tsx
+++ b/apps/cloud/src/trpc/react.tsx
@@ -41,7 +41,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 				}),
 				httpBatchStreamLink({
 					transformer: SuperJSON,
-					url: getBaseUrl() + "/api/trpc",
+					url: getBaseUrl() + "/api/web/v1",
 					headers() {
 						return {
 							"x-trpc-source": "client",


### PR DESCRIPTION
## Summary
- Fixed 404 errors in API key settings page by correcting tRPC client endpoint configuration
- Changed client URL from `/api/trpc` to `/api/web/v1` to match existing route handlers

## Problem
The tRPC client in the cloud app was configured to call `/api/trpc`, but the actual route handlers are located at:
- `/api/web/v1/[trpc]/route.ts` (for web clients) 
- `/api/cli/v1/[trpc]/route.ts` (for CLI clients)

This mismatch caused 404 errors when the API key settings page tried to call `apiKey.list`, `apiKey.revoke`, and `apiKey.delete` procedures.

## Solution
Updated `apps/cloud/src/trpc/react.tsx` to use the correct endpoint `/api/web/v1` instead of `/api/trpc`.

## Test plan
- [ ] Navigate to API key settings page in cloud app
- [ ] Verify API key list loads without 404 errors
- [ ] Test creating, revoking, and deleting API keys
- [ ] Confirm all tRPC calls resolve successfully

🤖 Generated with [Claude Code](https://claude.ai/code)