### PR TITLE
fix(security): narrow CSP from *.vercel.app to specific domains

### DIFF
--- a/vendor/security/src/csp/analytics.ts
+++ b/vendor/security/src/csp/analytics.ts
@@ -8,8 +8,9 @@ import type { PartialCspDirectives } from "./types";
  * - vitals.vercel-insights.com: Performance metrics endpoint
  * - us.i.posthog.com: PostHog analytics endpoint (direct)
  * - us-assets.i.posthog.com: PostHog script CDN
- * - *.vercel.app: PostHog reverse proxy (prevents ad blocking)
- * - *.ingest.sentry.io: Sentry error tracking
+ * - lightfast-www.vercel.app: PostHog reverse proxy for www app
+ * - lightfast-auth.vercel.app: PostHog reverse proxy for auth app
+ * - *.ingest.sentry.io: Sentry error tracking (all regions)
  *
  * @returns Partial CSP directives for Analytics (Vercel + PostHog + Sentry)
  *
@@ -23,18 +24,20 @@ import type { PartialCspDirectives } from "./types";
  */
 export function createAnalyticsCspDirectives(): PartialCspDirectives {
   return {
-    // Scripts: Vercel Analytics and PostHog (direct + proxy)
+    // Scripts: Vercel Analytics and PostHog (direct + specific proxies)
     scriptSrc: [
       "https://va.vercel-scripts.com",
       "https://us-assets.i.posthog.com",
-      "https://*.vercel.app", // PostHog reverse proxy
+      "https://lightfast-www.vercel.app", // PostHog reverse proxy (www)
+      "https://lightfast-auth.vercel.app", // PostHog reverse proxy (auth)
     ],
 
     // Connections: Performance vitals, PostHog, and Sentry
     connectSrc: [
       "https://vitals.vercel-insights.com",
       "https://us.i.posthog.com",
-      "https://*.vercel.app", // PostHog reverse proxy
+      "https://lightfast-www.vercel.app", // PostHog reverse proxy (www)
+      "https://lightfast-auth.vercel.app", // PostHog reverse proxy (auth)
       "https://*.ingest.sentry.io",
       "https://*.ingest.us.sentry.io",
     ],


### PR DESCRIPTION
## Summary

Replaces overly broad `*.vercel.app` wildcard with specific Lightfast deployment domains, significantly improving CSP security.

## The Problem

PR #299 introduced `*.vercel.app` wildcard in CSP:

```typescript
scriptSrc: [
  "https://*.vercel.app",  // ← SECURITY RISK!
]

connectSrc: [
  "https://*.vercel.app",  // ← SECURITY RISK!
]
```

### Security Risk

This allows **ANY** Vercel deployment to:
- ✗ Load and execute JavaScript on our site
- ✗ Make network connections from our origin
- ✗ Potentially exfiltrate user data
- ✗ Inject malicious code

**Examples of what's allowed**:
- `https://random-user-app.vercel.app` ← Anyone's deployment
- `https://malicious-actor.vercel.app` ← Attacker's deployment
- `https://competitor-site.vercel.app` ← Competitor's deployment

This defeats the entire purpose of CSP!

## The Solution

Use **specific** Lightfast deployment domains:

```typescript
scriptSrc: [
  "https://lightfast-www.vercel.app",   // Our www app only
  "https://lightfast-auth.vercel.app",  // Our auth app only
]

connectSrc: [
  "https://lightfast-www.vercel.app",   // Our www app only
  "https://lightfast-auth.vercel.app",  // Our auth app only
]
```

### Security Improvement

- ✅ Only our specific deployments allowed
- ✅ Zero risk from arbitrary Vercel deployments
- ✅ Minimal CSP attack surface
- ✅ Still supports PostHog reverse proxy pattern

## Changes

**File**: `vendor/security/src/csp/analytics.ts`

```diff
 scriptSrc: [
   "https://va.vercel-scripts.com",
   "https://us-assets.i.posthog.com",
-  "https://*.vercel.app",
+  "https://lightfast-www.vercel.app",
+  "https://lightfast-auth.vercel.app",
 ],

 connectSrc: [
   "https://vitals.vercel-insights.com",
   "https://us.i.posthog.com",
-  "https://*.vercel.app",
+  "https://lightfast-www.vercel.app",
+  "https://lightfast-auth.vercel.app",
   "https://*.ingest.sentry.io",
   "https://*.ingest.us.sentry.io",
 ],
```

## Before & After

### Before (insecure):
```
✓ https://lightfast-www.vercel.app/ingest/...      (our deployment)
✓ https://lightfast-auth.vercel.app/ingest/...     (our deployment)
✓ https://random-user-app.vercel.app/malicious.js  (anyone's deployment!)
✓ https://attacker-site.vercel.app/steal-data.js   (attacker's deployment!)
```

### After (secure):
```
✓ https://lightfast-www.vercel.app/ingest/...      (our deployment)
✓ https://lightfast-auth.vercel.app/ingest/...     (our deployment)
✗ https://random-user-app.vercel.app/malicious.js  (blocked)
✗ https://attacker-site.vercel.app/steal-data.js   (blocked)
```

## Testing

1. **PostHog still works**:
   ```bash
   pnpm dev:www
   # PostHog loads via lightfast-www.vercel.app ✓
   ```

2. **Random deployments blocked**:
   ```bash
   # Try loading from arbitrary vercel.app domain
   # Should be blocked by CSP ✓
   ```

## Impact

✅ **Security**: Eliminated broad wildcard vulnerability  
✅ **PostHog**: Reverse proxy still functional  
✅ **Minimal**: Only necessary domains whitelisted  
✅ **Maintainable**: Explicit list of allowed deployments

## Future Apps

If additional apps need PostHog proxy, add them **explicitly**:

```typescript
"https://lightfast-console.vercel.app",
"https://lightfast-chat.vercel.app",
```

**NEVER** use `*.vercel.app` wildcard - defeats CSP security entirely.

## References

- **CSP wildcards security**: https://csper.io/blog/csp-wildcards
- **CSP best practices**: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>