### PR TITLE
fix: add solid background and border to mobile navbar

### DIFF
--- a/apps/www/src/components/app-mobile-nav.tsx
+++ b/apps/www/src/components/app-mobile-nav.tsx
@@ -29,7 +29,7 @@ export function AppMobileNav() {
       </SheetTrigger>
       <SheetPrimitive.Portal>
         <SheetPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <SheetPrimitive.Content className="fixed inset-y-0 left-0 z-50 h-full w-screen bg-background/95 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left data-[state=closed]:duration-300 data-[state=open]:duration-500">
+        <SheetPrimitive.Content className="fixed inset-y-0 left-0 z-50 h-full w-screen bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left data-[state=closed]:duration-300 data-[state=open]:duration-500">
           {/* Visually hidden title for accessibility */}
           <SheetPrimitive.Title className="sr-only">
             Navigation Menu

--- a/apps/www/src/components/app-navbar.tsx
+++ b/apps/www/src/components/app-navbar.tsx
@@ -10,7 +10,7 @@ import { AppNavbarMenu } from "./app-navbar-menu";
  */
 export function AppNavbar() {
   return (
-    <div id="app-navbar" className="shrink-0 py-4 page-gutter bg-transparent">
+    <div id="app-navbar" className="shrink-0 py-4 page-gutter bg-background md:bg-transparent border-b border-border md:border-b-0">
       {/* Centered nav container */}
       <div className="relative flex items-center justify-center">
         {/* Desktop: Centered nav pill */}


### PR DESCRIPTION
## Summary
- Adds `bg-background` and `border-b` to the mobile navbar so it no longer overlays on page content
- Desktop navbar remains transparent with no border
- Makes mobile nav sheet fully opaque (`bg-background` instead of `bg-background/95`)

## Test plan
- [ ] Open site on mobile viewport — navbar should have solid background and bottom border
- [ ] Open site on desktop — navbar should remain transparent with glass pill style
- [ ] Open mobile sheet menu — should be fully opaque

🤖 Generated with [Claude Code](https://claude.com/claude-code)