### PR TITLE
feat(cli): add login, listen, and logout commands

### DIFF
--- a/apps/console/src/app/api/cli/lib/verify-jwt.ts
+++ b/apps/console/src/app/api/cli/lib/verify-jwt.ts
@@ -1,0 +1,18 @@
+import { verifyToken } from "@clerk/nextjs/server";
+
+export async function verifyCliJwt(
+  req: Request
+): Promise<{ userId: string } | null> {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const token = authHeader.replace("Bearer ", "");
+  try {
+    const payload = await verifyToken(token, {
+      secretKey: process.env.CLERK_SECRET_KEY ?? "",
+    });
+    return { userId: payload.sub };
+  } catch {
+    return null;
+  }
+}

--- a/apps/console/src/app/api/cli/login/route.ts
+++ b/apps/console/src/app/api/cli/login/route.ts
@@ -1,0 +1,28 @@
+// POST /api/cli/login
+// Auth: Clerk JWT in Authorization header (from localhost callback)
+//
+// Response: { organizations: [{ id, slug, name, role }] }
+
+import { clerkClient } from "@clerk/nextjs/server";
+import { verifyCliJwt } from "../lib/verify-jwt";
+
+export async function POST(req: Request) {
+  const session = await verifyCliJwt(req);
+  if (!session) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const clerk = await clerkClient();
+  const memberships = await clerk.users.getOrganizationMembershipList({
+    userId: session.userId,
+  });
+
+  const organizations = memberships.data.map((m) => ({
+    id: m.organization.id,
+    slug: m.organization.slug,
+    name: m.organization.name,
+    role: m.role,
+  }));
+
+  return Response.json({ organizations });
+}

--- a/apps/console/src/app/api/cli/setup/route.ts
+++ b/apps/console/src/app/api/cli/setup/route.ts
@@ -1,0 +1,54 @@
+// POST /api/cli/setup
+// Auth: Clerk JWT in Authorization header
+// Body: { orgId: "org_xxx" }
+//
+// Response: { apiKey, orgId, orgSlug, orgName }
+
+import { clerkClient } from "@clerk/nextjs/server";
+import { generateOrgApiKey, hashApiKey } from "@repo/console-api-key";
+import { db } from "@db/console/client";
+import { orgApiKeys } from "@db/console/schema";
+import { verifyCliJwt } from "../lib/verify-jwt";
+
+export async function POST(req: Request) {
+  const session = await verifyCliJwt(req);
+  if (!session) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json()) as Record<string, unknown>;
+  const { orgId } = body;
+  if (!orgId || typeof orgId !== "string") {
+    return Response.json({ error: "orgId required" }, { status: 400 });
+  }
+
+  // Verify user is a member of this org
+  const clerk = await clerkClient();
+  const memberships = await clerk.users.getOrganizationMembershipList({
+    userId: session.userId,
+  });
+  const membership = memberships.data.find((m) => m.organization.id === orgId);
+  if (!membership) {
+    return Response.json({ error: "not_a_member" }, { status: 403 });
+  }
+
+  // Generate org API key
+  const { key, prefix, suffix } = generateOrgApiKey();
+  const keyHash = await hashApiKey(key);
+
+  await db.insert(orgApiKeys).values({
+    clerkOrgId: orgId,
+    createdByUserId: session.userId,
+    name: "CLI (auto-generated)",
+    keyHash,
+    keyPrefix: prefix,
+    keySuffix: suffix,
+  });
+
+  return Response.json({
+    apiKey: key,
+    orgId: membership.organization.id,
+    orgSlug: membership.organization.slug,
+    orgName: membership.organization.name,
+  });
+}

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -67,7 +67,7 @@ const isOrgPageRoute = createRouteMatcher(["/:slug", "/:slug/(.*)"]);
 
 // v1 API routes - auth handled at route level (API key or session)
 // Must bypass Clerk middleware to allow API key authentication
