### PR TITLE
test: webhook probe 6b - qstash error logging

### DIFF
--- a/apps/relay/.webhook-test-6
+++ b/apps/relay/.webhook-test-6
@@ -1,1 +1,2 @@
 probe6
+probe6b


### PR DESCRIPTION
Debug: checking if qstash.publishJSON() throws or succeeds inside publish-to-console step.