### PR TITLE
fix(console): add missing @vendor/analytics dependency

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -47,6 +47,7 @@
     "@trpc/server": "catalog:",
     "@trpc/tanstack-react-query": "catalog:",
     "@upstash/redis": "catalog:",
+    "@vendor/analytics": "workspace:*",
     "@vendor/clerk": "workspace:*",
     "@vendor/next": "workspace:*",
     "@vendor/observability": "workspace:*",


### PR DESCRIPTION
## Summary
- Add `@vendor/analytics` to console app dependencies

## Problem
The console app's `layout.tsx` imports from `@vendor/analytics/vercel` but the package was not listed in the `package.json` dependencies, causing build failures.

## Solution
Add `@vendor/analytics: "workspace:*"` to the dependencies in `apps/console/package.json`.

## Test Plan
- [x] Added dependency to package.json
- [x] Ran `pnpm install` successfully
- [x] Ran `pnpm build:console` successfully
- [x] Build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)