### PR TITLE
fix(neural): unify SourceEvent.sourceType format across all sources

### DIFF
--- a/packages/console-types/src/integrations/event-types.ts
+++ b/packages/console-types/src/integrations/event-types.ts
@@ -577,6 +577,72 @@ export function toExternalGitHubEvent(
   return INTERNAL_TO_GITHUB[internalType];
 }
 
+// ─── Helper Function ──────────────────────────────────────────────────────────
+
+/**
+ * Strip source prefix from internal event type.
+ * Converts "github:pull-request.opened" → "pull-request.opened"
+ * @param internalType - Internal event type with source prefix
+ */
+function stripSourcePrefix(internalType: string): string {
+  const colonIndex = internalType.indexOf(":");
+  return colonIndex > 0 ? internalType.slice(colonIndex + 1) : internalType;
+}
+
+// ─── External Format Functions (SourceEvent.sourceType) ──────────────────────
+
+/**
+ * GitHub: external event format -> SourceEvent.sourceType (WITHOUT prefix).
+ * Use this when creating SourceEvents in transformers.
+ * @param event - GitHub event name (e.g., "pull_request")
+ * @param action - GitHub action (e.g., "opened")
+ */
+export function toExternalGitHubEventType(
+  event: string,
+  action?: string,
+): string | undefined {
+  const internal = toInternalGitHubEvent(event, action);
+  if (!internal) return undefined;
+  return stripSourcePrefix(internal);
+}
+
+/**
+ * Vercel: event type string -> SourceEvent.sourceType (WITHOUT prefix).
+ * Use this when creating SourceEvents in transformers.
+ */
+export function toExternalVercelEventType(
+  eventType: string,
+): string | undefined {
+  const internal = toInternalVercelEvent(eventType);
+  if (!internal) return undefined;
+  return stripSourcePrefix(internal);
+}
+
+/**
+ * Sentry: event type string -> SourceEvent.sourceType (WITHOUT prefix).
+ * Use this when creating SourceEvents in transformers.
+ */
+export function toExternalSentryEventType(
+  eventType: string,
+): string | undefined {
+  const internal = toInternalSentryEvent(eventType);
+  if (!internal) return undefined;
+  return stripSourcePrefix(internal);
+}
+
+/**
+ * Linear: webhook type + action -> SourceEvent.sourceType (WITHOUT prefix).
+ * Use this when creating SourceEvents in transformers.
+ */
+export function toExternalLinearEventType(
+  type: string,
+  action: string,
+): string | undefined {
+  const internal = toInternalLinearEvent(type, action);
+  if (!internal) return undefined;
+  return stripSourcePrefix(internal);
+}
+
 // ─── Auto-Derived UI Display Events ───────────────────────────────────────────
 
 export const GITHUB_EVENTS = EVENT_CATEGORIES.github;

--- a/packages/console-webhooks/src/transformers/github.ts
+++ b/packages/console-webhooks/src/transformers/github.ts
@@ -3,7 +3,7 @@ import type {
   SourceReference,
   TransformContext,
 } from "@repo/console-types";
