### PR TITLE
fix(ci): remove hardcoded pnpm version from workflows

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.5.2
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.5.2
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Removes hardcoded `version: 10.5.2` from `pnpm/action-setup@v4` in `db-migrate.yml` and `release.yml`
- `pnpm/action-setup@v4` now auto-detects the version from `packageManager: pnpm@10.32.1` in `package.json`
- Resolves `ERR_PNPM_BAD_PM_VERSION` conflict between the two version sources

## Test plan
- [ ] `db-migrate` workflow runs without pnpm version mismatch error
- [ ] `release` workflow runs without pnpm version mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)