### PR TITLE
refactor(deps): add named Zod catalogs for future v4 migration

### DIFF
--- a/api/chat/package.json
+++ b/api/chat/package.json
@@ -53,7 +53,7 @@
 		"nanoid": "catalog:",
 		"react": "catalog:react19",
 		"superjson": "catalog:",
-		"zod": "catalog:"
+		"zod": "catalog:zod3"
 	},
 	"devDependencies": {
 		"@repo/eslint-config": "workspace:*",

--- a/api/console/package.json
+++ b/api/console/package.json
@@ -75,7 +75,7 @@
 		"react": "catalog:react19",
 		"superjson": "catalog:",
 		"yaml": "^2.7.0",
-		"zod": "catalog:"
+		"zod": "catalog:zod3"
 	},
 	"devDependencies": {
 		"@repo/eslint-config": "workspace:*",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -46,7 +46,7 @@
     "react-dom": "19.2.1",
     "react-hook-form": "^7.61.1",
     "svix": "^1.62.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -90,7 +90,7 @@
     "use-debounce": "^10.0.5",
     "use-stick-to-bottom": "1.1.1",
     "usehooks-ts": "^3.1.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -83,7 +83,7 @@
     "shiki": "^3.9.2",
     "sonner": "^2.0.6",
     "superjson": "catalog:",
-    "zod": "catalog:",
+    "zod": "catalog:zod3",
     "zustand": "catalog:"
   },
   "devDependencies": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -38,7 +38,7 @@
     "react-dom": "19.2.1",
     "shiki": "^3.9.2",
     "tailwind-merge": "^3.3.1",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -63,7 +63,7 @@
     "react-hook-form": "catalog:",
     "shiki": "^3.9.2",
     "tailwind-merge": "catalog:",
-    "zod": "catalog:",
+    "zod": "catalog:zod3",
     "zustand": "catalog:"
   },
   "devDependencies": {

--- a/core/ai-sdk/package.json
+++ b/core/ai-sdk/package.json
@@ -123,7 +123,7 @@
     "pino": "^9.7.0",
     "resumable-stream": "^2.0.0",
     "uuid": "^11.1.0",
-    "zod": "^3.25.76"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/core/mcp/package.json
+++ b/core/mcp/package.json
@@ -51,7 +51,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@repo/console-types": "workspace:*",
     "lightfast": "workspace:*",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/db/chat/package.json
+++ b/db/chat/package.json
@@ -40,7 +40,7 @@
     "ai": "catalog:",
     "drizzle-orm": "catalog:",
     "drizzle-zod": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/db/console/package.json
+++ b/db/console/package.json
@@ -41,7 +41,7 @@
     "drizzle-orm": "catalog:",
     "friendlier-words": "^1.1.3",
     "postgres": "^3.4.5",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@planetscale/database": "^1.19.0",

--- a/examples/nextjs-ai-chatbot/package.json
+++ b/examples/nextjs-ai-chatbot/package.json
@@ -27,7 +27,7 @@
     "@ai-sdk/gateway": "^1.0.15",
     "@ai-sdk/openai": "^0.0.70",
     "@ai-sdk/react": "2.0.15",
-    "@lightfastai/ai-sdk": "file:../../core/ai-sdk",
+    "@lightfastai/ai-sdk": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -83,6 +83,6 @@
     "use-stick-to-bottom": "1.1.1",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
-    "zod": "^3.25.76"
+    "zod": "catalog:zod3"
   }
 }

--- a/packages/ai-tools/package.json
+++ b/packages/ai-tools/package.json
@@ -28,7 +28,7 @@
     "@t3-oss/env-nextjs": "^0.12.0",
     "playwright": "^1.54.1",
     "playwright-core": "^1.54.1",
-    "zod": "^3.25.76"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -49,7 +49,7 @@
     "exa-js": "^1.6.13",
     "resumable-stream": "^2.0.0",
     "voyage-ai-provider": "^1.0.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/app-urls/package.json
+++ b/packages/app-urls/package.json
@@ -22,7 +22,7 @@
     "@t3-oss/env-nextjs": "^0.12.0",
     "@vercel/related-projects": "^1.0.0",
     "typescript": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/chat-ai/package.json
+++ b/packages/chat-ai/package.json
@@ -27,7 +27,7 @@
     "ai": "catalog:",
     "braintrust": "catalog:",
     "exa-js": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/cms-workflows/package.json
+++ b/packages/cms-workflows/package.json
@@ -24,7 +24,7 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-api-key/package.json
+++ b/packages/console-api-key/package.json
@@ -23,7 +23,7 @@
     "@db/console": "workspace:*",
     "@repo/lib": "workspace:*",
     "@trpc/server": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-auth-middleware/package.json
+++ b/packages/console-auth-middleware/package.json
@@ -37,7 +37,7 @@
     "@trpc/server": "catalog:",
     "@vendor/clerk": "workspace:*",
     "drizzle-orm": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-clerk-m2m/package.json
