### PR TITLE
fix(@vendor/observability): emit JS output for Vercel runtime compatibility

### DIFF
--- a/vendor/observability/package.json
+++ b/vendor/observability/package.json
@@ -5,21 +5,54 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    "./sentry-env": "./src/env/sentry-env.ts",
-    "./sentry": "./src/sentry.ts",
-    "./betterstack-env": "./src/env/betterstack-env.ts",
-    "./log": {
-      "types": "./dist/src/log.d.ts",
-      "default": "./src/log.ts"
+    "./sentry-env": {
+      "types": "./dist/env/sentry-env.d.ts",
+      "default": "./dist/env/sentry-env.js"
     },
-    "./client-log": "./src/client-log.ts",
-    "./types": "./src/types.ts",
-    "./error": "./src/error.ts",
-    "./async-executor": "./src/async-executor.ts",
-    "./error-formatter": "./src/error-formatter.ts",
-    "./use-logger": "./src/use-logger.ts",
-    "./service-log": "./src/service-log.ts",
-    "./print-routes": "./src/print-routes.ts"
+    "./sentry": {
+      "types": "./dist/sentry.d.ts",
+      "default": "./dist/sentry.js"
+    },
+    "./betterstack-env": {
+      "types": "./dist/env/betterstack-env.d.ts",
+      "default": "./dist/env/betterstack-env.js"
+    },
+    "./log": {
+      "types": "./dist/log.d.ts",
+      "default": "./dist/log.js"
+    },
+    "./client-log": {
+      "types": "./dist/client-log.d.ts",
+      "default": "./dist/client-log.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    },
+    "./error": {
+      "types": "./dist/error.d.ts",
+      "default": "./dist/error.js"
+    },
+    "./async-executor": {
+      "types": "./dist/async-executor.d.ts",
+      "default": "./dist/async-executor.js"
+    },
+    "./error-formatter": {
+      "types": "./dist/error-formatter.d.ts",
+      "default": "./dist/error-formatter.js"
+    },
+    "./use-logger": {
+      "types": "./dist/use-logger.d.ts",
+      "default": "./dist/use-logger.js"
+    },
+    "./service-log": {
+      "types": "./dist/service-log.d.ts",
+      "default": "./dist/service-log.js"
+    },
+    "./print-routes": {
+      "types": "./dist/print-routes.d.ts",
+      "default": "./dist/print-routes.js"
+    }
   },
   "license": "MIT",
   "scripts": {

--- a/vendor/observability/tsconfig.json
+++ b/vendor/observability/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false
+  },
   "include": ["*.ts", "src"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- `@vendor/observability` exports pointed to raw `.ts` source files, causing `ERR_MODULE_NOT_FOUND` on Vercel for all three Hono services (gateway, relay, backfill)
- Override `emitDeclarationOnly: false` so `tsc` emits `.js` alongside `.d.ts`
- Update all 12 export subpaths to reference compiled `dist/*.js` files
- Fix stale `./log` types path (was pointing to nonexistent `dist/src/log.d.ts`)

Same pattern previously applied to `@vendor/inngest` (`aae89d045`) and `@db/console` (`3e9c9fd72`).

## Test plan

- [x] `pnpm --filter @vendor/observability build` emits `.js` files in `dist/`
- [x] Gateway builds successfully (`vercel build`)
- [x] Relay builds successfully (`vercel build`)
- [x] Backfill builds successfully (`turbo build`)
- [ ] Deploy to Vercel — no `ERR_MODULE_NOT_FOUND` at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)