### PR TITLE
fix(auth): rework invite + GitHub OAuth flow to correctly pass legalAccepted

### DIFF
--- a/apps/auth/src/app/(app)/(auth)/_components/error-banner.tsx
+++ b/apps/auth/src/app/(app)/(auth)/_components/error-banner.tsx
@@ -1,22 +1,24 @@
 import { Button } from "@repo/ui/components/ui/button";
 import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
+import { AUTH_ERROR_MESSAGES, type AuthErrorCode } from "../_lib/search-params";
 
 interface ErrorBannerProps {
   backUrl: string;
-  isWaitlist: boolean;
-  message: string;
+  errorCode?: AuthErrorCode | null;
+  message?: string | null;
 }
 
-export function ErrorBanner({
-  message,
-  isWaitlist,
-  backUrl,
-}: ErrorBannerProps) {
-  if (isWaitlist) {
+export function ErrorBanner({ message, errorCode, backUrl }: ErrorBannerProps) {
+  const displayMessage =
+    message ??
+    (errorCode ? AUTH_ERROR_MESSAGES[errorCode] : null) ??
+    "An error occurred.";
+
+  if (errorCode === "waitlist") {
     return (
       <div className="space-y-4">
         <div className="rounded-lg border border-border bg-destructive/30 p-3">
-          <p className="text-foreground text-sm">{message}</p>
+          <p className="text-foreground text-sm">{displayMessage}</p>
         </div>
         <Button asChild className="w-full" size="lg">
           <MicrofrontendLink href="/early-access">
@@ -30,10 +32,26 @@ export function ErrorBanner({
     );
   }
 
+  if (errorCode === "account_not_found") {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-lg border border-border bg-destructive/30 p-3">
+          <p className="text-foreground text-sm">{displayMessage}</p>
+        </div>
+        <Button asChild className="w-full" size="lg">
+          <a href="/sign-up">Sign Up</a>
+        </Button>
+        <Button asChild className="w-full" size="lg" variant="outline">
+          <a href={backUrl}>Try again</a>
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-red-200 bg-red-50 p-3">
-        <p className="text-red-800 text-sm">{message}</p>
+      <div className="rounded-lg border border-border bg-destructive/30 p-3">
+        <p className="text-foreground text-sm">{displayMessage}</p>
       </div>
       <Button asChild className="w-full" size="lg" variant="outline">
         <a href={backUrl}>Try again</a>

--- a/apps/auth/src/app/(app)/(auth)/_components/oauth-button.tsx
+++ b/apps/auth/src/app/(app)/(auth)/_components/oauth-button.tsx
@@ -8,10 +8,11 @@ import { useSignIn, useSignUp } from "@vendor/clerk/client";
 import type { OAuthStrategy } from "@vendor/clerk/types";
 import * as React from "react";
 import { consoleUrl } from "~/lib/related-projects";
+import type { AuthErrorCode } from "../_lib/search-params";
 
 interface OAuthButtonProps {
   mode: "sign-in" | "sign-up";
-  onError?: (message: string, isWaitlist?: boolean) => void;
+  onError?: (errorCode: AuthErrorCode) => void;
   ticket?: string | null;
 }
 
@@ -21,6 +22,51 @@ export function OAuthButton({ mode, ticket, onError }: OAuthButtonProps) {
   const [loading, setLoading] = React.useState(false);
 
   async function handleTicketSignUp(strategy: OAuthStrategy) {
+    // Step 1: Apply the ticket to the sign-up resource.
+    // signUp.sso() silently drops the `ticket` param — confirmed by clerk-js@5.125.3
+    // source inspection. The only path that sends ticket to FAPI is signUp.create().
+    const { error: createError } = await startSpan(
+      {
+        name: "auth.ticket.create",
+        op: "auth",
+        attributes: { strategy, mode },
+      },
+      () =>
+        signUp.create({
+          ticket: ticket!,
+        })
+    );
+    if (createError) {
+      const errCode = createError.code;
+      if (errCode === "sign_up_restricted_waitlist") {
+        addBreadcrumb({
+          category: "auth",
+          message: "OAuth blocked by waitlist (ticket create step)",
+          level: "warning",
+          data: { strategy },
+        });
+        if (onError) {
+          onError("waitlist");
+        } else {
+          window.location.href = "/sign-up?errorCode=waitlist";
+        }
+      } else {
+        toast.error(
+          createError.longMessage ??
+            createError.message ??
+            "Authentication failed"
+        );
+      }
+      setLoading(false);
+      return;
+    }
+
+    // Step 2: Initiate OAuth. FAPI uses the session cookie to identify the
+    // existing sign-up (with ticket attached) rather than creating a fresh one.
+    // legalAccepted is passed directly to sso() — SignUpFutureSSOParams extends
+    // SignUpFutureAdditionalParams which includes legalAccepted. This sends it
+    // in the same FAPI request that initiates the OAuth redirect.
+    // InviteOAuthCompleter handles it as a fallback if FAPI resets it post-callback.
     const { error } = await startSpan(
       {
         name: "auth.oauth.initiate",
@@ -28,15 +74,12 @@ export function OAuthButton({ mode, ticket, onError }: OAuthButtonProps) {
         attributes: { strategy, mode },
       },
       () =>
-        signUp.sso(
-          // Clerk FAPI accepts `ticket` in sso() for invitation flows; TS types omit this field
-          {
-            strategy,
-            ticket: ticket!,
-            redirectCallbackUrl: "/sign-up/sso-callback",
-            redirectUrl: `${consoleUrl}/account/welcome`,
-          } as unknown as Parameters<typeof signUp.sso>[0]
-        )
+        signUp.sso({
+          strategy,
+          redirectCallbackUrl: `/sign-up/sso-callback?__clerk_ticket=${encodeURIComponent(ticket!)}`,
+          redirectUrl: `${consoleUrl}/account/welcome`,
+          legalAccepted: true,
+        })
     );
     if (error) {
       const errCode = error.code;
@@ -47,12 +90,10 @@ export function OAuthButton({ mode, ticket, onError }: OAuthButtonProps) {
           level: "warning",
           data: { strategy },
         });
-        const msg =
-          "Sign-ups are currently unavailable. Join the waitlist to be notified when access becomes available.";
         if (onError) {
-          onError(msg, true);
+          onError("waitlist");
         } else {
-          window.location.href = `/sign-up?error=${encodeURIComponent(msg)}&waitlist=true`;
+          window.location.href = "/sign-up?errorCode=waitlist";
         }
       } else {
         toast.error(
@@ -86,10 +127,11 @@ export function OAuthButton({ mode, ticket, onError }: OAuthButtonProps) {
           level: "warning",
           data: { strategy: "oauth_github" },
         });
-        onError?.(
-          "Sign-ups are currently unavailable. Join the waitlist to be notified when access becomes available.",
-          true
-        );
+        if (onError) {
+          onError("waitlist");
+        } else {
+          window.location.href = "/sign-in?errorCode=waitlist";
+        }
       } else {
         toast.error(
           error.longMessage ?? error.message ?? "Authentication failed"
@@ -122,12 +164,10 @@ export function OAuthButton({ mode, ticket, onError }: OAuthButtonProps) {
           level: "warning",
           data: { strategy: "oauth_github" },
         });
-        const msg =
-          "Sign-ups are currently unavailable. Join the waitlist to be notified when access becomes available.";
         if (onError) {
-          onError(msg, true);
+          onError("waitlist");
         } else {
-          window.location.href = `/sign-up?error=${encodeURIComponent(msg)}&waitlist=true`;
+          window.location.href = "/sign-up?errorCode=waitlist";
         }
       } else {
         toast.error(

--- a/apps/auth/src/app/(app)/(auth)/_lib/search-params.ts
+++ b/apps/auth/src/app/(app)/(auth)/_lib/search-params.ts
@@ -8,12 +8,25 @@ import {
 const signInSteps = ["email", "code", "activate"] as const;
 const signUpSteps = ["email", "code"] as const;
 
+// Typed error codes — the authoritative discriminant for error rendering.
+// Known errors carry their canonical message here; `error` is for dynamic
+// validation messages only (e.g. "Please enter a valid email address").
+export const authErrorCodes = ["waitlist", "account_not_found"] as const;
+export type AuthErrorCode = (typeof authErrorCodes)[number];
+
+export const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
+  waitlist:
+    "Sign-ups are currently unavailable. Join the waitlist to be notified when access becomes available.",
+  account_not_found:
+    "No Lightfast account is linked to this GitHub account. Sign up to create one.",
+};
+
 export const signInSearchParams = {
   step: parseAsStringLiteral(signInSteps).withDefault("email"),
   email: parseAsString,
   error: parseAsString,
   token: parseAsString,
-  waitlist: parseAsString,
+  errorCode: parseAsStringLiteral(authErrorCodes),
 };
 
 export const signUpSearchParams = {
@@ -22,7 +35,7 @@ export const signUpSearchParams = {
   error: parseAsString,
   ticket: parseAsString,
   __clerk_ticket: parseAsString, // Clerk invitation URL parameter
-  waitlist: parseAsString,
+  errorCode: parseAsStringLiteral(authErrorCodes),
 };
 
 export const loadSignInSearchParams = createLoader(signInSearchParams);

--- a/apps/auth/src/app/(app)/(auth)/sign-in/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-in/page.tsx
@@ -44,13 +44,15 @@ interface PageProps {
 }
 
 export default async function SignInPage({ searchParams }: PageProps) {
-  const { step, email, error, token, waitlist } =
+  const { step, email, error, token, errorCode } =
     await loadSignInSearchParams(searchParams);
+
+  const hasError = !!(error ?? errorCode);
 
   return (
     <div className="w-full space-y-8">
       {/* Header — only on email step */}
-      {step === "email" && !error && (
+      {step === "email" && !hasError && (
         <div className="text-center">
           <h1 className="font-medium font-pp text-3xl text-foreground">
             Log in to Lightfast
@@ -60,16 +62,16 @@ export default async function SignInPage({ searchParams }: PageProps) {
 
       <div className="space-y-4">
         {/* Error display */}
-        {error && (
+        {(error ?? errorCode) && (
           <ErrorBanner
             backUrl="/sign-in"
-            isWaitlist={waitlist === "true"}
+            errorCode={errorCode}
             message={error}
           />
         )}
 
         {/* Step: email — server component form + client OAuth island */}
-        {!error && step === "email" && (
+        {!hasError && step === "email" && (
           <>
             <EmailForm action="sign-in" />
             <SeparatorWithText text="Or" />
@@ -78,7 +80,7 @@ export default async function SignInPage({ searchParams }: PageProps) {
         )}
 
         {/* Step: code — client island (irreducible: OTP + Clerk FAPI) */}
-        {!error && step === "code" && email && (
+        {!hasError && step === "code" && email && (
           <OTPIsland email={email} mode="sign-in" />
         )}
 

--- a/apps/auth/src/app/(app)/(auth)/sign-in/sso-callback/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-in/sso-callback/page.tsx
@@ -2,18 +2,20 @@
 
 import { AuthenticateWithRedirectCallback } from "@vendor/clerk/client";
 
+const ACCOUNT_NOT_FOUND_URL = "/sign-in?errorCode=account_not_found";
+
 export default function Page() {
   // Handle the redirect flow by calling the Clerk.handleRedirectCallback() method
   // or rendering the prebuilt <AuthenticateWithRedirectCallback/> component.
   // This is the final step in the custom OAuth flow.
   //
   // Clerk's task system handles redirection:
-  // - Pending users (no org) → taskUrls["choose-organization"] → /account/teams/new
   // - Active users (with org) → signInFallbackRedirectUrl → /account/welcome → /:orgSlug
+  // - Unregistered GitHub account → continueSignUpUrl → /sign-in?error=...&accountNotFound=true
 
   return (
     <AuthenticateWithRedirectCallback
-      continueSignUpUrl="/sign-in"
+      continueSignUpUrl={ACCOUNT_NOT_FOUND_URL}
       signInFallbackRedirectUrl="/account/welcome"
       signUpFallbackRedirectUrl="/account/welcome"
     />

--- a/apps/auth/src/app/(app)/(auth)/sign-up/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-up/page.tsx
@@ -61,7 +61,7 @@ interface PageProps {
 }
 
 export default async function SignUpPage({ searchParams }: PageProps) {
-  const { step, email, error, ticket, __clerk_ticket, waitlist } =
+  const { step, email, error, ticket, __clerk_ticket, errorCode } =
     await loadSignUpSearchParams(searchParams);
 
   // Support both ?ticket= (nuqs) and ?__clerk_ticket= (Clerk invitation URL)
@@ -75,10 +75,12 @@ export default async function SignUpPage({ searchParams }: PageProps) {
     ? decodeTicketExpiry(invitationTicket)
     : null;
 
+  const hasError = !!(error ?? errorCode);
+
   return (
     <div className="w-full max-w-md space-y-8">
       {/* Header — only on email step */}
-      {step === "email" && !error && (
+      {step === "email" && !hasError && (
         <div className="text-center">
           <h1 className="font-medium font-pp text-3xl text-foreground">
             {invitationTicket
@@ -90,16 +92,16 @@ export default async function SignUpPage({ searchParams }: PageProps) {
 
       <div className="space-y-4">
         {/* Error display */}
-        {error && (
+        {hasError && (
           <ErrorBanner
             backUrl={signUpBaseUrl}
-            isWaitlist={waitlist === "true"}
+            errorCode={errorCode}
             message={error}
           />
         )}
 
         {/* Step: email */}
-        {!error &&
+        {!hasError &&
           step === "email" &&
           (invitationTicket ? (
             // Invitation flow — GitHub primary, email form secondary
@@ -151,13 +153,13 @@ export default async function SignUpPage({ searchParams }: PageProps) {
           ))}
 
         {/* Step: code */}
-        {!error && step === "code" && email && (
+        {!hasError && step === "code" && email && (
           <OTPIsland email={email} mode="sign-up" ticket={invitationTicket} />
         )}
       </div>
 
       {/* Sign In Link — only on email step */}
-      {step === "email" && !error && (
+      {step === "email" && !hasError && (
         <div className="text-center text-sm">
           <span className="text-muted-foreground">
             Already have an account?{" "}

--- a/apps/auth/src/app/(app)/(auth)/sign-up/sso-callback/page.tsx
+++ b/apps/auth/src/app/(app)/(auth)/sign-up/sso-callback/page.tsx
@@ -1,21 +1,68 @@
 "use client";
 
-import { AuthenticateWithRedirectCallback } from "@vendor/clerk/client";
+import { AuthenticateWithRedirectCallback, useSignUp } from "@vendor/clerk/client";
+import { useSearchParams } from "next/navigation";
+import * as React from "react";
+import { consoleUrl } from "~/lib/related-projects";
 
-export default function Page() {
-  // Handle the redirect flow by calling the Clerk.handleRedirectCallback() method
-  // or rendering the prebuilt <AuthenticateWithRedirectCallback/> component.
-  // This is the final step in the custom OAuth flow.
-  //
-  // Clerk's task system handles redirection:
-  // - Pending users (no org) → taskUrls["choose-organization"] → /account/teams/new
-  // - Active users (with org) → signUpFallbackRedirectUrl → /account/welcome → /:orgSlug
+function SSOCallback() {
+  const { signUp } = useSignUp();
+  const searchParams = useSearchParams();
+  const clerkTicket = searchParams.get("__clerk_ticket");
+  const updateStarted = React.useRef(false);
+
+  // Effect 1: After AuthenticateWithRedirectCallback processes the OAuth callback,
+  // if only legal_accepted is missing (expected for invite + GitHub flow), apply it
+  // inline without navigating away. continueSignUpUrl={null} keeps this page mounted.
+  React.useEffect(() => {
+    if (!clerkTicket || !signUp || updateStarted.current) return;
+    if (signUp.status !== "missing_requirements") return;
+
+    const missing = signUp.missingFields ?? [];
+    if (
+      missing.length !== 1 ||
+      missing[0] !== "legal_accepted" ||
+      signUp.verifications?.externalAccount?.status !== "verified"
+    ) {
+      return;
+    }
+
+    updateStarted.current = true;
+    signUp.update({ legalAccepted: true }).catch(() => {
+      updateStarted.current = false;
+    });
+  }, [signUp, clerkTicket]);
+
+  // Effect 2: Finalize once the sign-up reaches "complete" after our update.
+  // Runs in a separate cycle so it reads the fresh reactive signUp from Core 3 Signals.
+  React.useEffect(() => {
+    if (!updateStarted.current || !signUp || signUp.status !== "complete") return;
+
+    signUp
+      .finalize({
+        navigate: async () => {
+          window.location.href = `${consoleUrl}/account/welcome`;
+        },
+      })
+      .catch(() => {});
+  }, [signUp]);
 
   return (
     <AuthenticateWithRedirectCallback
-      continueSignUpUrl="/sign-up"
-      signInFallbackRedirectUrl="/account/welcome"
-      signUpFallbackRedirectUrl="/account/welcome"
+      // Invite flow: continueSignUpUrl={null} prevents Clerk from navigating away
+      // when status is missing_requirements. Our effects handle legal_accepted inline.
+      // Non-invite flow: not reached (no ticket → no sign-up callback here).
+      continueSignUpUrl={clerkTicket ? null : "/sign-up"}
+      signInFallbackRedirectUrl={`${consoleUrl}/account/welcome`}
+      signUpFallbackRedirectUrl={`${consoleUrl}/account/welcome`}
     />
+  );
+}
+
+export default function Page() {
+  return (
+    <React.Suspense>
+      <SSOCallback />
+    </React.Suspense>
   );
 }


### PR DESCRIPTION
## Summary

- **Delete `InviteOAuthCompleter`** — had a stale-closure bug (checked `signUp.status` in the same async closure after `update()`, always reading pre-update state) and relied on a cross-page bounce hack
- **Fix ticket + OAuth flow**: `create({ ticket })` attaches the invite ticket first (required — `sso()` silently drops it per clerk-js source); `sso({ legalAccepted: true })` drives the OAuth redirect (correct per `SignUpFutureSSOParams extends SignUpFutureAdditionalParams`)
- **Inline `legal_accepted` handling in SSO callback**: `continueSignUpUrl={null}` keeps the page mounted when Clerk returns `missing_requirements` post-OAuth. Two `useEffect` hooks read fresh Core 3 Signal state across separate render cycles — Effect 1 calls `update({ legalAccepted: true })`, Effect 2 calls `finalize()` once status reaches `complete`
- **Suspense boundary** around `useSearchParams()` to satisfy Next.js static generation requirement
- **`errorCode` search param** replaces the old `waitlist` key across sign-in/sign-up pages

## Test plan

- [ ] Invite via ticket URL → click "Continue with GitHub" → OAuth completes → lands on `/account/welcome` (no page bounce)
- [ ] Standard sign-up (no ticket) → GitHub OAuth → correct flow unaffected
- [ ] Sign-in with unregistered GitHub account → redirects to `/sign-in?errorCode=account_not_found`
- [ ] Waitlist-blocked OAuth → shows waitlist error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)