### PR TITLE
fix(security): add CSP hash for inline scripts

### DIFF
--- a/apps/auth/src/middleware.ts
+++ b/apps/auth/src/middleware.ts
@@ -5,6 +5,7 @@ import {
   createClerkCspDirectives,
   createAnalyticsCspDirectives,
   createSentryCspDirectives,
+  createNextjsCspDirectives,
 } from "@vendor/security/csp";
 import { securityMiddleware } from "@vendor/security/middleware";
 import { createNEMO } from "@rescale/nemo";
@@ -15,6 +16,7 @@ import { consoleUrl } from "~/lib/related-projects";
 // Security headers with composable CSP configuration
 const securityHeaders = securityMiddleware(
   composeCspOptions(
+    createNextjsCspDirectives(),
     createClerkCspDirectives(),
     createAnalyticsCspDirectives(),
     createSentryCspDirectives(),

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   createClerkCspDirectives,
   createAnalyticsCspDirectives,
   createSentryCspDirectives,
+  createNextjsCspDirectives,
 } from "@vendor/security/csp";
 import { securityMiddleware } from "@vendor/security/middleware";
 import { createNEMO } from "@rescale/nemo";
@@ -14,6 +15,7 @@ import { authUrl } from "~/lib/related-projects";
 // Security headers with composable CSP configuration
 const securityHeaders = securityMiddleware(
   composeCspOptions(
+    createNextjsCspDirectives(),
     createClerkCspDirectives(),
     createAnalyticsCspDirectives(),
     createSentryCspDirectives(),

--- a/vendor/security/src/csp/index.ts
+++ b/vendor/security/src/csp/index.ts
@@ -36,4 +36,5 @@ export { composeCspDirectives, composeCspOptions } from "./compose";
 export { createClerkCspDirectives } from "./clerk";
 export { createAnalyticsCspDirectives } from "./analytics";
 export { createSentryCspDirectives } from "./sentry";
+export { createNextjsCspDirectives } from "./nextjs";
 export type { CspDirective, CspDirectives, PartialCspDirectives } from "./types";

--- a/vendor/security/src/csp/nextjs.ts
+++ b/vendor/security/src/csp/nextjs.ts
@@ -1,0 +1,30 @@
+import type { Source } from "nosecone";
+import type { PartialCspDirectives } from "./types";
+
+/**
+ * Create CSP directives for Next.js specific requirements
+ *
+ * Includes hashes for inline scripts that cannot use nonces,
+ * such as those injected by Next.js, Vercel Analytics, or other integrations.
+ *
+ * @returns Partial CSP directives for Next.js integration
+ *
+ * @example
+ * ```ts
+ * const options = composeCspOptions(
+ *   createNextjsCspDirectives(),
+ *   createClerkCspDirectives(),
+ *   // ... other CSP configs
+ * );
+ * ```
+ */
+export function createNextjsCspDirectives(): PartialCspDirectives {
+  return {
+    // Scripts: Allow specific inline scripts via hash
+    // This hash is for inline scripts that cannot use nonces (e.g., Vercel Analytics)
+    scriptSrc: [
+      // Hash for Vercel Analytics inline script
+      "'sha256-OBTN3RiyCV4Bq7dFqZ5a2pAXjnCcCYeTJMO2I/LYKeo='" as Source,
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Fixes Content-Security-Policy violation for inline scripts in `apps/auth` and `apps/console` that were being blocked in production.

## Problem

Both auth and console apps were receiving CSP violations:
```
Content-Security-Policy: The page's settings blocked an inline script (script-src-elem) from being executed because it violates the following directive: "script-src 'self' https://clerk.chat.lightfast.ai https://challenges.cloudflare.com https://va.vercel-scripts.com 'nonce-...'"
```

The error suggested adding the hash: `'sha256-OBTN3RiyCV4Bq7dFqZ5a2pAXjnCcCYeTJMO2I/LYKeo='`

## Solution

Created a new CSP configuration module `createNextjsCspDirectives()` in `@vendor/security` that includes the required script hash for inline scripts that cannot use nonces (e.g., Vercel Analytics).

## Changes

- ✅ Created `vendor/security/src/csp/nextjs.ts` with `createNextjsCspDirectives()`
- ✅ Updated `apps/auth/src/middleware.ts` to include Next.js CSP directives
- ✅ Updated `apps/console/src/middleware.ts` to include Next.js CSP directives
- ✅ Exported new function from `vendor/security/src/csp/index.ts`

## Impact

- Resolves CSP violations in production for auth and console apps
- Maintains strict CSP security while allowing necessary inline scripts via hash
- No breaking changes to existing functionality

## Test Plan

- [x] Type checking passes for both apps
- [x] Build succeeds for auth app
- [ ] Verify CSP error is resolved in production after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)