### PR TITLE
chore: remove 7 unused deps from core/*

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -22,12 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@repo/console-chunking": "workspace:*",
-    "@repo/console-config": "workspace:*",
-    "@repo/console-embed": "workspace:*",
-    "chalk": "^5.4.1",
-    "commander": "^13.1.0",
-    "ora": "^8.1.1"
+    "commander": "^13.1.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/core/lightfast/package.json
+++ b/core/lightfast/package.json
@@ -56,9 +56,6 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --fix"
   },
-  "dependencies": {
-    "zod": "^3.25.76"
-  },
   "devDependencies": {
     "@repo/console-types": "workspace:*",
     "@repo/eslint-config": "workspace:*",

--- a/core/mcp/package.json
+++ b/core/mcp/package.json
@@ -57,8 +57,7 @@
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "tsup": "^8.5.0",
-    "typescript": "catalog:",
-    "vitest": "^3.2.4"
+    "typescript": "catalog:"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1315,24 +1315,9 @@ importers:
 
   core/cli:
     dependencies:
-      '@repo/console-chunking':
-        specifier: workspace:*
-        version: link:../../packages/console-chunking
-      '@repo/console-config':
-        specifier: workspace:*
-        version: link:../../packages/console-config
-      '@repo/console-embed':
-        specifier: workspace:*
-        version: link:../../packages/console-embed
-      chalk:
-        specifier: ^5.4.1
-        version: 5.6.2
       commander:
         specifier: ^13.1.0
         version: 13.1.0
-      ora:
-        specifier: ^8.1.1
-        version: 8.2.0
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1360,10 +1345,6 @@ importers:
         version: 5.9.3
 
   core/lightfast:
-    dependencies:
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
     devDependencies:
       '@repo/console-types':
         specifier: workspace:*
@@ -1423,9 +1404,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
   db/console:
     dependencies:
@@ -3095,34 +3073,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-
-  packages/url-utils:
-    dependencies:
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-    devDependencies:
-      '@repo/eslint-config':
-        specifier: workspace:*
-        version: link:../../internal/eslint
-      '@repo/prettier-config':
-        specifier: workspace:*
-        version: link:../../internal/prettier
-      '@repo/typescript-config':
-        specifier: workspace:*
-        version: link:../../internal/typescript
-      '@types/node':
-        specifier: 'catalog:'
-        version: 20.19.22
-      eslint:
-        specifier: 'catalog:'
-        version: 9.38.0(jiti@2.6.1)
-      next:
-        specifier: catalog:next16
-        version: 16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      prettier:
-        specifier: 'catalog:'
-        version: 3.6.2
 
   vendor/analytics:
     dependencies:


### PR DESCRIPTION
## Summary
Remove 7 unused dependencies across 3 core packages identified by knip and verified via import analysis.

| Package | Removed | Type |
|---|---|---|
| `core/cli` | `@repo/console-chunking`, `@repo/console-config`, `@repo/console-embed`, `chalk`, `ora` | dep |
| `core/lightfast` | `zod` | dep |
| `core/mcp` | `vitest` | devDep |

## Test plan
- [x] `pnpm install` succeeds
- [x] All 3 changed packages typecheck clean
- [x] Note: `@repo/ai` typecheck failure is pre-existing (missing tsconfig.json), unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)