### PR TITLE
feat(providers): mark vercel, linear, sentry as optional with coming-soon UI

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -52,6 +52,7 @@
     "@tanstack/react-query": "catalog:",
     "@trpc/client": "catalog:",
     "@trpc/server": "catalog:",
+    "@trpc/tanstack-react-query": "catalog:",
     "@upstash/redis": "catalog:",
     "@use-gesture/react": "^10.3.1",
     "@vendor/analytics": "workspace:*",

--- a/apps/console/src/app/(app)/(org)/[slug]/[workspaceName]/(manage)/sources/new/_components/sources-section.tsx
+++ b/apps/console/src/app/(app)/(org)/[slug]/[workspaceName]/(manage)/sources/new/_components/sources-section.tsx
@@ -1,15 +1,40 @@
 "use client";
 
-import { PROVIDER_SLUGS } from "@repo/console-providers";
-import { Accordion } from "@repo/ui/components/ui/accordion";
+import { PROVIDER_DISPLAY, PROVIDER_SLUGS } from "@repo/console-providers";
+import { Accordion, AccordionItem } from "@repo/ui/components/ui/accordion";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@repo/ui/components/ui/tooltip";
+import { IntegrationLogoIcons } from "@repo/ui/integration-icons";
 import { ProviderSourceItem } from "./provider-source-item";
 
 export function SourcesSection() {
   return (
     <Accordion className="w-full rounded-lg border" type="multiple">
-      {PROVIDER_SLUGS.map((slug) => (
-        <ProviderSourceItem key={slug} provider={slug} />
-      ))}
+      {PROVIDER_SLUGS.map((slug) => {
+        const display = PROVIDER_DISPLAY[slug];
+        if ((display as { comingSoon?: true }).comingSoon) {
+          const Icon = IntegrationLogoIcons[slug];
+          return (
+            <AccordionItem key={slug} value={slug}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex cursor-not-allowed items-center gap-3 px-4 py-4 opacity-50">
+                    <Icon className="h-5 w-5 shrink-0" />
+                    <span className="text-sm font-medium">
+                      {display.displayName}
+                    </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>Coming soon</TooltipContent>
+              </Tooltip>
+            </AccordionItem>
+          );
+        }
+        return <ProviderSourceItem key={slug} provider={slug} />;
+      })}
     </Accordion>
   );
 }

--- a/apps/console/src/app/(app)/(org)/[slug]/[workspaceName]/(manage)/sources/new/page.tsx
+++ b/apps/console/src/app/(app)/(org)/[slug]/[workspaceName]/(manage)/sources/new/page.tsx
@@ -1,4 +1,4 @@
-import { PROVIDER_SLUGS } from "@repo/console-providers";
+import { ACTIVE_PROVIDER_SLUGS } from "@repo/console-providers";
 import { HydrateClient, orgTrpc, prefetch } from "@repo/console-trpc/server";
 import { Suspense } from "react";
 import { LinkSourcesButton } from "./_components/link-sources-button";
