### PR TITLE
refactor: standardize Hono service routes to root paths

### DIFF
--- a/apps/backfill/src/app.ts
+++ b/apps/backfill/src/app.ts
@@ -46,8 +46,8 @@ app.onError((err, c) => {
 app.get("/", (c) => c.json({ service: "backfill", status: "ok" }));
 
 // API routes
-app.route("/api/trigger", trigger);
-app.route("/api/estimate", estimate);
+app.route("/trigger", trigger);
+app.route("/estimate", estimate);
 app.route("/api/inngest", inngestRoute);
 
 export default app;

--- a/apps/backfill/src/routes/estimate.test.ts
+++ b/apps/backfill/src/routes/estimate.test.ts
@@ -33,7 +33,7 @@ import { Hono } from "hono";
 import { estimate } from "./estimate.js";
 
 const app = new Hono();
-app.route("/api/estimate", estimate);
+app.route("/estimate", estimate);
 
 function request(
   body: Record<string, unknown> | string,
@@ -43,7 +43,7 @@ function request(
   if (!h.has("content-type")) {
     h.set("content-type", "application/json");
   }
-  return app.request("/api/estimate", {
+  return app.request("/estimate", {
     method: "POST",
     headers: h,
     body: typeof body === "object" ? JSON.stringify(body) : body,

--- a/apps/console/next.config.ts
+++ b/apps/console/next.config.ts
@@ -183,15 +183,15 @@ const config: NextConfig = withSentry(
           },
           {
             source: "/services/gateway/:path*",
-            destination: `${gatewayUrl}/services/gateway/:path*`,
+            destination: `${gatewayUrl}/:path*`,
           },
           {
             source: "/services/relay/:path*",
-            destination: `${relayUrl}/api/:path*`,
+            destination: `${relayUrl}/:path*`,
           },
           {
             source: "/services/backfill/:path*",
-            destination: `${backfillUrl}/api/:path*`,
+            destination: `${backfillUrl}/:path*`,
           },
         ];
       },

--- a/apps/console/src/app/(app)/(org)/[slug]/[workspaceName]/(manage)/sources/new/_components/provider-source-item.tsx
+++ b/apps/console/src/app/(app)/(org)/[slug]/[workspaceName]/(manage)/sources/new/_components/provider-source-item.tsx
@@ -51,7 +51,11 @@ export function ProviderSourceItem({ provider }: Props) {
   // ── OAuth ────────────────────────────────────────────────────────────────
   const listInstallationsOpts =
     trpc.connections.generic.listInstallations.queryOptions({ provider });
-  const { handleConnect: connectOAuth, isConnecting, openCustomUrl } = useOAuthPopup({
+  const {
+    handleConnect: connectOAuth,
+    isConnecting,
+    openCustomUrl,
+  } = useOAuthPopup({
     provider,
     queryKeysToInvalidate: [
       listInstallationsOpts.queryKey,
@@ -437,10 +441,16 @@ export function ProviderSourceItem({ provider }: Props) {
             <p className="text-muted-foreground text-sm">
               {display.description}
             </p>
-            <Button disabled={isConnecting} onClick={handleConnect} variant="outline">
+            <Button
+              disabled={isConnecting}
+              onClick={handleConnect}
+              variant="outline"
+            >
               <Icon className="mr-2 h-4 w-4" />
               Connect {display.displayName}
-              {isConnecting && <Loader2 className="ml-2 h-4 w-4 animate-spin" />}
+              {isConnecting && (
+                <Loader2 className="ml-2 h-4 w-4 animate-spin" />
+              )}
             </Button>
           </div>
         )}

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -44,8 +44,8 @@ app.onError((err, c) => {
 // Health check
 app.get("/", (c) => c.json({ service: "gateway", status: "ok" }));
 
-// API routes
-app.route("/services/gateway", connections);
-app.route("/services/gateway/workflows", workflows);
+// API routes (more specific first to avoid /:id capturing "workflows")
+app.route("/workflows", workflows);
+app.route("/", connections);
 
 export default app;

--- a/apps/gateway/src/lib/urls.ts
+++ b/apps/gateway/src/lib/urls.ts
@@ -27,12 +27,12 @@ const isDevelopment =
  * Relay base URL — used for webhook registration callbacks.
  * Linear webhook callbacks must point at the relay, not the gateway service.
  */
-export const relayBaseUrl = `${withRelatedProject({
+export const relayBaseUrl = withRelatedProject({
   projectName: "lightfast-relay",
   defaultHost: isDevelopment
     ? "http://localhost:4108"
     : "https://relay.lightfast.ai",
-})}/api`;
+});
 
 // Get the console URL dynamically based on environment
 export const consoleUrl = withRelatedProject({

--- a/apps/relay/src/app.ts
+++ b/apps/relay/src/app.ts
@@ -62,8 +62,8 @@ app.onError((err, c) => {
 app.get("/", (c) => c.json({ service: "relay", status: "ok" }));
 
 // API routes
-app.route("/api/webhooks", webhooks);
-app.route("/api/admin", admin);
-app.route("/api/workflows", workflows);
+app.route("/webhooks", webhooks);
+app.route("/admin", admin);
+app.route("/workflows", workflows);
 
 export default app;

--- a/apps/relay/src/lib/urls.ts
+++ b/apps/relay/src/lib/urls.ts
@@ -7,8 +7,8 @@ import { env } from "../env.js";
 export const relayBaseUrl = (() => {
   if (env.VERCEL_ENV === "preview") {
     return env.VERCEL_URL
-      ? `https://${env.VERCEL_URL}/api`
-      : "http://localhost:4108/api";
+      ? `https://${env.VERCEL_URL}`
+      : "http://localhost:4108";
   }
 
   if (env.VERCEL_ENV === "production") {
@@ -17,10 +17,10 @@ export const relayBaseUrl = (() => {
         "VERCEL_PROJECT_PRODUCTION_URL is required in production but was not set"
       );
     }
-    return `https://${env.VERCEL_PROJECT_PRODUCTION_URL}/api`;
+    return `https://${env.VERCEL_PROJECT_PRODUCTION_URL}`;
   }
 
-  return "http://localhost:4108/api";
+  return "http://localhost:4108";
 })();
 
 const isDevelopment =
@@ -29,5 +29,5 @@ const isDevelopment =
 // Get the console URL dynamically based on environment
 export const consoleUrl = withRelatedProject({
   projectName: "lightfast-console",
-  defaultHost: isDevelopment ? "http://localhost:4107" : "https://lightfast.ai",
+  defaultHost: isDevelopment ? "http://localhost:3024" : "https://lightfast.ai",
 });

--- a/apps/relay/src/routes/admin.test.ts
+++ b/apps/relay/src/routes/admin.test.ts
@@ -182,7 +182,7 @@ import { Hono } from "hono";
 import { admin } from "./admin.js";
 
 const app = new Hono();
-app.route("/api/admin", admin);
+app.route("/admin", admin);
 
 function request(
   path: string,
@@ -207,7 +207,7 @@ beforeEach(resetAllMocks);
 
 // ── Tests ──
 
-describe("POST /api/admin/replay/catchup", () => {
+describe("POST /admin/replay/catchup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDbSelect.reset();
@@ -229,7 +229,7 @@ describe("POST /api/admin/replay/catchup", () => {
   // ── Auth ──
 
   it("returns 401 without X-API-Key", async () => {
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       body: {},
     });
     expect(res.status).toBe(401);
@@ -242,7 +242,7 @@ describe("POST /api/admin/replay/catchup", () => {
     // First select: deliveries query returns empty
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: { installationId: "inst-1" },
     });
@@ -256,7 +256,7 @@ describe("POST /api/admin/replay/catchup", () => {
   });
 
   it("returns 400 when installationId is missing", async () => {
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: {},
     });
@@ -290,7 +290,7 @@ describe("POST /api/admin/replay/catchup", () => {
       failed: [],
     });
 
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: { installationId: "inst-1" },
     });
@@ -326,7 +326,7 @@ describe("POST /api/admin/replay/catchup", () => {
       failed: [],
     });
 
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: { installationId: "inst-2", provider: "linear" },
     });
@@ -346,7 +346,7 @@ describe("POST /api/admin/replay/catchup", () => {
   it("clamps batchSize to minimum of 1", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: { installationId: "inst-1", batchSize: -5 },
     });
@@ -360,7 +360,7 @@ describe("POST /api/admin/replay/catchup", () => {
   it("clamps batchSize to maximum of 200", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: { installationId: "inst-1", batchSize: 500 },
     });
@@ -403,7 +403,7 @@ describe("POST /api/admin/replay/catchup", () => {
       failed: [],
     });
 
-    const res = await request("/api/admin/replay/catchup", {
+    const res = await request("/admin/replay/catchup", {
       headers: { "X-API-Key": "test-api-key" },
       body: { installationId: "inst-1" },
     });
@@ -419,12 +419,12 @@ describe("POST /api/admin/replay/catchup", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
-// GET /api/admin/health
+// GET /admin/health
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("GET /api/admin/health", () => {
+describe("GET /admin/health", () => {
   it("returns 200 with status=ok when Redis and DB are healthy", async () => {
-    const res = await request("/api/admin/health", { method: "GET" });
+    const res = await request("/admin/health", { method: "GET" });
     expect(res.status).toBe(200);
     const json = (await res.json()) as Record<string, unknown>;
     expect(json).toMatchObject({
@@ -437,7 +437,7 @@ describe("GET /api/admin/health", () => {
 
   it("returns 503 with status=degraded when Redis ping fails", async () => {
     mockRedisPing.mockRejectedValueOnce(new Error("Redis unavailable"));
-    const res = await request("/api/admin/health", { method: "GET" });
+    const res = await request("/admin/health", { method: "GET" });
     expect(res.status).toBe(503);
     expect(await res.json()).toMatchObject({
       status: "degraded",
@@ -448,7 +448,7 @@ describe("GET /api/admin/health", () => {
 
   it("returns 503 with status=degraded when DB execute fails", async () => {
     mockDbExecute.mockRejectedValueOnce(new Error("DB unavailable"));
-    const res = await request("/api/admin/health", { method: "GET" });
+    const res = await request("/admin/health", { method: "GET" });
     expect(res.status).toBe(503);
     expect(await res.json()).toMatchObject({
       status: "degraded",
@@ -460,7 +460,7 @@ describe("GET /api/admin/health", () => {
   it("returns 503 when both Redis and DB fail", async () => {
     mockRedisPing.mockRejectedValueOnce(new Error("Redis down"));
     mockDbExecute.mockRejectedValueOnce(new Error("DB down"));
-    const res = await request("/api/admin/health", { method: "GET" });
+    const res = await request("/admin/health", { method: "GET" });
     expect(res.status).toBe(503);
     expect(await res.json()).toMatchObject({
       status: "degraded",
@@ -470,7 +470,7 @@ describe("GET /api/admin/health", () => {
   });
 
   it("response always includes redis, database, and uptime_ms fields", async () => {
-    const res = await request("/api/admin/health", { method: "GET" });
+    const res = await request("/admin/health", { method: "GET" });
     const json = await res.json();
     expect(json).toHaveProperty("redis");
     expect(json).toHaveProperty("database");
@@ -479,18 +479,18 @@ describe("GET /api/admin/health", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
-// POST /api/admin/cache/rebuild
+// POST /admin/cache/rebuild
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("POST /api/admin/cache/rebuild", () => {
+describe("POST /admin/cache/rebuild", () => {
   it("returns 401 without X-API-Key", async () => {
-    const res = await request("/api/admin/cache/rebuild");
+    const res = await request("/admin/cache/rebuild");
     expect(res.status).toBe(401);
   });
 
   it("returns { status: 'rebuilt', count: 0 } when no active resources", async () => {
     mockDbSelect.setResults([[]]);
-    const res = await request("/api/admin/cache/rebuild", {
+    const res = await request("/admin/cache/rebuild", {
       headers: { "X-API-Key": "test-api-key" },
     });
     expect(res.status).toBe(200);
@@ -514,7 +514,7 @@ describe("POST /api/admin/cache/rebuild", () => {
       },
     ];
     mockDbSelect.setResults([resources]);
-    const res = await request("/api/admin/cache/rebuild", {
+    const res = await request("/admin/cache/rebuild", {
       headers: { "X-API-Key": "test-api-key" },
     });
     expect(res.status).toBe(200);
@@ -532,7 +532,7 @@ describe("POST /api/admin/cache/rebuild", () => {
     ];
     mockDbSelect.setResults([resources]);
 
-    await request("/api/admin/cache/rebuild", {
+    await request("/admin/cache/rebuild", {
       headers: { "X-API-Key": "test-api-key" },
     });
 
@@ -559,7 +559,7 @@ describe("POST /api/admin/cache/rebuild", () => {
     ];
     mockDbSelect.setResults([resources]);
 
-    await request("/api/admin/cache/rebuild", {
+    await request("/admin/cache/rebuild", {
       headers: { "X-API-Key": "test-api-key" },
     });
 
@@ -569,12 +569,12 @@ describe("POST /api/admin/cache/rebuild", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
-// GET /api/admin/dlq
+// GET /admin/dlq
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("GET /api/admin/dlq", () => {
+describe("GET /admin/dlq", () => {
   it("returns 401 without X-API-Key", async () => {
-    const res = await request("/api/admin/dlq", { method: "GET" });
+    const res = await request("/admin/dlq", { method: "GET" });
     expect(res.status).toBe(401);
   });
 
@@ -582,7 +582,7 @@ describe("GET /api/admin/dlq", () => {
     const items = [{ id: "d1", provider: "github", status: "dlq" }];
     mockDbSelect.setResults([items]);
 
-    const res = await request("/api/admin/dlq", {
+    const res = await request("/admin/dlq", {
       method: "GET",
       headers: { "X-API-Key": "test-api-key" },
     });
@@ -594,7 +594,7 @@ describe("GET /api/admin/dlq", () => {
   it("respects ?limit= and ?offset= query params", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/dlq?limit=10&offset=20", {
+    const res = await request("/admin/dlq?limit=10&offset=20", {
       method: "GET",
       headers: { "X-API-Key": "test-api-key" },
     });
@@ -610,7 +610,7 @@ describe("GET /api/admin/dlq", () => {
   it("clamps limit to max 100", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/dlq?limit=999", {
+    const res = await request("/admin/dlq?limit=999", {
       method: "GET",
       headers: { "X-API-Key": "test-api-key" },
     });
@@ -622,7 +622,7 @@ describe("GET /api/admin/dlq", () => {
   it("clamps limit to min 1", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/dlq?limit=0", {
+    const res = await request("/admin/dlq?limit=0", {
       method: "GET",
       headers: { "X-API-Key": "test-api-key" },
     });
@@ -634,7 +634,7 @@ describe("GET /api/admin/dlq", () => {
   it("handles NaN limit gracefully (falls back to 50)", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/dlq?limit=abc", {
+    const res = await request("/admin/dlq?limit=abc", {
       method: "GET",
       headers: { "X-API-Key": "test-api-key" },
     });
@@ -646,7 +646,7 @@ describe("GET /api/admin/dlq", () => {
   it("returns { items, limit, offset } shape", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/dlq", {
+    const res = await request("/admin/dlq", {
       method: "GET",
       headers: { "X-API-Key": "test-api-key" },
     });
@@ -658,17 +658,17 @@ describe("GET /api/admin/dlq", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
-// POST /api/admin/dlq/replay
+// POST /admin/dlq/replay
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("POST /api/admin/dlq/replay", () => {
+describe("POST /admin/dlq/replay", () => {
   it("returns 401 without X-API-Key", async () => {
-    const res = await request("/api/admin/dlq/replay");
+    const res = await request("/admin/dlq/replay");
     expect(res.status).toBe(401);
   });
 
   it("returns 400 with invalid_json on malformed body", async () => {
-    const res = await request("/api/admin/dlq/replay", {
+    const res = await request("/admin/dlq/replay", {
       headers: { "X-API-Key": "test-api-key" },
       body: "not-json",
     });
@@ -677,7 +677,7 @@ describe("POST /api/admin/dlq/replay", () => {
   });
 
   it("returns 400 when deliveryIds is empty array", async () => {
-    const res = await request("/api/admin/dlq/replay", {
+    const res = await request("/admin/dlq/replay", {
       headers: { "X-API-Key": "test-api-key" },
       body: { deliveryIds: [] },
     });
@@ -686,7 +686,7 @@ describe("POST /api/admin/dlq/replay", () => {
   });
 
   it("returns 400 when deliveryIds is absent", async () => {
-    const res = await request("/api/admin/dlq/replay", {
+    const res = await request("/admin/dlq/replay", {
       headers: { "X-API-Key": "test-api-key" },
       body: {},
     });
@@ -697,7 +697,7 @@ describe("POST /api/admin/dlq/replay", () => {
   it("returns 404 when no matching DLQ entries found", async () => {
     mockDbSelect.setResults([[]]);
 
-    const res = await request("/api/admin/dlq/replay", {
+    const res = await request("/admin/dlq/replay", {
       headers: { "X-API-Key": "test-api-key" },
       body: { deliveryIds: [{ provider: "github", deliveryId: "del-1" }] },
     });
@@ -723,7 +723,7 @@ describe("POST /api/admin/dlq/replay", () => {
       failed: [],
     });
 
-    const res = await request("/api/admin/dlq/replay", {
+    const res = await request("/admin/dlq/replay", {
       headers: { "X-API-Key": "test-api-key" },
       body: { deliveryIds: [{ provider: "github", deliveryId: "del-1" }] },
     });
@@ -750,7 +750,7 @@ describe("POST /api/admin/dlq/replay", () => {
       failed: [],
     });
 
-    const res = await request("/api/admin/dlq/replay", {
+    const res = await request("/admin/dlq/replay", {
       headers: { "X-API-Key": "test-api-key" },
       body: {
         deliveryIds: [
@@ -766,12 +766,12 @@ describe("POST /api/admin/dlq/replay", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
-// POST /api/admin/delivery-status
+// POST /admin/delivery-status
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("POST /api/admin/delivery-status", () => {
+describe("POST /admin/delivery-status", () => {
   it("returns 401 without Upstash-Signature header", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       body: { messageId: "msg-1", state: "delivered" },
     });
     expect(res.status).toBe(401);
@@ -781,7 +781,7 @@ describe("POST /api/admin/delivery-status", () => {
   it("returns 401 when QStash signature is invalid", async () => {
     mockQStashVerify.mockRejectedValueOnce(new Error("invalid signature"));
 
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "bad-sig" },
       body: { messageId: "msg-1", state: "delivered" },
     });
@@ -790,7 +790,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("returns 400 when messageId is missing", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { state: "delivered" },
     });
@@ -801,7 +801,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("returns 400 when state is missing", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1" },
     });
@@ -812,7 +812,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("returns 400 on malformed JSON", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: "not-json",
     });
@@ -821,7 +821,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("updates delivery to 'delivered' when state='delivered' and deliveryId present", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1", state: "delivered", deliveryId: "del-1" },
     });
@@ -835,7 +835,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("updates delivery to 'dlq' when state='error' and deliveryId present", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1", state: "error", deliveryId: "del-1" },
     });
@@ -848,7 +848,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("does NOT update when state is unrecognized", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1", state: "pending", deliveryId: "del-1" },
     });
@@ -857,7 +857,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("does NOT update when deliveryId is absent", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1", state: "delivered" },
     });
@@ -866,7 +866,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("applies provider query param as additional WHERE condition", async () => {
-    const res = await request("/api/admin/delivery-status?provider=github", {
+    const res = await request("/admin/delivery-status?provider=github", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1", state: "delivered", deliveryId: "del-1" },
     });
@@ -876,7 +876,7 @@ describe("POST /api/admin/delivery-status", () => {
   });
 
   it("always returns { status: 'received' }", async () => {
-    const res = await request("/api/admin/delivery-status", {
+    const res = await request("/admin/delivery-status", {
       headers: { "Upstash-Signature": "valid-sig" },
       body: { messageId: "msg-1", state: "delivered", deliveryId: "del-1" },
     });

--- a/apps/relay/src/routes/workflows.test.ts
+++ b/apps/relay/src/routes/workflows.test.ts
@@ -105,7 +105,7 @@ vi.mock("@db/console/schema", () => ({
 }));
 
 vi.mock("../lib/urls", () => ({
-  relayBaseUrl: "https://relay.test/api",
+  relayBaseUrl: "https://relay.test",
   consoleUrl: "https://console.test",
 }));
 
@@ -222,8 +222,7 @@ describe("webhook-delivery workflow", () => {
         }),
         retries: 5,
         deduplicationId: "github:del-001",
-        callback:
-          "https://relay.test/api/admin/delivery-status?provider=github",
+        callback: "https://relay.test/admin/delivery-status?provider=github",
       })
     );
 

--- a/packages/console-openapi/openapi.json
+++ b/packages/console-openapi/openapi.json
@@ -46,9 +46,7 @@
   "paths": {
     "/v1/search": {
       "post": {
-        "tags": [
-          "Search"
-        ],
+        "tags": ["Search"],
         "operationId": "search",
         "summary": "Search",
         "description": "Search across your team's knowledge with semantic understanding and multi-path retrieval.",
@@ -91,9 +89,7 @@
     },
     "/v1/contents": {
       "post": {
-        "tags": [
-          "Contents"
-        ],
+        "tags": ["Contents"],
         "operationId": "get-contents",
         "summary": "Get Contents",
         "description": "Fetch full content for specific documents or observations by their IDs. Batch endpoint supporting up to 50 IDs per request.",
@@ -136,9 +132,7 @@
     },
     "/v1/findsimilar": {
       "post": {
-        "tags": [
-          "Find Similar"
-        ],
+        "tags": ["Find Similar"],
         "operationId": "find-similar",
         "summary": "Find Similar",
         "description": "Find content similar to a given document or URL using vector similarity, entity overlap, and cluster analysis.",
@@ -181,9 +175,7 @@
     },
     "/v1/related": {
       "post": {
-        "tags": [
-          "Related"
-        ],
+        "tags": ["Related"],
         "operationId": "find-related",
         "summary": "Find Related Events",
         "description": "Find events related to a specific observation, grouped by source and relationship type.",
@@ -253,11 +245,7 @@
             "default": "balanced",
             "description": "Search quality mode: 'fast' (speed), 'balanced' (default), 'thorough' (quality)",
             "type": "string",
-            "enum": [
-              "fast",
-              "balanced",
-              "thorough"
-            ]
+            "enum": ["fast", "balanced", "thorough"]
           },
           "filters": {
             "description": "Optional filters to scope results by source type, observation type, or date range",
@@ -305,9 +293,7 @@
             }
           }
         },
-        "required": [
-          "query"
-        ]
+        "required": ["query"]
       },
       "ContentsRequest": {
         "type": "object",
@@ -322,9 +308,7 @@
             "description": "Array of document or observation IDs to fetch (1-50 IDs)"
           }
         },
-        "required": [
-          "ids"
-        ]
+        "required": ["ids"]
       },
       "FindSimilarRequest": {
         "type": "object",
@@ -430,9 +414,7 @@
             }
           }
         },
-        "required": [
-          "id"
-        ]
+        "required": ["id"]
       },
       "SearchResponse": {
         "type": "object",
@@ -503,10 +485,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "key",
-                      "category"
-                    ],
+                    "required": ["key", "category"],
                     "additionalProperties": false
                   }
                 },
@@ -528,10 +507,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "id"
-                    ],
+                    "required": ["type", "id"],
                     "additionalProperties": false
                   }
                 }
@@ -584,11 +560,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "topic",
-                    "summary",
-                    "keywords"
-                  ],
+                  "required": ["topic", "summary", "keywords"],
                   "additionalProperties": false
                 }
               }
@@ -614,11 +586,7 @@
               },
               "mode": {
                 "type": "string",
-                "enum": [
-                  "fast",
-                  "balanced",
-                  "thorough"
-                ]
+                "enum": ["fast", "balanced", "thorough"]
               },
               "paths": {
                 "type": "object",
@@ -633,22 +601,11 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "vector",
-                  "entity",
-                  "cluster"
-                ],
+                "required": ["vector", "entity", "cluster"],
                 "additionalProperties": false
               }
             },
-            "required": [
-              "total",
-              "limit",
-              "offset",
-              "took",
-              "mode",
-              "paths"
-            ],
+            "required": ["total", "limit", "offset", "took", "mode", "paths"],
             "additionalProperties": false
           },
           "latency": {
@@ -699,22 +656,14 @@
                 "minimum": 0
               }
             },
-            "required": [
-              "total",
-              "retrieval",
-              "rerank"
-            ],
+            "required": ["total", "retrieval", "rerank"],
             "additionalProperties": false
           },
           "requestId": {
             "type": "string"
           }
         },
-        "required": [
-          "data",
-          "meta",
-          "requestId"
-        ],
+        "required": ["data", "meta", "requestId"],
         "additionalProperties": false
       },
       "ContentsResponse": {
@@ -795,10 +744,7 @@
                 }
               }
             },
-            "required": [
-              "items",
-              "missing"
-            ],
+            "required": ["items", "missing"],
             "additionalProperties": false
           },
           "meta": {
@@ -808,20 +754,14 @@
                 "type": "number"
               }
             },
-            "required": [
-              "total"
-            ],
+            "required": ["total"],
             "additionalProperties": false
           },
           "requestId": {
             "type": "string"
           }
         },
-        "required": [
-          "data",
-          "meta",
-          "requestId"
-        ],
+        "required": ["data", "meta", "requestId"],
         "additionalProperties": false
       },
       "FindSimilarResponse": {
@@ -843,11 +783,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "id",
-                  "title",
-                  "type"
-                ],
+                "required": ["id", "title", "type"],
                 "additionalProperties": false
               },
               "similar": {
@@ -916,10 +852,7 @@
                 }
               }
             },
-            "required": [
-              "source",
-              "similar"
-            ],
+            "required": ["source", "similar"],
             "additionalProperties": false
           },
           "meta": {
@@ -932,21 +865,14 @@
                 "type": "number"
               }
             },
-            "required": [
-              "total",
-              "took"
-            ],
+            "required": ["total", "took"],
             "additionalProperties": false
           },
           "requestId": {
             "type": "string"
           }
         },
-        "required": [
-          "data",
-          "meta",
-          "requestId"
-        ],
+        "required": ["data", "meta", "requestId"],
         "additionalProperties": false
       },
       "RelatedResponse": {
@@ -1096,11 +1022,7 @@
                 }
               }
             },
-            "required": [
-              "root",
-              "nodes",
-              "edges"
-            ],
+            "required": ["root", "nodes", "edges"],
             "additionalProperties": false
           },
           "meta": {
@@ -1119,23 +1041,14 @@
                 "type": "number"
               }
             },
-            "required": [
-              "depth",
-              "nodeCount",
-              "edgeCount",
-              "took"
-            ],
+            "required": ["depth", "nodeCount", "edgeCount", "took"],
             "additionalProperties": false
           },
           "requestId": {
             "type": "string"
           }
         },
-        "required": [
-          "data",
-          "meta",
-          "requestId"
-        ],
+        "required": ["data", "meta", "requestId"],
         "additionalProperties": false
       }
     },

--- a/packages/gateway-service-clients/src/gateway.ts
+++ b/packages/gateway-service-clients/src/gateway.ts
@@ -44,10 +44,10 @@ export function createGatewayClient(config: ServiceClientConfig) {
     },
 
     async getToken(installationId: string): Promise<GatewayTokenResult> {
-      const response = await fetch(
-        `${gatewayUrl}/${installationId}/token`,
-        { headers: h, signal: AbortSignal.timeout(30_000) }
-      );
+      const response = await fetch(`${gatewayUrl}/${installationId}/token`, {
+        headers: h,
+        signal: AbortSignal.timeout(30_000),
+      });
       if (!response.ok) {
         throw new Error(
           `Gateway getToken failed: ${response.status} for ${installationId}`
@@ -169,16 +169,13 @@ export function createGatewayClient(config: ServiceClientConfig) {
       context: { orgId: string; userId: string; redirectTo?: string }
     ): Promise<{ url: string; state: string }> {
       const qs = context.redirectTo ? `?redirect_to=${context.redirectTo}` : "";
-      const response = await fetch(
-        `${gatewayUrl}/${provider}/authorize${qs}`,
-        {
-          headers: {
-            ...h,
-            "X-Org-Id": context.orgId,
-            "X-User-Id": context.userId,
-          },
-        }
-      );
+      const response = await fetch(`${gatewayUrl}/${provider}/authorize${qs}`, {
+        headers: {
+          ...h,
+          "X-Org-Id": context.orgId,
+          "X-User-Id": context.userId,
+        },
+      });
       if (!response.ok) {
         throw new Error(`Gateway getAuthorizeUrl failed: ${response.status}`);
       }

--- a/packages/integration-tests/src/backfill-relay-dispatch.integration.test.ts
+++ b/packages/integration-tests/src/backfill-relay-dispatch.integration.test.ts
@@ -109,7 +109,7 @@ function webhookReq(
   body: Record<string, unknown>,
   headers: Record<string, string> = {}
 ) {
-  return relayApp.request(`/api/webhooks/${provider}`, {
+  return relayApp.request(`/webhooks/${provider}`, {
     method: "POST",
     headers: new Headers({
       "Content-Type": "application/json",

--- a/packages/integration-tests/src/connections-backfill-trigger.integration.test.ts
+++ b/packages/integration-tests/src/connections-backfill-trigger.integration.test.ts
@@ -2,7 +2,7 @@
  * Suite 2: Backfill Trigger (QStash Contract)
  *
  * Verifies the backfill trigger endpoint auth/validation, that the
- * cancel message from cancelBackfillService matches POST /api/trigger/cancel,
+ * cancel message from cancelBackfillService matches POST /trigger/cancel,
  * and that OAuth callbacks no longer trigger backfill directly.
  *
  * Infrastructure: PGlite (for reactivated-installation test), in-memory
@@ -217,23 +217,23 @@ afterAll(async () => {
 // ── Tests ──
 
 describe("Suite 2.2 — Backfill trigger endpoint auth and validation", () => {
-  it("POST /api/trigger rejects missing API key with 401", async () => {
-    const res = await triggerReq("/api/trigger", {
+  it("POST /trigger rejects missing API key with 401", async () => {
+    const res = await triggerReq("/trigger", {
       body: { installationId: "inst-1", provider: "github", orgId: "org-1" },
     });
     expect(res.status).toBe(401);
   });
 
-  it("POST /api/trigger rejects wrong API key with 401", async () => {
-    const res = await triggerReq("/api/trigger", {
+  it("POST /trigger rejects wrong API key with 401", async () => {
+    const res = await triggerReq("/trigger", {
       body: { installationId: "inst-1", provider: "github", orgId: "org-1" },
       headers: { "X-API-Key": "wrong-secret-key" },
     });
     expect(res.status).toBe(401);
   });
 
-  it("POST /api/trigger rejects body missing required fields with 400", async () => {
-    const res = await triggerReq("/api/trigger", {
+  it("POST /trigger rejects body missing required fields with 400", async () => {
+    const res = await triggerReq("/trigger", {
       body: { installationId: "inst-1" }, // missing provider and orgId
       headers: { "X-API-Key": API_KEY },
     });
@@ -261,12 +261,12 @@ describe("Suite 2.3 — cancelBackfillService publishes cancel body", () => {
     };
 
     expect(call.url).toContain("/trigger/cancel");
-    expect(call.url).toContain("localhost:4109");
+    expect(call.url).toContain("localhost:3024");
     expect(call.headers).toMatchObject({ "X-API-Key": API_KEY });
     expect(call.body).toEqual({ installationId: "inst-cancel-1" });
   });
 
-  it("captured cancel body delivered to POST /api/trigger/cancel returns 200 and fires run.cancelled", async () => {
+  it("captured cancel body delivered to POST /trigger/cancel returns 200 and fires run.cancelled", async () => {
     await cancelBackfillService({ installationId: "inst-cancel-e2e" });
 
     const capturedMsg = qstashMessages[0];
@@ -276,7 +276,7 @@ describe("Suite 2.3 — cancelBackfillService publishes cancel body", () => {
     }
     const capturedHeaders = capturedMsg.headers ?? {};
 
-    const res = await triggerReq("/api/trigger/cancel", {
+    const res = await triggerReq("/trigger/cancel", {
       body: capturedMsg.body as Record<string, unknown>,
       headers: capturedHeaders,
     });

--- a/packages/integration-tests/src/event-ordering.integration.test.ts
+++ b/packages/integration-tests/src/event-ordering.integration.test.ts
@@ -342,7 +342,7 @@ describe("Suite 6.1 — Teardown effects are order-independent", () => {
               m.url.includes("/trigger/cancel")
             );
             if (cancelMsg) {
-              await backfillApp.request("/api/trigger/cancel", {
+              await backfillApp.request("/trigger/cancel", {
                 method: "POST",
                 headers: new Headers({
                   "Content-Type": "application/json",
@@ -421,7 +421,7 @@ describe("Suite 6.2 — Concurrent relay dispatches are order-independent", () =
       effects: deliveryIds.map((deliveryId) => ({
         label: `webhook-${deliveryId}`,
         deliver: async () => {
-          const res = await relayApp.request("/api/webhooks/github", {
+          const res = await relayApp.request("/webhooks/github", {
             method: "POST",
             headers: new Headers({
               "Content-Type": "application/json",
@@ -488,7 +488,7 @@ describe("Suite 6.3 — Backfill notify + relay dispatch are order-independent",
           label: "notify-backfill",
           deliver: async () => {
             // Deliver backfill trigger directly (previously routed via notifyBackfillService)
-            const res = await backfillApp.request("/api/trigger", {
+            const res = await backfillApp.request("/trigger", {
               method: "POST",
               headers: new Headers({
                 "Content-Type": "application/json",
@@ -506,7 +506,7 @@ describe("Suite 6.3 — Backfill notify + relay dispatch are order-independent",
         {
           label: "relay-webhook-dispatch",
           deliver: async () => {
-            await relayApp.request("/api/webhooks/github", {
+            await relayApp.request("/webhooks/github", {
               method: "POST",
               headers: new Headers({
                 "Content-Type": "application/json",
@@ -584,7 +584,7 @@ describe("Suite 6.4 — All 4 gateway teardown steps are order-independent (24 o
           deliver: async () => {
             // Simulate teardown step 1: publish cancel message to backfill service
             await qstashMock.publishJSON({
-              url: "http://localhost:4109/api/trigger/cancel",
+              url: "http://localhost:3024/services/backfill/trigger/cancel",
               body: { installationId: inst.id },
             });
           },
@@ -736,7 +736,7 @@ describe("Suite 6.5 — Relay dedup prevents double-dispatch in both orderings",
     const DELIVERY_ID = "del-dedup-suite65";
 
     async function sendWebhook() {
-      await relayApp.request("/api/webhooks/github", {
+      await relayApp.request("/webhooks/github", {
         method: "POST",
         headers: new Headers({
           "Content-Type": "application/json",

--- a/packages/integration-tests/src/full-stack-connection-lifecycle.integration.test.ts
+++ b/packages/integration-tests/src/full-stack-connection-lifecycle.integration.test.ts
@@ -250,9 +250,9 @@ afterAll(async () => {
 // ── Tests ──
 
 describe("Suite 5.1 — Happy path: notify → trigger → orchestrator → connection details", () => {
-  it("POST /api/trigger fires run.requested Inngest event", async () => {
+  it("POST /trigger fires run.requested Inngest event", async () => {
     // Deliver a backfill trigger directly to the backfill service
-    const res = await backfillApp.request("/api/trigger", {
+    const res = await backfillApp.request("/trigger", {
       method: "POST",
       headers: new Headers({
         "Content-Type": "application/json",
@@ -352,21 +352,24 @@ describe("Suite 5.1 — Happy path: notify → trigger → orchestrator → conn
     // Simulate the dispatch step at the end of the entity worker loop
     const restore = installServiceRouter({ relayApp });
     try {
-      const res = await fetch("http://localhost:4108/api/webhooks/github", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-API-Key": "0".repeat(64),
-        },
-        body: JSON.stringify({
-          connectionId: "conn-lifecycle-1",
-          orgId: "org-lifecycle-1",
-          deliveryId: "del-lifecycle-e2e-1",
-          eventType: "push",
-          payload: { repository: { id: 99_999 } },
-          receivedAt: Date.now(),
-        }),
-      });
+      const res = await fetch(
+        "http://localhost:3024/services/relay/webhooks/github",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": "0".repeat(64),
+          },
+          body: JSON.stringify({
+            connectionId: "conn-lifecycle-1",
+            orgId: "org-lifecycle-1",
+            deliveryId: "del-lifecycle-e2e-1",
+            eventType: "push",
+            payload: { repository: { id: 99_999 } },
+            receivedAt: Date.now(),
+          }),
+        }
+      );
 
       const json = (await res.json()) as { status: string };
       expect(json.status).toBe("accepted");
@@ -404,7 +407,7 @@ describe("Suite 5.2 — Teardown path: cancel → trigger/cancel → Inngest run
     expect(capturedMsg.url).toContain("/trigger/cancel");
 
     // 2. Deliver captured QStash body to backfill cancel endpoint
-    const res = await backfillApp.request("/api/trigger/cancel", {
+    const res = await backfillApp.request("/trigger/cancel", {
       method: "POST",
       headers: new Headers({
         "Content-Type": "application/json",
@@ -466,7 +469,7 @@ describe("Suite 5.2 — Teardown path: cancel → trigger/cancel → Inngest run
     };
 
     // First dispatch — accepted
-    const first = await relayApp.request("/api/webhooks/github", {
+    const first = await relayApp.request("/webhooks/github", {
       method: "POST",
       headers: new Headers({
         "Content-Type": "application/json",
@@ -479,7 +482,7 @@ describe("Suite 5.2 — Teardown path: cancel → trigger/cancel → Inngest run
     );
 
     // Second dispatch (retry with same deliveryId) — deduplicated
-    const second = await relayApp.request("/api/webhooks/github", {
+    const second = await relayApp.request("/webhooks/github", {
       method: "POST",
       headers: new Headers({
         "Content-Type": "application/json",
@@ -554,7 +557,7 @@ describe("Suite 5.3 — Full teardown path", () => {
     );
 
     // ── 4. Deliver cancel QStash to backfill → run.cancelled fires ──
-    const cancelRes = await backfillApp.request("/api/trigger/cancel", {
+    const cancelRes = await backfillApp.request("/trigger/cancel", {
       method: "POST",
       headers: new Headers({
         "Content-Type": "application/json",

--- a/packages/integration-tests/src/harness.ts
+++ b/packages/integration-tests/src/harness.ts
@@ -274,18 +274,32 @@ export function installServiceRouter(apps: ServiceApps): () => void {
     // gatewayUrl / relayUrl / backfillUrl all route through localhost:3024 in dev.
     if (port === "3024") {
       if (appPath.startsWith("/services/gateway/")) {
-        if (!gatewayApp) throw new Error(`[serviceRouter] gatewayApp not registered`);
-        return gatewayApp.request(appPath, init);
+        if (!gatewayApp) {
+          throw new Error("[serviceRouter] gatewayApp not registered");
+        }
+        return gatewayApp.request(
+          appPath.slice("/services/gateway".length),
+          init
+        );
       }
       if (appPath.startsWith("/services/relay/")) {
-        if (!relayApp) throw new Error(`[serviceRouter] relayApp not registered`);
-        return relayApp.request("/api/" + appPath.slice("/services/relay/".length), init);
+        if (!relayApp) {
+          throw new Error("[serviceRouter] relayApp not registered");
+        }
+        return relayApp.request(appPath.slice("/services/relay".length), init);
       }
       if (appPath.startsWith("/services/backfill/")) {
-        if (!backfillApp) throw new Error(`[serviceRouter] backfillApp not registered`);
-        return backfillApp.request("/api/" + appPath.slice("/services/backfill/".length), init);
+        if (!backfillApp) {
+          throw new Error("[serviceRouter] backfillApp not registered");
+        }
+        return backfillApp.request(
+          appPath.slice("/services/backfill".length),
+          init
+        );
       }
-      throw new Error(`[serviceRouter] No rewrite for path ${appPath} on port 3024`);
+      throw new Error(
+        `[serviceRouter] No rewrite for path ${appPath} on port 3024`
+      );
     }
 
     const app = portToApp[port];

--- a/packages/integration-tests/src/lineage-integrity.test.ts
+++ b/packages/integration-tests/src/lineage-integrity.test.ts
@@ -128,7 +128,7 @@ async function sendWebhook(
   deliveryId: string,
   options?: { holdForReplay?: boolean }
 ) {
-  return relayApp.request("/api/webhooks/github", {
+  return relayApp.request("/webhooks/github", {
     method: "POST",
     headers: new Headers({
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- All three Hono apps (gateway, relay, backfill) previously registered routes under their own service prefix — making the apps aware of console proxy routing. Apps should be plain root apps; the prefix belongs only to the Next.js rewrite layer
- `next.config.ts` rewrites now uniformly strip `/services/X/` before forwarding to each service
- Test harness mirrors the same strip logic for in-process routing
- `relayBaseUrl` in both relay and gateway drops the `/api` suffix; relay's `consoleUrl` dev default corrected from port `4107` → `3024`

## Changes

| App | Before | After |
|-----|--------|-------|
| gateway | `/services/gateway`, `/services/gateway/workflows` | `/`, `/workflows` |
| relay | `/api/webhooks`, `/api/admin`, `/api/workflows` | `/webhooks`, `/admin`, `/workflows` |
| backfill | `/api/trigger`, `/api/estimate` | `/trigger`, `/estimate` (`/api/inngest` unchanged) |
| next.config.ts | asymmetric rewrites (gateway passthrough, relay/backfill strip+prefix) | uniform prefix-strip for all three |

## Test plan

- [ ] `pnpm check` passes
- [ ] Integration tests pass (`pnpm --filter @repo/integration-tests test`)
- [ ] Dev: services reachable via console proxy (`localhost:3024/services/gateway`, `/services/relay`, `/services/backfill`)