### PR TITLE
fix(integration-specs): webhook URLs must point directly to relay

### DIFF
--- a/.claude/commands/create_issue.md
+++ b/.claude/commands/create_issue.md
@@ -1,0 +1,40 @@
+---
+description: Create a GitHub issue using gh CLI
+---
+
+# Create GitHub Issue
+
+Create a GitHub issue based on what the user describes.
+
+## Templates
+
+Refer to `.github/ISSUE_TEMPLATE/` for the available templates:
+- `bug_report.md` — bugs and unexpected behavior
+- `feature_request.md` — new features and improvements
+
+## Process
+
+1. **Understand the issue:**
+   - Ask the user what type of issue this is (bug or feature) if not clear
+   - Gather the title and key details from the conversation
+
+2. **Draft the issue:**
+   - Pick the appropriate template from `.github/ISSUE_TEMPLATE/`
+   - Fill in the relevant sections based on what the user described
+   - Keep it concise — don't pad with placeholders
+
+3. **Present to the user:**
+   - Show the title and body you'll use
+   - Ask: "Shall I create this issue?"
+
+4. **Create on confirmation:**
+   ```bash
+   gh issue create --title "<title>" --body "<body>" --label "<label>"
+   ```
+   - Show the issue URL when done
+
+## Important
+
+- Use `--label bug` for bug reports, `--label enhancement` for features
+- Write in third person, present tense (e.g. "Search returns no results when...")
+- Do not add assignees or milestones unless the user asks

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Description
+
+<!-- What happened? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should have happened? -->
+
+## Actual Behavior
+
+<!-- What actually happened? -->
+
+## Additional Context
+
+<!-- Logs, screenshots, environment details, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Description
+
+<!-- What do you want to build or change? -->
+
+## Motivation
+
+<!-- Why is this needed? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- How should it work? -->
+
+## Additional Context
+
+<!-- Mockups, references, related issues, etc. -->

