### PR TITLE
chore(auth): remove 7 unused dependencies

### DIFF
--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -15,9 +15,7 @@ import { env } from "~/env";
 let config: NextConfig = withBetterStack(
 	mergeNextConfig(vendorConfig, {
 		transpilePackages: [
-			"@repo/og",
 			"@repo/ui",
-			"@repo/url-utils",
 			"@vendor/seo",
 			"@vendor/observability",
 			"@vendor/next",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -15,21 +15,16 @@
     "with-env": "dotenv -e ./.vercel/.env.development.local --"
   },
   "dependencies": {
-    "@clerk/elements": "catalog:",
     "@clerk/nextjs": "catalog:",
     "@clerk/shared": "catalog:",
-    "@clerk/themes": "catalog:",
     "@clerk/types": "catalog:",
     "@hookform/resolvers": "^3.10.0",
-    "@repo/og": "workspace:*",
     "@repo/ui": "workspace:*",
-    "@repo/url-utils": "workspace:*",
     "@rescale/nemo": "^2.0.2",
     "@sentry/nextjs": "catalog:",
     "@t3-oss/env-nextjs": "catalog:",
     "@vendor/analytics": "workspace:*",
     "@vendor/clerk": "workspace:*",
-    "@vendor/db": "workspace:*",
     "@vendor/forms": "workspace:*",
     "@vendor/next": "workspace:*",
     "@vendor/observability": "workspace:*",
@@ -39,11 +34,9 @@
     "@vercel/related-projects": "catalog:",
     "geist": "catalog:",
     "lucide-react": "catalog:",
-    "neverthrow": "catalog:",
     "next": "catalog:next16",
     "react": "19.2.1",
     "react-dom": "19.2.1",
-    "svix": "^1.62.0",
     "zod": "catalog:zod3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ catalogs:
     '@clerk/shared':
       specifier: 3.45.0
       version: 3.45.0
-    '@clerk/themes':
-      specifier: 2.4.52
-      version: 2.4.52
     '@clerk/types':
       specifier: 4.101.15
       version: 4.101.15
@@ -413,33 +410,21 @@ importers:
 
   apps/auth:
     dependencies:
-      '@clerk/elements':
-        specifier: 'catalog:'
-        version: 0.24.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/nextjs':
         specifier: 'catalog:'
         version: 6.37.4(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/shared':
         specifier: 'catalog:'
         version: 3.45.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@clerk/themes':
-        specifier: 'catalog:'
-        version: 2.4.52(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/types':
         specifier: 'catalog:'
         version: 4.101.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.71.1(react@19.2.1))
-      '@repo/og':
-        specifier: workspace:*
-        version: link:../../packages/og
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      '@repo/url-utils':
-        specifier: workspace:*
-        version: link:../../packages/url-utils
       '@rescale/nemo':
         specifier: ^2.0.2
         version: 2.0.2(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
@@ -455,9 +440,6 @@ importers:
       '@vendor/clerk':
         specifier: workspace:*
         version: link:../../vendor/clerk
-      '@vendor/db':
-        specifier: workspace:*
-        version: link:../../vendor/db
       '@vendor/forms':
         specifier: workspace:*
         version: link:../../vendor/forms
@@ -485,9 +467,6 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 0.451.0(react@19.2.1)
-      neverthrow:
-        specifier: 'catalog:'
-        version: 8.2.0
       next:
         specifier: catalog:next16
         version: 16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -497,9 +476,6 @@ importers:
       react-dom:
         specifier: ^19.2.1
         version: 19.2.1(react@19.2.1)
-      svix:
-        specifier: ^1.62.0
-        version: 1.77.0
       zod:
         specifier: catalog:zod3
         version: 3.25.76
@@ -2453,6 +2429,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/console-providers: {}
+
   packages/console-remotion:
     dependencies:
       '@remotion/bundler':
@@ -2796,6 +2774,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/console-upstash-realtime: {}
+
   packages/console-validation:
     dependencies:
       '@repo/console-reserved-names':
@@ -2943,6 +2923,8 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/gateway-service-clients: {}
 
   packages/gateway-types:
     devDependencies:
@@ -4229,6 +4211,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  vendor/upstash-realtime: {}
+
   vendor/upstash-workflow:
     dependencies:
       '@t3-oss/env-nextjs':
@@ -4986,10 +4970,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  '@clerk/themes@2.4.52':
-    resolution: {integrity: sha512-27UWgn+QKnUE02yu9MZ6UgTYg7k5y7qig76WFwIviVEFxXYLk0o4ttqvDjvJKTfe2UMCkZLUmyglqGErlvvPzQ==}
-    engines: {node: '>=18.17.0'}
 
   '@clerk/types@4.101.15':
     resolution: {integrity: sha512-Tb9FYlBQcUkyeX4ILMpNPzvZPwokk/gsDlWOayV+PQKcWvhWD2+xZYrXGv4eaxqIcbXLAMaUo8Gal+lVjQFDeg==}
@@ -18845,14 +18825,6 @@ snapshots:
     optionalDependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-
-  '@clerk/themes@2.4.52(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
-    dependencies:
-      '@clerk/shared': 3.45.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@clerk/types@4.101.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:


### PR DESCRIPTION
## Summary
- Remove 7 unused dependencies from `apps/auth` (declared but never imported):
  - `@clerk/elements`, `@clerk/themes`
  - `@repo/og`, `@repo/url-utils` (also cleaned from `transpilePackages` in next.config.ts)
  - `@vendor/db`, `neverthrow`, `svix`

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm --filter @lightfast/auth typecheck` passes
- [ ] `pnpm build:auth` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)