### PR TITLE
feat(tech-stack-detector): add unmatched domain logger

### DIFF
--- a/packages/tech-stack-detector/src/cli.ts
+++ b/packages/tech-stack-detector/src/cli.ts
@@ -71,6 +71,14 @@ function formatTable(result: DetectionResult): string {
 		lines.push("");
 	}
 
+	if (result.unmatchedDomains && result.unmatchedDomains.length > 0) {
+		lines.push("  UNMATCHED DOMAINS");
+		for (const d of result.unmatchedDomains) {
+			lines.push(`    \u2022 ${d}`);
+		}
+		lines.push("");
+	}
+
 	const warnings = result.detected.filter((t) => t.level === "possible").length;
 	lines.push(
 		`  ${result.totalChecked} tools checked \u00b7 ${result.detected.length} detected \u00b7 ${warnings} warnings`,
@@ -118,6 +126,17 @@ function formatDeepResult(result: DeepDetectionResult): string {
 			lines.push("  " + "\u2500".repeat(70));
 			lines.push(formatTable(sub));
 		}
+	}
+
+	// Aggregated unmatched domains
+	if (result.unmatchedDomains && result.unmatchedDomains.length > 0) {
+		lines.push("  " + "\u2500".repeat(70));
+		lines.push("");
+		lines.push("  UNMATCHED DOMAINS (aggregated)");
+		for (const d of result.unmatchedDomains) {
+			lines.push(`    \u2022 ${d}`);
+		}
+		lines.push("");
 	}
 
 	// Summary

--- a/packages/tech-stack-detector/src/index.ts
+++ b/packages/tech-stack-detector/src/index.ts
@@ -2,6 +2,7 @@ export { detect } from "./pipeline.js";
 export { deepDetect } from "./deep-detect.js";
 export { discover } from "./discovery/index.js";
 export { SIGNATURES } from "./registry.js";
