### PR TITLE
fix(auth): migrate middleware.ts to proxy.ts for Next.js 16

### DIFF
--- a/apps/auth/src/proxy.ts
+++ b/apps/auth/src/proxy.ts
@@ -77,10 +77,10 @@ const composedMiddleware = createNEMO(
 );
 
 // =============================================================================
-// Main Middleware
+// Main Proxy (Next.js 16)
 // =============================================================================
 
-export default clerkMiddleware(
+export const proxy = clerkMiddleware(
   async (auth, req: NextRequest, event: NextFetchEvent) => {
     const { userId, orgId, orgSlug } = await auth({
       treatPendingAsSignedOut: false,


### PR DESCRIPTION
## Summary
- Renames `apps/auth/src/middleware.ts` → `apps/auth/src/proxy.ts`
- Changes export from `export default clerkMiddleware(...)` to `export const proxy = clerkMiddleware(...)`
- Required by Next.js 16 which renamed `middleware.ts` to `proxy.ts` (Node.js runtime only)

## Verification
- `pnpm build:auth` passes cleanly — build output shows `ƒ Proxy (Middleware)` confirming Next.js 16 detected the file correctly
- `pnpm --filter @lightfast/auth typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)