### PR TITLE
chore: remove 24 unused deps from packages/*

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -34,21 +34,14 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "2.0.4",
-    "@ai-sdk/google": "^1.2.17",
-    "@ai-sdk/google-vertex": "^2.2.21",
     "@ai-sdk/openai": "^0.0.70",
-    "@ai-sdk/react": "2.0.15",
     "@fal-ai/client": "^1.2.0",
     "@fal-ai/server-proxy": "^1.1.1",
-    "@openrouter/ai-sdk-provider": "^0.4.5",
     "@t3-oss/env-core": "catalog:",
     "@t3-oss/env-nextjs": "catalog:",
     "ai": "5.0.52",
     "autoevals": "^0.0.103",
     "braintrust": "^0.2.1",
-    "exa-js": "^1.6.13",
-    "resumable-stream": "^2.0.0",
-    "voyage-ai-provider": "^1.0.0",
     "zod": "catalog:zod3"
   },
   "devDependencies": {

--- a/packages/cms-workflows/package.json
+++ b/packages/cms-workflows/package.json
@@ -21,14 +21,12 @@
     "publish:changelog": "pnpm with-env tsx scripts/publish-changelog.ts"
   },
   "dependencies": {
-    "@repo/ai": "workspace:*",
     "@vendor/cms": "workspace:*",
     "basehub": "^9.5.2",
     "gray-matter": "^4.0.3",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
-    "unified": "^11.0.0",
-    "zod": "catalog:zod3"
+    "unified": "^11.0.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-ai/package.json
+++ b/packages/console-ai/package.json
@@ -33,7 +33,6 @@
     "@lightfastai/ai-sdk": "workspace:*",
     "@repo/console-ai-types": "workspace:*",
     "@repo/console-types": "workspace:*",
-    "ai": "catalog:",
     "zod": "catalog:zod3"
   },
   "devDependencies": {

--- a/packages/console-api-key/package.json
+++ b/packages/console-api-key/package.json
@@ -21,10 +21,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@db/console": "workspace:*",
-    "@repo/lib": "workspace:*",
-    "@trpc/server": "catalog:",
-    "zod": "catalog:zod3"
+    "@repo/lib": "workspace:*"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-auth-middleware/package.json
+++ b/packages/console-auth-middleware/package.json
@@ -38,8 +38,7 @@
     "@repo/console-clerk-cache": "workspace:*",
     "@trpc/server": "catalog:",
     "@vendor/clerk": "workspace:*",
-    "drizzle-orm": "catalog:",
-    "zod": "catalog:zod3"
+    "drizzle-orm": "catalog:"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/console-chunking/package.json
+++ b/packages/console-chunking/package.json
@@ -22,7 +22,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@repo/console-types": "workspace:*",
     "gray-matter": "^4.0.3",
     "js-tiktoken": "^1.0.15"
   },

--- a/packages/console-clerk-m2m/package.json
+++ b/packages/console-clerk-m2m/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@clerk/backend": "catalog:",
     "@t3-oss/env-nextjs": "catalog:",
-    "@vendor/clerk": "workspace:*",
     "zod": "catalog:zod3"
   },
   "devDependencies": {

--- a/packages/console-config/package.json
+++ b/packages/console-config/package.json
@@ -22,7 +22,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@db/console": "workspace:*",
     "@repo/console-validation": "workspace:*",
     "fast-glob": "^3.3.2",
     "neverthrow": "catalog:",

--- a/packages/console-embed/package.json
+++ b/packages/console-embed/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@repo/console-config": "workspace:*",
-    "@repo/console-types": "workspace:*",
     "@repo/console-validation": "workspace:*",
     "@vendor/embed": "workspace:*"
   },

--- a/packages/console-octokit-github/package.json
+++ b/packages/console-octokit-github/package.json
@@ -31,7 +31,6 @@
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/webhooks-types": "^7.6.1",
     "@t3-oss/env-nextjs": "catalog:",
-    "minimatch": "^10.2.3",
     "octokit": "^5.0.3",
     "zod": "catalog:zod3"
   },

--- a/packages/console-rerank/package.json
+++ b/packages/console-rerank/package.json
@@ -20,8 +20,6 @@
   },
   "dependencies": {
     "@ai-sdk/gateway": "catalog:",
-    "@repo/console-config": "workspace:*",
-    "@vendor/embed": "workspace:*",
     "@vendor/observability": "workspace:*",
     "ai": "catalog:",
     "cohere-ai": "^7.19.0",

--- a/packages/console-webhooks/package.json
+++ b/packages/console-webhooks/package.json
@@ -29,9 +29,7 @@
     "@db/console": "workspace:*",
     "@octokit/webhooks-types": "^7.6.1",
     "@repo/console-types": "workspace:*",
-    "@repo/console-validation": "workspace:*",
-    "@repo/lib": "workspace:*",
-    "zod": "catalog:zod3"
+    "@repo/console-validation": "workspace:*"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,7 +49,6 @@
 		"typescript": "catalog:"
 	},
 	"dependencies": {
-		"@hookform/resolvers": "^3.10.0",
 		"@radix-ui/react-accordion": "^1.2.11",
 		"@radix-ui/react-alert-dialog": "^1.1.14",
 		"@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -80,7 +79,6 @@
 		"@radix-ui/react-use-controllable-state": "^1.2.2",
 		"@tanstack/react-table": "^8.21.3",
 		"@vendor/forms": "workspace:*",
-		"@vendor/observability": "workspace:*",
 		"ai": "catalog:",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
@@ -90,9 +88,7 @@
 		"geist": "catalog:",
 		"hast-util-to-jsx-runtime": "^2.3.6",
 		"input-otp": "^1.4.2",
-		"isomorphic-dompurify": "^2.26.0",
 		"lucide-react": "catalog:",
-		"mermaid": "^11.11.0",
 		"nanoid": "catalog:",
 		"next-themes": "^0.4.6",
 		"react": "19.2.1",
@@ -105,7 +101,6 @@
 		"sonner": "^2.0.6",
 		"streamdown": "^1.2.0",
 		"tailwind-merge": "^3.3.1",
-		"tailwindcss-animate": "^1.0.7",
 		"tw-animate-css": "^1.3.7",
 		"use-stick-to-bottom": "1.1.1",
 		"vaul": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ importers:
         version: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.3.3)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.3.3)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   api/console:
     dependencies:
@@ -370,7 +370,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   apps/auth:
     dependencies:
@@ -555,7 +555,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   apps/console:
     dependencies:
@@ -802,7 +802,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   apps/docs:
     dependencies:
@@ -1020,7 +1020,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   apps/relay:
     dependencies:
@@ -1102,7 +1102,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   apps/www:
     dependencies:
@@ -1425,7 +1425,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   db/console:
     dependencies:
@@ -1572,27 +1572,15 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 2.0.4
         version: 2.0.4(zod@3.25.76)
-      '@ai-sdk/google':
-        specifier: ^1.2.17
-        version: 1.2.22(zod@3.25.76)
-      '@ai-sdk/google-vertex':
-        specifier: ^2.2.21
-        version: 2.2.27(encoding@0.1.13)(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^0.0.70
         version: 0.0.70(zod@3.25.76)
-      '@ai-sdk/react':
-        specifier: 2.0.15
-        version: 2.0.15(react@19.2.1)(zod@3.25.76)
       '@fal-ai/client':
         specifier: ^1.2.0
         version: 1.7.0
       '@fal-ai/server-proxy':
         specifier: ^1.1.1
         version: 1.1.1(express@4.21.2)(hono@4.12.3)(next@16.1.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@openrouter/ai-sdk-provider':
-        specifier: ^0.4.5
-        version: 0.4.6(zod@3.25.76)
       '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.10(typescript@5.9.3)(zod@3.25.76)
@@ -1608,15 +1596,6 @@ importers:
       braintrust:
         specifier: ^0.2.1
         version: 0.2.6(@aws-sdk/credential-provider-web-identity@3.928.0)(zod@3.25.76)
-      exa-js:
-        specifier: ^1.6.13
-        version: 1.10.2(encoding@0.1.13)(ws@8.18.3(bufferutil@4.1.0))
-      resumable-stream:
-        specifier: ^2.0.0
-        version: 2.2.8
-      voyage-ai-provider:
-        specifier: ^1.0.0
-        version: 1.1.1(zod@3.25.76)
       zod:
         specifier: catalog:zod3
         version: 3.25.76
@@ -1642,9 +1621,6 @@ importers:
 
   packages/cms-workflows:
     dependencies:
-      '@repo/ai':
-        specifier: workspace:*
-        version: link:../ai
       '@vendor/cms':
         specifier: workspace:*
         version: link:../../vendor/cms
@@ -1663,9 +1639,6 @@ importers:
       unified:
         specifier: ^11.0.0
         version: 11.0.5
-      zod:
-        specifier: catalog:zod3
-        version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1709,9 +1682,6 @@ importers:
       '@repo/console-types':
         specifier: workspace:*
         version: link:../console-types
-      ai:
-        specifier: 'catalog:'
-        version: 5.0.52(zod@3.25.76)
       zod:
         specifier: catalog:zod3
         version: 3.25.76
@@ -1774,18 +1744,9 @@ importers:
 
   packages/console-api-key:
     dependencies:
-      '@db/console':
-        specifier: workspace:*
-        version: link:../../db/console
       '@repo/lib':
         specifier: workspace:*
         version: link:../lib
-      '@trpc/server':
-        specifier: 'catalog:'
-        version: 11.11.0(typescript@5.9.3)
-      zod:
-        specifier: catalog:zod3
-        version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1826,9 +1787,6 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.43.1(@cloudflare/workers-types@4.20260301.1)(@electric-sql/pglite@0.2.17)(@libsql/client@0.14.0(bufferutil@4.1.0))(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/pg@8.15.6)(postgres@3.4.7)
-      zod:
-        specifier: catalog:zod3
-        version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1887,13 +1845,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/console-chunking:
     dependencies:
-      '@repo/console-types':
-        specifier: workspace:*
-        version: link:../console-types
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1968,9 +1923,6 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.10(typescript@5.9.3)(zod@3.25.76)
-      '@vendor/clerk':
-        specifier: workspace:*
-        version: link:../../vendor/clerk
       zod:
         specifier: catalog:zod3
         version: 3.25.76
@@ -1999,9 +1951,6 @@ importers:
 
   packages/console-config:
     dependencies:
-      '@db/console':
-        specifier: workspace:*
-        version: link:../../db/console
       '@repo/console-validation':
         specifier: workspace:*
         version: link:../console-validation
@@ -2048,9 +1997,6 @@ importers:
       '@repo/console-config':
         specifier: workspace:*
         version: link:../console-config
-      '@repo/console-types':
-        specifier: workspace:*
-        version: link:../console-types
       '@repo/console-validation':
         specifier: workspace:*
         version: link:../console-validation
@@ -2131,9 +2077,6 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.10(typescript@5.9.3)(zod@3.25.76)
-      minimatch:
-        specifier: ^10.2.3
-        version: 10.2.4
       octokit:
         specifier: ^5.0.3
         version: 5.0.4
@@ -2237,8 +2180,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  packages/console-providers: {}
-
   packages/console-remotion:
     dependencies:
       '@remotion/bundler':
@@ -2326,12 +2267,6 @@ importers:
       '@ai-sdk/gateway':
         specifier: 'catalog:'
         version: 1.0.7(zod@3.25.76)
-      '@repo/console-config':
-        specifier: workspace:*
-        version: link:../console-config
-      '@vendor/embed':
-        specifier: workspace:*
-        version: link:../../vendor/embed
       '@vendor/observability':
         specifier: workspace:*
         version: link:../../vendor/observability
@@ -2582,8 +2517,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  packages/console-upstash-realtime: {}
-
   packages/console-validation:
     dependencies:
       '@repo/console-reserved-names':
@@ -2666,12 +2599,6 @@ importers:
       '@repo/console-validation':
         specifier: workspace:*
         version: link:../console-validation
-      '@repo/lib':
-        specifier: workspace:*
-        version: link:../lib
-      zod:
-        specifier: catalog:zod3
-        version: 3.25.76
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -2731,8 +2658,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-
-  packages/gateway-service-clients: {}
 
   packages/gateway-types:
     devDependencies:
@@ -2825,7 +2750,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/lib:
     dependencies:
@@ -2865,7 +2790,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/og:
     dependencies:
@@ -2959,9 +2884,6 @@ importers:
 
   packages/ui:
     dependencies:
-      '@hookform/resolvers':
-        specifier: ^3.10.0
-        version: 3.10.0(react-hook-form@7.71.1(react@19.2.1))
       '@radix-ui/react-accordion':
         specifier: ^1.2.11
         version: 1.2.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3052,9 +2974,6 @@ importers:
       '@vendor/forms':
         specifier: workspace:*
         version: link:../../vendor/forms
-      '@vendor/observability':
-        specifier: workspace:*
-        version: link:../../vendor/observability
       ai:
         specifier: 'catalog:'
         version: 5.0.52(zod@3.25.76)
@@ -3082,15 +3001,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      isomorphic-dompurify:
-        specifier: ^2.26.0
-        version: 2.29.0(bufferutil@4.1.0)(postcss@8.5.6)
       lucide-react:
         specifier: 'catalog:'
         version: 0.451.0(react@19.2.1)
-      mermaid:
-        specifier: ^11.11.0
-        version: 11.12.0
       nanoid:
         specifier: 'catalog:'
         version: 5.1.6
@@ -3127,9 +3040,6 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@4.1.11)
       tw-animate-css:
         specifier: ^1.3.7
         version: 1.4.0
@@ -3977,8 +3887,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  vendor/upstash-realtime: {}
-
   vendor/upstash-workflow:
     dependencies:
       '@t3-oss/env-nextjs':
@@ -4064,12 +3972,6 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/anthropic@1.2.12':
-    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-
   '@ai-sdk/anthropic@2.0.4':
     resolution: {integrity: sha512-ii2bZEUPwBitUiK1dpX+HsOarcDGY71G9TVdSJqbfXSVqa+speJNZ8PA/bjuNMml0NyX8VxNsaMg3SwBUCZspA==}
     engines: {node: '>=18'}
@@ -4088,18 +3990,6 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  '@ai-sdk/google-vertex@2.2.27':
-    resolution: {integrity: sha512-iDGX/2yrU4OOL1p/ENpfl3MWxuqp9/bE22Z8Ip4DtLCUx6ismUNtrKO357igM1/3jrM6t9C6egCPniHqBsHOJA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-
-  '@ai-sdk/google@1.2.22':
-    resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-
   '@ai-sdk/openai@0.0.70':
     resolution: {integrity: sha512-RYLfiIG093bq6a3BJe2uUTL51zjxnDQLo4qHlNk3PLKSOxbb9Ap/vmhCLnPKo+flqFhqiD6YE9wuNZv++reHaA==}
     engines: {node: '>=18'}
@@ -4114,15 +4004,6 @@ packages:
 
   '@ai-sdk/provider-utils@1.0.22':
     resolution: {integrity: sha512-YHK2rpj++wnLVc9vPGzGFP3Pjeld2MwhKinetA0zKXOoHAT/Jit5O8kZsxcSlJPu9wvcGT1UGZEjZrtO7PfFOQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
-  '@ai-sdk/provider-utils@2.1.10':
-    resolution: {integrity: sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -4150,10 +4031,6 @@ packages:
 
   '@ai-sdk/provider@0.0.26':
     resolution: {integrity: sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/provider@1.0.9':
-    resolution: {integrity: sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@1.1.3':
@@ -6530,12 +6407,6 @@ packages:
   '@octokit/webhooks@14.1.3':
     resolution: {integrity: sha512-gcK4FNaROM9NjA0mvyfXl0KPusk7a1BeA8ITlYEZVQCXF5gcETTd4yhAU0Kjzd8mXwYHppzJBWgdBVpIR9wUcQ==}
     engines: {node: '>= 20'}
-
-  '@openrouter/ai-sdk-provider@0.4.6':
-    resolution: {integrity: sha512-oUa8xtssyUhiKEU/aW662lsZ0HUvIUTRk8vVIF3Ha3KI/DnqX54zmVIuzYnaDpermqhy18CHqblAY4dDt1JW3g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -10646,9 +10517,6 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -11498,10 +11366,6 @@ packages:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
 
-  dotenv@16.4.7:
-    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
-    engines: {node: '>=12'}
-
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -11618,9 +11482,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   edge-runtime@2.5.9:
     resolution: {integrity: sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==}
@@ -12082,9 +11943,6 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
-
-  exa-js@1.10.2:
-    resolution: {integrity: sha512-nObBipoXKL5uL6Dc8Q3c9GA4xEfunQMdGGqtcCkQSNilzR6AExyVkBxTdpWqC20jKa3/dvXu6otXQLaRyZNqGw==}
 
   execa@3.2.0:
     resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
@@ -12681,10 +12539,6 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
-  google-auth-library@9.15.1:
-    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
-    engines: {node: '>=14'}
-
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
     engines: {node: '>=14'}
@@ -12710,10 +12564,6 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
-
-  gtoken@7.1.0:
-    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
-    engines: {node: '>=14.0.0'}
 
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -13354,10 +13204,6 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isomorphic-dompurify@2.29.0:
-    resolution: {integrity: sha512-Bgw5M9GMsuGeGSRpS81gk68t9/+r3AwuJJ5WnSxZK+tuazDodlRgmwz4ItMAfNYDgiNaizREYeiefkFQWkG7ow==}
-    engines: {node: '>=18'}
-
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -13536,12 +13382,6 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
-
-  jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
@@ -14512,18 +14352,6 @@ packages:
   openai@4.47.1:
     resolution: {integrity: sha512-WWSxhC/69ZhYWxH/OBsLEirIjUcfpQ5+ihkXKp06hmeYXgBBIUCa9IptMzYx6NdkiOCsSGYCnTIsxaic3AjRCQ==}
     hasBin: true
-
-  openai@5.23.2:
-    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
 
   openapi-sampler@1.6.2:
     resolution: {integrity: sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg==}
@@ -16035,11 +15863,6 @@ packages:
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
-  tailwindcss-animate@1.0.7:
-    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
-
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
 
@@ -16796,14 +16619,6 @@ packages:
       jsdom:
         optional: true
 
-  voyage-ai-provider@1.1.1:
-    resolution: {integrity: sha512-hejcOjAZPU+wcJUk4RvFdGzMJC/aVqJ6odlKDI12xVUAPZCtEsecKagQ1OZr4vvNUawtot4/ag4U/cMrnse0fg==}
-    peerDependencies:
-      zod: ^3.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -17155,12 +16970,6 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-
   '@ai-sdk/anthropic@2.0.4(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -17185,24 +16994,6 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.3(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/google-vertex@2.2.27(encoding@0.1.13)(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
-      '@ai-sdk/google': 1.2.22(zod@3.25.76)
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@ai-sdk/google@1.2.22(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-
   '@ai-sdk/openai@0.0.70(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
@@ -17219,15 +17010,6 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 0.0.26
       eventsource-parser: 1.1.2
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-    optionalDependencies:
-      zod: 3.25.76
-
-  '@ai-sdk/provider-utils@2.1.10(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.9
-      eventsource-parser: 3.0.6
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
@@ -17270,10 +17052,6 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider@0.0.26':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/provider@1.0.9':
     dependencies:
       json-schema: 0.4.0
 
@@ -17428,6 +17206,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 11.2.2
+    optional: true
 
   '@asamuzakjp/dom-selector@6.7.2':
     dependencies:
@@ -17436,8 +17215,10 @@ snapshots:
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.2
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@asteasolutions/zod-to-openapi@6.4.0(zod@3.25.76)':
     dependencies:
@@ -18349,12 +18130,14 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@csstools/color-helpers@5.1.0': {}
+  '@csstools/color-helpers@5.1.0':
+    optional: true
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+    optional: true
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -18362,16 +18145,20 @@ snapshots:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+    optional: true
 
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)':
     dependencies:
       postcss: 8.5.6
+    optional: true
 
-  '@csstools/css-tokenizer@3.0.4': {}
+  '@csstools/css-tokenizer@3.0.4':
+    optional: true
 
   '@date-fns/tz@1.4.1': {}
 
@@ -19817,12 +19604,6 @@ snapshots:
       '@octokit/openapi-webhooks-types': 12.0.3
       '@octokit/request-error': 7.0.1
       '@octokit/webhooks-methods': 6.0.0
-
-  '@openrouter/ai-sdk-provider@0.4.6(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.9
-      '@ai-sdk/provider-utils': 2.1.10(zod@3.25.76)
-      zod: 3.25.76
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
@@ -24393,7 +24174,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -24910,6 +24691,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   big.js@5.2.2: {}
 
@@ -25012,8 +24794,6 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-crc32@0.2.13: {}
-
-  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -25479,6 +25259,7 @@ snapshots:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
+    optional: true
 
   css.escape@1.5.1: {}
 
@@ -25491,6 +25272,7 @@ snapshots:
       css-tree: 3.1.0
     transitivePeerDependencies:
       - postcss
+    optional: true
 
   csstype@3.1.3: {}
 
@@ -25686,6 +25468,7 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
+    optional: true
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -25735,7 +25518,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -25887,8 +25671,6 @@ snapshots:
 
   dotenv@16.0.3: {}
 
-  dotenv@16.4.7: {}
-
   dotenv@16.6.1: {}
 
   dotenv@9.0.2: {}
@@ -25927,10 +25709,6 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
 
   edge-runtime@2.5.9:
     dependencies:
@@ -26696,17 +26474,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  exa-js@1.10.2(encoding@0.1.13)(ws@8.18.3(bufferutil@4.1.0)):
-    dependencies:
-      cross-fetch: 4.1.0(encoding@0.1.13)
-      dotenv: 16.4.7
-      openai: 5.23.2(ws@8.18.3(bufferutil@4.1.0))(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-
   execa@3.2.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -27418,18 +27185,6 @@ snapshots:
 
   globrex@0.1.2: {}
 
-  google-auth-library@9.15.1(encoding@0.1.13):
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)
-      gcp-metadata: 6.1.1(encoding@0.1.13)
-      gtoken: 7.1.0(encoding@0.1.13)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   google-logging-utils@0.0.2: {}
 
   gopd@1.2.0: {}
@@ -27451,14 +27206,6 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
-
-  gtoken@7.1.0(encoding@0.1.13):
-    dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   gzip-size@6.0.0:
     dependencies:
@@ -27700,6 +27447,7 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -28105,7 +27853,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-potential-custom-element-name@1.0.1: {}
+  is-potential-custom-element-name@1.0.1:
+    optional: true
 
   is-promise@4.0.0: {}
 
@@ -28186,17 +27935,6 @@ snapshots:
     optional: true
 
   isexe@2.0.0: {}
-
-  isomorphic-dompurify@2.29.0(bufferutil@4.1.0)(postcss@8.5.6):
-    dependencies:
-      dompurify: 3.3.0
-      jsdom: 27.0.1(bufferutil@4.1.0)(postcss@8.5.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - postcss
-      - supports-color
-      - utf-8-validate
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -28312,6 +28050,7 @@ snapshots:
       - postcss
       - supports-color
       - utf-8-validate
+    optional: true
 
   jsesc@3.1.0: {}
 
@@ -28392,17 +28131,6 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
-
-  jwa@2.0.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@4.0.1:
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
 
@@ -28853,7 +28581,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.12.2:
+    optional: true
 
   media-typer@0.3.0: {}
 
@@ -29604,11 +29333,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@5.23.2(ws@8.18.3(bufferutil@4.1.0))(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.18.3(bufferutil@4.1.0)
-      zod: 3.25.76
-
   openapi-sampler@1.6.2:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -29798,6 +29522,7 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+    optional: true
 
   parseley@0.12.1:
     dependencies:
@@ -30732,7 +30457,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rrweb-cssom@0.8.0: {}
+  rrweb-cssom@0.8.0:
+    optional: true
 
   run-async@2.4.1: {}
 
@@ -30782,6 +30508,7 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
   scheduler@0.27.0: {}
 
@@ -31400,15 +31127,12 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.6.0(react@19.2.1)
 
-  symbol-tree@3.2.4: {}
+  symbol-tree@3.2.4:
+    optional: true
 
   tailwind-merge@3.3.1: {}
 
   tailwind-merge@3.4.0: {}
-
-  tailwindcss-animate@1.0.7(tailwindcss@4.1.11):
-    dependencies:
-      tailwindcss: 4.1.11
 
   tailwindcss@4.1.11: {}
 
@@ -31547,11 +31271,13 @@ snapshots:
       no-case: 2.3.2
       upper-case: 1.1.3
 
-  tldts-core@7.0.17: {}
+  tldts-core@7.0.17:
+    optional: true
 
   tldts@7.0.17:
     dependencies:
       tldts-core: 7.0.17
+    optional: true
 
   tmp@0.0.33:
     dependencies:
@@ -31572,6 +31298,7 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.17
+    optional: true
 
   tr46@0.0.3: {}
 
@@ -31582,6 +31309,7 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -32621,52 +32349,6 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.0(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.2.2
-      magic-string: 0.30.19
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.0(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@edge-runtime/vm': 3.2.0
-      '@types/debug': 4.1.12
-      '@types/node': 20.19.22
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
-      happy-dom: 20.7.0(bufferutil@4.1.0)
-      jsdom: 27.0.1(bufferutil@4.1.0)(postcss@8.5.6)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
@@ -32713,7 +32395,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.3.3)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.3.3)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -32759,13 +32441,6 @@ snapshots:
       - tsx
       - yaml
 
-  voyage-ai-provider@1.1.1(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-    optionalDependencies:
-      zod: 3.25.76
-
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -32786,6 +32461,7 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+    optional: true
 
   watchpack@2.5.1:
     dependencies:
@@ -32810,7 +32486,8 @@ snapshots:
 
   webidl-conversions@4.0.2: {}
 
-  webidl-conversions@8.0.0: {}
+  webidl-conversions@8.0.0:
+    optional: true
 
   webpack-bundle-analyzer@4.10.1(bufferutil@4.1.0):
     dependencies:
@@ -32934,17 +32611,20 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+    optional: true
 
   whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@3.0.0: {}
 
-  whatwg-mimetype@4.0.0: {}
+  whatwg-mimetype@4.0.0:
+    optional: true
 
   whatwg-url@15.1.0:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.0
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -33061,9 +32741,11 @@ snapshots:
     dependencies:
       sax: 1.4.1
 
-  xml-name-validator@5.0.0: {}
+  xml-name-validator@5.0.0:
+    optional: true
 
-  xmlchars@2.2.0: {}
+  xmlchars@2.2.0:
+    optional: true
 
   xstate@5.23.0: {}
 


### PR DESCRIPTION
## Summary
Remove 24 unused dependencies across 13 packages identified by knip and verified via import analysis.

| Package | Removed |
|---|---|
| `packages/ai` | `@ai-sdk/google`, `@ai-sdk/google-vertex`, `@ai-sdk/react`, `@openrouter/ai-sdk-provider`, `exa-js`, `resumable-stream`, `voyage-ai-provider` |
| `packages/cms-workflows` | `@repo/ai`, `zod` |
| `packages/console-ai` | `ai` |
| `packages/console-api-key` | `@db/console`, `@trpc/server`, `zod` |
| `packages/console-auth-middleware` | `zod` |
| `packages/console-chunking` | `@repo/console-types` |
| `packages/console-clerk-m2m` | `@vendor/clerk` |
| `packages/console-config` | `@db/console` |
| `packages/console-embed` | `@repo/console-types` |
| `packages/console-octokit-github` | `minimatch` |
| `packages/console-rerank` | `@repo/console-config`, `@vendor/embed` |
| `packages/console-webhooks` | `@repo/lib`, `zod` |
| `packages/ui` | `@hookform/resolvers`, `@vendor/observability`, `isomorphic-dompurify`, `mermaid`, `tailwindcss-animate` |

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm typecheck` passes (124/124 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)