### PR TITLE
feat: integrate password authentication in chat app

### DIFF
--- a/apps/chat/CLAUDE.md
+++ b/apps/chat/CLAUDE.md
@@ -1,0 +1,29 @@
+# Chat App Development Guide
+
+## Local Testing
+
+When testing the chat app locally, password login is configured with the following test credentials:
+
+- **Email**: `admin@lightfast.ai`
+- **Password**: `ijXFdBJ3U2eMDFnKqngp`
+
+Testing with new fresh accounts:
+
+- **Email**: `some-email+clerk_test@lightfast.ai`
+- **Verification Code**: `424242`
+
+## Development Commands
+
+```bash
+# Start chat app development server
+pnpm dev:chat
+
+# Build chat app only
+pnpm build:chat
+
+# Type check chat app
+pnpm --filter @lightfast/chat typecheck
+
+# Lint chat app
+pnpm --filter @lightfast/chat lint
+```

--- a/apps/chat/src/app/(auth)/_components/sign-in-form.tsx
+++ b/apps/chat/src/app/(auth)/_components/sign-in-form.tsx
@@ -5,18 +5,19 @@ import { Button } from "@repo/ui/components/ui/button";
 import { Separator } from "@repo/ui/components/ui/separator";
 import { SignInEmailInput } from "./sign-in-email-input";
 import { SignInCodeVerification } from "./sign-in-code-verification";
