### PR TITLE
chore(microfrontends): fix default app schema, cross-zone prefetch, proxy.ts migration

### DIFF
--- a/apps/app/microfrontends.json
+++ b/apps/app/microfrontends.json
@@ -6,19 +6,7 @@
       "development": {
         "local": 4107,
         "fallback": "lightfast-app.vercel.app"
-      },
-      "routing": [
-        {
-          "group": "auth",
-          "paths": [
-            "/sign-in",
-            "/sign-in/:path*",
-            "/sign-up",
-            "/sign-up/:path*",
-            "/early-access"
-          ]
-        }
-      ]
+      }
     },
     "lightfast-www": {
       "packageName": "@lightfast/www",
@@ -36,25 +24,22 @@
             "/changelog/:path*",
             "/blog",
             "/blog/:path*",
-            "/use-cases/agent-builders",
-            "/use-cases/engineering-leaders",
-            "/use-cases/platform-engineers",
-            "/use-cases/technical-founders",
+            "/use-cases/:path*",
             "/legal/:path*",
             "/search",
             "/pitch-deck",
             "/api/health",
+            "/api/search",
             "/images/:path*",
             "/fonts/:path*",
             "/favicon.ico",
+            "/favicon-16x16.png",
+            "/favicon-32x32.png",
             "/android-chrome-192x192.png",
             "/android-chrome-512x512.png",
             "/apple-touch-icon.png",
-            "/favicon-16x16.png",
-            "/favicon-32x32.png",
             "/docs",
             "/docs/:path*",
-            "/api/search",
             "/sitemap.xml",
             "/robots.txt",
             "/manifest.json",

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -1,5 +1,6 @@
 import { createNEMO } from "@rescale/nemo";
 import { clerkMiddleware, createRouteMatcher } from "@vendor/clerk/server";
+import { runMicrofrontendsMiddleware } from "@vercel/microfrontends/next/middleware";
 import {
   composeCspOptions,
   createAnalyticsCspDirectives,
@@ -109,6 +110,13 @@ const composedMiddleware = createNEMO(
  */
 export default clerkMiddleware(
   async (auth, req: NextRequest, event) => {
+    // Handle microfrontends client-config endpoint for cross-zone prefetching
+    const mfeResponse = await runMicrofrontendsMiddleware({
+      request: req,
+      flagValues: {},
+    });
+    if (mfeResponse) return mfeResponse;
+
     // Single auth check - detect both pending and active users
     const { userId, orgId, orgSlug } = await auth({
       treatPendingAsSignedOut: false,
@@ -219,6 +227,7 @@ export default clerkMiddleware(
 
 export const config = {
   matcher: [
+    "/.well-known/vercel/microfrontends/client-config",
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     // Always run for API routes
     "/(api|trpc)(.*)",


### PR DESCRIPTION
## Summary

- **Schema fix**: `lightfast-app` had `routing` entries, making it schema-invalid — `DefaultApplication` has `additionalProperties: false` and no `routing` field. Removed routing so it correctly identifies as the default catch-all app.
- **Cross-zone prefetching**: Added `runMicrofrontendsMiddleware` to serve `/.well-known/vercel/microfrontends/client-config`, enabling the `PrefetchCrossZoneLinksProvider` (already in place) to actually work.
- **Path consolidation**: `/use-cases/:path*` replaces four individual use-case paths.
- **Next.js 16 migration**: Renamed `middleware.ts` → `proxy.ts` (Node.js runtime instead of Edge).

## Test plan

- [ ] Verify `pnpm dev:full` starts without errors on port 3024
- [ ] Auth routes (`/sign-in`, `/sign-up`, `/early-access`) still serve from `lightfast-app`
- [ ] Marketing routes (`/`, `/blog`, `/docs`) still serve from `lightfast-www`
- [ ] `/use-cases/agent-builders` (and any new use-case path) routes to `lightfast-www`
- [ ] `/.well-known/vercel/microfrontends/client-config` returns a response (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)