### PR TITLE
fix: remove duplicate horizontal padding on blog mobile layout

### DIFF
--- a/apps/www/src/app/(app)/(marketing)/(content)/blog/(listing)/layout.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/blog/(listing)/layout.tsx
@@ -11,7 +11,7 @@ export default async function BlogListingLayout({
   const allCategories = await categoriesAPI.getCategories();
 
   return (
-    <div className="w-full max-w-2xl mx-auto px-4 pt-24 pb-32">
+    <div className="w-full max-w-2xl mx-auto pt-24 pb-32">
       <div className="flex items-center justify-between mb-12">
         <h1 className="text-3xl font-pp text-foreground font-medium">Blog</h1>
         <Link

--- a/apps/www/src/app/(app)/(marketing)/(content)/blog/[slug]/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/blog/[slug]/page.tsx
@@ -251,7 +251,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             {/* Structured data for SEO */}
             <JsonLd code={structuredData as any} />
 
-            <article className="w-full max-w-2xl mx-auto px-4 pb-32 pt-24">
+            <article className="w-full max-w-2xl mx-auto pb-32 pt-24">
               <p className="text-sm text-muted-foreground mb-8">
                 Blog
                 {primaryCategory?._title ? (

--- a/apps/www/src/components/blog-category-nav.tsx
+++ b/apps/www/src/components/blog-category-nav.tsx
@@ -27,7 +27,7 @@ export function CategoryNav({ categories }: CategoryNavProps) {
           variant="link"
           size="sm"
           asChild
-          className={`w-full justify-start py-1 h-fit h-auto font-normal ${
+          className={`w-full justify-start px-0 py-1 h-fit h-auto font-normal ${
             isHomePage ? "text-foreground" : "text-muted-foreground"
           }`}
         >
@@ -39,7 +39,7 @@ export function CategoryNav({ categories }: CategoryNavProps) {
             variant="link"
             size="sm"
             asChild
-            className={`w-full justify-start py-1 h-fit h-auto font-normal ${
+            className={`w-full justify-start px-0 py-1 h-fit h-auto font-normal ${
               currentCategory === category._slug
                 ? "text-foreground"
                 : "text-muted-foreground"


### PR DESCRIPTION
## Summary
- Removed `px-4` from blog listing layout and blog post article that was stacking on parent `page-gutter` (`px-8`), causing extra horizontal padding on mobile
- Added `px-0` to category nav buttons to remove inherited `px-3` from `size="sm"` variant, aligning links flush with content
- Blog containers now match changelog layout behavior

## Test plan
- [ ] Verify blog listing page on mobile has consistent padding with changelog
- [ ] Verify individual blog post pages have correct padding on mobile
- [ ] Verify category nav links align flush on both mobile and desktop