### PR TITLE
feat(pitch-deck): add tagline to title slide

### DIFF
--- a/apps/www/src/app/(app)/(internal)/pitch-deck/_components/slide-content/custom-title-slide.tsx
+++ b/apps/www/src/app/(app)/(internal)/pitch-deck/_components/slide-content/custom-title-slide.tsx
@@ -30,20 +30,8 @@ export function CustomTitleSlide({
         ))}
       </div>
 
-      {/* Subtitle */}
-      <span
-        className={cn(
-          "absolute text-white/60 font-normal pointer-events-none",
-          isFixed
-            ? "left-6 bottom-6 text-sm"
-            : "left-4 bottom-4 text-[10px] sm:text-xs",
-        )}
-      >
-        {slide.subtitle}
-      </span>
-
-      {/* Centered logo + text */}
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+      {/* Centered logo + title + tagline */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
         <div className="flex items-center gap-2 sm:gap-3 md:gap-4">
           <Icons.logoShort
             className={cn(
@@ -64,6 +52,18 @@ export function CustomTitleSlide({
             {slide.title}
           </h1>
         </div>
+        {slide.subtitle && (
+          <p
+            className={cn(
+              "text-white font-normal text-center",
+              isFixed
+                ? "mt-6 text-lg max-w-[600px]"
+                : "mt-3 sm:mt-4 md:mt-5 text-[10px] sm:text-xs md:text-sm lg:text-xl max-w-[80%] sm:max-w-[70%] md:max-w-[500px]",
+            )}
+          >
+            {slide.subtitle}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/www/src/config/pitch-deck-data.ts
+++ b/apps/www/src/config/pitch-deck-data.ts
@@ -4,7 +4,8 @@ export const PITCH_SLIDES = [
     id: "title",
     type: "title" as const,
     title: "LIGHTFAST",
-    subtitle: "Pitch deck 2026 —",
+    subtitle:
+      "Lightfast surfaces every decision your team makes across your tools — searchable, cited, and ready for people and agents.",
     bgColor: "bg-[var(--pitch-deck-red)]",
   },
   // Slide 2: Problem


### PR DESCRIPTION
## Summary
- Add product tagline below centered logo on title slide
- Reposition subtitle from bottom-left corner to centered below logo/title
- Responsive sizing with max-width constraint for clean wrapping

## Test plan
- [ ] Visual verification on `pnpm dev:www`

🤖 Generated with [Claude Code](https://claude.com/claude-code)