-const isV1ApiRoute = createRouteMatcher(["/v1/(.*)"]);
+const isV1ApiRoute = createRouteMatcher(["/v1/(.*)", "/api/cli/(.*)"]);
 
 /**
  * Compose middleware with NEMO

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@db/console": "workspace:*",
     "@neondatabase/serverless": "catalog:",
+    "@repo/console-api-key": "workspace:*",
     "@repo/console-validation": "workspace:*",
     "@repo/gateway-types": "workspace:*",
     "@repo/lib": "workspace:*",

--- a/apps/relay/src/app.ts
+++ b/apps/relay/src/app.ts
@@ -9,6 +9,7 @@ import { requestId } from "./middleware/request-id.js";
 import { sentry } from "./middleware/sentry.js";
 import { admin } from "./routes/admin.js";
 import { backfill } from "./routes/backfill.js";
+import { cliRouter } from "./routes/cli.js";
 import { webhooks } from "./routes/webhooks.js";
 import { workflows } from "./routes/workflows.js";
 
@@ -67,5 +68,6 @@ app.route("/api/webhooks", webhooks);
 app.route("/api/admin", admin);
 app.route("/api/backfill", backfill);
 app.route("/api/workflows", workflows);
+app.route("/api/cli", cliRouter);
 
 export default app;

--- a/apps/relay/src/lib/cli-events.ts
+++ b/apps/relay/src/lib/cli-events.ts
@@ -1,0 +1,35 @@
+import { redis } from "@vendor/upstash";
+
+export interface CLIWebhookEvent {
+  provider: string;
+  deliveryId: string;
+  eventType: string;
+  resourceId: string | null;
+  receivedAt: number;
+  payload: unknown;
+}
+
+/**
+ * Publish a webhook event to the CLI event stream for an org.
+ * Fire-and-forget — errors are logged but don't affect webhook processing.
+ */
+export async function publishCLIEvent(
+  orgId: string,
+  event: CLIWebhookEvent
+): Promise<void> {
+  try {
+    const streamKey = `cli:events:${orgId}`;
+    const pipeline = redis.pipeline();
+    pipeline.xadd(streamKey, "*", { data: JSON.stringify(event) }, {
+      trim: {
+        type: "MAXLEN",
+        threshold: 1000,
+        comparison: "~",
+      },
+    });
+    pipeline.expire(streamKey, 3600);
+    await pipeline.exec();
+  } catch (err) {
+    console.error("[cli-events] Failed to publish:", err);
+  }
+}

--- a/apps/relay/src/middleware/cli-auth.ts
+++ b/apps/relay/src/middleware/cli-auth.ts
@@ -1,0 +1,39 @@
+import { createMiddleware } from "hono/factory";
+import { hashApiKey, isValidApiKeyFormat } from "@repo/console-api-key";
+import { db } from "@db/console/client";
+import { orgApiKeys } from "@db/console/schema";
+import { eq, and, isNull, or, gt } from "@vendor/db";
+
+export const cliApiKeyAuth = createMiddleware<{
+  Variables: { cliOrgId: string };
+}>(async (c, next) => {
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return c.json({ error: "Missing Authorization header" }, 401);
+  }
+
+  const apiKey = authHeader.replace("Bearer ", "");
+  if (!isValidApiKeyFormat(apiKey)) {
+    return c.json({ error: "Invalid API key format" }, 401);
+  }
+
+  const keyHash = await hashApiKey(apiKey);
+  const [result] = await db
+    .select({ orgId: orgApiKeys.clerkOrgId })
+    .from(orgApiKeys)
+    .where(
+      and(
+        eq(orgApiKeys.keyHash, keyHash),
+        eq(orgApiKeys.isActive, true),
+        or(isNull(orgApiKeys.expiresAt), gt(orgApiKeys.expiresAt, new Date().toISOString()))
+      )
+    )
+    .limit(1);
+
+  if (!result) {
+    return c.json({ error: "Invalid or expired API key" }, 401);
+  }
+
+  c.set("cliOrgId", result.orgId);
+  await next();
+});

