### PR TITLE
fix: remove tsBuildInfoFile overrides to fix turbo typecheck output warnings

### DIFF
--- a/core/ai-sdk/tsconfig.json
+++ b/core/ai-sdk/tsconfig.json
@@ -5,7 +5,6 @@
 		"declaration": true,
 		"declarationMap": true,
 		"outDir": "./dist",
-		"tsBuildInfoFile": "./dist/.tsbuildinfo",
 		"types": ["node"],
 		"lib": ["ES2022", "DOM"]
 	},

--- a/db/console/tsconfig.json
+++ b/db/console/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "dist/.tsbuildinfo.json"
-  },
+  "compilerOptions": {},
   "include": ["env.ts", "src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vendor/db/tsconfig.json
+++ b/vendor/db/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "dist/.tsbuildinfo.json",
     "paths": {
       "~/*": [
         "src/*"

--- a/vendor/qstash/tsconfig.json
+++ b/vendor/qstash/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "dist/.tsbuildinfo.json",
     "paths": {
       "~/env": ["./env.ts"]
     }

--- a/vendor/upstash-workflow/tsconfig.json
+++ b/vendor/upstash-workflow/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@repo/typescript-config/internal-package.json",
   "compilerOptions": {
     "rootDir": ".",
-    "tsBuildInfoFile": "dist/.tsbuildinfo.json",
     "paths": {
       "~/env": ["./env.ts"]
     }

--- a/vendor/upstash/tsconfig.json
+++ b/vendor/upstash/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "dist/.tsbuildinfo.json",
     "paths": {
       "~/env": [
         "./env.ts"

--- a/vendor/vercel-flags/tsconfig.json
+++ b/vendor/vercel-flags/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "dist/.tsbuildinfo.json",
     "paths": {
       "~/env": ["./env.ts"]
     }


### PR DESCRIPTION
## Summary
- Removed unnecessary `tsBuildInfoFile` overrides from 7 packages that pointed to `dist/.tsbuildinfo.json` instead of the expected `.cache/tsbuildinfo.json`
- The base tsconfig (`internal/typescript/base.json`) already sets the correct path, and the root `turbo.json` expects typecheck output there
- Build scripts are unaffected since they use `--incremental false` or `tsup` only

## Packages fixed
- `@db/console`
- `@lightfastai/ai-sdk`
- `@vendor/vercel-flags`
- `@vendor/upstash`
- `@vendor/qstash`
- `@vendor/db`
- `@vendor/upstash-workflow`

## Test plan
- [x] `pnpm typecheck` produces no "no output files found" warnings
- [ ] CI passes