+import { SignInPassword } from "./sign-in-password";
 import { OAuthSignIn } from "./oauth-sign-in";
 
 interface SignInFormProps {
-	verificationStep?: "email" | "code";
-	onVerificationStepChange?: (step: "email" | "code") => void;
+	verificationStep?: "email" | "code" | "password";
+	onVerificationStepChange?: (step: "email" | "code" | "password") => void;
 }
 
 export function SignInForm({
 	verificationStep: controlledStep,
 	onVerificationStepChange,
 }: SignInFormProps = {}) {
-	const [internalStep, setInternalStep] = React.useState<"email" | "code">(
+	const [internalStep, setInternalStep] = React.useState<"email" | "code" | "password">(
 		"email",
 	);
 	const verificationStep = controlledStep ?? internalStep;
@@ -41,10 +42,15 @@ export function SignInForm({
 		setError(errorMessage);
 	}
 
+	function handlePasswordSuccess() {
+		// Password sign-in is complete, redirect happens via Clerk
+		setError("");
+	}
+
 	return (
 		<div className="w-full space-y-8">
-			{/* Header - only show on email step */}
-			{verificationStep === "email" && (
+			{/* Header - only show on email and password steps */}
+			{(verificationStep === "email" || verificationStep === "password") && (
 				<div className="text-center">
 					<h1 className="text-3xl font-semibold text-foreground">
 						Log in to Lightfast
@@ -79,8 +85,44 @@ export function SignInForm({
 							</div>
 						</div>
 
+						{/* Password Sign In Option */}
+						<Button
+							variant="outline"
+							onClick={() => setVerificationStep("password")}
+							className="w-full h-12"
+						>
+							Sign in with Password
+						</Button>
+
+						{/* Separator */}
+						<div className="relative">
+							<div className="absolute inset-0 flex items-center">
+								<Separator className="w-full" />
+							</div>
+							<div className="relative flex justify-center text-xs uppercase">
+								<span className="bg-background px-2 text-muted-foreground">Or</span>
+							</div>
+						</div>
+
 						{/* OAuth Sign In */}
 						<OAuthSignIn />
+					</>
+				)}
+
+				{!error && verificationStep === "password" && (
+					<>
+						<SignInPassword
+							onSuccess={handlePasswordSuccess}
+							onError={handleError}
+						/>
+						
+						<Button
+							variant="ghost"
+							onClick={handleReset}
+							className="w-full h-12 text-muted-foreground hover:text-foreground"
+						>
+							← Back to other options
+						</Button>
 					</>
 				)}
 
@@ -93,8 +135,8 @@ export function SignInForm({
 				)}
 			</div>
 
-			{/* Sign Up Link - only show on email step */}
-			{verificationStep === "email" && (
+			{/* Sign Up Link - only show on email and password steps */}
+			{(verificationStep === "email" || verificationStep === "password") && (
 				<div className="text-center text-sm">
 					<span className="text-muted-foreground">Don't have an account? </span>
 					<Button

--- a/apps/chat/src/app/(auth)/_components/sign-in-password.tsx
+++ b/apps/chat/src/app/(auth)/_components/sign-in-password.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import * as React from "react";
+import { useSignIn } from "@clerk/nextjs";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@repo/ui/components/ui/button";
+import { Input } from "@repo/ui/components/ui/input";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormMessage,
+} from "@repo/ui/components/ui/form";
+import { Icons } from "@repo/ui/components/icons";
+import { handleClerkError } from "~/app/lib/clerk/error-handler";
+import { useLogger } from "@vendor/observability/client-log";
+
+const passwordSchema = z.object({
+	identifier: z.string().min(1, "Email or username is required"),
+	password: z.string().min(1, "Password is required"),
+});
+
+type PasswordFormData = z.infer<typeof passwordSchema>;
+
+interface SignInPasswordProps {
+	onSuccess: () => void;
+	onError: (error: string) => void;
+}
+
+export function SignInPassword({ onSuccess, onError }: SignInPasswordProps) {
+	const { signIn, isLoaded } = useSignIn();
+	const log = useLogger();
+
+	const form = useForm<PasswordFormData>({
+		resolver: zodResolver(passwordSchema),
+		defaultValues: {
+			identifier: "",
+			password: "",
+		},
+	});
+
+	async function onSubmit(data: PasswordFormData) {
+		if (!signIn) return;
+
+		try {
+			// Attempt to sign in with password
+			const result = await signIn.create({
+				identifier: data.identifier,
+				password: data.password,
+			});
+
+			if (result.status === "complete") {
+				log.info("[SignInPassword] Authentication success", {
+					identifier: data.identifier,
+					timestamp: new Date().toISOString(),
+				});
+				onSuccess();
+			} else {
+				throw new Error("Sign-in incomplete");
+			}
+		} catch (err) {
+			// Log the error
+			log.error("[SignInPassword] Authentication failed", {
+				identifier: data.identifier,
+				error: err,
+			});
+			
+			// Handle the error with proper context
+			const errorResult = handleClerkError(err, {
+				component: "SignInPassword",
+				action: "password_sign_in",
+				identifier: data.identifier,
+			});
+			
+			// Pass the user-friendly error message to parent
+			onError(errorResult.userMessage);
+		}
+	}
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+				<FormField
+					control={form.control}
+					name="identifier"
+					render={({ field }) => (
+						<FormItem>
+							<FormControl>
+								<Input
+									type="text"
+									placeholder="Email or username"
+									className="h-12 bg-background dark:bg-background"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="password"
+					render={({ field }) => (
+						<FormItem>
+							<FormControl>
+								<Input
+									type="password"
+									placeholder="Password"
+									className="h-12 bg-background dark:bg-background"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<Button
+					type="submit"
+					className="w-full h-12"
+					disabled={!isLoaded || form.formState.isSubmitting}
+				>
+					{form.formState.isSubmitting ? (
+						<>
+							<Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+							Signing in...
+						</>
+					) : (
+						"Sign in with Password"
+					)}
+				</Button>
+			</form>
+		</Form>
+	);
+}

--- a/apps/chat/src/app/(auth)/_components/sign-up-form.tsx
+++ b/apps/chat/src/app/(auth)/_components/sign-up-form.tsx
@@ -4,13 +4,14 @@ import { Button } from "@repo/ui/components/ui/button";
 import { Separator } from "@repo/ui/components/ui/separator";
 import { SignUpEmailInput } from "./sign-up-email-input";
 import { SignUpCodeVerification } from "./sign-up-code-verification";
+import { SignUpPassword } from "./sign-up-password";
 import { OAuthSignUp } from "./oauth-sign-up";
 import Link from "next/link";
 import { siteConfig } from "@repo/site-config";
 
 export function SignUpForm() {
 	const [verificationStep, setVerificationStep] = React.useState<
-		"email" | "code"
+		"email" | "code" | "password"
 	>("email");
 	const [emailAddress, setEmailAddress] = React.useState("");
 	const [error, setError] = React.useState("");
@@ -31,10 +32,16 @@ export function SignUpForm() {
 		setError(errorMessage);
 	}
 
+	function handlePasswordSuccess(email: string) {
+		setEmailAddress(email);
+		setVerificationStep("code");
+		setError("");
+	}
+
 	return (
 		<div className="w-full space-y-8">
-			{/* Header - only show on email step */}
-			{verificationStep === "email" && (
+			{/* Header - only show on email and password steps */}
+			{(verificationStep === "email" || verificationStep === "password") && (
 				<div className="text-center">
 					<h1 className="text-3xl font-semibold text-foreground">
 						Sign up for Lightfast
@@ -98,8 +105,66 @@ export function SignUpForm() {
 							</div>
 						</div>
 
+						{/* Password Sign Up Option */}
+						<Button
+							variant="outline"
+							onClick={() => setVerificationStep("password")}
+							className="w-full h-12"
+						>
+							Sign up with Password
+						</Button>
+
+						{/* Separator */}
+						<div className="relative">
+							<div className="absolute inset-0 flex items-center">
+								<Separator className="w-full" />
+							</div>
+							<div className="relative flex justify-center text-xs uppercase">
+								<span className="bg-background px-2 text-muted-foreground">Or</span>
+							</div>
+						</div>
+
 						{/* OAuth Sign Up */}
 						<OAuthSignUp />
+					</>
+				)}
+
+				{!error && verificationStep === "password" && (
+					<>
+						<SignUpPassword
+							onSuccess={handlePasswordSuccess}
+							onError={handleError}
+						/>
+						
+						{/* Legal compliance text for password step */}
+						<p className="text-xs text-center text-muted-foreground">
+							By joining, you agree to our{" "}
+							<Link
+								href={siteConfig.links.terms.href}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-foreground hover:text-foreground/80 underline"
+							>
+								Terms of Service
+							</Link>{" "}
+							and{" "}
+							<Link
+								href={siteConfig.links.privacy.href}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-foreground hover:text-foreground/80 underline"
+							>
+								Privacy Policy
+							</Link>
+						</p>
+						
+						<Button
+							variant="ghost"
+							onClick={handleReset}
+							className="w-full h-12 text-muted-foreground hover:text-foreground"
+						>
+							← Back to other options
+						</Button>
 					</>
 				)}
 
@@ -112,8 +177,8 @@ export function SignUpForm() {
 				)}
 			</div>
 
-			{/* Sign In Link - only show on email step */}
-			{verificationStep === "email" && (
+			{/* Sign In Link - only show on email and password steps */}
+			{(verificationStep === "email" || verificationStep === "password") && (
 				<div className="text-center text-sm">
 					<span className="text-muted-foreground">Already have an account? </span>
 					<Button

--- a/apps/chat/src/app/(auth)/_components/sign-up-password.tsx
+++ b/apps/chat/src/app/(auth)/_components/sign-up-password.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+import { useSignUp } from "@clerk/nextjs";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@repo/ui/components/ui/button";
+import { Input } from "@repo/ui/components/ui/input";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormMessage,
+} from "@repo/ui/components/ui/form";
+import { Icons } from "@repo/ui/components/icons";
+import { handleClerkError } from "~/app/lib/clerk/error-handler";
+import { useLogger } from "@vendor/observability/client-log";
+
+const passwordSchema = z.object({
+	emailAddress: z.string().email("Please enter a valid email address"),
+	password: z.string().min(8, "Password must be at least 8 characters long"),
+});
+
+type PasswordFormData = z.infer<typeof passwordSchema>;
+
+interface SignUpPasswordProps {
+	onSuccess: (email: string) => void;
+	onError: (error: string) => void;
+}
+
+export function SignUpPassword({ onSuccess, onError }: SignUpPasswordProps) {
+	const { signUp, isLoaded } = useSignUp();
+	const log = useLogger();
+
+	const form = useForm<PasswordFormData>({
+		resolver: zodResolver(passwordSchema),
+		defaultValues: {
+			emailAddress: "",
+			password: "",
+		},
+	});
+
+	async function onSubmit(data: PasswordFormData) {
+		if (!signUp) return;
+
+		try {
+			// Create sign-up attempt with password
+			await signUp.create({
+				emailAddress: data.emailAddress,
+				password: data.password,
+			});
+
+			// Send verification code to email
+			await signUp.prepareEmailAddressVerification({
+				strategy: "email_code",
+			});
+
+			log.info("[SignUpPassword] Sign-up created, verification code sent", {
+				email: data.emailAddress,
+				timestamp: new Date().toISOString(),
+			});
+
+			onSuccess(data.emailAddress);
+		} catch (err) {
+			// Log the error
+			log.error("[SignUpPassword] Sign-up failed", {
+				email: data.emailAddress,
+				error: err,
+			});
+			
+			// Handle the error with proper context
+			const errorResult = handleClerkError(err, {
+				component: "SignUpPassword",
+				action: "password_sign_up",
+				email: data.emailAddress,
+			});
+			
+			// Pass the user-friendly error message to parent
+			onError(errorResult.userMessage);
+		}
+	}
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+				<FormField
+					control={form.control}
+					name="emailAddress"
+					render={({ field }) => (
+						<FormItem>
+							<FormControl>
+								<Input
+									type="email"
+									placeholder="Email Address"
+									className="h-12 bg-background dark:bg-background"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="password"
+					render={({ field }) => (
+						<FormItem>
+							<FormControl>
+								<Input
+									type="password"
+									placeholder="Password (8+ characters)"
+									className="h-12 bg-background dark:bg-background"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<Button
+					type="submit"
+					className="w-full h-12"
+					disabled={!isLoaded || form.formState.isSubmitting}
+				>
+					{form.formState.isSubmitting ? (
+						<>
+							<Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+							Creating account...
+						</>
+					) : (
+						"Create Account with Password"
+					)}
+				</Button>
+			</form>
+		</Form>
+	);
+}


### PR DESCRIPTION
## Summary
- Added complete password login functionality to the chat app (`apps/chat`)
- Created password sign-in and sign-up components mirroring the apps/auth implementation
- Updated existing forms to include password authentication options alongside email verification and OAuth

## Features Added
- **SignInPassword Component**: Email/username + password authentication with proper validation
- **SignUpPassword Component**: Email + password (8+ characters) with email verification flow
- **Multi-step Authentication Flow**: Users can seamlessly switch between email codes, password, and OAuth methods
- **Form Validation**: Zod schema validation for all password input fields
- **Error Handling**: Integrated with existing Clerk error handling system
- **Development Testing**: Added test credentials documentation in `apps/chat/CLAUDE.md`

## Test Plan
- [x] TypeScript compilation passes without errors
- [x] Build succeeds with all static pages generated correctly  
- [x] Lint checks pass cleanly
- [x] Development server starts and serves password login options on both sign-in and sign-up pages
- [x] HTML verification confirms components render correctly with proper button text
- [x] Form validation works with appropriate error messages
- [x] Navigation between auth methods functions smoothly

## Development Testing
Available test credentials (development only):
- **Email**: `admin@lightfast.ai`
- **Password**: `ijXFdBJ3U2eMDFnKqngp` 
- **Fresh account email**: `some-email+clerk_test@lightfast.ai`
- **Verification code**: `424242`

🤖 Generated with [Claude Code](https://claude.ai/code)