-import { toInternalGitHubEvent } from "@repo/console-types";
+import { toExternalGitHubEventType } from "@repo/console-types";
 import type {
   PushEvent,
   PullRequestEvent,
@@ -70,7 +70,7 @@ export function transformGitHubPush(
 
   const event: SourceEvent = {
     source: "github",
-    sourceType: toInternalGitHubEvent("push") ?? "github:push",
+    sourceType: toExternalGitHubEventType("push") ?? "push",
     sourceId: `push:${payload.repository.full_name}:${payload.after}`,
     title: sanitizeTitle(`[Push] ${rawTitle}`),
     body: sanitizeBody(rawBody),
@@ -205,11 +205,11 @@ export function transformGitHubPullRequest(
   // Determine effective action (merged is a special case of closed)
   const effectiveAction =
     payload.action === "closed" && pr.merged ? "merged" : payload.action;
-  const internalType = toInternalGitHubEvent("pull_request", effectiveAction);
+  const sourceType = toExternalGitHubEventType("pull_request", effectiveAction);
 
   const event: SourceEvent = {
     source: "github",
-    sourceType: internalType ?? `github:pull-request.${effectiveAction}`,
+    sourceType: sourceType ?? `pull-request.${effectiveAction}`,
     sourceId: `pr:${payload.repository.full_name}#${pr.number}:${effectiveAction}`,
     title: sanitizeTitle(`[${actionTitle}] ${pr.title.slice(0, 100)}`),
     body: sanitizeBody(rawBody),
@@ -297,11 +297,11 @@ export function transformGitHubIssue(
   // SEMANTIC CONTENT ONLY (for embedding)
   const rawBody = [issue.title, issue.body || ""].join("\n");
 
-  const internalType = toInternalGitHubEvent("issue", payload.action);
+  const sourceType = toExternalGitHubEventType("issues", payload.action);
 
   const event: SourceEvent = {
     source: "github",
-    sourceType: internalType ?? `github:issue.${payload.action}`,
+    sourceType: sourceType ?? `issue.${payload.action}`,
     sourceId: `issue:${payload.repository.full_name}#${issue.number}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitle}] ${issue.title.slice(0, 100)}`),
     body: sanitizeBody(rawBody),
@@ -362,11 +362,11 @@ export function transformGitHubRelease(
   // SEMANTIC CONTENT ONLY (for embedding)
   const rawBody = release.body || "";
 
-  const internalType = toInternalGitHubEvent("release", payload.action);
+  const sourceType = toExternalGitHubEventType("release", payload.action);
 
   const event: SourceEvent = {
     source: "github",
-    sourceType: internalType ?? `github:release.${payload.action}`,
+    sourceType: sourceType ?? `release.${payload.action}`,
     sourceId: `release:${payload.repository.full_name}:${release.tag_name}`,
     title: sanitizeTitle(`[${actionTitle}] ${release.name || release.tag_name}`),
     body: sanitizeBody(rawBody),
@@ -432,11 +432,11 @@ export function transformGitHubDiscussion(
   // SEMANTIC CONTENT ONLY (for embedding)
   const rawBody = [discussion.title, discussion.body || ""].join("\n");
 
-  const internalType = toInternalGitHubEvent("discussion", payload.action);
+  const sourceType = toExternalGitHubEventType("discussion", payload.action);
 
   const event: SourceEvent = {
     source: "github",
-    sourceType: internalType ?? `github:discussion.${payload.action}`,
+    sourceType: sourceType ?? `discussion.${payload.action}`,
     sourceId: `discussion:${payload.repository.full_name}#${discussion.number}`,
     title: sanitizeTitle(`[${actionTitle}] ${discussion.title.slice(0, 100)}`),
     body: sanitizeBody(rawBody),

--- a/packages/console-webhooks/src/transformers/linear.ts
+++ b/packages/console-webhooks/src/transformers/linear.ts
@@ -12,7 +12,7 @@ import type {
   SourceReference,
   TransformContext,
 } from "@repo/console-types";
-import { toInternalLinearEvent } from "@repo/console-types";
+import { toExternalLinearEventType } from "@repo/console-types";
 import { validateSourceEvent } from "../validation.js";
 import { sanitizeTitle, sanitizeBody } from "../sanitize.js";
 
@@ -452,7 +452,7 @@ export function transformLinearIssue(
 
   const event: SourceEvent = {
     source: "linear",
-    sourceType: toInternalLinearEvent("Issue", payload.action) ?? `linear:issue.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
+    sourceType: toExternalLinearEventType("Issue", payload.action) ?? `issue.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
     sourceId: `linear-issue:${issue.team.key}:${issue.identifier}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitles[payload.action]}] ${issue.identifier}: ${issue.title.slice(0, 80)}`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -538,7 +538,7 @@ export function transformLinearComment(
 
   const event: SourceEvent = {
     source: "linear",
-    sourceType: toInternalLinearEvent("Comment", payload.action) ?? `linear:comment.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
+    sourceType: toExternalLinearEventType("Comment", payload.action) ?? `comment.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
     sourceId: `linear-comment:${comment.issue.identifier}:${comment.id}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitles[payload.action]}] ${comment.issue.identifier}: ${comment.body.slice(0, 60)}...`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -627,7 +627,7 @@ export function transformLinearProject(
 
   const event: SourceEvent = {
     source: "linear",
-    sourceType: toInternalLinearEvent("Project", payload.action) ?? `linear:project.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
+    sourceType: toExternalLinearEventType("Project", payload.action) ?? `project.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
     sourceId: `linear-project:${project.slugId}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitles[payload.action]}] Project: ${project.name}`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -715,7 +715,7 @@ export function transformLinearCycle(
 
   const event: SourceEvent = {
     source: "linear",
-    sourceType: toInternalLinearEvent("Cycle", payload.action) ?? `linear:cycle.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
+    sourceType: toExternalLinearEventType("Cycle", payload.action) ?? `cycle.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
     sourceId: `linear-cycle:${cycle.team.key}:${cycle.number}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitles[payload.action]}] ${cycleName} (${cycle.team.name})`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -786,7 +786,7 @@ export function transformLinearProjectUpdate(
 
   const event: SourceEvent = {
     source: "linear",
-    sourceType: toInternalLinearEvent("ProjectUpdate", payload.action) ?? `linear:project-update.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
+    sourceType: toExternalLinearEventType("ProjectUpdate", payload.action) ?? `project-update.${payload.action === "create" ? "created" : payload.action === "update" ? "updated" : "deleted"}`,
     sourceId: `linear-project-update:${update.project.id}:${update.id}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitles[payload.action]}] ${update.project.name}: ${update.body.slice(0, 60)}...`),
     body: sanitizeBody(bodyParts.join("\n")),

--- a/packages/console-webhooks/src/transformers/sentry.ts
+++ b/packages/console-webhooks/src/transformers/sentry.ts
@@ -12,7 +12,7 @@ import type {
   SourceReference,
   TransformContext,
 } from "@repo/console-types";
-import { toInternalSentryEvent } from "@repo/console-types";
+import { toExternalSentryEventType } from "@repo/console-types";
 import { validateSourceEvent } from "../validation.js";
 import { sanitizeTitle, sanitizeBody } from "../sanitize.js";
 
@@ -314,7 +314,7 @@ export function transformSentryIssue(
 
   const event: SourceEvent = {
     source: "sentry",
-    sourceType: toInternalSentryEvent(`issue.${payload.action}`) ?? `sentry:issue.${payload.action}`,
+    sourceType: toExternalSentryEventType(`issue.${payload.action}`) ?? `issue.${payload.action}`,
     sourceId: `sentry-issue:${issue.project.slug}:${issue.shortId}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitles[payload.action]}] ${errorType}: ${errorValue.slice(0, 80)}`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -399,7 +399,7 @@ export function transformSentryError(
 
   const event_out: SourceEvent = {
     source: "sentry",
-    sourceType: toInternalSentryEvent("error") ?? "sentry:error",
+    sourceType: toExternalSentryEventType("error") ?? "error",
     sourceId: `sentry-error:${event.project}:${event.event_id}`,
     title: sanitizeTitle(`[Error] ${errorType}: ${errorValue.slice(0, 80)}`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -468,7 +468,7 @@ export function transformSentryEventAlert(
 
   const event_out: SourceEvent = {
     source: "sentry",
-    sourceType: toInternalSentryEvent("event_alert") ?? "sentry:event-alert",
+    sourceType: toExternalSentryEventType("event_alert") ?? "event-alert",
     sourceId: `sentry-alert:${event.project}:${event.event_id}:${triggered_rule.replace(/\s/g, "-")}`,
     title: sanitizeTitle(`[Alert Triggered] ${triggered_rule}: ${errorType}`),
     body: sanitizeBody(bodyParts.join("\n")),
@@ -524,7 +524,7 @@ export function transformSentryMetricAlert(
 
   const event: SourceEvent = {
     source: "sentry",
-    sourceType: toInternalSentryEvent("metric_alert") ?? "sentry:metric-alert",
+    sourceType: toExternalSentryEventType("metric_alert") ?? "metric-alert",
     sourceId: `sentry-metric-alert:${alertRule.organization_id}:${metric_alert.id}:${payload.action}`,
     title: sanitizeTitle(`[${actionTitle}] ${alertRule.name}`),
     body: sanitizeBody(bodyParts.join("\n")),

--- a/packages/console-webhooks/src/transformers/vercel.ts
+++ b/packages/console-webhooks/src/transformers/vercel.ts
@@ -3,7 +3,7 @@ import type {
   SourceReference,
   TransformContext,
 } from "@repo/console-types";
-import { toInternalVercelEvent } from "@repo/console-types";
+import { toExternalVercelEventType } from "@repo/console-types";
 import type {
   VercelWebhookPayload,
   VercelWebhookEventType,
@@ -109,11 +109,11 @@ export function transformVercelDeployment(
     .filter(Boolean)
     .join("\n");
 
-  const internalType = toInternalVercelEvent(eventType);
+  const sourceType = toExternalVercelEventType(eventType);
 
   const event: SourceEvent = {
     source: "vercel",
-    sourceType: internalType ?? `vercel:${eventType}`,
+    sourceType: sourceType ?? eventType,
     sourceId: `deployment:${deployment.id}`,
     title: sanitizeTitle(`[${actionTitle}] ${project.name} from ${branch}`),
     body: sanitizeBody(rawBody),


### PR DESCRIPTION
## Summary

Fixes critical format mismatch bugs in the observation capture pipeline that prevented events from being correctly filtered and processed. This PR unifies the `SourceEvent.sourceType` format across all sources (GitHub, Vercel, Sentry, Linear) by removing redundant source prefixes and normalizing format inconsistencies.

## Problem

There were TWO critical issues in the observation capture pipeline:

### Issue 1: SourceType Format Mismatch
1. **SourceEvent type definition**: Documents format as `"pull-request.merged"` (NO prefix)
2. **Transformers produced**: `"github:pull-request.opened"` (WITH prefix)
3. **getBaseEventType() expected**: `"pull-request.opened"` (NO prefix)
4. **Comparison failed**: `"github:pull_request" !== "pull_request"` → events filtered incorrectly

### Issue 2: Additional Format Mismatches
- **Sentry**: Registry uses hyphens (`event-alert`), config uses underscores (`event_alert`)
- **Linear**: Transformers output lowercase with dots (`issue.created`), config expects PascalCase (`Issue`)

### Issue 3: Inconsistent Fallback Behavior
When integration lookup failed, the system had contradictory behavior:
- **No resourceId**: Allow all ✓ (permissive)
- **No integration**: Allow all ✓ (permissive)  
- **Integration found but empty events**: Reject all ✗ (strict)

This created backwards behavior where unconfigured resources passed through while properly configured ones got blocked.

## Changes

### Phase 1: Critical Fixes (observation-capture.ts)
- ✅ Add defensive prefix stripping in `getBaseEventType()`
- ✅ Fix permissive fallback to strict rejection (no resourceId/integration → reject)

### Phase 2: GitHub & Vercel (event-types.ts + transformers)
- ✅ Add `toExternalGitHubEventType()`, `toExternalVercelEventType()` functions
- ✅ Update `github.ts` to use `toExternalGitHubEventType()` → removes prefix
- ✅ Update `vercel.ts` to use `toExternalVercelEventType()` → removes prefix

### Phase 3: Sentry & Linear (event-types.ts + transformers + observation-capture.ts)
- ✅ Add `toExternalSentryEventType()`, `toExternalLinearEventType()` functions
- ✅ Update `sentry.ts` to use `toExternalSentryEventType()` → removes prefix
- ✅ Update `linear.ts` to use `toExternalLinearEventType()` → removes prefix
- ✅ Fix Sentry format: convert hyphens to underscores (`event-alert` → `event_alert`)
- ✅ Fix Linear format: extract base + capitalize (`issue.created` → `Issue`)

## Impact

### Event Coverage
- ✅ **All 41 events now properly supported**
  - 13 GitHub events
  - 6 Vercel events
  - 7 Sentry events
  - 15 Linear events

### Bugs Fixed
1. **GitHub/Vercel actor reconciliation** - The push event check was NEVER working before (comparing `"github:push" !== "push"`). Now fixed!
2. **Sentry event-alert & metric-alert** - Format mismatch prevented these from matching config
3. **Linear all events** - Format mismatch prevented all Linear events from matching config
4. **Strict filtering** - Now consistently enforces "no config = reject" across all scenarios

### Consistency
- ✅ `SourceEvent.sourceType` never includes source prefix (matches type spec)
- ✅ Event filtering works correctly for all sources
- ✅ Defensive prefix stripping handles both old and new formats for backward compatibility

## Testing

- ✅ All typechecks pass
  - `@repo/console-types` - Event registry & utilities
  - `@repo/console-webhooks` - All transformers
  - `@api/console` - Observation capture workflow
- ⏳ Ready for integration testing with sandbox datasets

## Manual Testing Plan

```bash
# 1. Seed integrations with correct providerResourceIds
pnpm --filter @repo/console-test-data seed-integrations:prod -- -w <workspaceId> -u <userId>

# 2. Inject test data
pnpm --filter @repo/console-test-data inject -- -w <workspaceId> -s sandbox-1

# 3. Verify correct filtering:
# - GitHub events: captured ✅
# - Vercel events: captured ✅
# - Sentry events: captured ✅
# - Linear events: captured ✅

# 4. Test strict fallback (delete all integrations, verify all events rejected)
```

## Files Changed

- `api/console/src/inngest/workflow/neural/observation-capture.ts` - getBaseEventType() fixes + strict fallback
- `packages/console-types/src/integrations/event-types.ts` - Add toExternal* functions
- `packages/console-webhooks/src/transformers/github.ts` - Use toExternalGitHubEventType()
- `packages/console-webhooks/src/transformers/vercel.ts` - Use toExternalVercelEventType()
- `packages/console-webhooks/src/transformers/sentry.ts` - Use toExternalSentryEventType()
- `packages/console-webhooks/src/transformers/linear.ts` - Use toExternalLinearEventType()

## Related

- Plan: `thoughts/shared/plans/2026-02-09-unify-sourcetype-format.md`