--- a/apps/relay/src/routes/cli.ts
+++ b/apps/relay/src/routes/cli.ts
@@ -1,0 +1,52 @@
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { redis } from "@vendor/upstash";
+import { cliApiKeyAuth } from "../middleware/cli-auth.js";
+
+export const cliRouter = new Hono<{
+  Variables: { cliOrgId: string };
+}>();
+
+const POLL_INTERVAL_MS = 200;
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+cliRouter.get("/stream", cliApiKeyAuth, (c) => {
+  const orgId = c.get("cliOrgId");
+  const lastEventId = c.req.header("Last-Event-ID") ?? "0-0";
+  const streamKey = `cli:events:${orgId}`;
+
+  return streamSSE(c, async (stream) => {
+    let cursor = lastEventId;
+    let heartbeatCounter = 0;
+    const heartbeatEvery = Math.floor(HEARTBEAT_INTERVAL_MS / POLL_INTERVAL_MS);
+
+    await redis.expire(streamKey, 3600);
+
+    while (true) {
+      // Poll Redis stream for new events since cursor
+      const entries = await redis.xrange(streamKey, `(${cursor}`, "+", 50);
+
+      if (Object.keys(entries).length > 0) {
+        for (const [id, fields] of Object.entries(entries)) {
+          const data = (fields as Record<string, string>).data;
+          if (data) {
+            await stream.writeSSE({ data, event: "webhook", id });
+            cursor = id;
+          }
+        }
+      }
+
+      heartbeatCounter++;
+      if (heartbeatCounter >= heartbeatEvery) {
+        await stream.writeSSE({
+          data: JSON.stringify({ type: "ping" }),
+          event: "heartbeat",
+          id: `hb-${Date.now()}`,
+        });
+        heartbeatCounter = 0;
+      }
+
+      await stream.sleep(POLL_INTERVAL_MS);
+    }
+  });
+});

--- a/apps/relay/src/routes/webhooks.ts
+++ b/apps/relay/src/routes/webhooks.ts
@@ -14,6 +14,7 @@ import type { LifecycleVariables } from "../middleware/lifecycle.js";
 import { db } from "@db/console/client";
 import { gwWebhookDeliveries } from "@db/console/schema";
 import { isConsoleFanOutEnabled } from "../lib/flags.js";
+import { publishCLIEvent } from "../lib/cli-events.js";
 
 const webhooks = new Hono<{ Variables: LifecycleVariables }>();
 
