### PR TITLE
fix: remove console.lightfast.ai subdomain and align middleware patterns

### DIFF
--- a/apps/auth/src/lib/related-projects.ts
+++ b/apps/auth/src/lib/related-projects.ts
@@ -12,9 +12,10 @@ export const wwwUrl = withRelatedProject({
 });
 
 // Get the console URL dynamically based on environment
+// Console is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const consoleUrl = withRelatedProject({
   projectName: 'lightfast-console',
   defaultHost: isDevelopment
     ? `http://localhost:${env.NEXT_PUBLIC_CONSOLE_PORT}`
-    : 'https://console.lightfast.ai',
+    : 'https://lightfast.ai',
 });

--- a/apps/console/src/app/layout.tsx
+++ b/apps/console/src/app/layout.tsx
@@ -19,13 +19,13 @@ export const metadata: Metadata = createMetadata({
   description:
     "Build powerful AI workflow orchestration with natural language. Connect AI to any tool via MCP and automate complex workflows without code.",
   image: siteConfig.ogImage,
-  metadataBase: new URL("https://console.lightfast.ai"),
+  metadataBase: new URL("https://lightfast.ai"),
   authors: [{ name: siteConfig.name, url: siteConfig.url }],
   creator: siteConfig.name,
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://console.lightfast.ai",
+    url: "https://lightfast.ai",
     title: "Console - AI Workflow Orchestration",
     description:
       "Build powerful AI workflow orchestration with natural language. Connect AI to any tool via MCP and automate complex workflows without code.",

--- a/apps/console/src/app/robots.ts
+++ b/apps/console/src/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: "/api/",
     },
-    sitemap: "https://console.lightfast.ai/sitemap.xml",
+    sitemap: "https://lightfast.ai/sitemap.xml",
   };
 }

--- a/apps/docs/src/lib/related-projects.ts
+++ b/apps/docs/src/lib/related-projects.ts
@@ -18,9 +18,10 @@ export const chatUrl = isDevelopment
   : 'https://chat.lightfast.ai';
 
 // Get the console URL dynamically based on environment
+// Console is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const consoleUrl = isDevelopment
   ? `http://localhost:${env.NEXT_PUBLIC_CONSOLE_PORT}`
-  : 'https://console.lightfast.ai';
+  : 'https://lightfast.ai';
 
 // Helper for auth URLs (replicates getAuthUrls from url-config)
 export function getAuthUrls() {

--- a/apps/www/src/lib/related-projects.ts
+++ b/apps/www/src/lib/related-projects.ts
@@ -20,9 +20,10 @@ export const authUrl = withRelatedProject({
 });
 
 // Get the console URL dynamically based on environment
+// Console is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const consoleUrl = withRelatedProject({
   projectName: 'lightfast-console',
   defaultHost: isDevelopment
     ? `http://localhost:${env.NEXT_PUBLIC_CONSOLE_PORT}`
-    : 'https://console.lightfast.ai',
+    : 'https://lightfast.ai',
 });

--- a/apps/www/src/middleware.ts
+++ b/apps/www/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   createClerkCspDirectives,
   createAnalyticsCspDirectives,
   createSentryCspDirectives,
+  createNextjsCspDirectives,
 } from "@vendor/security/csp";
 import { securityMiddleware } from "@vendor/security/middleware";
 import { createNEMO } from "@rescale/nemo";
@@ -14,6 +15,7 @@ import { consoleUrl, authUrl } from "~/lib/related-projects";
 // Security headers with composable CSP configuration
 const securityHeaders = securityMiddleware(
   composeCspOptions(
+    createNextjsCspDirectives(),
     createClerkCspDirectives(),
     createAnalyticsCspDirectives(),
     createSentryCspDirectives(),

--- a/packages/url-utils/src/cors.ts
+++ b/packages/url-utils/src/cors.ts
@@ -56,7 +56,7 @@ export function getCorsConfig(additionalOrigins: string[] = []): CorsConfig {
     "https://chat.lightfast.ai",
     "https://docs.lightfast.ai",
     "https://playground.lightfast.ai",
-    "https://console.lightfast.ai",
+    "https://lightfast.ai",
     "https://experimental.lightfast.ai",
     // Development URLs
     "http://localhost:4101", // www


### PR DESCRIPTION
## Summary

Removes all references to `console.lightfast.ai` subdomain and aligns middleware patterns across all apps. Console is served from `lightfast.ai` via microfrontends, not a separate subdomain.

## Problem

1. **Incorrect subdomain references**: Code referenced `console.lightfast.ai` but console is actually served from `lightfast.ai` via microfrontend routing
2. **Unnecessary CORS**: Auth app had CORS handling for cross-origin requests, but all apps are on the same origin (`lightfast.ai`)
3. **Inconsistent middleware**: Auth app middleware pattern differed from console/www apps

## Solution

### Remove console.lightfast.ai subdomain
- Updated all `consoleUrl` references to use `lightfast.ai` (not `console.lightfast.ai`)
- Console app is served via Vercel microfrontends on `lightfast.ai` with path-based routing
- Updated metadata in `apps/console` (layout.tsx, robots.ts)
- Updated `related-projects.ts` in apps/auth, apps/www, apps/docs
- Updated CORS allowlist in `packages/url-utils`

### Remove CORS from auth app
- Removed `handleCorsPreflightRequest()` and `applyCorsHeaders()` imports and usage
- All apps are on the same origin (`lightfast.ai`) via microfrontends
- CORS is only needed for different origins (different domains/subdomains)
- Since microfrontends share the same domain, no CORS needed

### Align middleware patterns
All three apps (auth, console, www) now follow identical pattern:
1. Security headers via `securityMiddleware(composeCspOptions(...))`
2. NEMO composed middleware
3. Apply security headers to final response
4. Return final response (no CORS needed - same origin)

Added missing `createNextjsCspDirectives()` to `apps/www` for consistent CSP.

## Changes

**apps/auth/src/lib/related-projects.ts**
- `consoleUrl`: `console.lightfast.ai` → `lightfast.ai`

**apps/auth/src/middleware.ts**
- Removed CORS imports and handling
- Simplified to match console/www pattern
- Added `createNextjsCspDirectives()`

**apps/www/src/lib/related-projects.ts**
- `consoleUrl`: `console.lightfast.ai` → `lightfast.ai`

**apps/www/src/middleware.ts**
- Added `createNextjsCspDirectives()` for consistent CSP

**apps/console/src/app/layout.tsx**
- `metadataBase`: `console.lightfast.ai` → `lightfast.ai`
- `openGraph.url`: `console.lightfast.ai` → `lightfast.ai`

**apps/console/src/app/robots.ts**
- `sitemap`: `console.lightfast.ai` → `lightfast.ai`

**apps/docs/src/lib/related-projects.ts**
- `consoleUrl`: `console.lightfast.ai` → `lightfast.ai`

**packages/url-utils/src/cors.ts**
- Updated allowlist: `console.lightfast.ai` → `lightfast.ai`

## Impact

- ✅ Correct domain references (lightfast.ai, not console.lightfast.ai)
- ✅ Consistent middleware architecture across all apps
- ✅ Correct CSP configuration (unsafe-inline without nonces)
- ✅ No CORS complexity (same-origin microfrontends)
- ✅ All apps follow identical security header pattern

## Test Plan

- [x] Type checking passes for auth, www, console apps
- [ ] Verify console routes work at lightfast.ai (not console.lightfast.ai)
- [ ] Verify auth redirects work correctly to lightfast.ai
- [ ] Verify CSP headers are applied correctly
- [ ] Verify no CORS errors in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)