### PR TITLE
fix(auth): add inline waitlist error handling for OAuth sign-in

### DIFF
--- a/apps/auth/src/app/(app)/(auth)/_components/oauth-sign-in.tsx
+++ b/apps/auth/src/app/(app)/(auth)/_components/oauth-sign-in.tsx
@@ -10,7 +10,11 @@ import { handleClerkError } from "~/app/lib/clerk/error-handler";
 import { useLogger } from "@vendor/observability/client-log";
 import { consoleUrl } from "~/lib/related-projects";
 
-export function OAuthSignIn() {
+interface OAuthSignInProps {
+	onError?: (error: string, isSignUpRestricted?: boolean) => void;
+}
+
+export function OAuthSignIn({ onError }: OAuthSignInProps = {}) {
 	const { signIn, isLoaded } = useSignIn();
 	const [loading, setLoading] = React.useState<OAuthStrategy | null>(null);
 	const log = useLogger();
@@ -37,7 +41,13 @@ export function OAuthSignIn() {
 				strategy,
 			});
 
-			toast.error(errorResult.userMessage);
+			// For waitlist errors, pass to parent form for inline display
+			// For other errors, show toast
+			if (errorResult.isSignUpRestricted && onError) {
+				onError(errorResult.userMessage, errorResult.isSignUpRestricted);
+			} else {
+				toast.error(errorResult.userMessage);
+			}
 			setLoading(null);
 		}
 	};

--- a/apps/auth/src/app/(app)/(auth)/_components/sign-in-email-input.tsx
+++ b/apps/auth/src/app/(app)/(auth)/_components/sign-in-email-input.tsx
@@ -26,7 +26,7 @@ type EmailFormData = z.infer<typeof emailSchema>;
 
 interface SignInEmailInputProps {
 	onSuccess: (email: string) => void;
-	onError: (error: string) => void;
+	onError: (error: string, isSignUpRestricted?: boolean) => void;
 }
 
 export function SignInEmailInput({ onSuccess, onError }: SignInEmailInputProps) {
@@ -69,21 +69,18 @@ export function SignInEmailInput({ onSuccess, onError }: SignInEmailInputProps) 
 			});
 			onSuccess(data.email);
 		} catch (err) {
-			// Log the error
 			log.error("[SignInEmailInput] Authentication failed", {
 				email: data.email,
 				error: err,
 			});
-			
-			// Handle the error with proper context
+
 			const errorResult = handleClerkError(err, {
 				component: "SignInEmailInput",
 				action: "create_sign_in",
 				email: data.email,
 			});
-			
-			// Pass the user-friendly error message to parent
-			onError(errorResult.userMessage);
+
+			onError(errorResult.userMessage, errorResult.isSignUpRestricted);
 		}
 	}
 

--- a/apps/auth/src/app/(app)/(auth)/sign-in/sso-callback/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-in/sso-callback/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
 
 export default function Page() {
@@ -8,5 +10,14 @@ export default function Page() {
   // Clerk's task system handles redirection:
   // - Pending users (no org) → taskUrls["choose-organization"] → /account/teams/new
   // - Active users (with org) → signInFallbackRedirectUrl → console
-  return <AuthenticateWithRedirectCallback />
+
+  return (
+    <AuthenticateWithRedirectCallback
+      continueSignUpUrl="/sign-in"
+      signInFallbackRedirectUrl="/account/teams/new"
+      signUpFallbackRedirectUrl="/account/teams/new"
+      afterSignInUrl="/account/teams/new"
+      afterSignUpUrl="/account/teams/new"
+    />
+  )
 }

--- a/apps/auth/src/app/layout.tsx
+++ b/apps/auth/src/app/layout.tsx
@@ -82,6 +82,7 @@ export default function RootLayout({
       publishableKey={env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
+      waitlistUrl="/early-access"
       signInFallbackRedirectUrl={`${consoleUrl}/account/teams/new`}
       signUpFallbackRedirectUrl={`${consoleUrl}/account/teams/new`}
       taskUrls={{

--- a/apps/auth/src/app/lib/clerk/error-handling.ts
+++ b/apps/auth/src/app/lib/clerk/error-handling.ts
@@ -82,6 +82,19 @@ export function isAccountLockedError(err: unknown): { locked: boolean; expiresIn
 }
 
 /**
+ * Check if error is due to sign-up waitlist restriction
+ */
+export function isSignUpRestricted(err: unknown): boolean {
+  if (isClerkAPIResponseError(err)) {
+    return err.errors.some(
+      (error: ClerkAPIError) => error.code === 'sign_up_restricted_waitlist'
+    )
+  }
+
+  return false
+}
+
+/**
  * Check if error is due to rate limiting
  */
 export function isRateLimitError(err: unknown): { rateLimited: boolean; retryAfterSeconds?: number } {


### PR DESCRIPTION
## Summary

Fixes Clerk waitlist redirect issue where users were redirected to non-existent `accounts.lightfast.ai` domain instead of seeing a helpful inline error message.

## Changes

### Error Detection
- Added `isSignUpRestricted()` utility to detect waitlist errors (code: `sign_up_restricted_waitlist`)
- Extended `ClerkErrorResult` interface with `isSignUpRestricted` flag
- Updated error handler to return waitlist state

### OAuth Error Handling  
- Detect waitlist errors in `signIn.firstFactorVerification.error` after OAuth redirect
- Error is stored in Clerk's signIn object (not thrown as exception)

### UI Updates
- Display inline message with neutral styling (not error red)
- "Join the Waitlist" button → redirects to `/early-access`
- "Back to Sign In" button to reset form
- Follows same UI pattern as regular error handling

### Cleanup
- Removed all debug logging
- Simplified to only check actual error code from Clerk
- Removed unused imports and URL parameter checks

## Clerk Dashboard Configuration

⚠️ **Manual step required**: Update Clerk Dashboard paths:
- Sign-in URL: `/sign-in` (relative path, not `https://accounts.lightfast.ai/sign-in`)
- Sign-up URL: `/sign-up` (relative path, not `https://accounts.lightfast.ai/sign-up`)

## Testing

### Automated
- ✅ TypeScript compilation passes
- ✅ ESLint passes
- ✅ Build succeeds

### Manual (after Clerk Dashboard update)
1. Enable waitlist mode in Clerk Dashboard
2. Try OAuth sign-in with non-approved account
3. Verify inline waitlist message displays
4. Click "Join the Waitlist" → redirects to `/early-access`
5. Click "Back to Sign In" → resets form

## Related

- Plan: `thoughts/shared/plans/2026-02-08-clerk-waitlist-redirect-bug.md`
- Research: `thoughts/shared/research/2026-02-08-clerk-waitlist-redirect-bug.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)