### PR TITLE
docs: reposition Lightfast as operating infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,87 +6,58 @@
 [![CI Status](https://github.com/lightfastai/lightfast/actions/workflows/ci.yml/badge.svg)](https://github.com/lightfastai/lightfast/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/lightfastai/lightfast)](https://github.com/lightfastai/lightfast/stargazers)
 
-**Lightfast is the memory layer for teams. Every decision across your tools — surfaced, cited, and ready for people and agents.**
+**An operating infrastructure between your agents and apps.**
 
-> **Early Access** — Lightfast is currently in early access. [Request access →](https://lightfast.ai/early-access)
-
-[Website](https://lightfast.ai) · [Documentation](https://lightfast.ai/docs/get-started/overview) · [Chat Demo](https://chat.lightfast.ai) · [Discord](https://discord.gg/YqPDfcar2C)
+[Website](https://lightfast.ai) · [Documentation](https://lightfast.ai/docs/get-started/overview) · [Discord](https://discord.gg/YqPDfcar2C)
 
 ## Why Lightfast?
 
-Every team generates decisions across PRs, docs, incidents, and conversations — but that knowledge gets buried. Lightfast surfaces it all so engineers and AI agents can:
+Your team's work happens across dozens of tools. Your agents need to understand and act across all of them. Lightfast is the layer in between — it observes what's happening, remembers what happened, and gives agents and people a single system to operate through.
 
-- **Search by meaning** — not just keywords
-- **Get cited answers** — trace every decision back to its source
-- **Power agents** — production-ready retrieval for people and AI alike
+- **Observe** — Ingest every event across your tools, automatically and continuously
+- **Remember** — Search by meaning across everything that happened, always citing sources
+- **Act** — Agents express intent, the system resolves what to do and where
 
-## Supported Sources
+## Rollout
 
-**Available now:**
-- **GitHub** — Pull requests, issues, code, discussions
-- **Vercel** — Deployments, logs, project activity
+Lightfast ships in three phases. Each builds on the last.
+
+### Events — Available now
+
+A unified event system across your tools. Connect your sources, receive structured events in real time. No waitlist.
+
+**Supported sources:**
+- **GitHub** — Push, pull requests, issues, code reviews
+- **Vercel** — Deployments, project activity
+- **Sentry** — Errors, issues, alerts
+- **Linear** — Issues, comments, projects, cycles
 
 **Coming soon:**
-- Linear, Sentry, Slack, Notion, Confluence
-- PlanetScale, Pulumi, Terraform, Zendesk
+- Slack, Notion, Confluence, PagerDuty
 - [Request an integration →](https://github.com/lightfastai/lightfast/issues)
 
-## Use Cases
+### Memory — Coming soon
+
+Semantic search and cited answers across your entire tool stack. Everything from the event system gets indexed, connected, and made searchable by meaning. Powered by the same event pipeline — no additional setup.
 
 ```typescript
-// "Why did we choose Postgres over MongoDB?"
-await lightfast.search({ query: "database selection decision postgres mongodb" });
-
-// "How does our payment integration work?"
-await lightfast.search({ query: "stripe payment flow implementation" });
-
 // "What broke in last week's deployment?"
-await lightfast.search({ query: "production incident postmortem", filters: { dateRange: "7d" } });
+await lightfast.search({ query: "production incident deployment", filters: { dateRange: "7d" } });
 
-// "Find PRs similar to this refactor"
+// "Who has context on the auth system?"
+await lightfast.search({ query: "authentication ownership context" });
+
+// "Find things related to this PR"
 await lightfast.findSimilar({ url: "https://github.com/org/repo/pull/123" });
-
-// "What do we know about rate limiting?"
-await lightfast.search({ query: "rate limiting implementation patterns" });
 ```
 
-**Example response:**
+### Operating Layer — [Join the waitlist →](https://lightfast.ai/waitlist)
 
-```json
-{
-  "results": [
-    {
-      "id": "doc_abc123",
-      "type": "pull_request",
-      "title": "Add rate limiting to API endpoints",
-      "snippet": "Implemented token bucket algorithm with Redis...",
-      "score": 0.92,
-      "source": "github",
-      "url": "https://github.com/org/repo/pull/456",
-      "metadata": { "author": "jane", "mergedAt": "2024-12-01" }
-    }
-  ],
-  "meta": { "total": 24, "latency": { "total": 145 } }
-}
-```
-
-## Security
-
-- **Your code stays yours** — We index metadata and content for search, never train on your data
-- **Encrypted at rest and in transit** — Industry-standard security practices
-- **Role-based access** — Workspace permissions mirror your source permissions
-- **Self-hosted option** — Coming soon for enterprises with strict data residency requirements
-
-## Requirements
-
-- Node.js >= 18
-- A Lightfast API key ([request access](https://lightfast.ai/early-access))
+The full operating infrastructure. Agents express what they want in natural language — Lightfast resolves it to the right tool, enforces your team's rules, and tracks everything that happens. Processes that run for seconds or months. Invariants that span tools. Intent resolution that learns from your team.
 
 ## Integrate in 2 Ways
 
 ### 1. TypeScript SDK
-
-Install the `lightfast` package to add semantic search to any application:
 
 ```bash
 npm install lightfast
@@ -95,10 +66,9 @@ npm install lightfast
 ```typescript
 import { Lightfast } from "lightfast";
 
-// Pass API key directly or use LIGHTFAST_API_KEY environment variable
 const lightfast = new Lightfast({ apiKey: process.env.LIGHTFAST_API_KEY });
 
-// Search your workspace memory
+// Search your workspace
 const results = await lightfast.search({
   query: "how does authentication work",
   limit: 10,
@@ -118,7 +88,7 @@ const similar = await lightfast.findSimilar({
 
 ### 2. MCP Server (Claude, Cursor, Codex)
 
-Connect AI assistants directly to your workspace memory via [Model Context Protocol](https://modelcontextprotocol.io/).
+Connect AI assistants directly to your workspace via [Model Context Protocol](https://modelcontextprotocol.io/).
 
 <details>
 <summary><strong>Claude Desktop</strong></summary>
@@ -203,15 +173,21 @@ LIGHTFAST_API_KEY = "sk-lf-..."
 </details>
 
 **Available tools:**
-- `lightfast_search` — Search workspace memory
+- `lightfast_search` — Search your workspace
 - `lightfast_contents` — Fetch full document content
 - `lightfast_find_similar` — Find semantically similar documents
 
-## Get an API Key
+## Security
 
-1. [Request early access](https://lightfast.ai/early-access) to join the waitlist
-2. Create a workspace and connect your sources (GitHub, docs, etc.)
-3. Generate an API key from your workspace settings
+- **Your data stays yours** — We never train on your data. Complete tenant isolation.
+- **Encrypted at rest and in transit** — Industry-standard security practices
+- **Role-based access** — Workspace permissions mirror your source permissions
+- **Self-hosted option** — Coming soon for enterprises with strict data residency requirements
+
+## Requirements
+
+- Node.js >= 18
+- A Lightfast API key — [get started](https://lightfast.ai)
 
 ## Documentation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,113 +1,65 @@
 # Lightfast — Vision & Mission
 
-Last Updated: 2025-12-09
+Last Updated: 2026-03-02
 
-Lightfast is the memory layer for teams. Every decision across your tools — surfaced, cited, and ready for people and agents.
+An operating infrastructure between your agents and apps.
 
 ---
 
 ## Mission
 
-Be the memory layer for every team — so nothing gets lost and every answer cites its source.
+Be the operating layer for every team — so agents and people can observe, reason, and act across your entire tool stack through a single system.
 
 ## Vision
 
-Any engineer or agent can ask "what broke?", "who owns this?", "why was this decision made?" and get accurate, cited answers across your entire engineering ecosystem, in real time.
+Any agent or engineer can understand what's happening, why it happened, and what should happen next — across every tool, every team, every decision — without knowing which tools exist or how they work.
 
 ---
 
 ## Positioning
 
-- **Decisions, surfaced:** Every decision your team makes across your tools — searchable, cited, and ready.
-- **Explainable by design:** See who owns what, what depends on what, and why decisions were made.
-- **People and agents:** Four simple API routes. MCP tools for agents. Integrate in minutes.
+- **Operating infrastructure:** Not a feature — a layer. Agents and people operate through Lightfast the way programs operate through an OS.
+- **Tool-agnostic by design:** Express intent, not API calls. The system resolves what to do and where.
+- **Agents and people:** Same primitives for both. REST API, MCP tools, and webhooks. Integrate in minutes.
 
 ---
 
-## What We Remember
+## What We Do
 
-- **Code & Changes:** Pull requests, commits, code reviews, and discussions from source control (GitHub, GitLab, Bitbucket).
-- **Deployments & Infrastructure:** Deployment events, build logs, environment changes, and infrastructure state (Vercel, Railway, Pulumi, Terraform).
-- **Incidents & Errors:** Error events, incident timelines, resolutions, and post-mortems (Sentry, PagerDuty).
-- **Decisions & Context:** Capture why decisions were made, what was discussed, and who was involved.
-- **People & Ownership:** Track who owns what, who worked on what, and who has context on any topic.
-
-Memory is broad and evidence-backed. Context emerges from what actually happened, not narrow predefined categories.
+- **Observe:** Ingest every event across your tools — code changes, deployments, incidents, decisions, messages — automatically and continuously.
+- **Remember:** Build a living graph of what happened, who was involved, how things relate, and why decisions were made. Searchable by meaning, always citing sources.
+- **Reason:** Detect patterns, predict outcomes, compute truth across conflicting sources, and enforce invariants your team defines.
+- **Act:** Resolve intent to action across any connected tool. Agents express what they want — the system figures out where and how.
 
 ---
 
 ## Principles
 
-- **Search by meaning:** Understand intent, not just match keywords.
-- **Always cite sources:** Every answer shows where it came from.
-- **Privacy by default:** Your data stays yours. Complete tenant isolation.
-- **Continuously improve:** Measure quality, learn from usage, adapt over time.
-
----
-
-## How We Build
-
-- **Simple API:** Four routes do everything—search, contents, similar, answer. Same tools for REST and MCP.
-- **Smart retrieval:** Search understands meaning and context. Results are ranked by relevance and recency.
-- **Organized memory:** Consolidate related information. Surface what's important. Archive what's not.
-- **Quality first:** Measure every query. Learn from feedback. Improve accuracy over time.
-
----
-
-## API
-
-Four routes power everything:
-
-- **POST `/v1/search`** — Search and rank results. Optionally include rationale and highlights.
-- **POST `/v1/contents`** — Get full documents, metadata, and relationships.
-- **POST `/v1/similar`** — Find related content based on meaning.
-- **POST `/v1/answer`** — Get synthesized answers with citations. Supports streaming.
-
-Available via REST API and MCP tools for agent runtimes.
+- **Primitives over features:** Composable building blocks. Every capability is a configuration, not a new subsystem.
+- **Events are facts:** Immutable, causally ordered. Interpretations layer on top. History is never rewritten.
+- **Intent over API calls:** Agents express what they want. The system resolves how.
+- **Cite everything:** Every answer, every action, every decision traces back to source events.
+- **Privacy by default:** Complete tenant isolation. Your data stays yours.
 
 ---
 
 ## What We Measure
 
-- **Speed and quality:** How fast users get accurate answers with sources.
-- **Trust:** How often answers include rationale and verifiable evidence.
-- **Adoption:** How quickly developers integrate and how actively agents use the API.
-- **Coverage:** How much of your team's knowledge is searchable and connected.
+- **Coverage:** How much of your team's operations are observed and connected.
+- **Speed and accuracy:** How fast agents and people get correct, cited answers.
+- **Trust:** How often answers include verifiable evidence and causal rationale.
+- **Adoption:** How quickly teams integrate and how actively agents operate through the layer.
 
 ---
 
 ## What We Don't Do
 
-- **Complex graph queries:** We focus on 1-2 hop relationships (ownership, dependencies), not deep graph traversal.
-- **General analytics:** We're not a data warehouse or BI tool. We're built for memory and context.
-- **Black-box answers:** Every answer must cite its sources. No summarization without verification.
+- **Replace your tools:** We mediate between them. Your team keeps using what they use.
+- **General analytics:** We're an operating layer, not a data warehouse or BI tool.
+- **Black-box decisions:** Every action traces to source events. No summarization without verification.
 
 ---
 
 ## Technical
 
-**Architecture:**
-- Storage: PlanetScale (MySQL) for metadata, S3 for bodies, Redis for cache/queues
-- Indexing: Pinecone for vector search; namespaced per workspace and embedding version
-- Multi-view embeddings: title, snippet, body, summary embedded separately
-
-**Retrieval:**
-- Hybrid pipeline: dense + lexical + graph bias + recency + importance + profile similarity
-- Cross-encoder rerank on top-K for precision
-- Router modes: knowledge | neural | hybrid (internal; API stays simple)
-
-**Memory System:**
-- Chunks: durable document slices for high-recall retrieval
-- Observations: atomic moments (decisions, incidents, highlights) with multi-view embeddings
-- Summaries: clustered rollups by entity/topic/time
-- Profiles: per-entity centroids and descriptors for personalization
-
-**Graph:**
-- Explicit entities and typed relationships
-- Short-hop reasoning (1-2 hops) with bounded, explainable rationale
-- Graph influence tracked per query
-
-**Quality:**
-- Continuous evaluation: recall@k, rerank lift, snippet accuracy, rationale faithfulness
-- Per-workspace calibration: weights, thresholds, decay factors
-- Feedback loops tune ranking over time
+**Observe → Remember → Reason → Act** — a pipeline where events flow in from tools, get stored as a temporal graph with semantic embeddings, are reasoned over by processes and invariants, and result in actions resolved back to tools.


### PR DESCRIPTION
## Summary
- Update SPEC.md and README.md to reflect new direction: "An operating infrastructure between your agents and apps"
- Introduce 3-phase rollout: events (live), memory (coming soon), operating layer (waitlist)
- Remove early access gate — events are available now with GitHub, Vercel, Sentry, Linear

## Test plan
- [ ] Verify SPEC.md reads correctly at high level
- [ ] Verify README.md renders properly on GitHub