@@ -51,6 +52,7 @@ webhooks.post("/:provider", async (c) => {
       orgId: string;
       deliveryId: string;
       eventType: string;
+      resourceId?: string | null;
       payload: unknown;
       receivedAt: number;
     };
@@ -75,6 +77,16 @@ webhooks.post("/:provider", async (c) => {
     } catch {
       return c.json({ error: "invalid_payload" }, 400);
     }
+
+    // Publish to CLI event stream (fire-and-forget)
+    void publishCLIEvent(body.orgId, {
+      provider: provider.name,
+      deliveryId: body.deliveryId,
+      eventType: body.eventType,
+      resourceId: body.resourceId ?? null,
+      receivedAt: body.receivedAt,
+      payload: parsedPayload,
+    });
 
     // Dedup — same Redis SET NX as the standard webhook path.
     // Prevents duplicates from backfill retries and re-runs.
@@ -176,6 +188,23 @@ webhooks.post("/:provider", async (c) => {
     resourceId = provider.extractResourceId(payload);
   } catch {
     return c.json({ error: "extraction_failed", provider: providerName }, 400);
+  }
+
+  // Resolve org for CLI streaming (non-blocking)
+  if (resourceId) {
+    const cached = await redis.hgetall<{ connectionId: string; orgId: string }>(
+      `gw:resource:${provider.name}:${resourceId}`
+    );
+    if (cached?.orgId) {
+      void publishCLIEvent(cached.orgId, {
+        provider: provider.name,
+        deliveryId,
+        eventType,
+        resourceId,
+        receivedAt: Date.now(),
+        payload,
+      });
+    }
   }
 
   // Trigger durable workflow — processing happens asynchronously with

--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -22,12 +22,17 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@inquirer/select": "^4.0.0",
     "@repo/console-chunking": "workspace:*",
     "@repo/console-config": "workspace:*",
     "@repo/console-embed": "workspace:*",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
-    "ora": "^8.1.1"
+    "eventsource-parser": "^3.0.0",
+    "nanoid": "^5.0.0",
+    "open": "^10.1.0",
+    "ora": "^8.1.1",
+    "picocolors": "^1.1.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
@@ -38,6 +43,9 @@
     "prettier": "catalog:",
     "tsup": "^8.5.0",
     "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "prettier": "@repo/prettier-config"
 }

--- a/core/cli/src/bin.ts
+++ b/core/cli/src/bin.ts
@@ -2,21 +2,23 @@
 
 /**
  * CLI binary entrypoint
- * 
+ *
  * Sets up commander and registers all commands.
  */
 
 import { Command } from "commander";
+import { loginCommand } from "./commands/login.js";
+import { logoutCommand } from "./commands/logout.js";
+import { listenCommand } from "./commands/listen.js";
 
 const program = new Command();
-
 program
   .name("lightfast")
-  .description("CLI for Lightfast configuration and testing")
+  .description("Lightfast CLI — connect to your webhook pipeline")
   .version("0.1.0");
 
-// Commands will be registered here in next phase
-// program.addCommand(validateCommand);
-// program.addCommand(testSearchCommand);
+program.addCommand(loginCommand);
+program.addCommand(logoutCommand);
+program.addCommand(listenCommand);
 
 program.parse();

--- a/core/cli/src/commands/listen.ts
+++ b/core/cli/src/commands/listen.ts
@@ -1,0 +1,81 @@
+import { Command } from "commander";
+import pc from "picocolors";
+import { getConfig } from "../lib/config.js";
+import { getStreamUrl } from "../lib/api.js";
+import { connectSSE } from "../lib/sse.js";
+
+interface WebhookEvent {
+  provider: string;
+  deliveryId: string;
+  eventType: string;
+  resourceId: string | null;
+  receivedAt: number;
+  payload: unknown;
+}
+
+export const listenCommand = new Command("listen")
+  .description("Stream real-time webhook events")
+  .option("--json", "Output raw JSON events")
+  .action(async (opts: { json?: boolean }) => {
+    const config = getConfig();
+    if (!config) {
+      console.log(pc.red("  Not logged in. Run `lightfast login` first."));
+      process.exit(1);
+    }
+
+    console.log(
+      `  Listening for events in ${pc.bold(config.orgName)}...`
+    );
+    console.log(pc.dim("  Press Ctrl+C to stop."));
+    console.log();
+
+    const controller = new AbortController();
+    process.on("SIGINT", () => {
+      console.log();
+      controller.abort();
+    });
+
+    await connectSSE({
+      url: getStreamUrl(),
+      token: config.apiKey,
+      signal: controller.signal,
+      onConnect: () => {
+        console.log(pc.green("  Connected."));
+      },
+      onDisconnect: (reason) => {
+        console.log(pc.yellow(`  ${reason}`));
+      },
+      onEvent: (event) => {
+        if (event.event === "heartbeat") return;
+        if (event.event !== "webhook") return;
+
+        const data = JSON.parse(event.data) as WebhookEvent;
+
+        if (opts.json) {
+          console.log(JSON.stringify(data));
+          return;
+        }
+
+        const time = new Date(data.receivedAt).toLocaleTimeString();
+        const provider = colorProvider(data.provider);
+        console.log(
+          `  ${pc.dim(time)}  ${provider}  ${pc.bold(data.eventType)}  ${pc.dim(data.deliveryId.slice(0, 8))}`
+        );
+      },
+    });
+  });
+
+function colorProvider(p: string): string {
+  switch (p) {
+    case "github":
+      return pc.white(p);
+    case "vercel":
+      return pc.cyan(p);
+    case "linear":
+      return pc.magenta(p);
+    case "sentry":
+      return pc.red(p);
+    default:
+      return pc.gray(p);
+  }
+}

--- a/core/cli/src/commands/login.ts
+++ b/core/cli/src/commands/login.ts
@@ -1,0 +1,94 @@
+import { Command } from "commander";
+import open from "open";
+import ora from "ora";
+import pc from "picocolors";
+import select from "@inquirer/select";
+import { startAuthServer } from "../lib/auth-server.js";
+import { listOrganizations, setupOrg } from "../lib/api.js";
+import { saveConfig, getConfig } from "../lib/config.js";
+
+const getBaseUrl = () =>
+  process.env.LIGHTFAST_API_URL ?? "https://lightfast.ai";
+
+export const loginCommand = new Command("login")
+  .description("Authenticate with Lightfast and select an organization")
+  .action(async () => {
+    const existing = getConfig();
+    if (existing && existing.orgName !== "env") {
+      console.log(`  Currently linked to: ${pc.bold(existing.orgName)}`);
+      console.log();
+    }
+
+    // Step 1: Start localhost server
+    const { port, state, waitForToken } = await startAuthServer();
+    const authUrl = `${getBaseUrl()}/cli/auth?port=${port}&state=${encodeURIComponent(state)}`;
+
+    console.log(`  Opening browser to authenticate...`);
+    console.log(pc.dim(`  If it doesn't open, visit: ${authUrl}`));
+    console.log();
+
+    try {
+      await open(authUrl);
+    } catch {
+      // Browser didn't open — user will use the URL manually
+    }
+
+    // Step 2: Wait for JWT callback
+    const authSpinner = ora("Waiting for authentication...").start();
+    const { token: jwt } = await waitForToken();
+    authSpinner.succeed("Authenticated!");
+    console.log();
+
+    // Step 3: List organizations
+    const orgSpinner = ora("Fetching organizations...").start();
+    let orgs: Awaited<ReturnType<typeof listOrganizations>>;
+    try {
+      orgs = await listOrganizations(jwt);
+    } catch {
+      orgSpinner.fail("Failed to fetch organizations. Please try again.");
+      process.exit(1);
+    }
+    orgSpinner.stop();
+
+    if (orgs.length === 0) {
+      console.log(
+        pc.yellow(
+          "  No organizations found. Create one at lightfast.ai first."
+        )
+      );
+      process.exit(1);
+    }
+
+    // Step 4: Interactive org selection
+    const selectedOrgId = await select({
+      message: "Which organization?",
+      choices: orgs.map((org) => ({
+        name: `${org.name} (${org.slug})`,
+        value: org.id,
+      })),
+    });
+
+    // Step 5: Create API key
+    const setupSpinner = ora("Setting up...").start();
+    let result: Awaited<ReturnType<typeof setupOrg>>;
+    try {
+      result = await setupOrg(jwt, selectedOrgId);
+    } catch {
+      setupSpinner.fail(
+        "Session expired. Please run `lightfast login` again."
+      );
+      process.exit(1);
+    }
+    setupSpinner.succeed(`Linked to ${pc.bold(result.orgName)}!`);
+
+    // Step 6: Save config
+    saveConfig({
+      orgId: result.orgId,
+      orgSlug: result.orgSlug,
+      orgName: result.orgName,
+      apiKey: result.apiKey,
+    });
+
+    console.log();
+    console.log(`  Run ${pc.cyan("lightfast listen")} to stream webhook events.`);
+  });

--- a/core/cli/src/commands/logout.ts
+++ b/core/cli/src/commands/logout.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { clearConfig, getConfig } from "../lib/config.js";
+
+export const logoutCommand = new Command("logout")
+  .description("Clear credentials and unlink organization")
+  .action(() => {
+    const config = getConfig();
+    if (!config) {
+      console.log("Not logged in.");
+      return;
+    }
+    clearConfig();
+    console.log("Logged out.");
+  });

--- a/core/cli/src/lib/api.ts
+++ b/core/cli/src/lib/api.ts
@@ -1,0 +1,51 @@
+const getBaseUrl = () =>
+  process.env.LIGHTFAST_API_URL ?? "https://lightfast.ai";
+
+interface Organization {
+  id: string;
+  slug: string;
+  name: string;
+  role: string;
+}
+
+export async function listOrganizations(jwt: string): Promise<Organization[]> {
+  const res = await fetch(`${getBaseUrl()}/api/cli/login`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+
+  if (!res.ok) throw new Error(`Failed to list organizations: ${res.status}`);
+  const data = (await res.json()) as { organizations: Organization[] };
+  return data.organizations;
+}
+
+export async function setupOrg(
+  jwt: string,
+  orgId: string
+): Promise<{ apiKey: string; orgId: string; orgSlug: string; orgName: string }> {
+  const res = await fetch(`${getBaseUrl()}/api/cli/setup`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ orgId }),
+  });
+
+  if (!res.ok) throw new Error(`Failed to setup organization: ${res.status}`);
+  return res.json() as Promise<{
+    apiKey: string;
+    orgId: string;
+    orgSlug: string;
+    orgName: string;
+  }>;
+}
+
+export function getStreamUrl(): string {
+  const base = process.env.LIGHTFAST_API_URL ?? "https://lightfast.ai";
+  return `${base}/services/relay/api/cli/stream`;
+}

