### PR TITLE
refactor: remove auth.lightfast.ai subdomain references

### DIFF
--- a/apps/auth/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-in/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = createMetadata({
     title: "Sign In - Lightfast Auth",
     description:
       "Sign in to your Lightfast account to access the AI agent platform.",
-    url: "https://auth.lightfast.ai/sign-in",
+    url: "https://lightfast.ai/sign-in",
   },
   twitter: {
     title: "Sign In - Lightfast Auth",
@@ -20,7 +20,7 @@ export const metadata: Metadata = createMetadata({
       "Sign in to your Lightfast account to access the AI agent platform.",
   },
   alternates: {
-    canonical: "https://auth.lightfast.ai/sign-in",
+    canonical: "https://lightfast.ai/sign-in",
   },
   robots: {
     index: true,

--- a/apps/auth/src/app/robots.ts
+++ b/apps/auth/src/app/robots.ts
@@ -19,6 +19,6 @@ export default function robots(): MetadataRoute.Robots {
         "/**/error", // Don't index error pages
       ],
     },
-    sitemap: "https://auth.lightfast.ai/sitemap.xml",
+    sitemap: "https://lightfast.ai/sitemap.xml",
   };
 }

--- a/apps/auth/src/app/sitemap.ts
+++ b/apps/auth/src/app/sitemap.ts
@@ -7,7 +7,7 @@ import type { MetadataRoute } from "next";
  * @returns {MetadataRoute.Sitemap} Next.js compatible sitemap configuration
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://auth.lightfast.ai";
+  const baseUrl = "https://lightfast.ai";
   const currentDate = new Date().toISOString();
 
   return [

--- a/apps/chat/src/lib/related-projects.ts
+++ b/apps/chat/src/lib/related-projects.ts
@@ -12,9 +12,10 @@ export const wwwUrl = withRelatedProject({
 });
 
 // Get the auth URL dynamically based on environment
+// Auth is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const authUrl = withRelatedProject({
   projectName: 'lightfast-auth',
   defaultHost: isDevelopment
     ? `http://localhost:${env.NEXT_PUBLIC_AUTH_PORT}`
-    : 'https://auth.lightfast.ai',
+    : 'https://lightfast.ai',
 });

--- a/apps/console/src/lib/related-projects.ts
+++ b/apps/console/src/lib/related-projects.ts
@@ -4,11 +4,12 @@ import { env } from '@repo/app-urls';
 const isDevelopment = env.NEXT_PUBLIC_VERCEL_ENV === 'development';
 
 // Get the auth URL dynamically based on environment
+// Auth is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const authUrl = withRelatedProject({
   projectName: 'lightfast-auth',
   defaultHost: isDevelopment
     ? `http://localhost:${env.NEXT_PUBLIC_AUTH_PORT}`
-    : 'https://auth.lightfast.ai',
+    : 'https://lightfast.ai',
 });
 
 // Get the www URL dynamically based on environment

--- a/apps/docs/src/lib/related-projects.ts
+++ b/apps/docs/src/lib/related-projects.ts
@@ -8,9 +8,10 @@ export const wwwUrl = isDevelopment
   : 'https://lightfast.ai';
 
 // Get the auth URL dynamically based on environment
+// Auth is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const authUrl = isDevelopment
   ? `http://localhost:${env.NEXT_PUBLIC_AUTH_PORT}`
-  : 'https://auth.lightfast.ai';
+  : 'https://lightfast.ai';
 
 // Get the chat URL dynamically based on environment
 export const chatUrl = isDevelopment

--- a/apps/www/src/lib/related-projects.ts
+++ b/apps/www/src/lib/related-projects.ts
@@ -12,11 +12,12 @@ export const wwwUrl = withRelatedProject({
 });
 
 // Get the auth URL dynamically based on environment
+// Auth is served from lightfast.ai via microfrontends (not a separate subdomain)
 export const authUrl = withRelatedProject({
   projectName: 'lightfast-auth',
   defaultHost: isDevelopment
     ? `http://localhost:${env.NEXT_PUBLIC_AUTH_PORT}`
-    : 'https://auth.lightfast.ai',
+    : 'https://lightfast.ai',
 });
 
 // Get the console URL dynamically based on environment

--- a/packages/url-utils/src/cors.ts
+++ b/packages/url-utils/src/cors.ts
@@ -51,12 +51,10 @@ export function getCorsConfig(additionalOrigins: string[] = []): CorsConfig {
     // Production URLs
     "https://lightfast.ai",
     "https://www.lightfast.ai",
-    "https://auth.lightfast.ai",
     "https://cloud.lightfast.ai",
     "https://chat.lightfast.ai",
     "https://docs.lightfast.ai",
     "https://playground.lightfast.ai",
-    "https://lightfast.ai",
     "https://experimental.lightfast.ai",
     // Development URLs
     "http://localhost:4101", // www


### PR DESCRIPTION
## Summary

Remove all references to `auth.lightfast.ai` subdomain and replace with `lightfast.ai`, following the same pattern as the console app microfrontend architecture.

## Changes

### Updated Files
- **packages/url-utils/src/cors.ts**: Removed `auth.lightfast.ai` from CORS allowed origins
- **apps/*/src/lib/related-projects.ts** (www, docs, console, chat): Updated authUrl production host to `lightfast.ai` with explanatory comments
- **apps/auth/src/app/robots.ts**: Updated sitemap URL to `lightfast.ai`
- **apps/auth/src/app/sitemap.ts**: Updated baseUrl to `lightfast.ai`
- **apps/auth/src/app/(app)/(auth)/sign-in/page.tsx**: Updated metadata URLs to `lightfast.ai`

### Architecture
Auth is served from `lightfast.ai` via microfrontends using path-based routing (not a separate subdomain), consistent with the console app pattern.

Development URLs remain unchanged (localhost with different ports per app).

## Testing
- ✅ Type checking passes for all modified files
- ✅ No remaining references to `auth.lightfast.ai` in codebase (excluding node_modules)
- ✅ Follows same pattern as `console.lightfast.ai` removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)