### PR TITLE
chore: explicit return type + session thoughts docs

### DIFF
--- a/packages/console-openapi/src/registry.ts
+++ b/packages/console-openapi/src/registry.ts
@@ -10,7 +10,7 @@ import {
 } from "@repo/console-validation/api";
 import { createDocument } from "zod-openapi";
 
-export function generateOpenAPIDocument() {
+export function generateOpenAPIDocument(): ReturnType<typeof createDocument> {
   return createDocument({
     openapi: "3.1.0",
     info: {

--- a/thoughts/shared/plans/2026-03-16-fix-vendor-observability-vercel-runtime.md
+++ b/thoughts/shared/plans/2026-03-16-fix-vendor-observability-vercel-runtime.md
@@ -1,0 +1,152 @@
+# Fix @vendor/observability Vercel Runtime ERR_MODULE_NOT_FOUND
+
+## Overview
+
+All three Hono services (gateway, relay, backfill) crash at startup on Vercel with `ERR_MODULE_NOT_FOUND` because `@vendor/observability`'s exports map points to raw `.ts` source files. Node.js cannot execute `.ts` files at runtime. The fix follows the established pattern used for `@vendor/inngest` (commit `aae89d045`) and `@db/console` (commit `3e9c9fd72`).
+
+## Current State Analysis
+
+**The error:**
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+'/var/task/apps/gateway/node_modules/@vendor/observability/src/sentry.ts'
+imported from /var/task/apps/gateway/src/sentry-init.js
+```
+
+**Root cause:** `vendor/observability/package.json` maps all 12 export subpaths to raw `.ts` source files (e.g. `"./sentry": "./src/sentry.ts"`). The build script (`tsc`) inherits `emitDeclarationOnly: true` from `internal-package.json`, so only `.d.ts` declaration files are emitted to `dist/` — no `.js` files exist.
+
+**Why it only affects Vercel:** Locally, `srvx --import tsx` handles `.ts` imports natively. On Vercel, the deployed function resolves `@vendor/observability/sentry` via the `node_modules` symlink → follows the exports map → finds `src/sentry.ts` → Node.js cannot execute `.ts`.
+
+### Key Discoveries:
+- All other 10 workspace deps consumed by the services already export compiled `dist/*.js` files
+- `@vendor/observability` is the sole broken package
+- The same fix pattern was already applied to `@vendor/inngest` and `@db/console`
+- Current `dist/` output has no `src/` prefix (e.g. `dist/sentry.d.ts`, not `dist/src/sentry.d.ts`)
+- The existing `./log` export has a stale `types` path pointing to `./dist/src/log.d.ts` which doesn't exist
+
+## Desired End State
+
+`@vendor/observability` emits `.js` files alongside `.d.ts` files, and all exports resolve to compiled `dist/*.js` paths. All three Hono services deploy and start successfully on Vercel.
+
+### Verification:
+- `pnpm --filter @vendor/observability build` produces `.js` files in `dist/`
+- `pnpm build:gateway`, `pnpm build:relay`, `pnpm build:backfill` succeed
+- `pnpm typecheck` passes
+- Services start without `ERR_MODULE_NOT_FOUND` on Vercel
+
+## What We're NOT Doing
+
+- Not changing the build tool from `tsc` to `tsup` (tsc is sufficient since observability has no complex bundling needs)
+- Not modifying any service code — only the vendor package
+- Not changing how `noExternal` works in the service tsup configs
+
+## Implementation Approach
+
+Single-phase fix: override `emitDeclarationOnly` and update exports map. Same pattern as `@vendor/inngest`.
+
+## Phase 1: Fix @vendor/observability Build and Exports
+
+### Overview
+Make `tsc` emit JS output and point all exports to compiled `dist/` files.
+
+### Changes Required:
+
+#### 1. Override emitDeclarationOnly in tsconfig
+**File**: `vendor/observability/tsconfig.json`
+**Changes**: Add `"emitDeclarationOnly": false` to compilerOptions
+
+```json
+{
+  "extends": "@repo/typescript-config/internal-package.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+#### 2. Update all exports to point to compiled dist/ files
+**File**: `vendor/observability/package.json`
+**Changes**: Replace all 12 export subpaths with `{ "types": "./dist/...", "default": "./dist/..." }` format
+
+```json
+"exports": {
+  "./sentry-env": {
+    "types": "./dist/env/sentry-env.d.ts",
+    "default": "./dist/env/sentry-env.js"
+  },
+  "./sentry": {
+    "types": "./dist/sentry.d.ts",
+    "default": "./dist/sentry.js"
+  },
+  "./betterstack-env": {
+    "types": "./dist/env/betterstack-env.d.ts",
+    "default": "./dist/env/betterstack-env.js"
+  },
+  "./log": {
+    "types": "./dist/log.d.ts",
+    "default": "./dist/log.js"
+  },
+  "./client-log": {
+    "types": "./dist/client-log.d.ts",
+    "default": "./dist/client-log.js"
+  },
+  "./types": {
+    "types": "./dist/types.d.ts",
+    "default": "./dist/types.js"
+  },
+  "./error": {
+    "types": "./dist/error.d.ts",
+    "default": "./dist/error.js"
+  },
+  "./async-executor": {
+    "types": "./dist/async-executor.d.ts",
+    "default": "./dist/async-executor.js"
+  },
+  "./error-formatter": {
+    "types": "./dist/error-formatter.d.ts",
+    "default": "./dist/error-formatter.js"
+  },
+  "./use-logger": {
+    "types": "./dist/use-logger.d.ts",
+    "default": "./dist/use-logger.js"
+  },
+  "./service-log": {
+    "types": "./dist/service-log.d.ts",
+    "default": "./dist/service-log.js"
+  },
+  "./print-routes": {
+    "types": "./dist/print-routes.d.ts",
+    "default": "./dist/print-routes.js"
+  }
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Build produces JS: `pnpm --filter @vendor/observability build && ls vendor/observability/dist/sentry.js`
+- [ ] All dist files exist: `ls vendor/observability/dist/{sentry,log,error,types,service-log,client-log,async-executor,error-formatter,use-logger,print-routes}.js vendor/observability/dist/env/{sentry-env,betterstack-env}.js`
+- [ ] Type checking passes: `pnpm typecheck`
+- [ ] Linting passes: `pnpm check`
+- [ ] Gateway builds: `pnpm build:gateway`
+- [ ] Relay builds: `pnpm build:relay`
+- [ ] Backfill builds: `pnpm build:backfill`
+
+#### Manual Verification:
+- [ ] Deploy gateway to Vercel — no ERR_MODULE_NOT_FOUND at startup
+- [ ] Deploy relay to Vercel — no ERR_MODULE_NOT_FOUND at startup
+- [ ] Deploy backfill to Vercel — no ERR_MODULE_NOT_FOUND at startup
+
+**Implementation Note**: After completing automated verification, deploy to Vercel to confirm the runtime fix works.
+
+---
+
+## References
+
+- Previous fix for `@vendor/inngest`: commit `aae89d045` — same pattern (emitDeclarationOnly override + export map update)
+- Previous fix for `@db/console`: commit `3e9c9fd72` — same pattern
+- Error source: `apps/gateway/src/sentry-init.ts:1` → `@vendor/observability/sentry`
+- Broken exports: `vendor/observability/package.json:7-22`
+- Build config: `vendor/observability/tsconfig.json` inherits `emitDeclarationOnly: true` from `internal/typescript/internal-package.json:7`

--- a/thoughts/shared/research/2026-03-16-web-analysis-vercel-related-projects-limit.md
+++ b/thoughts/shared/research/2026-03-16-web-analysis-vercel-related-projects-limit.md
@@ -1,0 +1,127 @@
+---
+date: 2026-03-16T00:00:00+00:00
+researcher: claude-sonnet-4-6
+topic: "Vercel Related Projects - Max Number of Related Projects"
+tags: [research, web-analysis, vercel, monorepo, microfrontends, related-projects]
+status: complete
+created_at: 2026-03-16
+confidence: high
+sources_count: 7
+---
+
+# Web Research: Vercel Related Projects — Max Number Limit
+
+**Date**: 2026-03-16
+**Topic**: What is the max number of related projects in Vercel, and what does the feature do?
+**Confidence**: High — sourced from official Vercel docs, npm registry, and changelog
+
+## Research Question
+
+Search up Vercel's "related projects" feature and investigate the "max number of related projects".
+
+## Executive Summary
+
+Vercel's **Related Projects** is a February 2025 feature that automatically syncs deployment URLs across separate Vercel projects in the same repository. The hard cap is **3 related projects per app** — a structural limit that cannot be raised by plan tier and is not separately listed on the general limits page.
+
+For Lightfast: if `console` wanted to auto-resolve URLs for `relay` (4108), `gateway` (4110), and `backfill` (4109), that already hits the limit exactly. Any fourth service linkage requires workarounds.
+
+## Key Metrics & Findings
+
+### Hard Limit
+**Finding**: Maximum **3 related projects** per app, declared in `vercel.json`
+**Source**: https://vercel.com/docs/monorepos
+
+> "While every app in your monorepo can list related projects in their own `vercel.json`, you can **only specify up to three related projects per app**."
+
+- Confirmed by third-party project issue tracker: https://github.com/PolicyEngine/policyengine-app-v2/issues/565
+- Not tier-gated (Hobby, Pro, Enterprise all share the same limit)
+- No documented escalation path to raise the limit
+
+### What the Feature Does
+**Finding**: Injects a `VERCEL_RELATED_PROJECTS` env var at build + runtime with the deployment URLs of related projects, eliminating manual `API_URL` environment variable management.
+**Source**: https://vercel.com/changelog/sync-projects-with-vercel-related-projects (Feb 20, 2025)
+
+- Use case: frontend auto-resolves backend preview URL without manual env var wiring
+- Works only with **Git-connected deployments** (not CLI deployments)
+- Only works within the same repository
+
+### Configuration
+**Source**: https://www.npmjs.com/package/@vercel/related-projects
+
+In `vercel.json` of the consuming app:
+
+```json
+{
+  "relatedProjects": ["prj_123", "prj_456"]
+}
+```
+
+In application code:
+
+```ts
+import { withRelatedProject } from '@vercel/related-projects';
+
+const apiHost = withRelatedProject({
+  projectName: 'my-api-project',
+  defaultHost: process.env.API_HOST,
+});
+```
+
+## Trade-off Analysis
+
+### Using Related Projects (≤3 services)
+| Factor | Impact | Notes |
+|--------|--------|-------|
+| URL sync | Automatic | Branch preview URLs injected at build + runtime |
+| Configuration | File-based | `vercel.json` only, no dashboard UI |
+| Limit exposure | Low (if ≤3) | Fits relay + gateway + backfill exactly |
+
+### Hitting the Limit (>3 services)
+| Factor | Impact | Notes |
+|--------|--------|-------|
+| Flexibility | Blocked | No workaround within the feature itself |
+| Fallback | Manual env vars | Same workflow as pre-2025, no auto-sync |
+| Escalation | None documented | Cannot raise limit via support or Enterprise |
+
+## Recommendations
+
+1. **Use Related Projects for the 3 Hono services** (relay, gateway, backfill): This exactly fills the limit for `console`. Keep microfrontend apps (`www`, `auth`) out of `console`'s `relatedProjects` since their URLs are already handled via microfrontends proxy rewrites.
+
+2. **Each app can declare its own `relatedProjects`**: The limit is per-app, not per-repo. `www` and `auth` can independently declare their own up-to-3 related projects if needed.
+
+3. **Do not rely on this for CLI deployments**: Feature only works with Git-triggered deploys. Local `vercel deploy` CLI calls will not inject `VERCEL_RELATED_PROJECTS`.
+
+## Known Limitations
+
+- `VERCEL_RELATED_PROJECTS` only contains **branch URLs** for previews, not commit-specific URLs — breaks E2E testing that needs exact deployment URLs
+  - Community thread: https://community.vercel.com/t/include-commit-urls-in-vercel-related-projects-and-deployment-webhooks-for-monorepo-e2e-testing/34003
+- No dashboard UI to configure — must use `vercel.json`
+- The 3-project limit is completely separate from "projects connected per git repo" (10 Hobby / 60 Pro)
+
+## Package Details
+
+- **npm**: `@vercel/related-projects`
+- **Version**: 1.0.1 (canary 1.1.0 as of Feb 2026)
+- **First published**: February 2025
+- **Weekly downloads**: ~21,300
+- **Source PR**: https://github.com/vercel/vercel/pull/13027 (merged Feb 11, 2025)
+
+## Sources
+
+### Official Documentation
+- [Vercel Monorepos Docs](https://vercel.com/docs/monorepos) — Vercel, states the 3-project limit
+- [Changelog: Sync Projects with Related Projects](https://vercel.com/changelog/sync-projects-with-vercel-related-projects) — Feb 20, 2025 (Tom Knickman, Mark Knichel)
+- [npm: @vercel/related-projects](https://www.npmjs.com/package/@vercel/related-projects) — usage docs and API reference
+
+### Community & Third-Party
+- [PolicyEngine issue #565](https://github.com/PolicyEngine/policyengine-app-v2/issues/565) — confirms "Max 3 related projects can be linked"
+- [Vercel Community: commit URLs in VERCEL_RELATED_PROJECTS](https://community.vercel.com/t/include-commit-urls-in-vercel-related-projects-and-deployment-webhooks-for-monorepo-e2e-testing/34003)
+
+### Implementation
+- [vercel/vercel PR #13027](https://github.com/vercel/vercel/pull/13027) — original implementation PR
+
+---
+
+**Last Updated**: 2026-03-16
+**Confidence Level**: High — official Vercel documentation directly states the limit
+**Next Steps**: If `console` needs URL sync for all 3 Hono services, the limit is exactly met. If a 4th service needs linking, fall back to manual env vars or restructure which app declares the `relatedProjects`.


### PR DESCRIPTION
## Summary

- Add `OpenAPIObject` return type to `generateOpenAPIDocument()` (surfaced by `tsc` after the internal-package tsconfig migration in #496 enabled declaration emit for this package)
- Commit implementation plan and research docs from the Vercel runtime module resolution fix session

Related to #495 and #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)