--- a/apps/gateway/integration-specs.json
+++ b/apps/gateway/integration-specs.json
@@ -22,7 +22,9 @@
     },
     "webhooks": {
       "active": true,
-      "url": "https://<ngrok-subdomain>.ngrok-free.dev/services/relay/webhooks/github",
+      "$comment_url": "Webhooks must go DIRECTLY to the relay — not through the console proxy (lightfast.ai/services/relay/...). The Next.js proxy re-streams the body, breaking GitHub's HMAC signature. Dev: run ngrok on port 4108 and use /api/webhooks/github. Prod: use the relay Vercel URL directly.",
+      "url_dev": "https://<ngrok-subdomain>.ngrok-free.dev/api/webhooks/github",
+      "url_prod": "https://lightfast-relay.vercel.app/api/webhooks/github",
       "events": ["installation", "meta", "pull_request", "issues"]
     },
     "permissions": {
@@ -64,7 +66,8 @@
       "configuration_url": "http://localhost:3024/settings/integrations/vercel"
     },
     "webhooks": {
-      "url": "https://<ngrok-subdomain>.ngrok-free.dev/services/relay/webhooks/vercel",
+      "url_dev": "https://<ngrok-subdomain>.ngrok-free.dev/api/webhooks/vercel",
+      "url_prod": "https://lightfast-relay.vercel.app/api/webhooks/vercel",
       "events": [
         "deployment.created",
         "deployment.succeeded",
@@ -108,7 +111,8 @@
     "client_credentials": "$comment: Copy CLIENT_ID and CLIENT_SECRET after creation (secret shown only once)",
     "webhooks": {
       "enabled": true,
-      "url": "https://<ngrok-subdomain>.ngrok-free.dev/services/relay/webhooks/linear",
+      "url_dev": "https://<ngrok-subdomain>.ngrok-free.dev/api/webhooks/linear",
+      "url_prod": "https://lightfast-relay.vercel.app/api/webhooks/linear",
       "resource_types": ["Issue", "Comment", "IssueLabel", "Project", "Cycle"]
     },
     "env_keys": [
@@ -133,7 +137,8 @@
       "authorized_javascript_origins": []
     },
     "webhooks": {
-      "url": "https://<ngrok-subdomain>.ngrok-free.dev/services/relay/webhooks/sentry",
+      "url_dev": "https://<ngrok-subdomain>.ngrok-free.dev/api/webhooks/sentry",
+      "url_prod": "https://lightfast-relay.vercel.app/api/webhooks/sentry",
       "resources": ["issue", "event_alert", "seer", "comment"]
     },
     "permissions": {

--- a/thoughts/shared/plans/2026-03-16-rework-observability-logging-layer.md
+++ b/thoughts/shared/plans/2026-03-16-rework-observability-logging-layer.md
@@ -1,0 +1,544 @@
+# Rework @vendor/observability Logging Layer
+
+## Overview
+
+Restructure `@vendor/observability` to organize logging into `log/next.ts` and `log/edge.ts`, rename all `LOGTAIL_*` env vars to `BETTERSTACK_*`, and make betterstack env composable via `extends: [betterstackEnv]` so edge services stop duplicating env var definitions.
+
+## Current State Analysis
+
+### File structure
+```
+vendor/observability/src/
+  env/betterstack-env.ts   — Next.js env (uses @t3-oss/env-nextjs), mixed LOGTAIL_*/BETTER_STACK_* naming
+  env/sentry-env.ts        — unchanged
+  log.ts                   — Next.js logger (uses @logtail/next)
+  service-log.ts           — Edge logger factory (uses @logtail/edge), no endpoint option
+  client-log.ts            — React hook logger (ZERO consumers)
+  use-logger.ts            — React hook logger (ZERO consumers)
+  types.ts                 — Logger interface
+```
+
+### Consumers
+| Export | Consumers |
+|---|---|
+| `./log` | 23 files in console app/api layer |
+| `./service-log` | relay, gateway, backfill (identical `logger.ts` pattern) |
+| `./betterstack-env` | console, auth, www (via `extends: [betterstackEnv]`) |
+| `./client-log` | **None** |
+| `./use-logger` | **None** |
+
+### Key problems
+1. `LOGTAIL_*` naming — should be `BETTERSTACK_*`
+2. Edge services define `LOGTAIL_SOURCE_TOKEN` directly in their own `env.ts` instead of extending a composable betterstack env
+3. `service-log.ts` line 42: `new Logtail(config.token!)` — no `endpoint` option
+4. `client-log.ts` and `use-logger.ts` have zero consumers — dead code
+5. `betterstack-env.ts` mixes `NEXT_PUBLIC_BETTER_STACK_*` and `NEXT_PUBLIC_LOGTAIL_*` naming
+
+### Key Discoveries
+- Edge services use `@t3-oss/env-core`, Next.js apps use `@t3-oss/env-nextjs` — need two env schemas
+- `extends` works cross-package: `env-core` objects can be extended by both `env-core` and `env-nextjs` calls (proven by `dbEnv` from `@t3-oss/env-core` being extended in console's `@t3-oss/env-nextjs` call)
+- All three Hono services have identical `logger.ts` files — same pattern, different `service` name
+- Single Better Stack source for all services (filter by `service` field in logs)
+
+## Desired End State
+
+```
+vendor/observability/src/
+  env/
+    betterstack.ts         — Next.js env (@t3-oss/env-nextjs), BETTERSTACK_* + VERCEL_ENV
+    betterstack-edge.ts    — Edge env (@t3-oss/env-core), BETTERSTACK_* + NODE_ENV
+    sentry-env.ts          — unchanged
+  log/
+    next.ts                — Next.js logger, re-exports betterstackEnv
+    edge.ts                — Edge logger factory, re-exports betterstackEdgeEnv
+    types.ts               — moved from src/types.ts
+  ...other files unchanged
+```
+
+**Package exports:**
+```json
+"./log/next":             "dist/log/next.js"
+"./log/edge":             "dist/log/edge.js"
+"./log/types":            "dist/log/types.js"
+"./betterstack-env":      "dist/env/betterstack.js"
+"./betterstack-edge-env": "dist/env/betterstack-edge.js"
+```
+
+**Consumer pattern (edge services):**
+```typescript
+// apps/relay/src/env.ts
+import { betterstackEdgeEnv } from "@vendor/observability/log/edge";
+extends: [vercel(), betterstackEdgeEnv, upstashEnv, qstashEnv, dbEnv]
+// No more BETTERSTACK_SOURCE_TOKEN in server schema or runtimeEnv — it comes from extends
+
+// apps/relay/src/logger.ts
+import { createLogger } from "@vendor/observability/log/edge";
+export const log = createLogger(
+  "relay",
+  env.BETTERSTACK_SOURCE_TOKEN,
+  env.BETTERSTACK_INGESTING_HOST,
+  env.VERCEL_ENV,
+);
+```
+
+**Consumer pattern (Next.js apps):**
+```typescript
+// apps/console/src/env.ts
+import { betterstackEnv } from "@vendor/observability/log/next";
+extends: [..., betterstackEnv, ...]
+// unchanged pattern, just new import path
+```
+
+### Verification
+- `pnpm check` passes
+- `pnpm typecheck` passes
+- All turbo.json cache keys use `BETTERSTACK_*` names
+- No remaining `LOGTAIL_*` references in source code
+- Relay/gateway/backfill `env.ts` files no longer define `BETTERSTACK_SOURCE_TOKEN` in their own server schema — it comes from `extends`
+
+#### Update `error.ts` — align with next-forge pattern
+**File**: `vendor/observability/src/error.ts`
+
+Align with next-forge: add `Sentry.captureException` + `log.error` side effects, import `log` from `./log/next`.
+
+```typescript
+// biome-ignore lint/performance/noNamespaceImport: Sentry SDK convention
+import * as Sentry from "@sentry/nextjs";
+import { log } from "./log/next";
+
+export const parseError = (error: unknown): string => {
+  let message = "An error occurred";
+
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (error && typeof error === "object" && "message" in error) {
+    message = error.message as string;
+  } else {
+    message = String(error);
+  }
+
+  try {
+    Sentry.captureException(error);
+    log.error(`Parsing error: ${message}`);
+  } catch (newError) {
+    console.error("Error parsing error:", newError);
+  }
+
+  return message;
+};
+```
+
+---
+
+## What We're NOT Doing
+
+- Changing Sentry integration
+- Modifying the `@logtail/next` or `@logtail/edge` package versions
+- Setting up Vercel log drains (separate concern)
+- Adding new logging functionality
+- Changing `@logtail/next`'s `withLogtail` Next.js config wrapper (if used)
+
+---
+
+## Phase 1: New env schemas + log modules in vendor/observability
+
+### Overview
+Create the new file structure, env schemas, and logger modules. Old files remain untouched so nothing breaks mid-refactor.
+
+### Changes Required:
+
+#### 1. Create edge betterstack env
+**File**: `vendor/observability/src/env/betterstack-edge.ts` (new)
+
+```typescript
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export const betterstackEdgeEnv = createEnv({
+  clientPrefix: "" as const,
+  client: {},
+  shared: {
+    NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  },
+  server: {
+    BETTERSTACK_SOURCE_TOKEN: z.string().min(1).optional(),
+    BETTERSTACK_INGESTING_HOST: z.string().url().optional(),
+  },
+  runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    BETTERSTACK_SOURCE_TOKEN: process.env.BETTERSTACK_SOURCE_TOKEN,
+    BETTERSTACK_INGESTING_HOST: process.env.BETTERSTACK_INGESTING_HOST,
+  },
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint",
+});
+```
+
+#### 2. Update Next.js betterstack env
+**File**: `vendor/observability/src/env/betterstack-env.ts` → rename to `vendor/observability/src/env/betterstack.ts`
+
+```typescript
+import { createEnv } from "@t3-oss/env-nextjs";
+import { vercel } from "@t3-oss/env-nextjs/presets-zod";
+import { z } from "zod";
+
+export const betterstackEnv = createEnv({
+  extends: [vercel()],
+  shared: {},
+  server: {
+    BETTERSTACK_SOURCE_TOKEN: z.string().min(1).optional(),
+    BETTERSTACK_INGESTING_HOST: z.string().url().optional(),
+  },
+  client: {
+    NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN: z.string().min(1).optional(),
+    NEXT_PUBLIC_BETTERSTACK_INGESTING_HOST: z.string().url().optional(),
+  },
+  experimental__runtimeEnv: {
+    NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN:
+      process.env.NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN,
+    NEXT_PUBLIC_BETTERSTACK_INGESTING_HOST:
+      process.env.NEXT_PUBLIC_BETTERSTACK_INGESTING_HOST,
+  },
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint",
+});
+```
+
+Changes from old file:
+- `LOGTAIL_SOURCE_TOKEN` → `BETTERSTACK_SOURCE_TOKEN`
+- `LOGTAIL_URL` → `BETTERSTACK_INGESTING_HOST`
+- `NEXT_PUBLIC_BETTER_STACK_SOURCE_TOKEN` → `NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN`
+- `NEXT_PUBLIC_BETTER_STACK_INGESTING_URL` → `NEXT_PUBLIC_BETTERSTACK_INGESTING_HOST`
+- Drop `NEXT_PUBLIC_LOGTAIL_SOURCE_TOKEN` (redundant)
+- Drop `NEXT_PUBLIC_VERCEL_ENV` from client — `VERCEL_ENV` is used server-side (comes from `vercel()` preset)
+
+#### 3. Move `types.ts` into `log/`
+**File**: `vendor/observability/src/types.ts` → `vendor/observability/src/log/types.ts`
+
+Content unchanged:
+```typescript
+export interface Logger {
+  debug: (message: string, metadata?: Record<string, unknown>) => void;
+  error: (message: string, metadata?: Record<string, unknown>) => void;
+  info: (message: string, metadata?: Record<string, unknown>) => void;
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+}
+```
+
+Update all existing internal imports of `"./types"` to `"./log/types"` (affects `sentry.ts`, `error.ts`, etc. — check with grep).
+
+#### 4. Create `log/edge.ts`
+**File**: `vendor/observability/src/log/edge.ts` (new)
+
+Minimal — return the Logtail instance directly with a console fallback. No custom interface wrapping.
+
+```typescript
+import { Logtail } from "@logtail/edge";
+
+export { betterstackEdgeEnv } from "../env/betterstack-edge";
+export type { Logger } from "./types";
+
+export function createLogger(
+  service: string,
+  token: string | undefined,
+  endpoint: string | undefined,
+  environment: string | undefined,
+) {
+  const shouldShip =
+    token && environment === "production";
+
+  if (!shouldShip) {
+    return { ...console, flush: () => Promise.resolve() };
+  }
+
+  const logger = new Logtail(token, { endpoint });
+  logger.use((log) => Promise.resolve({ ...log, service }));
+  return logger;
+}
+```
+
+No config object, no TypeScript interface wrappers — just the Logtail instance (which already has `debug`, `info`, `warn`, `error`, `flush`) or a console spread with a no-op `flush`.
+
+#### 4. Create `log/next.ts`
+**File**: `vendor/observability/src/log/next.ts` (new)
+
+Uses server-side `VERCEL_ENV` (from the `vercel()` preset) instead of the client-exposed `NEXT_PUBLIC_VERCEL_ENV`.
+
+```typescript
+import { log as logtail } from "@logtail/next";
+import { betterstackEnv } from "../env/betterstack";
+
+export { betterstackEnv } from "../env/betterstack";
+
+const shouldUseBetterStack = betterstackEnv.VERCEL_ENV === "production";
+
+export const log = shouldUseBetterStack ? logtail : console;
+
+export type Logger = typeof log;
+```
+
+#### 5. Update `package.json` exports
+**File**: `vendor/observability/package.json`
+
+Add new exports:
+```json
+"./log/next": {
+  "types": "./dist/log/next.d.ts",
+  "default": "./dist/log/next.js"
+},
+"./log/edge": {
+  "types": "./dist/log/edge.d.ts",
+  "default": "./dist/log/edge.js"
+},
+"./betterstack-edge-env": {
+  "types": "./dist/env/betterstack-edge.d.ts",
+  "default": "./dist/env/betterstack-edge.js"
+}
+```
+
+Update existing export path:
+```json
+"./betterstack-env": {
+  "types": "./dist/env/betterstack.d.ts",
+  "default": "./dist/env/betterstack.js"
+}
+```
+
+Keep old `./log`, `./service-log` temporarily (remove in Phase 3).
+
+#### 6. Update `tsup.config.ts`
+**File**: `vendor/observability/tsup.config.ts`
+
+Add new entry points:
+```typescript
+"log/next": "src/log/next.ts",
+"log/edge": "src/log/edge.ts",
+"env/betterstack-edge": "src/env/betterstack-edge.ts",
+```
+
+Update betterstack env entry:
+```typescript
+"env/betterstack": "src/env/betterstack.ts",  // was "env/betterstack-env"
+```
+
+#### 7. Add `@t3-oss/env-core` dependency
+**File**: `vendor/observability/package.json`
+
+Add to dependencies:
+```json
+"@t3-oss/env-core": "catalog:"
+```
+
+(Needed for `betterstack-edge.ts`. Check if `catalog:` resolves — if not, use the version from relay's lockfile.)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `pnpm --filter @vendor/observability build` succeeds
+- [x] `pnpm --filter @vendor/observability typecheck` passes
+- [x] New dist files exist: `dist/log/next.js`, `dist/log/edge.js`, `dist/env/betterstack-edge.js`, `dist/env/betterstack.js`
+
+#### Manual Verification:
+- [ ] Old exports still work (no consumers broken yet)
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation before proceeding to Phase 2.
+
+---
+
+## Phase 2: Update all consumers
+
+### Overview
+Switch all consumers to new import paths and env var names. Remove `LOGTAIL_SOURCE_TOKEN` from edge service env schemas — it now comes from `extends: [betterstackEdgeEnv]`.
+
+### Changes Required:
+
+#### 1. Update relay
+**File**: `apps/relay/src/env.ts`
+- Add import: `import { betterstackEdgeEnv } from "@vendor/observability/log/edge";`
+- Add to extends: `extends: [vercel(), betterstackEdgeEnv, upstashEnv, qstashEnv, dbEnv]`
+- Remove from server schema: `LOGTAIL_SOURCE_TOKEN: z.string().min(1).optional()`
+- Remove from runtimeEnv: `LOGTAIL_SOURCE_TOKEN: process.env.LOGTAIL_SOURCE_TOKEN`
+
+**File**: `apps/relay/src/logger.ts`
+```typescript
+import { createLogger } from "@vendor/observability/log/edge";
+import { env } from "./env.js";
+
+export const log = createLogger("relay", env.BETTERSTACK_SOURCE_TOKEN, env.BETTERSTACK_INGESTING_HOST, env.VERCEL_ENV);
+```
+
+#### 2. Update gateway
+**File**: `apps/gateway/src/env.ts`
+- Add import: `import { betterstackEdgeEnv } from "@vendor/observability/log/edge";`
+- Add to extends: `extends: [vercel(), betterstackEdgeEnv, upstashEnv, qstashEnv, dbEnv, ...PROVIDER_ENVS()]`
+- Remove from server schema: `LOGTAIL_SOURCE_TOKEN: z.string().min(1).optional()`
+- Remove from runtimeEnv: `LOGTAIL_SOURCE_TOKEN: process.env.LOGTAIL_SOURCE_TOKEN`
+
+**File**: `apps/gateway/src/logger.ts`
+```typescript
+import { createLogger } from "@vendor/observability/log/edge";
+import { env } from "./env.js";
+
+export const log = createLogger("gateway", env.BETTERSTACK_SOURCE_TOKEN, env.BETTERSTACK_INGESTING_HOST, env.VERCEL_ENV);
+```
+
+#### 3. Update backfill
+**File**: `apps/backfill/src/env.ts`
+- Add import: `import { betterstackEdgeEnv } from "@vendor/observability/log/edge";`
+- Add to extends: `extends: [vercel(), betterstackEdgeEnv]`
+- Remove from server schema: `LOGTAIL_SOURCE_TOKEN: z.string().min(1).optional()`
+- Remove from runtimeEnv: `LOGTAIL_SOURCE_TOKEN: process.env.LOGTAIL_SOURCE_TOKEN`
+
+**File**: `apps/backfill/src/logger.ts`
+```typescript
+import { createLogger } from "@vendor/observability/log/edge";
+import { env } from "./env.js";
+
+export const log = createLogger("backfill", env.BETTERSTACK_SOURCE_TOKEN, env.BETTERSTACK_INGESTING_HOST, env.VERCEL_ENV);
+```
+
+#### 4. Update console Next.js app
+**File**: `apps/console/src/env.ts`
+- Change import: `import { betterstackEnv } from "@vendor/observability/log/next";`
+- `extends` array stays the same (still `betterstackEnv`)
+
+All 23 console consumer files that import `{ log } from "@vendor/observability/log"` — update to:
+```typescript
+import { log } from "@vendor/observability/log/next";
+```
+
+#### 5. Update auth Next.js app
+**File**: `apps/auth/src/env.ts`
+- Change import: `import { betterstackEnv } from "@vendor/observability/log/next";`
+
+#### 6. Update www Next.js app
+**File**: `apps/www/src/env.ts`
+- Change import: `import { betterstackEnv } from "@vendor/observability/log/next";`
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `pnpm check` passes
+- [x] `pnpm typecheck` passes
+- [x] No remaining imports of `@vendor/observability/log` (without `/next` or `/edge` suffix)
+- [x] No remaining imports of `@vendor/observability/service-log`
+- [x] No remaining imports of `@vendor/observability/betterstack-env`
+
+#### Manual Verification:
+- [ ] `pnpm dev:relay` starts without env validation errors
+- [ ] `pnpm dev:console` starts without env validation errors
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation before proceeding to Phase 3.
+
+---
+
+## Phase 3: Update turbo.json cache keys + clean up
+
+### Overview
+Rename env var cache keys in all turbo.json files and delete dead code.
+
+### Changes Required:
+
+#### 1. Update turbo.json cache keys
+
+**File**: `turbo.json` (root)
+- `LOGTAIL_SOURCE_TOKEN` → `BETTERSTACK_SOURCE_TOKEN`
+
+**File**: `apps/console/turbo.json`
+- `LOGTAIL_SOURCE_TOKEN` → `BETTERSTACK_SOURCE_TOKEN`
+- `LOGTAIL_URL` → `BETTERSTACK_INGESTING_HOST`
+
+**File**: `apps/auth/turbo.json`
+- `NEXT_PUBLIC_LOGTAIL_SOURCE_TOKEN` → `NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN`
+- `LOGTAIL_SOURCE_TOKEN` → `BETTERSTACK_SOURCE_TOKEN`
+- `LOGTAIL_URL` → `BETTERSTACK_INGESTING_HOST`
+
+**File**: `apps/www/turbo.json`
+- `NEXT_PUBLIC_LOGTAIL_SOURCE_TOKEN` → `NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN`
+- `LOGTAIL_SOURCE_TOKEN` → `BETTERSTACK_SOURCE_TOKEN`
+- `LOGTAIL_URL` → `BETTERSTACK_INGESTING_HOST`
+
+#### 2. Delete dead files
+- `vendor/observability/src/log.ts` — replaced by `log/next.ts`
+- `vendor/observability/src/service-log.ts` — replaced by `log/edge.ts`
+- `vendor/observability/src/types.ts` — moved to `log/types.ts`
+- `vendor/observability/src/env/betterstack-env.ts` — replaced by `env/betterstack.ts`
+- `vendor/observability/src/client-log.ts` — zero consumers
+- `vendor/observability/src/use-logger.ts` — zero consumers
+- `vendor/observability/src/error-formatter.ts` — zero consumers outside package
+- `vendor/observability/src/async-executor.ts` — zero consumers outside package
+
+#### 3. Remove old exports from package.json
+**File**: `vendor/observability/package.json`
+
+Remove:
+```json
+"./log": { ... },
+"./service-log": { ... },
+"./client-log": { ... },
+"./use-logger": { ... }
+```
+
+#### 4. Update tsup.config.ts
+**File**: `vendor/observability/tsup.config.ts`
+
+Remove old entries:
+```typescript
+log: "src/log.ts",
+"client-log": "src/client-log.ts",
+"use-logger": "src/use-logger.ts",
+"service-log": "src/service-log.ts",
+"env/betterstack-env": "src/env/betterstack-env.ts",
+types: "src/types.ts",
+```
+
+Add new entries:
+```typescript
+"log/next": "src/log/next.ts",
+"log/edge": "src/log/edge.ts",
+"log/types": "src/log/types.ts",
+"env/betterstack": "src/env/betterstack.ts",
+"env/betterstack-edge": "src/env/betterstack-edge.ts",
+```
+
+#### 5. Update .env.example files (if any)
+Check `apps/relay/.env.example`, `apps/gateway/.env.example`, `apps/backfill/.env.example` for any `LOGTAIL_*` references and rename to `BETTERSTACK_*`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `pnpm check` passes
+- [x] `pnpm typecheck` passes
+- [x] `pnpm --filter @vendor/observability build` succeeds
+- [x] No remaining `LOGTAIL` references in source code: `grep -r "LOGTAIL" --include="*.ts" --include="*.json" vendor/ apps/ packages/` returns nothing
+- [x] No remaining imports of old paths: `grep -r "observability/log\"" --include="*.ts" apps/ packages/` returns nothing (only `log/next` and `log/edge` allowed)
+
+#### Manual Verification:
+- [ ] `pnpm dev:app` starts all services without errors
+- [ ] Confirm Better Stack Live Tail shows logs after deploying to Preview with `BETTERSTACK_SOURCE_TOKEN` set
+
+---
+
+## Env Var Migration Checklist (Vercel Dashboard)
+
+After code changes are deployed, update env vars in Vercel project settings:
+
+| Old Name | New Name | Projects |
+|---|---|---|
+| `LOGTAIL_SOURCE_TOKEN` | `BETTERSTACK_SOURCE_TOKEN` | all (relay, gateway, backfill, console, auth, www) |
+| `LOGTAIL_URL` | `BETTERSTACK_INGESTING_HOST` | all |
+| `NEXT_PUBLIC_LOGTAIL_SOURCE_TOKEN` | `NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN` | console, auth, www |
+| `NEXT_PUBLIC_BETTER_STACK_SOURCE_TOKEN` | `NEXT_PUBLIC_BETTERSTACK_SOURCE_TOKEN` | console, auth, www |
+| `NEXT_PUBLIC_BETTER_STACK_INGESTING_URL` | `NEXT_PUBLIC_BETTERSTACK_INGESTING_HOST` | console, auth, www |
+
+Single Better Stack source for all services — same token everywhere, filter by `service` field in logs.
+
+---
+
+## References
+
+- Research doc: `thoughts/shared/research/2026-03-16-web-analysis-betterstack-relay-integration.md`
+- Pattern reference: `vendor/db/env.ts` — composable `@t3-oss/env-core` env with `extends`
+- `@logtail/edge` docs: supports `{ endpoint }` option in constructor

--- a/thoughts/shared/research/2026-03-16-connection-status-state-machine.md
+++ b/thoughts/shared/research/2026-03-16-connection-status-state-machine.md
@@ -1,0 +1,331 @@
+---
+date: 2026-03-16T00:00:00+11:00
+researcher: claude
+git_commit: e14f0a0c5a66d7e16a939242631fef9f886e9b9c
+branch: fix/webhook-urls-direct-relay
+repository: lightfast
+topic: "Connection Status State Machine — Current Implementation"
+tags: [research, codebase, gateway, relay, state-machine, connections, webhooks, github, vercel]
+status: complete
+last_updated: 2026-03-16
+---
+
+# Research: Connection Status State Machine — Current Implementation
+
+**Date**: 2026-03-16
+**Git Commit**: `e14f0a0c5a66d7e16a939242631fef9f886e9b9c`
+**Branch**: `fix/webhook-urls-direct-relay`
+
+## Research Question
+
+Research the full implementation of connection status state machine in the lightfast gateway.
+
+Context: `gatewayInstallations` table has a `status` varchar field (`active|pending|error|revoked`). Planning to expand to: `active | pending | suspended | disconnected | error`.
+
+Research questions:
+1. Where does the GitHub App currently handle `installation` webhook events?
+2. How does the gateway handle connection teardown (Upstash Workflow)?
+3. What is the current `revoked` state — where is it set and by whom?
+4. Where are all the places `status` is read?
+5. How should the `installation` webhook handler be wired?
+6. What does the Vercel `integration-configuration.removed` event look like — is there already a handler?
+7. Are there any existing state transition guards?
+
+---
+
+## Summary
+
+The current state machine is binary: everything is either `"active"` or not. There is no formal transition table — guards are inline `!== "active"` checks; writes are unconditional `WHERE id = X` updates. Two provider-initiated lifecycle events (`installation.deleted/suspend/unsuspend` for GitHub; `integration-configuration.removed` for Vercel) are subscribed but silently DLQ'd today because the relay's connection-resolution step cannot match installation-level resource IDs. All teardown is currently UI-initiated via a single gateway `DELETE` endpoint.
+
+---
+
+## Detailed Findings
+
+### 1. DB Schema — `gatewayInstallations.status`
+
+**File**: `db/console/src/schema/tables/gateway-installations.ts:34`
+
+```typescript
+status: varchar("status", { length: 50 }).notNull(), // active|pending|error|revoked
+```
+
+- `varchar(50)` with no database-level CHECK constraint or enum type
+- Four values documented in an inline comment: `active | pending | error | revoked`
+- **`pending` is never written to the DB** — only appears as a Redis polling-response field during OAuth
+- TypeScript wire type is `z.string()` (open string, not constrained) — `packages/console-providers/src/gateway.ts:80`
+- `@repo/gateway-types` does not exist as a standalone package; connection types live in `@repo/console-providers`
+
+**Indexes** (`gateway-installations.ts:69–82`):
+- `UNIQUE INDEX` on `(provider, external_id)` — makes OAuth callback upsert idempotent
+- `INDEX` on `(org_id)`, `(org_id, provider)`, `(connected_by)`
+
+**Related tables**:
+- `gatewayResources.status`: `varchar(50)`, values `active | removed`
+- `gatewayWebhookDeliveries.status`: tracks per-delivery pipeline state (`received | dlq | ...`)
+
+**Drizzle relations** (`db/console/src/schema/relations.ts:21–28`):
+- `gatewayInstallations` → many `gatewayTokens`, many `gatewayResources`, many `workspaceIntegrations`
+
+---
+
+### 2. GitHub App `installation` Webhook — Current Handling
+
+**Subscribed events** (`apps/gateway/integration-specs.json:28–33`):
+```json
+"events": ["installation", "meta", "pull_request", "issues"]
+```
+The `installation` event is registered at the GitHub App platform level.
+
+**What happens today** (end-to-end):
+
+```
+GitHub → POST /api/webhooks/github (relay)
+  → 7-step middleware (providerGuard → signatureVerify → payloadParseAndExtract)
+  → extractEventType: headers.get("x-github-event") = "installation"
+  → extractResourceId: payload.installation.id (e.g., "12345678")
+  → Upstash workflow triggered → returns 200 immediately
+
+webhook-delivery workflow (relay/src/routes/workflows.ts):
+  Step 1: dedup — Redis SET NX passes
+  Step 2: persist — gatewayWebhookDeliveries, status="received", eventType="installation"
+  Step 3: resolve-connection
+    → Redis cache lookup: resource:github:12345678 → MISS
+    → DB lookup: gatewayResources.providerResourceId = "12345678" → MISS
+      (providerResourceId stores repo IDs, not installation IDs)
+    → connectionInfo = null
+  Step 3b: DLQ — QStash "webhook-dlq" topic; status → "dlq"
+```
+
+**Root cause of DLQ**: The relay's connection-resolution step (`workflows.ts:100–116`) queries `gatewayResources.providerResourceId` to find the org/connection. GitHub installation IDs are stored in `gatewayInstallations.externalId`, not in `gatewayResources`. The resource cache and DB fallback both miss.
+
+**No handler exists** for any `installation` action (`deleted`, `suspend`, `unsuspend`). The `console-providers` GitHub event map (`providers/github/index.ts:93–118`) only contains two keys: `pull_request` and `issues`. Even if connection resolution were fixed, `transformWebhookPayload` would return `null` for `installation` events.
+
+**No gateway lifecycle handler**: `apps/gateway/src/routes/connections.ts` has no route that receives or processes `installation` webhook events. The teardown workflow is triggered only by explicit `DELETE /:provider/:id`.
+
+---
+
+### 3. Gateway Teardown — Upstash Workflow
+
+**Trigger**: `DELETE /:provider/:id` (`apps/gateway/src/routes/connections.ts:925–958`)
+- Protected by `apiKeyAuth` (internal only)
+- Documented caller: `console tRPC (org/connections.disconnect)`
+- Fetches installation row to validate existence; returns 404 if not found
+- Calls `workflowClient.trigger()` with `{ installationId, provider, orgId }` payload
+- Returns `{ status: "teardown_initiated" }` immediately — does not wait for workflow
+
+**Workflow** (`apps/gateway/src/workflows/connection-teardown.ts:38–147`):
+
+| Step | Name | What it does |
+|------|------|--------------|
+| 1 | `cancel-backfill` | QStash POST to `${backfillUrl}/trigger/cancel` with `{ installationId }`. Best-effort, errors swallowed. |
+| 2 | `revoke-token` | Skips GitHub (no stored token). Fetches encrypted token from `gatewayTokens`, decrypts, calls `providerDef.oauth.revokeToken`. Best-effort. |
+| 3 | `cleanup-cache` | Queries `gatewayResources WHERE status = "active"` for the installation. Bulk-deletes Redis keys `gw:resource:{provider}:{resourceId}`. |
+| 4 | `soft-delete` | `db.batch()`: sets `gatewayInstallations.status = "revoked"` + `gatewayResources.status = "removed"`. |
+
+**No status guard before triggering**: `DELETE /:provider/:id` accepts any current status — will teardown an already-revoked installation.
+
+**Step 4 is unconditional**: `WHERE id = installationId` only, no `WHERE status = 'active'` guard on the UPDATE.
+
+---
+
+### 4. `revoked` State — All Write Sites
+
+| # | File | Line | Value | Trigger |
+|---|------|------|-------|---------|
+| 1a | `apps/gateway/src/routes/connections.ts` | 325 | `"active"` | OAuth callback INSERT |
+| 1b | `apps/gateway/src/routes/connections.ts` | 334 | `"active"` | OAuth callback `onConflictDoUpdate` (reinstall/reactivation) |
+| 2 | `apps/gateway/src/workflows/connection-teardown.ts` | 128 | `"revoked"` | Upstash Workflow step 4 — triggered by gateway `DELETE /:provider/:id` |
+| 3 | `api/console/src/router/org/connections.ts` | 128 | `"revoked"` | tRPC `connections.disconnect` — direct DB write, no workflow |
+| 4 | `api/console/src/router/org/connections.ts` | 449 | `"revoked"` | tRPC `connections.vercel.disconnect` — scoped by `provider = "vercel"`, no workflow |
+| 5 | `api/console/src/router/org/connections.ts` | 577 | `"error"` | tRPC `connections.generic.listResources` — inline on HTTP 401 from proxy |
+
+**`"pending"`**: Never written to `gatewayInstallations` in any production code path. The OAuth polling endpoint (`connections.ts:170`) writes `{ status: "pending" }` to a Redis hash, not the database.
+
+**`"error"`**: Only one write site — during resource listing when the provider returns 401. There is no automated recovery path from `"error"`.
+
+**Two disconnect paths**: Write sites 2–4 show two parallel paths to `"revoked"`:
+- **Durable path** (workflow): cancels backfill, revokes token, cleans Redis, then soft-deletes
+- **Direct path** (tRPC writes 3+4): sets `"revoked"` in DB only, no backfill cancellation, no token revocation, no Redis cleanup
+
+---
+
+### 5. Status Read Sites
+
+#### tRPC Routers (`api/console/src/router/org/`)
+
+All queries filter at the SQL level using `eq(gatewayInstallations.status, "active")`:
+
+| Procedure | File:Line | Behavior if not active |
+|-----------|-----------|------------------------|
+| `connections.list` | `connections.ts:91` | Row excluded from results |
+| `connections.github.validate` | `connections.ts:202` | `TRPCError NOT_FOUND` |
+| `connections.generic.listInstallations` | `connections.ts:490` | Returns `installations: []` |
+| `connections.generic.listResources` | `connections.ts:553` | `TRPCError NOT_FOUND` |
+| `workspace.create` (backfill trigger) | `workspace.ts:224` | Installation not backfilled |
+
+#### Gateway Routes (`apps/gateway/src/routes/connections.ts`)
+
+| Route | Line | Guard | Response |
+|-------|------|-------|----------|
+| `GET /:id/token` | 653 | `!== "active"` | HTTP 400 `installation_not_active` |
+| `POST /:id/proxy/execute` | 776 | `!== "active"` | HTTP 400 `installation_not_active` |
+| `POST /:id/resources` | 983 | `!== "active"` | HTTP 400 `installation_not_active` |
+| `GET /:id` | 499 | none | Returns `status` verbatim in JSON |
+
+Note: `GET /:id` returns any status unchanged — callers perform their own guards.
+
+#### Backfill Orchestrator (`apps/backfill/src/workflows/backfill-orchestrator.ts:70–74`)
+
+```typescript
+if (conn.status !== "active") {
+  throw new NonRetriableError(
+    `Connection is not active: ${installationId} (status: ${conn.status})`
+  );
+}
+```
+
+`NonRetriableError` causes Inngest to fail immediately without retrying. Entity workers (`entity-worker.ts`) do not re-check status — they call `gw.executeApi` which hits `POST /:id/proxy/execute`, which guards at line 776.
+
+#### Relay (`apps/relay/src/routes/`)
+
+The relay has **no reads on `gatewayInstallations.status`**. It only reads `gatewayResources.status = "active"` for:
+- Webhook connection routing (`workflows.ts:113`)
+- Cache rebuild (`admin.ts:84`)
+
+#### UI (`apps/console/src/`)
+
+UI reads are indirect — the server returns only active installations via SQL filtering:
+
+| Component | File | Display logic |
+|-----------|------|---------------|
+| Settings sources list | `settings/sources/_components/sources-list.tsx:42–90` | `connection` truthy → "Connected" + Disconnect button; falsy → "Not connected" + Connect button |
+| New source picker | `sources/new/_components/provider-source-item.tsx:96, 235–243` | `installations.length > 0` → "Connected" badge + resource picker |
+
+The `isActive` field returned by `connections.list` is hardcoded `true` in the tRPC router — it is always `true` because the query only returns active rows.
+
+---
+
+### 6. Vercel `integration-configuration.removed` — Current Handling
+
+**Subscribed** in `apps/gateway/integration-specs.json:85`.
+
+**What happens today**:
+
+```
+Vercel → POST /api/webhooks/vercel (relay)
+  → HMAC-SHA1 verification (x-vercel-signature against VERCEL_CLIENT_INTEGRATION_SECRET)
+  → extractEventType: payload.type = "integration-configuration.removed"
+  → extractResourceId: payload.payload.project.id → null (not present in this event type)
+  → Upstash workflow triggered
+
+webhook-delivery workflow:
+  Step 1: dedup — passes
+  Step 2: persist — gatewayWebhookDeliveries, status="received"
+  Step 3: resourceId is null → connectionInfo = null (skip DB/Redis lookup entirely)
+  Step 3b: DLQ — published to "webhook-dlq" topic; status → "dlq"
+```
+
+**Root cause**: `extractResourceId` for Vercel reads `payload.payload.project.id` (deployment-level field). `integration-configuration.removed` does not carry a project-level resource ID in the same position.
+
+**No teardown triggered**: The event reaches the DLQ without triggering the `connection-teardown` workflow. The current gateway has no path from provider-webhook → teardown.
+
+**`integration-configuration.removed` in accountInfo**: The string appears in `vercel/index.ts:354` inside the `accountInfo.events` array set during OAuth callback. This is informational metadata stored in `gatewayInstallations.providerAccountInfo` — it is not read anywhere in processing.
+
+---
+
+### 7. State Transition Guards
+
+**No state machine exists today.** Status transitions are not encoded with explicit allowed-from/allowed-to rules.
+
+**Guards by type**:
+
+| Type | Location | Condition |
+|------|----------|-----------|
+| Read block (operation rejected) | `connections.ts:653, 776, 983` | `installation.status !== "active"` → HTTP 400 |
+| NonRetriable error | `backfill-orchestrator.ts:70` | `conn.status !== "active"` |
+| SELECT filter | `connections.ts:487, 1001–1011` | `eq(gatewayResources.status, "active")` |
+| SELECT filter | `connection-teardown.ts:108–112` | `eq(gatewayResources.status, "active")` |
+| SELECT filter | `relay/workflows.ts:113` | `eq(gatewayResources.status, "active")` |
+| Idempotency check | `connections.ts:1093` | `resource.status === "removed"` → HTTP 400 |
+
+**No optimistic-locking on writes**: Status updates use `WHERE id = X` only — no `WHERE id = X AND status = 'current_status'` pattern anywhere.
+
+**No middleware-level guard**: `apps/gateway/src/middleware/` contains no connection-status middleware. All guards are inline within individual route handlers.
+
+**OAuth callback reactivation**: The upsert at `connections.ts:325–341` always writes `status: "active"` via `onConflictDoUpdate`, regardless of prior status. A `revoked` installation can be reactivated by completing the OAuth flow again — the handler detects this via a pre-check at lines 304–315 (sets a `reactivated` flag in Redis and redirect URL) but does not block the upsert.
+
+---
+
+## Code References
+
+- `db/console/src/schema/tables/gateway-installations.ts:34` — status column definition
+- `db/console/src/schema/tables/gateway-installations.ts:69–82` — indexes
+- `db/console/src/schema/relations.ts:21–28` — Drizzle relations
+- `apps/gateway/integration-specs.json:28–33` — GitHub subscribed events (including `installation`)
+- `apps/gateway/integration-specs.json:85` — Vercel `integration-configuration.removed` subscription
+- `apps/gateway/src/routes/connections.ts:65` — route definitions start
+- `apps/gateway/src/routes/connections.ts:325,334` — `"active"` write on OAuth callback
+- `apps/gateway/src/routes/connections.ts:653` — token endpoint status guard
+- `apps/gateway/src/routes/connections.ts:776` — proxy execute status guard
+- `apps/gateway/src/routes/connections.ts:925–958` — teardown trigger (`DELETE /:provider/:id`)
+- `apps/gateway/src/routes/connections.ts:983` — resource link status guard
+- `apps/gateway/src/workflows/connection-teardown.ts:38–147` — full 4-step teardown workflow
+- `apps/gateway/src/workflows/connection-teardown.ts:128` — `"revoked"` write
+- `apps/relay/src/routes/webhooks.ts:46` — single parameterized webhook POST route
+- `apps/relay/src/routes/workflows.ts:40–250` — webhook-delivery durable workflow
+- `apps/relay/src/routes/workflows.ts:84–135` — connection resolution step (resource lookup)
+- `apps/relay/src/routes/workflows.ts:163–194` — DLQ fallback
+- `apps/backfill/src/workflows/backfill-orchestrator.ts:68–82` — active status guard
+- `api/console/src/router/org/connections.ts:91` — `connections.list` active filter
+- `api/console/src/router/org/connections.ts:128` — `connections.disconnect` direct `"revoked"` write
+- `api/console/src/router/org/connections.ts:449` — `connections.vercel.disconnect` direct `"revoked"` write
+- `api/console/src/router/org/connections.ts:577` — `"error"` write on 401
+- `packages/console-providers/src/providers/github/index.ts:93–118` — GitHub events map (pull_request + issues only)
+- `packages/console-providers/src/providers/vercel/index.ts:251–277` — Vercel extractEventType + extractResourceId
+- `packages/console-providers/src/gateway.ts:72–86` — `GatewayConnection` schema (`status: z.string()`)
+
+---
+
+## Architecture Documentation
+
+### Current State Machine (implicit)
+
+```
+[any] ──OAuth callback──→ active
+active ──DELETE/:id + workflow──→ revoked
+active ──tRPC disconnect──→ revoked   (direct DB write, no workflow)
+active ──401 on listResources──→ error
+```
+
+`pending`, `suspended`, `disconnected` do not exist as DB values today.
+
+### Where the Binary `active` / not-active Split Exists
+
+Every read-site tests `=== "active"` or `!== "active"`. This means adding `suspended` and `disconnected` as additional non-active states would naturally flow through all existing guards without code changes — those endpoints would return the same `installation_not_active` errors or exclude the row from query results. The UI derives connection presence from the tRPC query returning a row at all (no row = no connection).
+
+### Webhook Lifecycle Gap
+
+Both GitHub `installation` events and Vercel `integration-configuration.removed` arrive at the relay, pass HMAC verification, and are DLQ'd. Neither triggers a connection status change. The teardown workflow has no inbound webhook path — only the explicit UI-initiated `DELETE /:provider/:id` call triggers it.
+
+### Two Disconnect Paths
+
+| Path | Files | Runs teardown workflow? |
+|------|-------|------------------------|
+| UI disconnect → tRPC `connections.disconnect` → direct DB | `api/console/src/router/org/connections.ts:126–135` | No |
+| UI disconnect → tRPC → `DELETE /gateway/:provider/:id` → workflow | `connections.ts:947` + `connection-teardown.ts` | Yes |
+
+Based on write sites 3+4, the tRPC `connections.disconnect` and `connections.vercel.disconnect` procedures write `"revoked"` directly without calling the gateway endpoint or triggering the workflow. Only the gateway `DELETE /:provider/:id` triggers the 4-step durable workflow.
+
+---
+
+## Open Questions
+
+1. **Installation webhook routing**: Should `installation.deleted/suspend/unsuspend` be handled in relay (routing layer) or gateway (connection lifecycle owner)? Relay would need to look up by `gatewayInstallations.externalId` instead of `gatewayResources.providerResourceId`. Gateway would need a new inbound webhook route.
+
+2. **tRPC disconnect duality**: Why do `connections.disconnect` and `connections.vercel.disconnect` write `"revoked"` directly without going through the gateway workflow? Should the tRPC procedures call `DELETE /gateway/:provider/:id` to ensure the full teardown chain runs?
+
+3. **`"error"` recovery**: There is no automated or manual path to go from `"error"` back to `"active"` without a full reconnect via OAuth. Is this intentional?
+
+4. **`"pending"` in DB**: The schema documents `pending` as a valid status but nothing writes it to the DB. Should the OAuth callback write `pending` initially and `active` only after token exchange completes, or should `pending` remain Redis-only?
+
+5. **`gatewayInstallations.externalId` for webhook routing**: The relay's resource-resolution step uses `gatewayResources.providerResourceId`. For installation-level events (GitHub `installation`, Vercel `integration-configuration`), a new resolution path against `gatewayInstallations.externalId` would be needed.

--- a/thoughts/shared/research/2026-03-16-web-analysis-betterstack-relay-integration.md
+++ b/thoughts/shared/research/2026-03-16-web-analysis-betterstack-relay-integration.md
@@ -1,0 +1,246 @@
+---
+date: 2026-03-16T00:00:00+00:00
+researcher: claude-sonnet-4-6
+topic: "Better Stack end-to-end integration for relay — Vercel log drain + SDK setup"
+tags: [research, web-analysis, betterstack, logtail, vercel, relay, logging, observability]
+status: complete
+created_at: 2026-03-16
+confidence: high
+sources_count: 6
+---
+
+# Web Research: Better Stack End-to-End Integration for Relay
+
+**Date**: 2026-03-16
+**Topic**: Better Stack (Logtail) complete setup — Vercel log drain + SDK logger for `apps/relay`
+**Confidence**: High — official docs + codebase analysis
+
+---
+
+## Research Question
+
+The Vercel log drain was configured through Vercel Sources but logs are not appearing in Better Stack. The internal SDK implementation in `apps/relay` was never fully set up. What is the complete end-to-end setup?
+
+---
+
+## Executive Summary
+
+There are **two independent pipelines** — Vercel log drain and SDK-based logging — that send to **different Better Stack sources**. The codebase already has the SDK integration built (`@logtail/edge` via `@vendor/observability/service-log`), but it has never been activated because `LOGTAIL_SOURCE_TOKEN` is not set in the relay's Vercel environment variables.
+
+The Vercel log drain (if configured) captures raw `stdout` from all Vercel functions. The SDK (`@logtail/edge`) captures only what you explicitly call `log.info()` etc. on — but gives structured context, service names, and correlation IDs.
+
+**Most likely root cause for missing logs**: `LOGTAIL_SOURCE_TOKEN` is not set as a Vercel environment variable for the relay project. Additionally, `service-log.ts` does not pass the `endpoint` option to `new Logtail()`, which can cause silent failures if your Better Stack source uses a non-default ingesting host.
+
+---
+
+## The Two Pipelines — Key Distinction
+
+| | Vercel Log Drain | SDK (`@logtail/edge`) |
+|---|---|---|
+| **What it captures** | All stdout/stderr, build output, static, edge, lambda | Only explicit `log.info()` etc. calls |
+| **Better Stack source type** | HTTP source | Node.js source |
+| **Auth** | `Authorization: Bearer <token>` header in Vercel drain config | `LOGTAIL_SOURCE_TOKEN` env var |
+| **Vercel plan required** | Pro or Enterprise only | Any plan |
+| **Structure** | Raw text / Vercel-formatted JSON | Structured JSON with service, env, ctx |
+| **In this codebase** | Configured externally in Vercel dashboard | `vendor/observability/src/service-log.ts` |
+
+These go to **separate Better Stack sources**. Copying the drain's source token into `LOGTAIL_SOURCE_TOKEN` will not fix the SDK logs — they will appear in the wrong source.
+
+---
+
+## Current Codebase State
+
+### What's already built and correct
+
+- `vendor/observability/src/service-log.ts` — `createServiceLogger` using `@logtail/edge ^0.5.8`
+- `apps/relay/src/logger.ts` — relay's logger singleton
+- `apps/relay/src/middleware/lifecycle.ts` — `waitUntil`-based flush (edge-safe)
+- `apps/relay/src/env.ts` line 20 — `LOGTAIL_SOURCE_TOKEN` defined as optional
+
+### What's missing / broken
+
+**1. `LOGTAIL_SOURCE_TOKEN` not set in Vercel project env vars**
+
+`service-log.ts` lines 27-29:
+```typescript
+const shouldShip =
+  config.token &&
+  (config.environment === "production" || config.environment === "preview");
+```
+If `config.token` is `undefined` (token not set), `shouldShip` is `false` and all logs silently fall back to `console`. No error is thrown. This is the most likely reason logs are not appearing.
+
+**2. `service-log.ts` does not pass `endpoint` to Logtail constructor**
+
+`service-log.ts` line 42:
+```typescript
+const logtail = new Logtail(config.token!);
+```
+No `endpoint` option is passed. The default endpoint is `https://in.logs.betterstack.com`. If your Better Stack source was created in a non-default region, or if Better Stack changes their ingesting host, logs will be silently dropped. This should be fixed by making the endpoint configurable.
+
+**3. Relay `env.ts` has no `LOGTAIL_INGESTING_URL` variable**
+
+`betterstack-env.ts` already defines `LOGTAIL_URL` for Next.js apps but the relay never wires it up. Without this, you cannot configure a custom endpoint for the relay's Logtail instance.
+
+---
+
+## Fix Plan
+
+### Step 1 — Create the right Better Stack source
+
+1. Go to **Better Stack → Logs → Sources → Connect source**
+2. Select platform: **Node.js** (not HTTP — that's for the log drain)
+3. Name it: `relay-production` (or `relay`)
+4. Note the **Source Token** and **Ingesting URL** from the Configure tab
+
+### Step 2 — Set env vars in Vercel
+
+In the relay's Vercel project settings → Environment Variables, add:
+
+```
+LOGTAIL_SOURCE_TOKEN = <source-token-from-step-1>
+```
+
+Set it for **Production** and **Preview** environments. It does not need to be set for Development (the codebase intentionally falls back to console there).
+
+### Step 3 — Pass endpoint to Logtail constructor (code fix)
+
+In `vendor/observability/src/service-log.ts`, update `ServiceLoggerConfig` and the Logtail instantiation:
+
+```typescript
+export interface ServiceLoggerConfig {
+  environment: string | undefined;
+  service: string;
+  token: string | undefined;
+  endpoint?: string;  // add this
+}
+
+// Line 42 — update to:
+const logtail = new Logtail(config.token!, {
+  endpoint: config.endpoint,  // falls back to default if undefined
+});
+```
+
+Then in `apps/relay/src/env.ts`, add:
+```typescript
+LOGTAIL_INGESTING_URL: z.string().url().optional(),
+```
+
+And in `apps/relay/src/logger.ts`, pass it through:
+```typescript
+export const log = createServiceLogger({
+  token: env.LOGTAIL_SOURCE_TOKEN,
+  service: "relay",
+  environment: env.VERCEL_ENV,
+  endpoint: env.LOGTAIL_INGESTING_URL,
+});
+```
+
+### Step 4 — Fix Vercel log drain (if you want both pipelines)
+
+The log drain setup requires:
+
+1. **Better Stack → Sources → Connect source → HTTP source** (separate from the SDK source)
+2. Note the **Source Token** and **Ingesting Host** (e.g. `in.logs.betterstack.com`)
+3. **Vercel → Team Settings → Log Drains → Add Log Drain → Custom Log Drain**
+   - Endpoint: `https://<INGESTING_HOST>` (no trailing slash, no path)
+   - Enable Custom Headers: `Authorization` = `Bearer <SOURCE_TOKEN>`
+   - Format: **NDJSON**
+   - Select the relay project
+4. Click **Test Log Drain** — a test event should appear in Better Stack Live Tail within seconds
+5. If it doesn't appear: check the authorization header value is exactly `Bearer <token>` with no quotes
+
+**Note**: Vercel log drain requires **Pro or Enterprise plan**. Hobby plan does not support it.
+
+---
+
+## Why `shouldShip` Blocks Development Logs
+
+This is intentional. The `VERCEL_ENV` check prevents log shipping in local dev, avoiding:
+- Polluting production Better Stack with development noise
+- Accidentally shipping sensitive debug data
+- Unnecessary Better Stack API calls in local dev
+
+To test the SDK integration without deploying, you can temporarily override locally:
+
+```bash
+VERCEL_ENV=preview LOGTAIL_SOURCE_TOKEN=<your-token> pnpm dev:relay
+```
+
+Logs should appear in Better Stack Live Tail within a few seconds of a request.
+
+---
+
+## Package Selection Rationale
+
+The codebase correctly uses `@logtail/edge` (not `@logtail/node`):
+
+| Package | Runtime | Notes |
+|---|---|---|
+| `@logtail/edge` ✅ | V8 isolates (Vercel Edge, CF Workers) | Used by relay |
+| `@logtail/node` ❌ | Node.js only | Uses `http` module — unavailable in edge |
+| `@logtail/next` | Next.js | Wraps console, used by console app |
+
+Using `@logtail/node` in an edge runtime will throw `Error: The "http" module is not available in the Edge Runtime`.
+
+---
+
+## Flush Pattern — Already Correct
+
+`apps/relay/src/middleware/lifecycle.ts` already implements the correct flush pattern:
+
+```typescript
+// waitUntil is edge-safe: response is sent, flush happens in background
+const safeFlush = log.flush().catch(() => undefined);
+try {
+  c.executionCtx.waitUntil(safeFlush);
+} catch {
+  await safeFlush; // fallback for Node.js runtime
+}
+```
+
+Without this, logs buffered after the response is sent would be dropped. This is already working correctly.
+
+---
+
+## Checklist
+
+- [ ] Create Node.js source in Better Stack (for SDK)
+- [ ] Set `LOGTAIL_SOURCE_TOKEN` in Vercel project env vars (Production + Preview)
+- [ ] Update `service-log.ts` to accept and pass `endpoint` option
+- [ ] Add `LOGTAIL_INGESTING_URL` to relay `env.ts`
+- [ ] Wire `endpoint` through relay `logger.ts`
+- [ ] (Optional) Create HTTP source + configure Vercel log drain for raw stdout capture
+- [ ] Verify with Live Tail: deploy to Preview and trigger a webhook
+
+---
+
+## Risk Assessment
+
+### High Priority
+- **Missing token**: All logs silently drop to console — no observability in production. Fix: set `LOGTAIL_SOURCE_TOKEN` in Vercel env vars.
+- **No endpoint**: If Better Stack changes default ingesting host or source is in different region, SDK calls fail silently. Fix: wire through `LOGTAIL_INGESTING_URL`.
+
+### Medium Priority
+- **Log drain vs SDK confusion**: Two sources means logs are split. For operations review, you'll need to check both sources unless you use Better Stack's unified dashboards.
+
+---
+
+## Sources
+
+### Official Documentation
+- [Better Stack Vercel Log Drain Setup](https://betterstack.com/docs/logs/vercel/log-drain/) — BetterStack, 2025
+- [Better Stack Node.js SDK](https://betterstack.com/docs/logs/javascript/) — BetterStack, 2025
+- [Better Stack Cloudflare Workers / Edge SDK](https://betterstack.com/docs/logs/cloudflare-worker/) — BetterStack, 2025
+- [@logtail/edge package](https://github.com/logtail/logtail-js/tree/main/packages/edge) — Logtail/BetterStack, 2024
+
+### Codebase References
+- `vendor/observability/src/service-log.ts` — SDK integration factory
+- `apps/relay/src/logger.ts` — relay logger singleton
+- `apps/relay/src/middleware/lifecycle.ts` — flush/waitUntil pattern
+- `apps/relay/src/env.ts` — env var definitions
+
+---
+
+**Last Updated**: 2026-03-16
+**Confidence Level**: High — based on official docs + direct codebase analysis
+**Next Steps**: Set `LOGTAIL_SOURCE_TOKEN` in Vercel project, then optionally wire `endpoint` through the config chain. The SDK flush/waitUntil pattern is already correct and does not need changes.


### PR DESCRIPTION
## Summary

- All provider webhook URLs updated to bypass the console Next.js proxy
- Adds `url_dev` and `url_prod` fields with direct relay URLs
- Adds comment explaining why (HMAC body integrity)

## Test plan
- [ ] Update GitHub App webhook URL in production to `https://lightfast-relay.vercel.app/api/webhooks/github`
- [ ] Trigger test webhook and verify 200