--- a/core/cli/src/lib/auth-server.ts
+++ b/core/cli/src/lib/auth-server.ts
@@ -1,0 +1,69 @@
+import { createServer } from "node:http";
+import { randomBytes } from "node:crypto";
+
+interface AuthResult {
+  token: string;
+  state: string;
+}
+
+/**
+ * Starts a localhost HTTP server, waits for the Clerk JWT callback
+ * from the /cli/auth page, then shuts down.
+ */
+export function startAuthServer(): Promise<{
+  port: number;
+  state: string;
+  waitForToken: () => Promise<AuthResult>;
+}> {
+  return new Promise((resolve, reject) => {
+    const state = randomBytes(24).toString("base64url");
+    let resolveToken: ((result: AuthResult) => void) | undefined;
+    const tokenPromise = new Promise<AuthResult>((res) => {
+      resolveToken = res;
+    });
+
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", `http://localhost`);
+
+      if (url.pathname === "/callback") {
+        const token = url.searchParams.get("token");
+        const returnedState = url.searchParams.get("state");
+
+        if (token && returnedState === state) {
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(`
+            <html><body style="display:flex;justify-content:center;align-items:center;height:100vh;font-family:system-ui">
+              <div style="text-align:center">
+                <h2>Authenticated</h2>
+                <p>You can close this window and return to your terminal.</p>
+              </div>
+            </body></html>
+          `);
+          resolveToken?.({ token, state: returnedState });
+          setTimeout(() => server.close(), 500);
+        } else {
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end("Invalid callback parameters");
+        }
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Failed to bind server"));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        state,
+        waitForToken: () => tokenPromise,
+      });
+    });
+
+    server.on("error", reject);
+  });
+}

