### PR TITLE
fix(providers): optional providers return null from createConfig when env vars absent

### DIFF
--- a/apps/gateway/src/routes/connections.ts
+++ b/apps/gateway/src/routes/connections.ts
@@ -40,19 +40,15 @@ const runtime: RuntimeConfig = { callbackBaseUrl: gatewayBaseUrl };
 // SAFETY: env is validated by @t3-oss/env-core at startup; the gateway's combined
 // env object is structurally compatible with Record<string, string> (all env vars
 // are strings). The intersection type from createEnv() cannot be expressed generically.
-// Optional providers (e.g. vercel) are skipped if their env vars are absent — they
-// will return "unknown_provider" on any request rather than crashing at startup.
+// Optional providers return null from createConfig when their env vars are absent —
+// they are excluded here and will return "unknown_provider" on any request.
 const providerConfigs: Record<string, unknown> = Object.fromEntries(
-  Object.entries(PROVIDERS).flatMap(([name, p]) => {
-    try {
-      return [
-        [name, p.createConfig(env as unknown as Record<string, string>, runtime)],
-      ];
-    } catch (err) {
-      if (p.optional) return [];
-      throw err;
-    }
-  })
+  Object.entries(PROVIDERS)
+    .map(([name, p]) => [
+      name,
+      p.createConfig(env as unknown as Record<string, string>, runtime),
+    ] as const)
+    .filter(([, config]) => config !== null)
 );
 
 const connections = new Hono<{ Variables: TenantVariables }>();

--- a/apps/gateway/src/workflows/connection-teardown.ts
+++ b/apps/gateway/src/workflows/connection-teardown.ts
@@ -73,6 +73,10 @@ export const connectionTeardownWorkflow = serve<TeardownPayload>(
         teardownRuntime
       );
 
+      if (!config) {
+        return; // optional provider not configured — no token to revoke
+      }
+
       const tokenRows = await db
         .select()
         .from(gatewayTokens)

--- a/packages/console-providers/src/define.ts
+++ b/packages/console-providers/src/define.ts
@@ -363,11 +363,12 @@ export interface ProviderDefinition<
   }) => z.infer<TProviderConfigSchema>;
   readonly categories: TCategories;
   readonly configSchema: z.ZodType<TConfig>;
-  /** Build runtime config from validated env + runtime values */
+  /** Build runtime config from validated env + runtime values.
+   *  Returns null for optional providers when their env vars are absent. */
   readonly createConfig: (
     env: Record<string, string>,
     runtime: RuntimeConfig
-  ) => TConfig;
+  ) => TConfig | null;
   /** Default sync event keys enabled when linking a new resource. Must be a subset of category keys. */
   readonly defaultSyncEvents: readonly string[];
   /** Map sourceType to observation type string for storage. */

