### PR TITLE
refactor: use typed env for Clerk publishable key across all apps

### DIFF
--- a/apps/auth/src/app/layout.tsx
+++ b/apps/auth/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { fonts } from "@repo/ui/lib/fonts";
 import { cn } from "@repo/ui/lib/utils";
 import { SpeedInsights, VercelAnalytics } from "@vendor/analytics/vercel";
 import { createMetadata } from "@vendor/seo/metadata";
+import { env } from "~/env";
 import { consoleUrl } from "~/lib/related-projects";
 
 export const metadata: Metadata = createMetadata({
@@ -78,7 +79,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider
-      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+      publishableKey={env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
       signInFallbackRedirectUrl={consoleUrl}

--- a/apps/chat/src/app/layout.tsx
+++ b/apps/chat/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { SpeedInsights, VercelAnalytics } from "@vendor/analytics/vercel";
 import { ThemeProvider } from "next-themes";
 import { StructuredData } from "~/components/structured-data";
 import { createMetadata } from "@vendor/seo/metadata";
+import { env } from "~/env";
 
 export const metadata: Metadata = createMetadata({
   title: "Lightfast Chat - Open-Source Model Agnostic AI Chat Interface",
@@ -108,7 +109,7 @@ export default function RootLayout({
 }>) {
 	return (
 		<ClerkProvider
-			publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+			publishableKey={env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
 			signInUrl="/sign-in"
 			signUpUrl="/sign-up"
 			signInFallbackRedirectUrl="/new"

--- a/apps/console/src/app/layout.tsx
+++ b/apps/console/src/app/layout.tsx
@@ -7,9 +7,11 @@ import { Toaster } from "@repo/ui/components/ui/sonner";
 import { fonts } from "@repo/ui/lib/fonts";
 import { cn } from "@repo/ui/lib/utils";
 import { ClerkProvider } from "@clerk/nextjs";
+import { SpeedInsights, VercelAnalytics } from "@vendor/analytics/vercel";
 import { TRPCReactProvider } from "@repo/console-trpc/react";
 import { createMetadata } from "@vendor/seo/metadata";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { env } from "~/env";
 import { authUrl } from "~/lib/related-projects";
 
 export const metadata: Metadata = createMetadata({
@@ -54,7 +56,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider
-      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+      publishableKey={env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       signInUrl={`${authUrl}/sign-in`}
       signUpUrl={`${authUrl}/sign-up`}
       signInFallbackRedirectUrl="/account/teams/new"
@@ -74,6 +76,8 @@ export default function RootLayout({
               <Toaster />
             </TRPCReactProvider>
           </NuqsAdapter>
+          <VercelAnalytics />
+          <SpeedInsights />
         </body>
       </html>
     </ClerkProvider>

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -16,6 +16,7 @@ import {
 } from "@vercel/microfrontends/next/client";
 
 import { createBaseUrl } from "~/lib/base-url";
+import { env } from "~/env";
 import { authUrl, consoleUrl } from "~/lib/related-projects";
 import { JsonLd } from "@vendor/seo/json-ld";
 import type { Organization, WebSite, WithContext } from "@vendor/seo/json-ld";
@@ -149,7 +150,7 @@ export default function RootLayout({
 
   return (
     <ClerkProvider
-      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+      publishableKey={env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       // Delegate sign-in/sign-up to auth app
       signInUrl={`${authUrl}/sign-in`}
       signUpUrl={`${authUrl}/sign-up`}


### PR DESCRIPTION
## Summary

This PR refactors all app layouts to use typed environment variables from `~/env` instead of directly accessing `process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`.

## Changes

### Updated Apps

- **apps/console**: Added VercelAnalytics + SpeedInsights + typed env for Clerk key
- **apps/chat**: Typed env for Clerk publishable key
- **apps/auth**: Typed env for Clerk publishable key
- **apps/www**: Typed env for Clerk publishable key

### Benefits

✅ **Type Safety**: Compile-time type checking for environment variables
✅ **Validation**: Zod schema validation via `@t3-oss/env-nextjs`
✅ **Consistency**: Unified environment variable access pattern across monorepo
✅ **Analytics**: Console app now has Vercel Analytics and SpeedInsights

## Technical Details

Each app now:
1. Imports `env` from `~/env`
2. Uses `env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` instead of `process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
3. Benefits from Zod validation defined in their respective `env.ts` files

## Testing

- [ ] All apps build successfully
- [ ] Clerk authentication works in all apps
- [ ] No type errors
- [ ] Analytics tracking works in console app

🤖 Generated with [Claude Code](https://claude.com/claude-code)