+++ b/packages/console-clerk-m2m/package.json
@@ -20,7 +20,7 @@
     "@clerk/backend": "catalog:",
     "@t3-oss/env-nextjs": "catalog:",
     "@vendor/clerk": "workspace:*",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-config/package.json
+++ b/packages/console-config/package.json
@@ -27,7 +27,7 @@
     "fast-glob": "^3.3.2",
     "neverthrow": "catalog:",
     "yaml": "^2.7.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-oauth/package.json
+++ b/packages/console-oauth/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@repo/lib": "workspace:*",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-octokit-github/package.json
+++ b/packages/console-octokit-github/package.json
@@ -27,7 +27,7 @@
     "@t3-oss/env-nextjs": "catalog:",
     "minimatch": "^10.1.1",
     "octokit": "^5.0.3",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-rerank/package.json
+++ b/packages/console-rerank/package.json
@@ -25,7 +25,7 @@
     "@vendor/observability": "workspace:*",
     "ai": "catalog:",
     "cohere-ai": "^7.19.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-types/package.json
+++ b/packages/console-types/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@repo/console-validation": "workspace:*",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-validation/package.json
+++ b/packages/console-validation/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@repo/console-reserved-names": "workspace:^",
     "friendlier-words": "^1.1.3",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-vercel/package.json
+++ b/packages/console-vercel/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-webhooks/package.json
+++ b/packages/console-webhooks/package.json
@@ -45,7 +45,7 @@
     "@repo/console-types": "workspace:*",
     "@repo/console-validation": "workspace:*",
     "@repo/lib": "workspace:*",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -31,7 +31,7 @@
     "react-email": "4.0.7",
     "tailwindcss": "catalog:tailwind4",
     "typescript": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -103,7 +103,7 @@
 		"tw-animate-css": "^1.3.7",
 		"use-stick-to-bottom": "1.1.1",
 		"vaul": "^1.1.2",
-		"zod": "catalog:"
+		"zod": "catalog:zod3"
 	},
 	"prettier": "@repo/prettier-config"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ catalogs:
     typescript-eslint:
       specifier: ^8.46.1
       version: 8.46.1
-    zod:
-      specifier: ^3.24.0
-      version: 3.25.76
     zustand:
       specifier: ^5.0.7
       version: 5.0.8
@@ -154,6 +151,10 @@ catalogs:
     tailwindcss:
       specifier: 4.1.11
       version: 4.1.11
+  zod3:
+    zod:
+      specifier: ^3.25.76
+      version: 3.25.76
 
 overrides:
   react: ^19.2.1
@@ -280,7 +281,7 @@ importers:
         specifier: 'catalog:'
         version: 2.2.2
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -303,7 +304,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   api/console:
     dependencies:
@@ -428,7 +429,7 @@ importers:
         specifier: ^2.7.0
         version: 2.8.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -487,7 +488,7 @@ importers:
         version: link:../../packages/url-utils
       '@rescale/nemo':
         specifier: ^2.0.2
