### PR TITLE
fix: correct microfrontend Link usage across apps/www and apps/auth

### DIFF
--- a/apps/auth/src/app/(app)/(auth)/_components/sign-up-form.tsx
+++ b/apps/auth/src/app/(app)/(auth)/_components/sign-up-form.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@repo/ui/components/ui/separator";
 import { SignUpEmailInput } from "./sign-up-email-input";
 import { SignUpCodeVerification } from "./sign-up-code-verification";
 import { OAuthSignUp } from "./oauth-sign-up";
-import Link from "next/link";
+import Link from "~/components/ui/link";
 import { siteConfig } from "@repo/site-config";
 
 export function SignUpForm() {
@@ -71,6 +71,7 @@ export function SignUpForm() {
 							By joining, you agree to our{" "}
 							<Link
 								href={siteConfig.links.terms.href}
+								microfrontend
 								target="_blank"
 								rel="noopener noreferrer"
 								className="text-foreground hover:text-foreground/80 underline"
@@ -80,6 +81,7 @@ export function SignUpForm() {
 							and{" "}
 							<Link
 								href={siteConfig.links.privacy.href}
+								microfrontend
 								target="_blank"
 								rel="noopener noreferrer"
 								className="text-foreground hover:text-foreground/80 underline"

--- a/apps/auth/src/app/(app)/(auth)/layout.tsx
+++ b/apps/auth/src/app/(app)/(auth)/layout.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import Link from "next/link";
+import Link from "~/components/ui/link";
 import { Button } from "@repo/ui/components/ui/button";
 import { Icons } from "@repo/ui/components/icons";
 import { SignedOut, RedirectToTasks } from "@clerk/nextjs";
-import { wwwUrl } from "~/lib/related-projects";
 
 export default function AuthLayout({
   children,
@@ -22,7 +21,7 @@ export default function AuthLayout({
             {/* Left: Logo */}
             <div className="-ml-2 flex items-center md:justify-self-start">
               <Button variant="ghost" size="lg" asChild>
-                <Link href={wwwUrl} className="flex items-center">
+                <Link href="/" microfrontend className="flex items-center">
                   <Icons.logoShort className="text-foreground size-6" />
                 </Link>
               </Button>
@@ -37,7 +36,7 @@ export default function AuthLayout({
                 asChild
                 className="rounded-full"
               >
-                <Link href={`${wwwUrl}/early-access`}>
+                <Link href="/early-access" microfrontend>
                   Join the Early Access
                 </Link>
               </Button>

--- a/apps/auth/src/components/ui/link.tsx
+++ b/apps/auth/src/components/ui/link.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import NextLink from "next/link";
+import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
+import * as React from "react";
+
+type NextLinkProps = React.ComponentProps<typeof NextLink>;
+type MicroLinkProps = React.ComponentProps<typeof MicrofrontendLink>;
+
+type Props =
+  | ({ microfrontend?: false } & NextLinkProps)
+  | ({ microfrontend: true } & MicroLinkProps);
+
+export function Link(props: Props) {
+  if ("microfrontend" in props && props.microfrontend) {
+    const { microfrontend: _mf, ...rest } = props as { microfrontend: true } & MicroLinkProps;
+    return <MicrofrontendLink {...rest} />;
+  }
+  const { microfrontend: _mf, ...rest } = props as { microfrontend?: false } & NextLinkProps;
+  return <NextLink {...rest} />;
+}
+
+export default Link;

--- a/apps/www/src/components/landing/footer-section.tsx
+++ b/apps/www/src/components/landing/footer-section.tsx
@@ -1,9 +1,8 @@
-import Link from "next/link";
+import Link from "~/components/ui/link";
 import { ArrowRight } from "lucide-react";
 
 import { emailConfig, siteConfig } from "@repo/site-config";
 import { Icons } from "@repo/ui/components/icons";
-import { consoleUrl } from "~/lib/related-projects";
 
 export function SiteFooter() {
   return (
@@ -27,13 +26,15 @@ export function SiteFooter() {
                 </h3>
                 <nav className="flex flex-col gap-2 sm:gap-3">
                   <Link
-                    href={consoleUrl}
+                    href="/account/teams"
+                    microfrontend
                     className="text-foreground hover:text-muted-foreground text-lg sm:text-xl lg:text-2xl font-bold transition-colors duration-200"
                   >
                     Console
                   </Link>
                   <Link
                     href="/docs/sdk"
+                    microfrontend
                     className="text-foreground hover:text-muted-foreground text-lg sm:text-xl lg:text-2xl font-bold transition-colors duration-200"
                   >
                     SDK

--- a/apps/www/src/components/login-dropdown.tsx
+++ b/apps/www/src/components/login-dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link from "~/components/ui/link";
 import { Button } from "@repo/ui/components/ui/button";
 import {
   DropdownMenu,
@@ -26,10 +26,10 @@ export function LoginDropdown({ chatUrl, consoleUrl }: LoginDropdownProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem asChild>
-          <Link href={chatUrl}>Chat</Link>
+          <Link href={chatUrl} microfrontend>Chat</Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link href={consoleUrl}>Console</Link>
+          <Link href={consoleUrl} microfrontend>Console</Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/www/src/components/marketing/marketing-navbar.tsx
+++ b/apps/www/src/components/marketing/marketing-navbar.tsx
@@ -13,7 +13,6 @@ import {
   NavigationMenuLink,
 } from "@repo/ui/components/ui/navigation-menu";
 import { Search } from "lucide-react";
-import { authUrl } from "~/lib/related-projects";
 import { INTERNAL_NAV, RESOURCES_NAV, FEATURES_NAV } from "~/config/nav";
 
 export function MarketingNavbar() {
@@ -129,7 +128,7 @@ export function MarketingNavbar() {
             className="rounded-full"
             asChild
           >
-            <Link href={`${authUrl}/sign-in`}>
+            <Link href="/sign-in" microfrontend>
               <span className="text-sm text-secondary-foreground font-medium">
                 Log In
               </span>

--- a/apps/www/src/components/search/search-navbar.tsx
+++ b/apps/www/src/components/search/search-navbar.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import Link from "next/link";
+import Link from "~/components/ui/link";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@repo/ui/components/ui/button";
-import { wwwUrl, authUrl } from "~/lib/related-projects";
 
 export function SearchNavbar() {
   return (
     <nav className="fixed top-0 left-0 border-b right-0 z-20 page-gutter py-4 flex items-center justify-between">
       <Button variant="outline" size="icon" className="rounded-full" asChild>
-        <Link href={wwwUrl}>
+        <Link href="/">
           <ArrowLeft className="h-5 w-5 text-muted-foreground" />
           <span className="sr-only">Back</span>
         </Link>
@@ -17,7 +16,7 @@ export function SearchNavbar() {
 
       <div className="flex items-center gap-4">
         <Button variant="secondary" size="lg" className="rounded-full" asChild>
-          <Link href={`${authUrl}/sign-in`}>
+          <Link href="/sign-in" microfrontend>
             <span className="text-sm text-foreground font-medium">Log In</span>
           </Link>
         </Button>


### PR DESCRIPTION
## Summary

This PR fixes cross-app navigation issues by ensuring all links pointing to different apps use the `microfrontend` prop correctly. Previously, several components were using regular `next/link` or missing the `microfrontend` prop, which caused cross-app navigation to fail.

## Problem

In our microfrontend setup where all apps are served from `lightfast.ai`:
- **www** (marketing pages)
- **auth** (authentication pages)  
- **console** (console pages)

Without the `microfrontend` prop, the custom Link component uses regular `NextLink`, which only works within the same app. Cross-app navigation requires using `MicrofrontendLink` from `@vercel/microfrontends`.

## Changes

### apps/www

1. **marketing-navbar.tsx**
   - ✅ Changed Log In link from `<Link href="${authUrl}/sign-in">` to `<Link href="/sign-in" microfrontend>`
   - ✅ Removed unused `authUrl` import

2. **search-navbar.tsx**
   - ✅ Replaced `import Link from "next/link"` with custom Link component
   - ✅ Added `microfrontend` prop to sign-in link
   - ✅ Simplified back link to use relative path

3. **login-dropdown.tsx**
   - ✅ Replaced `import Link from "next/link"` with custom Link component
   - ✅ Added `microfrontend` prop to chat and console links

4. **footer-section.tsx**
   - ✅ Replaced `import Link from "next/link"` with custom Link component
   - ✅ Added `microfrontend` prop to console link (`/account/teams`)
   - ✅ Added `microfrontend` prop to SDK docs link
   - ✅ Removed unused `consoleUrl` import

### apps/auth

1. **Created custom Link component** (`src/components/ui/link.tsx`)
   - ✅ Matches the pattern from apps/www
   - ✅ Supports both regular NextLink and MicrofrontendLink

2. **layout.tsx**
   - ✅ Replaced `import Link from "next/link"` with custom Link component
   - ✅ Added `microfrontend` prop to logo link (`/`)
   - ✅ Added `microfrontend` prop to early access link
   - ✅ Removed unused `wwwUrl` import

3. **sign-up-form.tsx**
   - ✅ Replaced `import Link from "next/link"` with custom Link component
   - ✅ Added `microfrontend` prop to Terms of Service link
   - ✅ Added `microfrontend` prop to Privacy Policy link

## Pattern Established

**Cross-app navigation** (different apps on same domain):
```tsx
<Link href="/sign-in" microfrontend>Log In</Link>
<Link href="/account/teams" microfrontend>Teams</Link>
```

**Same-app navigation**:
```tsx
<Link href="/pricing">Pricing</Link>
<Link href="/features">Features</Link>
```

## Testing

- ✅ All changes pass TypeScript type checking (`pnpm typecheck`)
- ✅ All modified files pass ESLint
- ✅ Verified custom Link component matches www app implementation

## Impact

This fix ensures:
1. ✅ Log In button in marketing navbar navigates to auth app correctly
2. ✅ Search page navigation works properly
3. ✅ Login dropdown links to chat/console work
4. ✅ Footer links to console and docs work
5. ✅ Auth app navigation back to www works
6. ✅ Terms/Privacy links from auth to www work

🤖 Generated with [Claude Code](https://claude.com/claude-code)