### PR TITLE
fix(security): add PostHog reverse proxy domain to CSP

### DIFF
--- a/vendor/security/src/csp/analytics.ts
+++ b/vendor/security/src/csp/analytics.ts
@@ -6,10 +6,12 @@ import type { PartialCspDirectives } from "./types";
  * Required domains:
  * - va.vercel-scripts.com: Analytics and Speed Insights scripts
  * - vitals.vercel-insights.com: Performance metrics endpoint
- * - us.i.posthog.com: PostHog analytics endpoint
- * - *.posthog.com: PostHog CDN for scripts
+ * - us.i.posthog.com: PostHog analytics endpoint (direct)
+ * - us-assets.i.posthog.com: PostHog script CDN
+ * - *.vercel.app: PostHog reverse proxy (prevents ad blocking)
+ * - *.ingest.sentry.io: Sentry error tracking
  *
- * @returns Partial CSP directives for Analytics (Vercel + PostHog)
+ * @returns Partial CSP directives for Analytics (Vercel + PostHog + Sentry)
  *
  * @example
  * ```ts
@@ -21,16 +23,19 @@ import type { PartialCspDirectives } from "./types";
  */
 export function createAnalyticsCspDirectives(): PartialCspDirectives {
   return {
-    // Scripts: Vercel Analytics and PostHog
+    // Scripts: Vercel Analytics and PostHog (direct + proxy)
     scriptSrc: [
       "https://va.vercel-scripts.com",
       "https://us-assets.i.posthog.com",
+      "https://*.vercel.app", // PostHog reverse proxy
     ],
 
-    // Connections: Performance vitals and PostHog endpoints
+    // Connections: Performance vitals, PostHog, and Sentry
     connectSrc: [
       "https://vitals.vercel-insights.com",
       "https://us.i.posthog.com",
+      "https://*.vercel.app", // PostHog reverse proxy
+      "https://*.ingest.sentry.io",
       "https://*.ingest.us.sentry.io",
     ],
   };


### PR DESCRIPTION
## Summary

Adds `*.vercel.app` to CSP to allow PostHog reverse proxy pattern, fixing CSP blocking of PostHog analytics scripts.

## The Problem

PostHog was blocked by CSP when using the recommended reverse proxy pattern:

```
Content-Security-Policy: blocked script (script-src-elem) at 
  https://lightfast-www.vercel.app/ingest/array/phc_.../config.js

Content-Security-Policy: blocked connection (connect-src) at
  https://lightfast-www.vercel.app/ingest/array/phc_.../config?ip=0...
```

### Why Reverse Proxy?

PostHog recommends using a reverse proxy to avoid ad blockers:

**Direct (easily blocked)**:
```typescript
api_host: "https://us.i.posthog.com"
```

**Reverse Proxy (harder to block)**:
```typescript
api_host: "https://lightfast-www.vercel.app/ingest"  // ← First-party domain
```

Our PostHog configuration (`vendor/analytics/src/providers/posthog/client.tsx`):
```typescript
posthog.init(key, {
  api_host: `${baseUrl}/ingest`,  // ← Reverse proxy
  ui_host: "https://us.posthog.com",
});
```

## The Solution

Add `https://*.vercel.app` to CSP analytics directives:

### scriptSrc
Allow PostHog proxy scripts to load

### connectSrc  
Allow PostHog proxy API calls + all Sentry regions

## Changes

**File**: `vendor/security/src/csp/analytics.ts`

```diff
 scriptSrc: [
   "https://va.vercel-scripts.com",
   "https://us-assets.i.posthog.com",
+  "https://*.vercel.app",  // PostHog reverse proxy
 ],

 connectSrc: [
   "https://vitals.vercel-insights.com",
   "https://us.i.posthog.com",
+  "https://*.vercel.app",  // PostHog reverse proxy
+  "https://*.ingest.sentry.io",  // All Sentry regions
   "https://*.ingest.us.sentry.io",
 ],
```

## Before & After

### Before (blocked):
```
✗ POST https://lightfast-www.vercel.app/ingest/e/?ip=0...
  CSP: script-src-elem violated

✗ GET https://lightfast-www.vercel.app/ingest/array/phc_.../config.js
  CSP: script-src-elem violated

✗ GET https://lightfast-www.vercel.app/ingest/array/phc_.../config?ip=0...
  CSP: connect-src violated
```

### After (allowed):
```
✓ POST https://lightfast-www.vercel.app/ingest/e/?ip=0...
✓ GET https://lightfast-www.vercel.app/ingest/array/phc_.../config.js
✓ GET https://lightfast-www.vercel.app/ingest/array/phc_.../config?ip=0...
```

## Testing

1. **Before this PR** (blocked):
   ```bash
   pnpm dev:www
   # Browser console shows CSP errors for *.vercel.app
   ```

2. **After this PR** (working):
   ```bash
   pnpm dev:www
   # No CSP errors
   # PostHog loads via reverse proxy ✓
   ```

## Impact

✅ **PostHog analytics** loads correctly via reverse proxy  
✅ **Ad blockers** less likely to block PostHog  
✅ **Sentry** works in all regions (`*.ingest.sentry.io`)  
✅ **Production analytics** work correctly

## About Clerk Error

The `clerk.lightfast.ai` 404 error in the logs is separate from this PR. It appears Clerk is auto-detecting or caching a custom domain that doesn't exist. The CSP correctly uses `charmed-shark-52.clerk.accounts.dev` (extracted from publishable key), so Clerk will fall back to that and work correctly.

## References

- **PostHog reverse proxy**: https://posthog.com/docs/advanced/proxy
- **PostHog anti-ad-blocker**: https://posthog.com/docs/libraries/js#advanced-configuration
- **CSP wildcard patterns**: https://www.w3.org/TR/CSP3/#match-url-to-source-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>