+export { findUnmatchedDomains } from "./unmatched.js";
 export type {
 	Category,
 	ConfidenceLevel,

--- a/packages/tech-stack-detector/src/types.ts
+++ b/packages/tech-stack-detector/src/types.ts
@@ -70,6 +70,7 @@ export interface DetectionResult {
 	totalChecked: number;
 	tiersUsed: Tier[];
 	durationMs: number;
+	unmatchedDomains?: string[];
 }
 
 export interface DetectOptions {
@@ -106,4 +107,5 @@ export interface DeepDetectionResult {
 	subResults: DetectionResult[];
 	allDetected: DetectedTool[];
 	totalDurationMs: number;
+	unmatchedDomains?: string[];
 }

--- a/packages/tech-stack-detector/src/unmatched.test.ts
+++ b/packages/tech-stack-detector/src/unmatched.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import {
+	collectKnownDomains,
+	collectKnownPatterns,
+	findUnmatchedDomains,
+} from "./unmatched.js";
+import type { ToolSignature } from "./types.js";
+
+// ─── Test fixtures ──────────────────────────────────────────────────────────
+
+const testSignatures: ToolSignature[] = [
+	{
+		id: "posthog",
+		name: "PostHog",
+		category: "growth",
+		rules: [
+			{
+				vector: "network_request",
+				tier: 3,
+				confidence: 0.9,
+				domains: ["us.i.posthog.com", "eu.i.posthog.com"],
+			},
+			{
+				vector: "network_request",
+				tier: 3,
+				confidence: 0.85,
+				pattern: /\.posthog\.com/,
+			},
+		],
+	},
+	{
+		id: "clerk",
+		name: "Clerk",
+		category: "engineering",
+		rules: [
+			{
+				vector: "network_request",
+				tier: 3,
+				confidence: 0.85,
+				domains: ["clerk.com", "api.clerk.com"],
+			},
+		],
+	},
+	{
+		id: "sentry",
+		name: "Sentry",
+		category: "engineering",
+		rules: [
+			{
+				vector: "network_request",
+				tier: 3,
+				confidence: 0.85,
+				domains: ["sentry.io", "ingest.sentry.io"],
+			},
+			{
+				vector: "script_src",
+				tier: 1,
+				confidence: 0.9,
+				pattern: /cdn\.sentry\.io/,
+			},
+		],
+	},
+];
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("collectKnownDomains", () => {
+	it("extracts all domains from rules", () => {
+		const domains = collectKnownDomains(testSignatures);
+		expect(domains).toContain("us.i.posthog.com");
+		expect(domains).toContain("eu.i.posthog.com");
+		expect(domains).toContain("clerk.com");
+		expect(domains).toContain("api.clerk.com");
+		expect(domains).toContain("sentry.io");
+		expect(domains).toContain("ingest.sentry.io");
+	});
+
+	it("returns empty set for signatures with no domain rules", () => {
+		const sigs: ToolSignature[] = [
+			{
+				id: "test",
+				name: "Test",
+				category: "engineering",
+				rules: [{ vector: "header", tier: 1, confidence: 0.9 }],
+			},
+		];
+		expect(collectKnownDomains(sigs).size).toBe(0);
+	});
+});
+
+describe("collectKnownPatterns", () => {
+	it("extracts patterns from network_request and script_src rules", () => {
+		const patterns = collectKnownPatterns(testSignatures);
+		expect(patterns).toHaveLength(2); // posthog network_request + sentry script_src
+	});
+
+	it("ignores patterns from other vectors", () => {
+		const sigs: ToolSignature[] = [
+			{
+				id: "test",
+				name: "Test",
+				category: "engineering",
+				rules: [
+					{ vector: "dns_cname", tier: 2, confidence: 0.9, pattern: /test/ },
+				],
+			},
+		];
+		expect(collectKnownPatterns(sigs)).toHaveLength(0);
+	});
+});
+
+describe("findUnmatchedDomains", () => {
+	it("returns unknown domains not in registry", () => {
+		const networkDomains = new Set([
+			"unknown-tool.com",
+			"another-unknown.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).toContain("another-unknown.io");
+		expect(result).toContain("unknown-tool.com");
+	});
+
+	it("filters target domain and its subdomains", () => {
+		const networkDomains = new Set([
+			"example.com",
+			"www.example.com",
+			"api.example.com",
+			"cdn.example.com",
+			"unknown.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).not.toContain("example.com");
+		expect(result).not.toContain("www.example.com");
+		expect(result).not.toContain("api.example.com");
+		expect(result).not.toContain("cdn.example.com");
+		expect(result).toContain("unknown.io");
+	});
+
+	it("filters infrastructure domains", () => {
+		const networkDomains = new Set([
+			"fonts.googleapis.com",
+			"cdn.jsdelivr.net",
+			"unpkg.com",
+			"unknown.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).not.toContain("fonts.googleapis.com");
+		expect(result).not.toContain("cdn.jsdelivr.net");
+		expect(result).not.toContain("unpkg.com");
+		expect(result).toContain("unknown.io");
+	});
+
+	it("matches via exact known domain", () => {
+		const networkDomains = new Set([
+			"clerk.com",
+			"sentry.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).not.toContain("clerk.com");
+		expect(result).not.toContain("sentry.io");
+	});
+
+	it("matches via suffix (subdomain of known domain)", () => {
+		const networkDomains = new Set([
+			"dashboard.clerk.com",
+			"o123456.ingest.sentry.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).not.toContain("dashboard.clerk.com");
+		expect(result).not.toContain("o123456.ingest.sentry.io");
+	});
+
+	it("matches via reverse root domain lookup", () => {
+		// cdn.posthog.com shares root with us.i.posthog.com (known domain)
+		const networkDomains = new Set(["cdn.posthog.com"]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).not.toContain("cdn.posthog.com");
+	});
+
+	it("matches via regex patterns", () => {
+		const networkDomains = new Set([
+			"app.posthog.com",
+			"cdn.sentry.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).not.toContain("app.posthog.com");
+		expect(result).not.toContain("cdn.sentry.io");
+	});
+
+	it("returns sorted results", () => {
+		const networkDomains = new Set([
+			"zebra.io",
+			"alpha.com",
+			"middle.net",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).toEqual(["alpha.com", "middle.net", "zebra.io"]);
+	});
+
+	it("returns empty array when all domains are known", () => {
+		const networkDomains = new Set([
+			"example.com",
+			"clerk.com",
+			"sentry.io",
+		]);
+		const result = findUnmatchedDomains(
+			networkDomains,
+			"example.com",
+			testSignatures,
+		);
+		expect(result).toEqual([]);
+	});
+
+	it("returns empty array for empty input", () => {
+		const result = findUnmatchedDomains(
+			new Set(),
+			"example.com",
+			testSignatures,
+		);
+		expect(result).toEqual([]);
+	});
+});

--- a/packages/tech-stack-detector/src/unmatched.ts
+++ b/packages/tech-stack-detector/src/unmatched.ts
@@ -1,0 +1,138 @@
+import { SIGNATURES } from "./registry.js";
+import { extractRootDomain } from "./discovery/utils.js";
+import type { ToolSignature } from "./types.js";
+
+/**
+ * Infrastructure domains that appear on most sites and are not third-party tools.
+ * These are generic CDNs, font services, and browser infrastructure.
+ */
+const INFRASTRUCTURE_DOMAINS = new Set([
+	// Google infrastructure (NOT analytics/GTM — those are registry-detected tools)
+	"fonts.googleapis.com",
+	"fonts.gstatic.com",
+	"www.gstatic.com",
+	"apis.google.com",
+	"www.google.com",
+	"pagead2.googlesyndication.com",
+	"adservice.google.com",
+	"translate.googleapis.com",
+	"maps.googleapis.com",
+	"maps.gstatic.com",
+	// Generic CDNs
+	"cdn.jsdelivr.net",
+	"unpkg.com",
+	"cdnjs.cloudflare.com",
+	"ajax.googleapis.com",
+	"cdn.cloudflare.com",
+	// Browser / standards
+	"localhost",
+	"accounts.google.com",
+	"play.google.com",
+	// Common image/media CDNs
+	"i.imgur.com",
+	"images.unsplash.com",
+]);
+
+/**
+ * Extracts all `domains[]` entries from all rules across all signatures into a Set.
+ */
+export function collectKnownDomains(sigs: ToolSignature[]): Set<string> {
+	const known = new Set<string>();
+	for (const sig of sigs) {
+		for (const rule of sig.rules) {
+			if (rule.domains) {
+				for (const d of rule.domains) {
+					known.add(d);
+				}
+			}
+		}
+	}
+	return known;
+}
+
+/**
+ * Extracts `pattern` regexes from `network_request` and `script_src` rules.
+ */
+export function collectKnownPatterns(sigs: ToolSignature[]): RegExp[] {
+	const patterns: RegExp[] = [];
+	for (const sig of sigs) {
+		for (const rule of sig.rules) {
+			if (
+				(rule.vector === "network_request" || rule.vector === "script_src") &&
+				rule.pattern
+			) {
+				patterns.push(rule.pattern);
+			}
+		}
+	}
+	return patterns;
+}
+
+/**
+ * Finds domains observed during a browser scan that have no match in the registry.
+ *
+ * Filters out:
+ * - Target domain and its subdomains
+ * - Infrastructure domains (static allowlist)
+ * - Domains matching known registry domains (exact + suffix match)
+ * - Domains matching known registry patterns
+ *
+ * @returns Sorted array of unmatched domain strings
+ */
+export function findUnmatchedDomains(
+	networkDomains: Set<string>,
+	targetDomain: string,
+	sigs: ToolSignature[] = SIGNATURES,
+): string[] {
+	const targetRoot = extractRootDomain(targetDomain);
+	const knownDomains = collectKnownDomains(sigs);
+	const knownPatterns = collectKnownPatterns(sigs);
+
+	const unmatched: string[] = [];
+
+	for (const domain of networkDomains) {
+		// Skip target domain and its subdomains
+		const domainRoot = extractRootDomain(domain);
+		if (domainRoot === targetRoot) continue;
+
+		// Skip infrastructure domains
+		if (INFRASTRUCTURE_DOMAINS.has(domain)) continue;
+
+		// Check exact match against known registry domains
+		if (knownDomains.has(domain)) continue;
+
+		// Check suffix match (domain is a subdomain of a known domain)
+		let suffixMatched = false;
+		for (const known of knownDomains) {
+			if (domain.endsWith(`.${known}`)) {
+				suffixMatched = true;
+				break;
+			}
+		}
+		if (suffixMatched) continue;
+
+		// Check if known domain is a subdomain of this domain's root
+		let reverseMatched = false;
+		for (const known of knownDomains) {
+			if (extractRootDomain(known) === domainRoot) {
+				reverseMatched = true;
+				break;
+			}
+		}
+		if (reverseMatched) continue;
+
+		// Check against known patterns
+		let patternMatched = false;
+		for (const pattern of knownPatterns) {
+			if (pattern.test(domain) || pattern.test(`https://${domain}/`)) {
+				patternMatched = true;
+				break;
+			}
+		}
+		if (patternMatched) continue;
+
+		unmatched.push(domain);
+	}
+
+	return unmatched.sort();
+}


### PR DESCRIPTION
## Summary

- Add `findUnmatchedDomains()` to surface third-party domains observed during Tier 3 browser scans that have no matching signature in the registry
- Attach optional `unmatchedDomains` field to `DetectionResult` and `DeepDetectionResult` types
- Aggregate unmatched domains across primary + sub-results in deep detection mode
- Render "UNMATCHED DOMAINS" section in CLI table output and deep result output
- Export `findUnmatchedDomains` from package index for programmatic consumers

## Test plan

- [x] 14 new unit tests for `findUnmatchedDomains` (target domain filtering, infrastructure allowlist, exact/suffix/reverse root matching, regex pattern matching, sorted output, empty cases)
- [x] 3 new pipeline tests (`unmatchedDomains` present with unknown domains, absent with `skipBrowser`, absent when all known)
- [x] All 130 tests passing
- [x] Typecheck clean
- [x] Lint clean
- [x] CodeRabbit review clean (fixed GA/GTM domain overlap on first pass)