### PR TITLE
chore(hono services): remove 5 unused dependencies

### DIFF
--- a/apps/backfill/package.json
+++ b/apps/backfill/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@repo/console-backfill": "workspace:*",
-    "@repo/gateway-types": "workspace:*",
     "@repo/lib": "workspace:*",
     "@t3-oss/env-core": "catalog:",
     "@vendor/inngest": "workspace:*",

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -23,7 +23,6 @@
     "@repo/console-linear": "workspace:*",
     "@repo/console-octokit-github": "workspace:*",
     "@repo/console-sentry": "workspace:*",
-    "@repo/console-validation": "workspace:*",
     "@repo/console-vercel": "workspace:*",
     "@repo/gateway-types": "workspace:*",
     "@repo/lib": "workspace:*",
@@ -36,7 +35,6 @@
     "@vendor/upstash-workflow": "workspace:*",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "postgres": "catalog:",
     "zod": "catalog:zod3"
   },
   "devDependencies": {

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -20,8 +20,6 @@
   },
   "dependencies": {
     "@db/console": "workspace:*",
-    "@neondatabase/serverless": "catalog:",
-    "@repo/console-validation": "workspace:*",
     "@repo/gateway-types": "workspace:*",
     "@repo/lib": "workspace:*",
     "@t3-oss/env-core": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,6 @@ catalogs:
     neverthrow:
       specifier: ^8.2.0
       version: 8.2.0
-    postgres:
-      specifier: ^3.4.5
-      version: 3.4.7
     prettier:
       specifier: ^3.5.3
       version: 3.6.2
@@ -534,9 +531,6 @@ importers:
       '@repo/console-backfill':
         specifier: workspace:*
         version: link:../../packages/console-backfill
-      '@repo/gateway-types':
-        specifier: workspace:*
-        version: link:../../packages/gateway-types
       '@repo/lib':
         specifier: workspace:*
         version: link:../../packages/lib
@@ -1050,9 +1044,6 @@ importers:
       '@repo/console-sentry':
         specifier: workspace:*
         version: link:../../packages/console-sentry
-      '@repo/console-validation':
-        specifier: workspace:*
-        version: link:../../packages/console-validation
       '@repo/console-vercel':
         specifier: workspace:*
         version: link:../../packages/console-vercel
@@ -1089,9 +1080,6 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.3
-      postgres:
-        specifier: 'catalog:'
-        version: 3.4.7
       zod:
         specifier: catalog:zod3
         version: 3.25.76
@@ -1141,12 +1129,6 @@ importers:
       '@db/console':
         specifier: workspace:*
         version: link:../../db/console
-      '@neondatabase/serverless':
-        specifier: 'catalog:'
-        version: 1.0.2
-      '@repo/console-validation':
-        specifier: workspace:*
-        version: link:../../packages/console-validation
       '@repo/gateway-types':
         specifier: workspace:*
         version: link:../../packages/gateway-types
@@ -30783,7 +30765,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  postgres@3.4.7: {}
+  postgres@3.4.7:
+    optional: true
 
   posthog-js@1.335.5:
     dependencies:


### PR DESCRIPTION
## Summary
- **backfill**: remove `@repo/gateway-types`
- **relay**: remove `@neondatabase/serverless`, `@repo/console-validation`
- **gateway**: remove `@repo/console-validation`, `postgres`

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm --filter @lightfast/backfill typecheck` passes
- [x] `pnpm --filter @lightfast/gateway typecheck` passes
- [x] Relay typecheck errors are pre-existing (vendor dist files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)