-        version: 2.0.2(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 2.0.2(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sentry/nextjs':
         specifier: ^10.20.0
         version: 10.20.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(webpack@5.102.1)
@@ -546,7 +547,7 @@ importers:
         specifier: ^1.62.0
         version: 1.77.0
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -796,7 +797,7 @@ importers:
         specifier: ^3.1.0
         version: 3.1.1(react@19.2.1)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -945,7 +946,7 @@ importers:
         version: link:../../packages/url-utils
       '@rescale/nemo':
         specifier: ^2.0.2
-        version: 2.0.2(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 2.0.2(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sentry/nextjs':
         specifier: ^10.20.0
         version: 10.20.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(webpack@5.102.1)
@@ -1014,7 +1015,7 @@ importers:
         version: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nuqs:
         specifier: ^2.8.0
-        version: 2.8.0(@tanstack/react-router@1.133.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.8.0(@tanstack/react-router@1.133.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       octokit:
         specifier: ^5.0.3
         version: 5.0.4
@@ -1043,7 +1044,7 @@ importers:
         specifier: 'catalog:'
         version: 2.2.2
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
       zustand:
         specifier: 'catalog:'
@@ -1161,7 +1162,7 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -1241,7 +1242,7 @@ importers:
         version: link:../../packages/url-utils
       '@rescale/nemo':
         specifier: ^2.0.2
-        version: 2.0.2(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 2.0.2(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sentry/nextjs':
         specifier: ^10.20.0
         version: 10.20.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(webpack@5.102.1)
@@ -1316,7 +1317,7 @@ importers:
         version: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nuqs:
         specifier: ^2.8.0
-        version: 2.8.0(@tanstack/react-router@1.133.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.8.0(@tanstack/react-router@1.133.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1339,7 +1340,7 @@ importers:
         specifier: 'catalog:'
         version: 3.3.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
       zustand:
         specifier: 'catalog:'
@@ -1442,7 +1443,7 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       zod:
-        specifier: ^3.25.76
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -1483,7 +1484,7 @@ importers:
         version: 6.4.0(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   core/cli:
     dependencies:
@@ -1556,7 +1557,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   core/mcp:
     dependencies:
@@ -1570,7 +1571,7 @@ importers:
         specifier: workspace:*
         version: link:../lightfast
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -1619,7 +1620,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.1(drizzle-orm@0.43.1(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/pg@8.15.5)(postgres@3.4.7))(zod@3.25.76)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -1677,7 +1678,7 @@ importers:
         specifier: ^3.4.5
         version: 3.4.7
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@planetscale/database':
@@ -1726,8 +1727,8 @@ importers:
         specifier: 2.0.15
         version: 2.0.15(react@19.2.1)(zod@3.25.76)
       '@lightfastai/ai-sdk':
-        specifier: file:../../core/ai-sdk
-        version: file:core/ai-sdk(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../core/ai-sdk
       '@radix-ui/react-accordion':
         specifier: ^1.2.11
         version: 1.2.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -1894,7 +1895,7 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       zod:
-        specifier: ^3.25.76
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@tailwindcss/postcss':
@@ -2052,7 +2053,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.1(zod@3.25.76)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2092,7 +2093,7 @@ importers:
         specifier: ^1.54.1
         version: 1.56.1
       zod:
-        specifier: ^3.25.76
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2129,7 +2130,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2172,7 +2173,7 @@ importers:
         specifier: 'catalog:'
         version: 1.10.2(encoding@0.1.13)(ws@8.18.3)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2378,7 +2379,7 @@ importers:
         specifier: ^11.0.0
         version: 11.0.5
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2418,7 +2419,7 @@ importers:
         specifier: 'catalog:'
         version: 11.6.0(typescript@5.9.3)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2513,7 +2514,7 @@ importers:
         specifier: 'catalog:'
         version: 0.43.1(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/pg@8.15.5)(postgres@3.4.7)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2652,7 +2653,7 @@ importers:
         specifier: workspace:*
         version: link:../../vendor/clerk
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2695,7 +2696,7 @@ importers:
         specifier: ^2.7.0
         version: 2.8.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2769,7 +2770,7 @@ importers:
         specifier: workspace:*
         version: link:../lib
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2818,7 +2819,7 @@ importers:
         specifier: ^5.0.3
         version: 5.0.4
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -2901,7 +2902,7 @@ importers:
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3048,7 +3049,7 @@ importers:
         specifier: workspace:*
         version: link:../console-validation
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3082,7 +3083,7 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3113,7 +3114,7 @@ importers:
         specifier: 'catalog:'
         version: 0.12.0(typescript@5.9.3)(zod@3.25.76)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3156,7 +3157,7 @@ importers:
         specifier: workspace:*
         version: link:../lib
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3248,7 +3249,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3539,7 +3540,7 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3623,10 +3624,10 @@ importers:
         version: 0.12.0(typescript@5.9.3)(zod@3.25.76)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 1.5.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@vercel/speed-insights':
         specifier: ^1.2.0
-        version: 1.2.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 1.2.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       next:
         specifier: 'catalog:'
         version: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3643,7 +3644,7 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3701,7 +3702,7 @@ importers:
         specifier: ^1.62.0
         version: 1.77.0
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@clerk/types':
@@ -3744,7 +3745,7 @@ importers:
         specifier: ^19.2.1
         version: 19.2.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3802,7 +3803,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.1(drizzle-orm@0.43.1(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/pg@8.15.5)(postgres@3.4.7))(zod@3.25.76)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3842,7 +3843,7 @@ importers:
         specifier: ^4.3.0
         version: 4.8.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3876,7 +3877,7 @@ importers:
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -3916,7 +3917,7 @@ importers:
         specifier: 'catalog:'
         version: 3.44.3(encoding@0.1.13)(express@4.21.2)(h3@1.15.4)(hono@4.10.7)(next@16.0.0(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)(zod@3.25.76)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -4036,7 +4037,7 @@ importers:
         specifier: ^19.2.1
         version: 19.2.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -4070,7 +4071,7 @@ importers:
         specifier: 'catalog:'
         version: 0.12.0(typescript@5.9.3)(zod@3.25.76)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -4119,7 +4120,7 @@ importers:
         specifier: ^19.2.1
         version: 19.2.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -4208,7 +4209,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -4242,7 +4243,7 @@ importers:
         specifier: ^1.35.1
         version: 1.35.6
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -4285,7 +4286,7 @@ importers:
         specifier: 'catalog:'
         version: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       zod:
-        specifier: 'catalog:'
+        specifier: catalog:zod3
         version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
@@ -6048,14 +6049,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lightfastai/ai-sdk@file:core/ai-sdk':
-    resolution: {directory: core/ai-sdk, type: directory}
-    engines: {node: '>=18'}
-
   '@lightfastai/dual@1.2.2':
     resolution: {integrity: sha512-N8U5cehWJ5QoOvbW+qArJ6vlUQ+bY5vBYfZIkt7NFJLiqo1nZ0QwM2qSUpGfyqjXRFQJJrXs13Rh1nx4f0EzzA==}
     engines: {node: '>=14.0.0'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -8020,7 +8016,6 @@ packages:
 
   '@rollup/rollup-darwin-arm64@4.52.5':
     resolution: {integrity: sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==}
-    cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.52.5':
@@ -12575,7 +12570,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.30.1:
@@ -16793,9 +16787,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@basehub/mutation-api-helpers@2.1.7(zod@3.25.76)':
+  '@basehub/mutation-api-helpers@2.1.7(zod@4.1.12)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.1.12
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -17934,26 +17928,6 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.4.7':
     optional: true
-
-  '@lightfastai/ai-sdk@file:core/ai-sdk(typescript@5.9.3)':
-    dependencies:
-      '@ai-sdk/anthropic': 2.0.4(zod@3.25.76)
-      '@ai-sdk/gateway': 1.0.41(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@t3-oss/env-core': 0.12.0(typescript@5.9.3)(zod@3.25.76)
-      '@upstash/qstash': 2.8.4
-      '@upstash/redis': 1.35.6
-      ai: 5.0.15(zod@3.25.76)
-      braintrust: 0.2.6(@aws-sdk/credential-provider-web-identity@3.928.0)(zod@3.25.76)
-      pino: 9.14.0
-      resumable-stream: 2.2.8
-      uuid: 11.1.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-provider-web-identity'
-      - supports-color
-      - typescript
-      - valibot
 
   '@lightfastai/dual@1.2.2':
     dependencies:
@@ -20213,7 +20187,7 @@ snapshots:
     dependencies:
       '@redis/client': 5.9.0
 
-  '@rescale/nemo@2.0.2(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@rescale/nemo@2.0.2(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       path-to-regexp: 6.2.1
@@ -21760,7 +21734,7 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@vercel/analytics@1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@vercel/analytics@1.5.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     optionalDependencies:
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
@@ -21789,8 +21763,8 @@ snapshots:
       nanoid: 3.3.11
       path-to-regexp: 6.2.1
     optionalDependencies:
-      '@vercel/analytics': 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
-      '@vercel/speed-insights': 1.2.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/analytics': 1.5.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/speed-insights': 1.2.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -21810,8 +21784,8 @@ snapshots:
       nanoid: 3.3.11
       path-to-regexp: 6.2.1
     optionalDependencies:
-      '@vercel/analytics': 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
-      '@vercel/speed-insights': 1.2.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/analytics': 1.5.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/speed-insights': 1.2.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -21834,8 +21808,8 @@ snapshots:
       path-to-regexp: 6.2.1
       semver: 7.7.3
     optionalDependencies:
-      '@vercel/analytics': 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
-      '@vercel/speed-insights': 1.2.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/analytics': 1.5.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/speed-insights': 1.2.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -21858,8 +21832,8 @@ snapshots:
       path-to-regexp: 6.2.1
       semver: 7.7.3
     optionalDependencies:
-      '@vercel/analytics': 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
-      '@vercel/speed-insights': 1.2.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/analytics': 1.5.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@vercel/speed-insights': 1.2.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -21873,7 +21847,7 @@ snapshots:
     optionalDependencies:
       ajv: 6.12.6
 
-  '@vercel/speed-insights@1.2.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@vercel/speed-insights@1.2.0(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     optionalDependencies:
       next: 15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
@@ -21937,7 +21911,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21986,7 +21960,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -22413,7 +22387,7 @@ snapshots:
 
   basehub@9.5.2(@babel/runtime@7.28.4)(@types/react@19.2.2)(react@19.2.1):
     dependencies:
-      '@basehub/mutation-api-helpers': 2.1.7(zod@3.25.76)
+      '@basehub/mutation-api-helpers': 2.1.7(zod@4.1.12)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.2)(react@19.2.1)
       '@shikijs/transformers': 1.17.7
       '@xmldom/xmldom': 0.9.8
@@ -22434,7 +22408,7 @@ snapshots:
       shiki: 1.17.7
       type-fest: 4.41.0
       typesense: 1.8.2(@babel/runtime@7.28.4)
-      zod: 3.25.76
+      zod: 4.1.12
     transitivePeerDependencies:
       - '@babel/runtime'
       - '@types/react'
@@ -23825,8 +23799,8 @@ snapshots:
       '@babel/parser': 7.28.4
       eslint: 9.38.0(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.1.12
+      zod-validation-error: 4.0.2(zod@4.1.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -26825,7 +26799,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.8.0(@tanstack/react-router@1.133.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1):
+  nuqs@2.8.0(@tanstack/react-router@1.133.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.1
@@ -29422,7 +29396,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -29740,9 +29714,9 @@ snapshots:
     dependencies:
       zod: 4.1.12
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.1.12):
     dependencies:
-      zod: 3.25.76
+      zod: 4.1.12
 
   zod@3.22.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,6 @@ catalog:
   superjson: ^2.2.1
   '@types/node': ^20.16.11
   '@types/eslint__js': 8.42.3
-  zod: ^3.24.0
   '@eslint/js': ^9.37.0
   eslint: ^9.23.0
   prettier: ^3.5.3
@@ -66,6 +65,10 @@ catalogs:
     postcss: 8.5.6
     '@tailwindcss/postcss': 4.1.11
     '@tailwindcss/typography': ^0.5.16
+  zod3:
+    zod: ^3.25.76
+  zod4:
+    zod: ^4.0.0
 onlyBuiltDependencies:
 - '@clerk/shared'
 - '@lightfastai/dual'
@@ -89,7 +92,7 @@ linkWorkspacePackages: true
 overrides:
   '@types/minimatch': 5.1.2
   '@browserbasehq/stagehand>dotenv': ^17.2.1
-  zod-to-json-schema>zod: ^3.24.0
+  zod-to-json-schema>zod: ^3.25.76
 publicHoistPattern:
 - '@ianvs/prettier-plugin-sort-imports'
 - prettier-plugin-tailwindcss

--- a/thoughts/shared/plans/2025-12-24-zod-mixed-versioning-strategy.md
+++ b/thoughts/shared/plans/2025-12-24-zod-mixed-versioning-strategy.md
@@ -1,0 +1,378 @@
+# Zod Mixed Versioning Strategy Implementation Plan
+
+## Overview
+
+Remove the centralized Zod catalog version and implement a mixed versioning strategy where packages use specific Zod versions based on their dependency constraints. This enables most packages to upgrade to Zod v4 while packages with incompatible dependencies (drizzle-zod, MCP SDK) remain on Zod v3.
+
+## Current State Analysis
+
+### Catalog Configuration
+- **Single catalog entry**: `zod: ^3.24.0` in `pnpm-workspace.yaml:19`
+- **Override**: `zod-to-json-schema>zod: ^3.24.0` in `pnpm-workspace.yaml:92`
+- **40 packages** use `catalog:` reference
+- **3 packages** already use specific version `^3.25.76`
+
+### Blocking Dependencies
+
+| Package | Blocker | Reason |
+|---------|---------|--------|
+| `@vendor/db` | drizzle-zod ^0.7.1 | No Zod v4 support |
+| `@db/chat` | drizzle-zod ^0.7.1 | Uses createInsertSchema/createSelectSchema |
+| `@api/chat` | drizzle-zod schemas | Consumes schemas from @db/chat |
+| `core/mcp` | @modelcontextprotocol/sdk | SDK incompatible with Zod v4 |
+
+### Shared Package Concern
+`@repo/console-types` is consumed by:
+- `core/mcp` (requires v3)
+- 9 other packages (can use v4)
+
+**Decision**: Keep `@repo/console-types` on Zod v3 for compatibility. MCP is a critical integration.
+
+## Desired End State
+
+1. No `zod` entry in the default catalog
+2. Two named catalogs: `zod3` and `zod4`
+3. Each package explicitly declares which Zod version it uses
+4. Packages with v3 blockers use `catalog:zod3`
+5. All other packages use `catalog:zod4`
+6. Override updated to reference `catalog:zod3`
+
+### Verification
+- `pnpm install` succeeds without errors
+- `pnpm typecheck` passes across all packages
+- `pnpm build` succeeds for all packages
+- `pnpm lint` passes
+
+## What We're NOT Doing
+
+1. **Not migrating code syntax** - Only version configuration changes
+2. **Not using subpath imports** (`zod/v4`) - Packages use single version
+3. **Not updating drizzle-zod** - Waiting for upstream v4 support
+4. **Not modifying MCP SDK integration** - Must stay on v3
+5. **Not running codemods** - Syntax migration is separate effort
+
+## Implementation Approach
+
+This is a configuration-only change. We modify `pnpm-workspace.yaml` and individual `package.json` files to use named catalogs instead of the default catalog entry.
+
+---
+
+## Phase 1: Create Named Catalogs
+
+### Overview
+Add `zod3` and `zod4` named catalogs to `pnpm-workspace.yaml` and remove the default `zod` entry.
+
+### Changes Required:
+
+#### 1. pnpm-workspace.yaml
+**File**: `pnpm-workspace.yaml`
+**Changes**: Remove default zod, add named catalogs, update override
+
+```yaml
+# REMOVE from catalog: (line 19)
+# zod: ^3.24.0
+
+# ADD to catalogs: section (after tailwind4)
+catalogs:
+  tailwind4:
+    tailwindcss: 4.1.11
+    postcss: 8.5.6
+    '@tailwindcss/postcss': 4.1.11
+    '@tailwindcss/typography': ^0.5.16
+  zod3:
+    zod: ^3.25.76
+  zod4:
+    zod: ^4.0.0
+
+# UPDATE override (line 92)
+# FROM: zod-to-json-schema>zod: ^3.24.0
+# TO:   zod-to-json-schema>zod: ^3.25.76
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] YAML syntax valid: `pnpm install` doesn't fail on parse
+- [ ] Named catalogs recognized: `pnpm why zod` shows both versions
+
+---
+
+## Phase 2: Update v3-Locked Packages
+
+### Overview
+Update packages that must stay on Zod v3 due to drizzle-zod or MCP SDK dependencies.
+
+### Changes Required:
+
+#### 1. @vendor/db
+**File**: `vendor/db/package.json`
+**Change**: `"zod": "catalog:"` → `"zod": "catalog:zod3"`
+
+#### 2. @db/chat
+**File**: `db/chat/package.json`
+**Change**: `"zod": "catalog:"` → `"zod": "catalog:zod3"`
+
+#### 3. @api/chat
+**File**: `api/chat/package.json`
+**Change**: `"zod": "catalog:"` → `"zod": "catalog:zod3"`
+
+#### 4. core/mcp
+**File**: `core/mcp/package.json`
+**Change**: `"zod": "catalog:"` → `"zod": "catalog:zod3"`
+
+#### 5. @repo/console-types (shared by MCP)
+**File**: `packages/console-types/package.json`
+**Change**: `"zod": "catalog:"` → `"zod": "catalog:zod3"`
+
+#### 6. Packages already on specific version (keep as-is or update to catalog:zod3)
+These packages already use `^3.25.76`:
+- `examples/nextjs-ai-chatbot/package.json`
+- `core/ai-sdk/package.json`
+- `packages/ai-tools/package.json`
+
+**Change**: `"zod": "^3.25.76"` → `"zod": "catalog:zod3"` (for consistency)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Install succeeds: `pnpm install`
+- [ ] Type check passes: `pnpm --filter @vendor/db typecheck`
+- [ ] Type check passes: `pnpm --filter @db/chat typecheck`
+- [ ] Type check passes: `pnpm --filter @api/chat typecheck`
+- [ ] Build passes: `pnpm --filter @api/chat build`
+
+---
+
+## Phase 3: Update v4-Compatible Packages
+
+### Overview
+Update all remaining packages to use Zod v4 via the named catalog.
+
+### Packages to Update (35 packages):
+
+#### Apps (5)
+- `apps/www/package.json`
+- `apps/console/package.json`
+- `apps/chat/package.json`
+- `apps/docs/package.json`
+- `apps/auth/package.json`
+
+#### API (1)
+- `api/console/package.json`
+
+#### Database (1)
+- `db/console/package.json`
+
+#### Vendor (11)
+- `vendor/upstash/package.json`
+- `vendor/storage/package.json`
+- `vendor/inngest/package.json`
+- `vendor/clerk/package.json`
+- `vendor/embed/package.json`
+- `vendor/cms/package.json`
+- `vendor/pinecone/package.json`
+- `vendor/observability/package.json`
+- `vendor/security/package.json`
+- `vendor/analytics/package.json`
+- `vendor/email/package.json`
+- `vendor/upstash-workflow/package.json`
+
+#### Packages (17)
+- `packages/email/package.json`
+- `packages/console-validation/package.json`
+- `packages/console-auth-middleware/package.json`
+- `packages/console-clerk-m2m/package.json`
+- `packages/console-config/package.json`
+- `packages/cms-workflows/package.json`
+- `packages/console-rerank/package.json`
+- `packages/ai/package.json`
+- `packages/chat-ai/package.json`
+- `packages/console-api-key/package.json`
+- `packages/console-oauth/package.json`
+- `packages/console-octokit-github/package.json`
+- `packages/ui/package.json`
+- `packages/console-vercel/package.json`
+- `packages/app-urls/package.json`
+- `packages/console-webhooks/package.json`
+
+### Change Pattern:
+For each file: `"zod": "catalog:"` → `"zod": "catalog:zod4"`
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Install succeeds: `pnpm install`
+- [ ] Full typecheck passes: `pnpm typecheck`
+- [ ] Full build passes: `pnpm build:console && pnpm build:www && pnpm build:chat`
+- [ ] Lint passes: `pnpm lint`
+
+#### Manual Verification:
+- [ ] Dev server starts: `pnpm dev:console`
+- [ ] No runtime Zod errors in browser console
+
+---
+
+## Phase 4: Verify Mixed Version Coexistence
+
+### Overview
+Confirm that v3 and v4 packages can coexist in the same monorepo without conflicts.
+
+### Verification Steps:
+
+1. **Check resolved versions**:
+```bash
+pnpm why zod
+# Should show both 3.25.76 and 4.0.0 in different packages
+```
+
+2. **Verify no version conflicts**:
+```bash
+pnpm ls zod --depth=0
+# Each package should have exactly one zod version
+```
+
+3. **Test package boundaries**:
+- v3 packages should not import from v4 packages that expose Zod types
+- v4 packages should not import from v3 packages that expose Zod types
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] No peer dependency warnings: `pnpm install 2>&1 | grep -i "peer"`
+- [ ] Full test suite passes: `pnpm test` (if available)
+- [ ] Build all apps: `SKIP_ENV_VALIDATION=true pnpm build`
+
+#### Manual Verification:
+- [ ] Console app functional with forms (uses Zod v4)
+- [ ] Chat app functional (uses Zod v3 for drizzle-zod schemas)
+- [ ] MCP server starts without errors
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Run existing test suites after migration
+- No new tests needed (configuration change only)
+
+### Integration Tests:
+- Build all packages
+- Start dev servers
+- Verify form validation works (react-hook-form + zod)
+- Verify tRPC routes work (input/output validation)
+- Verify drizzle-zod schemas still generate correctly
+
+### Manual Testing Steps:
+1. Start console app, submit a form with validation
+2. Start chat app, send a message (triggers drizzle-zod schemas)
+3. Run MCP server with a test query
+
+## Performance Considerations
+
+- **Bundle size**: Zod v4 is 2x smaller, should reduce bundle for v4 packages
+- **Install time**: Two versions installed, minimal impact
+- **Type checking**: May be slightly slower with mixed versions
+
+## Migration Notes
+
+### Future Migration Path
+When drizzle-zod adds Zod v4 support:
+1. Update `drizzle-zod` version in catalog
+2. Move `@vendor/db`, `@db/chat`, `@api/chat` to `catalog:zod4`
+3. Eventually remove `zod3` catalog when all packages migrated
+
+### Rollback Plan
+If issues arise:
+1. Revert `pnpm-workspace.yaml` changes
+2. Revert all `package.json` changes to use `catalog:`
+3. Run `pnpm install`
+
+## References
+
+- Research document: `thoughts/shared/research/2025-12-24-zod-v4-migration-breaking-changes.md`
+- drizzle-zod v4 support: https://github.com/drizzle-team/drizzle-orm/issues/4625
+- MCP SDK compatibility: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1429
+- Zod v4 changelog: https://zod.dev/v4/changelog
+
+---
+
+## Package Assignment Summary
+
+### catalog:zod3 (8 packages)
+| Package | Reason |
+|---------|--------|
+| `@vendor/db` | drizzle-zod dependency |
+| `@db/chat` | drizzle-zod usage |
+| `@api/chat` | consumes drizzle-zod schemas |
+| `core/mcp` | MCP SDK incompatibility |
+| `@repo/console-types` | consumed by MCP |
+| `examples/nextjs-ai-chatbot` | already on specific v3 |
+| `core/ai-sdk` | already on specific v3 |
+| `packages/ai-tools` | already on specific v3 |
+
+### catalog:zod4 (35 packages)
+All remaining packages that currently use `catalog:` reference.
+
+---
+
+## Implementation Results (2025-12-24)
+
+### What Was Implemented
+
+1. **Catalog Infrastructure Created** ✅
+   - Removed default `zod` entry from catalog
+   - Added `zod3` catalog: `zod: ^3.25.76`
+   - Added `zod4` catalog: `zod: ^4.0.0`
+   - Updated override: `zod-to-json-schema>zod: ^3.25.76`
+
+2. **All Packages on zod3** ✅
+   - All 43 packages now use `catalog:zod3`
+   - `examples/nextjs-ai-chatbot` updated from `file:` to `workspace:*` reference
+
+### Why All Packages Use zod3 (Not Mixed)
+
+During implementation, we discovered that Zod v4 has breaking API changes that require code migration:
+
+| Breaking Change | Affected Package | v3 API | v4 API |
+|-----------------|------------------|--------|--------|
+| `.passthrough()` signature | `@repo/console-validation` | `z.object({}).passthrough()` | Requires message argument |
+| `.ip()` removed | `@repo/console-validation` | `z.string().ip()` | Use `z.ipv4()` or `z.ipv6()` |
+| `ZodError.errors` | `@repo/console-config` | `error.errors` | Property renamed |
+| `z.record()` inference | `@api/console` | `Record<string, string>` | `Record<string, unknown>` |
+| `ZodType` shape | `@api/console` | Full type | Missing properties |
+
+Since `@repo/console-validation` is a foundational package imported by most of the codebase, and it uses v3-specific APIs, **all packages must remain on v3** to maintain type compatibility.
+
+### Verified Working
+
+- [x] `pnpm install` succeeds
+- [x] `pnpm build:console` succeeds
+- [x] `pnpm build:www` succeeds
+- [x] `pnpm build:chat` succeeds
+- [x] v3-locked packages typecheck: `@vendor/db`, `@db/chat`, `@api/chat`
+
+### Pre-existing Issues (Unrelated to Zod)
+
+- `@lightfastai/ai-sdk` typecheck: AI SDK type errors in test files (`toUIMessageStreamResponse`, `stepIndex`)
+- Lint failures across 33 packages: Pre-existing eslint issues
+
+### Path to Zod v4
+
+To enable v4 adoption, the following code migration is required:
+
+1. **Update `@repo/console-validation`**:
+   - Replace `.passthrough()` calls with v4 syntax
+   - Replace `.ip()` with `z.ipv4()` / `z.ipv6()`
+
+2. **Update `@repo/console-config`**:
+   - Update `ZodError` property access
+
+3. **Update `@api/console`**:
+   - Fix `z.record()` type annotations
+   - Update `ZodType` usage
+
+4. **Wait for upstream support**:
+   - drizzle-zod v4 support: https://github.com/drizzle-team/drizzle-orm/issues/4625
+   - MCP SDK v4 support: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1429
+
+Once code is migrated and upstream deps support v4, packages can be moved from `catalog:zod3` to `catalog:zod4` incrementally.

--- a/vendor/analytics/package.json
+++ b/vendor/analytics/package.json
@@ -50,6 +50,6 @@
 		"posthog-node": "^4.3.1",
 		"react": "catalog:react19",
 		"server-only": "^0.0.1",
-		"zod": "catalog:"
+		"zod": "catalog:zod3"
 	}
 }

--- a/vendor/clerk/package.json
+++ b/vendor/clerk/package.json
@@ -30,7 +30,7 @@
     "react": "catalog:react19",
     "react-dom": "catalog:react19",
     "svix": "^1.62.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@clerk/types": "catalog:",

--- a/vendor/cms/package.json
+++ b/vendor/cms/package.json
@@ -27,7 +27,7 @@
     "@t3-oss/env-nextjs": "catalog:",
     "basehub": "^9.5.2",
     "react": "19.2.1",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/vendor/db/package.json
+++ b/vendor/db/package.json
@@ -28,7 +28,7 @@
 		"ai": "catalog:",
 		"drizzle-orm": "catalog:",
 		"drizzle-zod": "catalog:",
-		"zod": "catalog:"
+		"zod": "catalog:zod3"
 	},
 	"devDependencies": {
 		"@repo/eslint-config": "workspace:*",

--- a/vendor/email/package.json
+++ b/vendor/email/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@t3-oss/env-nextjs": "catalog:",
     "resend": "^4.3.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/vendor/embed/package.json
+++ b/vendor/embed/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@t3-oss/env-core": "catalog:",
     "cohere-ai": "^7.19.0",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/vendor/inngest/package.json
+++ b/vendor/inngest/package.json
@@ -35,6 +35,6 @@
 		"@inngest/agent-kit": "^0.7.3",
 		"@inngest/middleware-sentry": "catalog:",
 		"inngest": "catalog:",
-		"zod": "catalog:"
+		"zod": "catalog:zod3"
 	}
 }

--- a/vendor/observability/package.json
+++ b/vendor/observability/package.json
@@ -41,6 +41,6 @@
     "@sentry/nextjs": "^10.20.0",
     "@t3-oss/env-nextjs": "catalog:",
     "react": "catalog:react19",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   }
 }

--- a/vendor/pinecone/package.json
+++ b/vendor/pinecone/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@pinecone-database/pinecone": "^6.1.3",
     "@t3-oss/env-nextjs": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/vendor/security/package.json
+++ b/vendor/security/package.json
@@ -43,6 +43,6 @@
     "@vendor/clerk": "workspace:^",
     "js-cookie": "^3.0.5",
     "react": "19.2.1",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   }
 }

--- a/vendor/storage/package.json
+++ b/vendor/storage/package.json
@@ -23,7 +23,7 @@
     "@t3-oss/env-nextjs": "catalog:",
     "@vendor/observability": "workspace:*",
     "@vercel/blob": "^1.1.1",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/vendor/upstash-workflow/package.json
+++ b/vendor/upstash-workflow/package.json
@@ -26,7 +26,7 @@
     "@t3-oss/env-nextjs": "catalog:",
     "@upstash/workflow": "^0.2.22",
     "next": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/vendor/upstash/package.json
+++ b/vendor/upstash/package.json
@@ -34,6 +34,6 @@
   "dependencies": {
     "@t3-oss/env-nextjs": "catalog:",
     "@upstash/redis": "^1.35.1",
-    "zod": "catalog:"
+    "zod": "catalog:zod3"
   }
 }


### PR DESCRIPTION
## Summary

- Add named `zod3` and `zod4` catalogs to `pnpm-workspace.yaml` for versioning flexibility
- Update all 43 packages to use `catalog:zod3` (^3.25.76)
- Prepare infrastructure for future incremental Zod v4 migration
- Fix `nextjs-ai-chatbot` to use `workspace:*` instead of `file:` reference

## Why All Packages Use zod3

During implementation, we discovered Zod v4 has breaking API changes requiring code migration:

| Breaking Change | Affected Package |
|-----------------|------------------|
| `.passthrough()` signature | `@repo/console-validation` |
| `.ip()` removed | `@repo/console-validation` |
| `ZodError.errors` renamed | `@repo/console-config` |
| `z.record()` inference | `@api/console` |

Since `@repo/console-validation` is a foundational package, all packages must remain on v3 for type compatibility.

## Path to v4

The `zod4` catalog is ready for incremental adoption when:
1. Code patterns are updated in validation packages
2. Upstream deps support v4 (drizzle-zod, MCP SDK)

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build:console` succeeds
- [x] `pnpm build:www` succeeds
- [x] `pnpm build:chat` succeeds
- [ ] Manual: Dev servers start without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)