### PR TITLE
perf(auth): apply Vercel React best practices

### DIFF
--- a/apps/auth/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-in/page.tsx
@@ -1,13 +1,19 @@
 import { createMetadata } from "@vendor/seo/metadata";
 import type { Metadata } from "next";
+import dynamic from "next/dynamic";
 import type { SearchParams } from "nuqs/server";
 import { EmailForm } from "../_components/email-form";
 import { ErrorBanner } from "../_components/error-banner";
 import { OAuthButton } from "../_components/oauth-button";
-import { OTPIsland } from "../_components/otp-island";
 import { SeparatorWithText } from "../_components/separator-with-text";
-import { SessionActivator } from "../_components/session-activator";
 import { loadSignInSearchParams } from "../_lib/search-params";
+
+const OTPIsland = dynamic(() =>
+  import("../_components/otp-island").then((m) => m.OTPIsland)
+);
+const SessionActivator = dynamic(() =>
+  import("../_components/session-activator").then((m) => m.SessionActivator)
+);
 
 export const metadata: Metadata = createMetadata({
   title: "Sign In - Lightfast Auth",

--- a/apps/auth/src/app/(app)/(auth)/sign-up/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-up/page.tsx
@@ -2,14 +2,18 @@ import { Button } from "@repo/ui/components/ui/button";
 import { createMetadata } from "@vendor/seo/metadata";
 import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import type { Metadata } from "next";
+import dynamic from "next/dynamic";
 import NextLink from "next/link";
 import type { SearchParams } from "nuqs/server";
 import { EmailForm } from "../_components/email-form";
 import { ErrorBanner } from "../_components/error-banner";
 import { OAuthButton } from "../_components/oauth-button";
-import { OTPIsland } from "../_components/otp-island";
 import { SeparatorWithText } from "../_components/separator-with-text";
 import { loadSignUpSearchParams } from "../_lib/search-params";
+
+const OTPIsland = dynamic(() =>
+  import("../_components/otp-island").then((m) => m.OTPIsland)
+);
 
 function decodeTicketExpiry(ticket: string): Date | null {
   try {

--- a/apps/auth/src/app/(app)/(user)/_components/user-page-header.tsx
+++ b/apps/auth/src/app/(app)/(user)/_components/user-page-header.tsx
@@ -3,6 +3,7 @@
 import { TeamSwitcher } from "@repo/ui/components/app-header/team-switcher";
 import { UserMenu } from "@repo/ui/components/app-header/user-menu";
 import { useClerk, useOrganizationList, useUser } from "@vendor/clerk/client";
+import { useCallback } from "react";
 
 export function UserPageHeader() {
   const { signOut } = useClerk();
@@ -17,11 +18,14 @@ export function UserPageHeader() {
     name: m.organization.name,
   }));
 
-  const handleOrgSelect = async (orgId: string) => {
-    if (setActive) {
-      await setActive({ organization: orgId });
-    }
-  };
+  const handleOrgSelect = useCallback(
+    async (orgId: string) => {
+      if (setActive) {
+        await setActive({ organization: orgId });
+      }
+    },
+    [setActive]
+  );
 
   const email =
     user?.primaryEmailAddress?.emailAddress ??

--- a/apps/auth/src/instrumentation-client.ts
+++ b/apps/auth/src/instrumentation-client.ts
@@ -10,6 +10,10 @@ import {
 
 import { env } from "~/env";
 
+const TOKEN_RE = /token=[^&]+/;
+const CLERK_TICKET_RE = /__clerk_ticket=[^&]+/;
+const TICKET_RE = /ticket=[^&]+/;
+
 initSentry({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN,
   environment: env.NEXT_PUBLIC_VERCEL_ENV,
@@ -23,9 +27,9 @@ initSentry({
   beforeBreadcrumb(breadcrumb) {
     if (breadcrumb.type === "navigation" && breadcrumb.data?.to) {
       breadcrumb.data.to = breadcrumb.data.to
-        .replace(/token=[^&]+/, "token=REDACTED")
-        .replace(/__clerk_ticket=[^&]+/, "__clerk_ticket=REDACTED")
-        .replace(/ticket=[^&]+/, "ticket=REDACTED");
+        .replace(TOKEN_RE, "token=REDACTED")
+        .replace(CLERK_TICKET_RE, "__clerk_ticket=REDACTED")
+        .replace(TICKET_RE, "ticket=REDACTED");
     }
     return breadcrumb;
   },


### PR DESCRIPTION
## Summary

- **`js-hoist-regexp`** — hoist 3 regex literals to module level in `instrumentation-client.ts`; `beforeBreadcrumb` fires on every navigation event so recreating them per-call is wasteful
- **`bundle-dynamic-imports`** — dynamically import `OTPIsland` and `SessionActivator` in sign-in/sign-up pages so the email step (most common entry point) doesn't load their JS upfront
- **`rerender-memo-with-default-value`** — wrap `handleOrgSelect` in `useCallback` in `UserPageHeader` to stabilise the prop reference passed to `TeamSwitcher`

## Test plan

- [ ] Sign-in email step loads and GitHub OAuth works
- [ ] Entering a 6-digit OTP code triggers verification (OTPIsland loads on demand)
- [ ] Session activator link flow works (`?step=activate&token=...`)
- [ ] Sign-up flow (standard + invitation ticket) works end-to-end
- [ ] Early access waitlist form submits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)