--- a/packages/console-providers/src/providers/linear/index.ts
+++ b/packages/console-providers/src/providers/linear/index.ts
@@ -149,17 +149,24 @@ async function exchangeLinearCode(
 export const linear = defineProvider({
   optional: true,
   envSchema: {
-    LINEAR_CLIENT_ID: z.string().min(1),
-    LINEAR_CLIENT_SECRET: z.string().min(1),
-    LINEAR_WEBHOOK_SIGNING_SECRET: z.string().min(1),
+    LINEAR_CLIENT_ID: z.string().min(1).optional(),
+    LINEAR_CLIENT_SECRET: z.string().min(1).optional(),
+    LINEAR_WEBHOOK_SIGNING_SECRET: z.string().min(1).optional(),
   },
-  createConfig: (env, runtime) =>
-    linearConfigSchema.parse({
-      clientId: env.LINEAR_CLIENT_ID,
-      clientSecret: env.LINEAR_CLIENT_SECRET,
-      webhookSigningSecret: env.LINEAR_WEBHOOK_SIGNING_SECRET,
+  createConfig: (env, runtime): LinearConfig | null => {
+    const clientId = env.LINEAR_CLIENT_ID;
+    const clientSecret = env.LINEAR_CLIENT_SECRET;
+    const webhookSigningSecret = env.LINEAR_WEBHOOK_SIGNING_SECRET;
+    if (!clientId || !clientSecret || !webhookSigningSecret) {
+      return null;
+    }
+    return linearConfigSchema.parse({
+      clientId,
+      clientSecret,
+      webhookSigningSecret,
       callbackBaseUrl: runtime.callbackBaseUrl,
-    }),
+    });
+  },
   name: "linear",
   displayName: "Linear",
   description: "Connect your Linear workspace",

--- a/packages/console-providers/src/providers/sentry/index.ts
+++ b/packages/console-providers/src/providers/sentry/index.ts
@@ -82,16 +82,19 @@ async function exchangeSentryCode(
 export const sentry = defineProvider({
   optional: true,
   envSchema: {
-    SENTRY_APP_SLUG: z.string().min(1),
-    SENTRY_CLIENT_ID: z.string().min(1),
-    SENTRY_CLIENT_SECRET: z.string().min(1),
+    SENTRY_APP_SLUG: z.string().min(1).optional(),
+    SENTRY_CLIENT_ID: z.string().min(1).optional(),
+    SENTRY_CLIENT_SECRET: z.string().min(1).optional(),
   },
-  createConfig: (env, _runtime) =>
-    sentryConfigSchema.parse({
-      appSlug: env.SENTRY_APP_SLUG,
-      clientId: env.SENTRY_CLIENT_ID,
-      clientSecret: env.SENTRY_CLIENT_SECRET,
-    }),
+  createConfig: (env, _runtime): SentryConfig | null => {
+    const appSlug = env.SENTRY_APP_SLUG;
+    const clientId = env.SENTRY_CLIENT_ID;
+    const clientSecret = env.SENTRY_CLIENT_SECRET;
+    if (!appSlug || !clientId || !clientSecret) {
+      return null;
+    }
+    return sentryConfigSchema.parse({ appSlug, clientId, clientSecret });
+  },
   name: "sentry",
   displayName: "Sentry",
   description: "Connect your Sentry projects",

--- a/packages/console-providers/src/providers/vercel/index.ts
+++ b/packages/console-providers/src/providers/vercel/index.ts
@@ -57,17 +57,24 @@ async function exchangeVercelCode(
 export const vercel = defineProvider({
   optional: true,
   envSchema: {
-    VERCEL_INTEGRATION_SLUG: z.string().min(1),
-    VERCEL_CLIENT_SECRET_ID: z.string().min(1),
-    VERCEL_CLIENT_INTEGRATION_SECRET: z.string().min(1),
+    VERCEL_INTEGRATION_SLUG: z.string().min(1).optional(),
+    VERCEL_CLIENT_SECRET_ID: z.string().min(1).optional(),
+    VERCEL_CLIENT_INTEGRATION_SECRET: z.string().min(1).optional(),
   },
-  createConfig: (env, runtime) =>
-    vercelConfigSchema.parse({
-      integrationSlug: env.VERCEL_INTEGRATION_SLUG,
-      clientSecretId: env.VERCEL_CLIENT_SECRET_ID,
-      clientIntegrationSecret: env.VERCEL_CLIENT_INTEGRATION_SECRET,
+  createConfig: (env, runtime): VercelConfig | null => {
+    const integrationSlug = env.VERCEL_INTEGRATION_SLUG;
+    const clientSecretId = env.VERCEL_CLIENT_SECRET_ID;
+    const clientIntegrationSecret = env.VERCEL_CLIENT_INTEGRATION_SECRET;
+    if (!integrationSlug || !clientSecretId || !clientIntegrationSecret) {
+      return null;
+    }
+    return vercelConfigSchema.parse({
+      integrationSlug,
+      clientSecretId,
+      clientIntegrationSecret,
       callbackBaseUrl: runtime.callbackBaseUrl,
-    }),
+    });
+  },
   name: "vercel",
   displayName: "Vercel",
   description: "Connect your Vercel projects",

--- a/packages/console-providers/src/registry.ts
+++ b/packages/console-providers/src/registry.ts
@@ -159,10 +159,8 @@ export function getDefaultSyncEvents(
 
 // ── Env Presets ───────────────────────────────────────────────────────────────
 
-/** Returns pre-built env presets for required (non-optional) providers — spread into @t3-oss/env-core `extends` arrays.
- *  Optional providers are excluded so builds succeed without their env vars being present. */
+/** Returns pre-built env presets for all providers — spread into @t3-oss/env-core `extends` arrays.
+ *  Optional providers declare their vars with `.optional()` schemas so builds succeed when absent. */
 export function PROVIDER_ENVS(): Record<string, string>[] {
-  return Object.values(PROVIDERS)
-    .filter((p) => !p.optional)
-    .map((p) => p.env);
+  return Object.values(PROVIDERS).map((p) => p.env);
 }


### PR DESCRIPTION
## Summary

- Vercel, Linear, and Sentry are `optional: true` providers, but their `createConfig` was calling `zod.parse()` unconditionally — throwing a `ZodError` at cold start when env vars weren't set, crashing the gateway process
- This was the root cause of the prod error logged 2026-03-16

## What changed

- **`envSchema` fields** for optional providers now use `.optional()` so their vars are declared as `string | undefined` in the gateway env (previously excluded entirely via `PROVIDER_ENVS()` filter)
- **`createConfig`** for optional providers guards missing vars and returns `null` instead of throwing
- **`PROVIDER_ENVS()`** includes all providers; the `!p.optional` filter is removed since `.optional()` schemas allow absent vars without build failure
- **`connections.ts`** filters out `null` configs with `.filter(([, config]) => config !== null)` — cleaner than the try/catch approach previously on main
- **`connection-teardown.ts`** guards null config before attempting token revocation

## Why this is better than the previous fix

The try/catch on main swallowed exceptions as a side effect — it happened to work but obscured the real contract. This makes the "optional = may not be configured" semantics explicit in the return type (`TConfig | null`), caught by TypeScript at every call site.

## Test plan

- [ ] Build passes (`pnpm build:gateway`) ✅
- [ ] Typechecks clean for `@repo/console-providers` and `@lightfast/gateway` ✅
- [ ] Gateway starts without crashing when only `GITHUB_*` env vars are set
- [ ] Optional providers return `{ error: "unknown_provider" }` when their env vars are absent