### PR TITLE
fix(ci): build @vendor/db before running db migrations

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build @vendor/db
+        run: pnpm --filter @vendor/db build
+
       - name: Show pending migrations
         working-directory: db/console
         env:

--- a/db/console/env.ts
+++ b/db/console/env.ts
@@ -1,10 +1,13 @@
-/**
- * Database environment variables for console
- *
- * Re-exports from @vendor/db/env to ensure single source of truth for validation.
- * The vendor package provides PlanetScale credential format validation:
- * - DATABASE_HOST must NOT start with credential prefixes (pscale_pw_, pscale_api_)
- * - DATABASE_USERNAME must start with pscale_api_
- * - DATABASE_PASSWORD must start with pscale_pw_
- */
-export { env } from "@vendor/db/env";
+import { createEnv } from "@t3-oss/env-core";
+import { env as vendorDbEnv } from "@vendor/db/env";
+
+export const env = createEnv({
+  extends: [vendorDbEnv],
+  clientPrefix: "" as const,
+  client: {},
+  server: {},
+  runtimeEnv: {},
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint",
+});

--- a/db/console/package.json
+++ b/db/console/package.json
@@ -46,8 +46,10 @@
     "@repo/console-providers": "workspace:*",
     "@repo/console-validation": "workspace:*",
     "@repo/lib": "workspace:*",
+    "@t3-oss/env-core": "catalog:",
     "@vendor/db": "workspace:*",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@planetscale/database": "^1.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,12 +1304,18 @@ importers:
       '@repo/lib':
         specifier: workspace:*
         version: link:../../packages/lib
+      '@t3-oss/env-core':
+        specifier: 'catalog:'
+        version: 0.13.10(typescript@5.9.3)(zod@4.3.6)
       '@vendor/db':
         specifier: workspace:*
         version: link:../../vendor/db
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.1(@cloudflare/workers-types@4.20260301.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.14.0(bufferutil@4.1.0))(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/pg@8.15.6)(@upstash/redis@1.36.3)(postgres@3.4.7)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@planetscale/database':
         specifier: ^1.19.0


### PR DESCRIPTION
## Summary
- The `db-migrate` workflow was failing because `drizzle.config.ts` imports from `@vendor/db/env` which resolves to `dist/env.js` — a build artifact not committed to git
- Added `pnpm --filter @vendor/db build` step to the workflow so `dist/` exists before `drizzle-kit migrate` runs
- Updated `db/console/env.ts` to use the `createEnv` with `extends` pattern (consistent with `apps/console/src/env.ts`) instead of a bare re-export
- Added `@t3-oss/env-core` and `zod` as explicit dependencies to `db/console/package.json`

## Test plan
- [ ] Trigger the `Database Migration` workflow manually — should no longer fail at the migration step with `Cannot find module ... dist/env.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)