@@ -13,8 +13,8 @@ export default async function AddSourcesPage({
 }) {
   const { slug, workspaceName } = await params;
 
-  // Prefetch connection status for all providers
-  for (const provider of PROVIDER_SLUGS) {
+  // Prefetch connection status for active providers only
+  for (const provider of ACTIVE_PROVIDER_SLUGS) {
     void prefetch(
       orgTrpc.connections.generic.listInstallations.queryOptions({ provider })
     );

--- a/apps/relay/src/env.ts
+++ b/apps/relay/src/env.ts
@@ -12,9 +12,10 @@ const server = {
 
   // Webhook verification secrets
   GITHUB_WEBHOOK_SECRET: z.string().min(1),
-  VERCEL_CLIENT_INTEGRATION_SECRET: z.string().min(1),
-  LINEAR_WEBHOOK_SIGNING_SECRET: z.string().min(1),
-  SENTRY_CLIENT_SECRET: z.string().min(1),
+  // Optional providers — only required when the provider is enabled
+  VERCEL_CLIENT_INTEGRATION_SECRET: z.string().min(1).optional(),
+  LINEAR_WEBHOOK_SIGNING_SECRET: z.string().min(1).optional(),
+  SENTRY_CLIENT_SECRET: z.string().min(1).optional(),
   SENTRY_DSN: z.string().url().optional(),
   LOGTAIL_SOURCE_TOKEN: z.string().min(1).optional(),
 };

--- a/packages/console-providers/src/define.ts
+++ b/packages/console-providers/src/define.ts
@@ -386,6 +386,8 @@ export interface ProviderDefinition<
   readonly getBaseEventType: (sourceType: string) => string;
   readonly name: string;
   readonly oauth: OAuthDef<TConfig, TAccountInfo>;
+  /** When true, all env vars are optional — the provider is disabled and its env preset is excluded from PROVIDER_ENVS(). */
+  readonly optional?: true;
   /** Zod schema for the provider_config JSONB blob stored in workspace_integrations. */
   readonly providerConfigSchema: TProviderConfigSchema;
   /** Normalize wire eventType to dispatch category key. Use identity `(et) => et` if 1:1. */

--- a/packages/console-providers/src/display.ts
+++ b/packages/console-providers/src/display.ts
@@ -11,6 +11,8 @@ interface ProviderDisplayEntry {
   readonly displayName: string;
   readonly icon: IconDef;
   readonly name: string;
+  /** When true, the provider is not yet available and will be shown as "Coming soon" in the UI */
+  readonly comingSoon?: true;
 }
 
 export const PROVIDER_DISPLAY = {
@@ -27,6 +29,7 @@ export const PROVIDER_DISPLAY = {
     name: "vercel",
     displayName: "Vercel",
     description: "Connect your Vercel projects",
+    comingSoon: true,
     icon: {
       viewBox: "0 0 24 24",
       d: "M24 22.525H0l12-21.05 12 21.05z",
@@ -36,6 +39,7 @@ export const PROVIDER_DISPLAY = {
     name: "linear",
     displayName: "Linear",
     description: "Connect your Linear workspace",
+    comingSoon: true,
     icon: {
       viewBox: "0 0 24 24",
       d: "M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z",
@@ -45,6 +49,7 @@ export const PROVIDER_DISPLAY = {
     name: "sentry",
     displayName: "Sentry",
     description: "Connect your Sentry projects",
+    comingSoon: true,
     icon: {
       viewBox: "0 0 24 24",
       d: "M13.91 2.505c-.873-1.448-2.972-1.448-3.844 0L6.904 7.92a15.478 15.478 0 0 1 8.53 12.811h-2.221A13.301 13.301 0 0 0 5.784 9.814l-2.926 5.06a7.65 7.65 0 0 1 4.435 5.848H2.194a.365.365 0 0 1-.298-.534l1.413-2.402a5.16 5.16 0 0 0-1.614-.913L.296 19.275a2.182 2.182 0 0 0 .812 2.999 2.24 2.24 0 0 0 1.086.288h6.983a9.322 9.322 0 0 0-3.845-8.318l1.11-1.922a11.47 11.47 0 0 1 4.95 10.24h5.915a17.242 17.242 0 0 0-7.885-15.28l2.244-3.845a.37.37 0 0 1 .504-.13c.255.14 9.75 16.708 9.928 16.9a.365.365 0 0 1-.327.543h-2.287c.029.612.029 1.223 0 1.831h2.297a2.206 2.206 0 0 0 1.922-3.31z",
@@ -60,6 +65,11 @@ export type ProviderSlug = keyof typeof PROVIDER_DISPLAY;
 
 /** Ordered list of provider slugs — order matches PROVIDER_DISPLAY definition order */
 export const PROVIDER_SLUGS = Object.keys(PROVIDER_DISPLAY) as ProviderSlug[];
+
+/** Provider slugs that are currently active (not coming soon) */
+export const ACTIVE_PROVIDER_SLUGS = PROVIDER_SLUGS.filter(
+  (slug) => !(PROVIDER_DISPLAY[slug] as ProviderDisplayEntry).comingSoon
+);
 
 /** Value/label pairs for search filter dropdowns */
 export const SOURCE_TYPE_OPTIONS = PROVIDER_SLUGS.map((key) => ({

--- a/packages/console-providers/src/index.ts
+++ b/packages/console-providers/src/index.ts
@@ -172,6 +172,7 @@ export { transformWebhookPayload } from "./dispatch";
 export type { ProviderSlug } from "./display";
 // ── Display Metadata (re-exported for server consumers) ─────────────────────
 export {
+  ACTIVE_PROVIDER_SLUGS,
   PROVIDER_DISPLAY,
   PROVIDER_SLUGS,
   SOURCE_TYPE_OPTIONS,

--- a/packages/console-providers/src/providers/linear/index.ts
+++ b/packages/console-providers/src/providers/linear/index.ts
@@ -147,6 +147,7 @@ async function exchangeLinearCode(
 // ── Provider Definition ──
 
 export const linear = defineProvider({
+  optional: true,
   envSchema: {
     LINEAR_CLIENT_ID: z.string().min(1),
     LINEAR_CLIENT_SECRET: z.string().min(1),

--- a/packages/console-providers/src/providers/sentry/index.ts
+++ b/packages/console-providers/src/providers/sentry/index.ts
@@ -80,6 +80,7 @@ async function exchangeSentryCode(
 // ── Provider Definition ──
 
 export const sentry = defineProvider({
+  optional: true,
   envSchema: {
     SENTRY_APP_SLUG: z.string().min(1),
     SENTRY_CLIENT_ID: z.string().min(1),

--- a/packages/console-providers/src/providers/vercel/index.ts
+++ b/packages/console-providers/src/providers/vercel/index.ts
@@ -55,6 +55,7 @@ async function exchangeVercelCode(
 // ── Provider Definition ──
 
 export const vercel = defineProvider({
+  optional: true,
   envSchema: {
     VERCEL_INTEGRATION_SLUG: z.string().min(1),
     VERCEL_CLIENT_SECRET_ID: z.string().min(1),

--- a/packages/console-providers/src/registry.ts
+++ b/packages/console-providers/src/registry.ts
@@ -159,8 +159,10 @@ export function getDefaultSyncEvents(
 
 // ── Env Presets ───────────────────────────────────────────────────────────────
 
-/** Returns pre-built env presets for all providers — spread into @t3-oss/env-core `extends` arrays.
- *  Called at consumer's createEnv() time, so validation only runs with provider env vars present. */
+/** Returns pre-built env presets for required (non-optional) providers — spread into @t3-oss/env-core `extends` arrays.
+ *  Optional providers are excluded so builds succeed without their env vars being present. */
 export function PROVIDER_ENVS(): Record<string, string>[] {
-  return Object.values(PROVIDERS).map((p) => p.env);
+  return Object.values(PROVIDERS)
+    .filter((p) => !p.optional)
+    .map((p) => p.env);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         version: 50.28.0(encoding@0.1.13)(rollup@4.59.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   api/console:
     dependencies:
@@ -623,6 +623,9 @@ importers:
       '@trpc/server':
         specifier: 'catalog:'
         version: 11.12.0(typescript@5.9.3)
+      '@trpc/tanstack-react-query':
+        specifier: 'catalog:'
+        version: 11.12.0(@tanstack/react-query@5.90.21(react@19.2.4))(@trpc/client@11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.12.0(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
       '@upstash/redis':
         specifier: 'catalog:'
         version: 1.36.3
@@ -1345,7 +1348,7 @@ importers:
     dependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/cms-workflows:
     dependencies:
@@ -27271,7 +27274,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.25.0)):
+  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.105.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -27936,7 +27939,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.1.10(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -28067,7 +28070,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.25.0))
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.105.0)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Adds `optional?: true` to `ProviderDefinition` — optional providers are excluded from `PROVIDER_ENVS()` so gateway/relay builds succeed without those env vars
- Marks vercel, linear, sentry with `optional: true` and `comingSoon: true` in display metadata
- Sources/new page renders coming-soon providers as dimmed, non-interactive accordion rows with a tooltip instead of the full OAuth flow
- `ACTIVE_PROVIDER_SLUGS` exported for consumers that only need live providers (page prefetch loop)
- Relay webhook secrets for optional providers made optional; existing `if (!secret)` guard already returns 400

## Test plan

- [ ] Gateway builds without vercel/linear/sentry env vars set
- [ ] Relay builds without `VERCEL_CLIENT_INTEGRATION_SECRET`, `LINEAR_WEBHOOK_SIGNING_SECRET`, `SENTRY_CLIENT_SECRET`
- [ ] Sources/new page shows GitHub as fully functional, vercel/linear/sentry as dimmed with "Coming soon" tooltip
- [ ] To re-enable a provider: remove `optional: true` from provider definition and `comingSoon: true` from display entry, add env vars