--- a/core/cli/src/lib/config.ts
+++ b/core/cli/src/lib/config.ts
@@ -1,0 +1,49 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CONFIG_DIR = join(homedir(), ".lightfast");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+export interface LightfastConfig {
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  apiKey: string;
+}
+
+function ensureConfigDir(): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+}
+
+export function getConfig(): LightfastConfig | null {
+  // Env var override for CI/CD
+  const envKey = process.env.LIGHTFAST_API_KEY;
+  if (envKey) {
+    return { orgId: "", orgSlug: "", orgName: "env", apiKey: envKey };
+  }
+
+  if (!existsSync(CONFIG_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, "utf-8")) as LightfastConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function saveConfig(config: LightfastConfig): void {
+  ensureConfigDir();
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+export function clearConfig(): void {
+  if (existsSync(CONFIG_FILE)) unlinkSync(CONFIG_FILE);
+}

--- a/core/cli/src/lib/sse.ts
+++ b/core/cli/src/lib/sse.ts
@@ -1,0 +1,72 @@
+import { EventSourceParserStream } from "eventsource-parser/stream";
+
+interface SSEEvent {
+  event: string;
+  data: string;
+  id?: string;
+}
+
+interface ConnectOptions {
+  url: string;
+  token: string;
+  onEvent: (event: SSEEvent) => void;
+  onConnect: () => void;
+  onDisconnect: (reason: string) => void;
+  signal?: AbortSignal;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function connectSSE(opts: ConnectOptions): Promise<void> {
+  let lastEventId = "";
+  let retryMs = 1000;
+
+  while (!opts.signal?.aborted) {
+    try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${opts.token}`,
+        Accept: "text/event-stream",
+      };
+      if (lastEventId) headers["Last-Event-ID"] = lastEventId;
+
+      const response = await fetch(opts.url, { headers, signal: opts.signal });
+      if (!response.ok) {
+        if (response.status === 401) {
+          opts.onDisconnect(
+            "API key invalid or expired. Run `lightfast login` again."
+          );
+          return;
+        }
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      retryMs = 1000;
+      opts.onConnect();
+
+      if (!response.body) throw new Error("No response body");
+      const stream = response
+        .body.pipeThrough(new TextDecoderStream())
+        .pipeThrough(new EventSourceParserStream());
+
+      for await (const event of stream) {
+        if (opts.signal?.aborted) break;
+        if (event.id) lastEventId = event.id;
+        opts.onEvent({
+          event: event.event ?? "message",
+          data: event.data,
+          id: event.id,
+        });
+      }
+
+      // Stream ended (Vercel 300s limit) — reconnect
+      opts.onDisconnect("Reconnecting...");
+    } catch {
+      if (opts.signal?.aborted) return;
+      opts.onDisconnect(`Connection lost. Reconnecting in ${retryMs / 1000}s...`);
+      await sleep(retryMs);
+      retryMs = Math.min(retryMs * 2, 30_000);
+    }
+  }
+}

--- a/core/cli/turbo.json
+++ b/core/cli/turbo.json
@@ -1,5 +1,9 @@
 {
   "extends": ["//"],
   "tags": ["core"],
-  "tasks": {}
+  "tasks": {
+    "build": {
+      "env": ["LIGHTFAST_API_URL", "LIGHTFAST_API_KEY"]
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,6 +1533,9 @@ importers:
       '@neondatabase/serverless':
         specifier: 'catalog:'
         version: 1.0.2
+      '@repo/console-api-key':
+        specifier: workspace:*
+        version: link:../../packages/console-api-key
       '@repo/console-validation':
         specifier: workspace:*
         version: link:../../packages/console-validation
@@ -1896,6 +1899,9 @@ importers:
 
   core/cli:
     dependencies:
+      '@inquirer/select':
+        specifier: ^4.0.0
+        version: 4.4.2(@types/node@20.19.22)
       '@repo/console-chunking':
         specifier: workspace:*
         version: link:../../packages/console-chunking
@@ -1911,9 +1917,21 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      eventsource-parser:
+        specifier: ^3.0.0
+        version: 3.0.6
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.6
+      open:
+        specifier: ^10.1.0
+        version: 10.2.0
       ora:
         specifier: ^8.1.1
         version: 8.2.0
+      picocolors:
+        specifier: ^1.1.0
+        version: 1.1.1
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -7468,6 +7486,19 @@ packages:
       '@sentry/types': '>=8.0.0'
       inngest: '>=3.42.3'
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.2':
     resolution: {integrity: sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==}
     engines: {node: '>=18'}
@@ -7480,6 +7511,24 @@ packages:
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -12390,6 +12439,10 @@ packages:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -13187,6 +13240,14 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
@@ -13197,6 +13258,10 @@ packages:
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -15125,6 +15190,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -15162,6 +15232,11 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -15292,6 +15367,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -16252,6 +16331,10 @@ packages:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -16559,6 +16642,10 @@ packages:
   onnxruntime-node@1.21.0:
     resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
     os: [win32, darwin, linux]
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -17601,6 +17688,10 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -19246,6 +19337,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xdg-app-paths@5.1.0:
     resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
@@ -21813,6 +21908,21 @@ snapshots:
       '@sentry/types': 10.20.0
       inngest: 3.44.3(@vercel/node@5.6.9(encoding@0.1.13)(rollup@4.59.0))(encoding@0.1.13)(express@5.2.1)(h3@1.15.4)(hono@4.12.3)(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)(zod@3.25.76)
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/core@10.3.2(@types/node@20.19.22)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.19.22)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.22
+
   '@inquirer/external-editor@1.0.2(@types/node@20.19.22)':
     dependencies:
       chardet: 2.1.0
@@ -21828,6 +21938,20 @@ snapshots:
       '@types/node': 25.3.3
 
   '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/select@4.4.2(@types/node@20.19.22)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@20.19.22)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.19.22)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.22
+
+  '@inquirer/type@3.0.10(@types/node@20.19.22)':
+    optionalDependencies:
+      '@types/node': 20.19.22
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -28059,6 +28183,10 @@ snapshots:
       node-gyp-build: 4.8.4
     optional: true
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bundle-require@5.1.0(esbuild@0.25.12):
     dependencies:
       esbuild: 0.25.12
@@ -28877,6 +29005,13 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
@@ -28888,6 +29023,8 @@ snapshots:
       gopd: 1.2.0
 
   define-lazy-prop@2.0.0: {}
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -31378,6 +31515,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
@@ -31409,6 +31548,10 @@ snapshots:
   is-hexadecimal@1.0.4: {}
 
   is-hexadecimal@2.0.1: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@1.0.0: {}
 
@@ -31511,6 +31654,10 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@2.0.5: {}
 
@@ -32724,6 +32871,8 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
+  mute-stream@2.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -33017,6 +33166,13 @@ snapshots:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
       tar: 7.5.9
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   open@8.4.2:
     dependencies:
@@ -34296,6 +34452,8 @@ snapshots:
       - supports-color
 
   rrweb-cssom@0.8.0: {}
+
+  run-applescript@7.1.0: {}
 
   run-async@2.4.1: {}
 
@@ -36774,6 +36932,10 @@ snapshots:
   ws@8.18.3(bufferutil@4.1.0):
     optionalDependencies:
       bufferutil: 4.1.0
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xdg-app-paths@5.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `lightfast login` — browser-based OAuth flow reusing existing `/cli/auth` page, interactive org selection in terminal, org API key creation and storage at `~/.lightfast/config.json`
- Add `lightfast listen` — real-time webhook event streaming via SSE from relay service with auto-reconnect, `Last-Event-ID` support, and `--json` output mode
- Add `lightfast logout` — clears local credentials

## Changes

**Console (server-side)**
- Add `/api/cli/login` route — verifies Clerk JWT, returns user's organizations
- Add `/api/cli/setup` route — verifies JWT + org membership, creates org API key
- Add `/api/cli/(.*)` to middleware bypass for custom auth handling

**Relay (server-side)**
- Publish webhook events to Redis Stream `cli:events:{orgId}` on receipt (fire-and-forget)
- Add SSE endpoint `GET /api/cli/stream` with org API key auth, Redis polling, heartbeat
- Add `cli-auth` middleware for API key verification via `@repo/console-api-key`

**CLI (client-side)**
- Config management (`~/.lightfast/config.json`, `LIGHTFAST_API_KEY` env override)
- Localhost callback server for browser OAuth flow
- SSE client with exponential backoff reconnection
- 5 new dependencies: `open`, `picocolors`, `ora`, `@inquirer/select`, `eventsource-parser`

## Test plan

- [ ] `lightfast login` → browser opens → sign in → pick org → "Linked to {org}!"
- [ ] `lightfast listen` → "Connected." → trigger webhook → event in terminal
- [ ] `lightfast listen --json` → raw JSON output
- [ ] Kill relay during listen → auto-reconnect
- [ ] `lightfast logout` → config cleared
- [ ] `LIGHTFAST_API_KEY=sk-lf-xxx lightfast listen` works without login

🤖 Generated with [Claude Code](https://claude.com/claude-code)