### PR TITLE
chore: scaffold gateway app (Hono on Vercel)

### DIFF
--- a/apps/gateway/eslint.config.js
+++ b/apps/gateway/eslint.config.js
@@ -1,0 +1,9 @@
+import baseConfig from "@repo/eslint-config/base";
+
+/** @type {import('typescript-eslint').Config} */
+export default [
+  {
+    ignores: ["dist/**"],
+  },
+  ...baseConfig,
+];

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@lightfast/gateway",
+  "license": "FSL-1.1-Apache-2.0",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "dev": "vercel dev --listen 4108",
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.12.2"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/prettier-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "typescript": "catalog:"
+  },
+  "prettier": "@repo/prettier-config"
+}

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => c.json({ service: "gateway", status: "ok" }));
+
+export default app;

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/gateway/vercel.json
+++ b/apps/gateway/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore"
+}


### PR DESCRIPTION
## Summary
- Scaffolds `apps/gateway/` — a minimal Hono service that will own webhook receipt and connection lifecycle
- Zero-config Vercel deployment (auto-detected from `src/index.ts`)
- Follows monorepo conventions (tsconfig, eslint, turbo-ignore)

## Test plan
- [x] `pnpm --filter @lightfast/gateway typecheck` passes
- [x] `pnpm --filter @lightfast/gateway build` passes
- [ ] Create Vercel project via dashboard, set root directory to `apps/gateway`

🤖 Generated with [Claude Code](https://claude.com/claude-code)