### PR TITLE
feat(www): manifesto page with GLSL shader

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -49,6 +49,7 @@
     "fumadocs-ui": "16.6.10",
     "geist": "catalog:",
     "github-slugger": "^2.0.0",
+    "gsap": "^3.14.2",
     "html2canvas-pro": "^1.6.6",
     "jspdf": "^4.2.0",
     "lucide-react": "catalog:",
@@ -57,6 +58,7 @@
     "react-dom": "19.2.4",
     "remove-markdown": "^0.6.3",
     "swr": "^2.4.1",
+    "three": "^0.183.2",
     "zod": "catalog:"
   },
   "devDependencies": {
@@ -70,6 +72,7 @@
     "@types/node": "catalog:",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@types/three": "^0.183.1",
     "autoprefixer": "^10.4.27",
     "babel-plugin-react-compiler": "catalog:",
     "dotenv-cli": "^8.0.0",

--- a/apps/www/src/app/(app)/(internal)/manifesto/_components/manifesto-shader.tsx
+++ b/apps/www/src/app/(app)/(internal)/manifesto/_components/manifesto-shader.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import gsap from "gsap";
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+// Color palette from research: thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md
+const COLORS = ["#000000", "#eff2c0", "#9feaf9", "#769ba2"] as const;
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  precision mediump float;
+
+  uniform float uTime;
+  uniform float uAmplitude;
+  uniform vec3 uColors[4];
+  uniform float uReveal;
+
+  varying vec2 vUv;
+
+  void main() {
+    vec2 uv = vUv;
+    vec2 c = 2.0 * uv - 1.0;
+    float d = uAmplitude * uReveal;
+
+    // Four layered sine-wave distortions on swapped axes
+    c += d * 0.4 * sin(1.0 * c.yx + vec2(1.2, 3.4) + uTime);
+    c += d * 0.2 * sin(5.2 * c.yx + vec2(3.5, 0.4) + uTime);
+    c += d * 0.3 * sin(3.5 * c.yx + vec2(1.2, 3.1) + uTime);
+    c += d * 1.6 * sin(0.4 * c.yx + vec2(0.8, 2.4) + uTime);
+
+    // Blend 4 colors using radial cosine weight
+    vec3 color = uColors[0];
+    for (int i = 0; i < 4; i++) {
+      float r = cos(float(i) * length(c));
+      color = mix(color, uColors[i], r);
+    }
+
+    // Reveal: fade from black — gates both alpha and distortion
+    gl_FragColor = vec4(mix(vec3(0.0), color, uReveal), 1.0);
+  }
+`;
+
+export function ManifestoShader() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const cursorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    // Renderer
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+
+    // Scene + camera (orthographic fullscreen quad)
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.z = 1;
+
+    // Uniforms
+    const uniforms = {
+      uTime: { value: 0 },
+      uAmplitude: { value: 0.65 },
+      uReveal: { value: 0 },
+      uColors: { value: COLORS.map((h) => new THREE.Color(h)) },
+    };
+
+    // Fullscreen quad
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 2),
+      new THREE.ShaderMaterial({ vertexShader, fragmentShader, uniforms })
+    );
+    scene.add(mesh);
+
+    // Resize handler
+    const resize = () => {
+      renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    // ── Cursor rect setup ─────────────────────────────────────────────────
+    const cursor = cursorRef.current!;
+    // Center rect on cursor hotspot via GSAP percentage offset
+    gsap.set(cursor, { xPercent: -50, yPercent: -50 });
+
+    const xTo = gsap.quickTo(cursor, "x", { duration: 0.3, ease: "power3" });
+    const yTo = gsap.quickTo(cursor, "y", { duration: 0.3, ease: "power3" });
+
+    // ── Interaction state ─────────────────────────────────────────────────
+    let targetAmplitude = 0.65;
+    let currentAmplitude = 0.65;
+    let targetSpeed = 0.008;
+    let currentSpeed = 0.008;
+
+    const onMouseMove = (e: MouseEvent) => {
+      xTo(e.clientX);
+      yTo(e.clientY);
+    };
+
+    const onEnter = () => {
+      gsap.to(cursor, { opacity: 1, duration: 0.17 });
+    };
+
+    const onDown = () => {
+      targetAmplitude = 1.3;
+      targetSpeed = 0.012;
+      gsap.to(cursor, { scale: 0.82, duration: 0.4, ease: "power2.out" });
+    };
+
+    const onUp = () => {
+      targetAmplitude = 0.65;
+      targetSpeed = 0.008;
+      gsap.to(cursor, { scale: 1, duration: 0.3, ease: "power2.out" });
+    };
+
+    const onLeave = () => {
+      targetAmplitude = 0.65;
+      targetSpeed = 0.008;
+      gsap.to(cursor, { opacity: 0, scale: 1, duration: 0.17 });
+    };
+
+    const wrapper = canvas.parentElement!;
+    wrapper.addEventListener("mousemove", onMouseMove);
+    wrapper.addEventListener("mouseenter", onEnter);
+    wrapper.addEventListener("mousedown", onDown);
+    wrapper.addEventListener("mouseup", onUp);
+    wrapper.addEventListener("mouseleave", onLeave);
+    wrapper.addEventListener("touchstart", onDown, { passive: true });
+    wrapper.addEventListener("touchend", onUp);
+
+    // Render loop via GSAP ticker
+    const tick = () => {
+      currentAmplitude += (targetAmplitude - currentAmplitude) * 0.03;
+      currentSpeed += (targetSpeed - currentSpeed) * 0.03;
+      uniforms.uAmplitude.value = currentAmplitude;
+      uniforms.uTime.value += currentSpeed;
+      renderer.render(scene, camera);
+    };
+    gsap.ticker.add(tick);
+
+    // Reveal animation: black → full color + distortion
+    gsap.to(uniforms.uReveal, {
+      value: 1,
+      duration: 2,
+      delay: 0.3,
+      ease: "power2.inOut",
+    });
+
+    return () => {
+      gsap.ticker.remove(tick);
+      window.removeEventListener("resize", resize);
+      wrapper.removeEventListener("mousemove", onMouseMove);
+      wrapper.removeEventListener("mouseenter", onEnter);
+      wrapper.removeEventListener("mousedown", onDown);
+      wrapper.removeEventListener("mouseup", onUp);
+      wrapper.removeEventListener("mouseleave", onLeave);
+      wrapper.removeEventListener("touchstart", onDown);
+      wrapper.removeEventListener("touchend", onUp);
+      renderer.dispose();
+    };
+  }, []);
+
+  return (
+    <>
+      <div
+        style={{
+          position: "relative",
+          overflow: "clip",
+          width: "100%",
+          height: "100%",
+        }}
+      >
+        <canvas
+          aria-hidden="true"
+          ref={canvasRef}
+          style={{ width: "100%", height: "100%", display: "block" }}
+          tabIndex={-1}
+        />
+        {/* Vignette + inset border overlay */}
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            inset: 0,
+            pointerEvents: "none",
+            zIndex: 2,
+            boxShadow: "rgb(0,0,0) 0px -2px 45px 30px inset",
+            outline: "rgb(0,0,0) solid 3px",
+            outlineOffset: "-1px",
+          }}
+        />
+      </div>
+      {/* Cursor rect — fixed, follows mouse via gsap.quickTo, xPercent/yPercent centers on hotspot */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed top-0 left-0 z-50 border border-white/40 px-4 py-2 opacity-0"
+        ref={cursorRef}
+      >
+        <span className="font-medium text-[11px] text-white/60 uppercase tracking-widest">
+          Hold
+        </span>
+      </div>
+    </>
+  );
+}

--- a/apps/www/src/app/(app)/(internal)/manifesto/layout.tsx
+++ b/apps/www/src/app/(app)/(internal)/manifesto/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Manifesto",
+  description: "The Lightfast manifesto.",
+};
+
+export default function ManifestoLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="dark min-h-screen bg-background text-foreground"
+      style={
+        {
+          "--background": "oklch(0 0 0)",
+          "--foreground": "oklch(0.95 0 0)",
+          "--card": "oklch(0.06 0 0)",
+          "--card-foreground": "oklch(0.95 0 0)",
+          "--popover": "oklch(0 0 0)",
+          "--popover-foreground": "oklch(0.95 0 0)",
+          "--muted": "oklch(0.12 0 0)",
+          "--muted-foreground": "oklch(0.55 0 0)",
+          "--border": "oklch(0.2 0 0)",
+          "--accent": "oklch(0.12 0 0)",
+          "--accent-foreground": "oklch(0.95 0 0)",
+          "--input": "oklch(0.15 0 0)",
+          "--input-bg": "oklch(0.06 0 0)",
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/www/src/app/(app)/(internal)/manifesto/page.tsx
+++ b/apps/www/src/app/(app)/(internal)/manifesto/page.tsx
@@ -1,0 +1,11 @@
+import { ManifestoShader } from "./_components/manifesto-shader";
+
+export default function ManifestoPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <div className="relative aspect-[4/3] w-full max-w-2xl">
+        <ManifestoShader />
+      </div>
+    </main>
+  );
+}

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "checkJs": false,
     "paths": {
       "~/*": ["./src/*"],
       "@/*": ["./*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
         version: 50.28.0(encoding@0.1.13)(rollup@4.59.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   api/app:
     dependencies:
@@ -531,7 +531,7 @@ importers:
         version: link:../../vendor/upstash
       '@vercel/microfrontends':
         specifier: ^2.3.0
-        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vercel/related-projects':
         specifier: 'catalog:'
         version: 1.0.1
@@ -555,7 +555,7 @@ importers:
         version: 16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.8.9(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -761,7 +761,7 @@ importers:
         version: link:../../vendor/seo
       '@vercel/microfrontends':
         specifier: ^2.3.0
-        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vercel/related-projects':
         specifier: 'catalog:'
         version: 1.0.1
@@ -773,22 +773,25 @@ importers:
         version: 11.18.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.6.10
-        version: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 14.2.9
-        version: 14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       fumadocs-openapi:
         specifier: ^10.3.16
-        version: 10.3.16(72905e834892305f3d26cb758dfc1475)
+        version: 10.3.16(bf91ca5af019d1af9184cb5492f81b75)
       fumadocs-ui:
         specifier: 16.6.10
-        version: 16.6.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       geist:
         specifier: 'catalog:'
         version: 1.7.0(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      gsap:
+        specifier: ^3.14.2
+        version: 3.14.2
       html2canvas-pro:
         specifier: ^1.6.6
         version: 1.6.6
@@ -813,6 +816,9 @@ importers:
       swr:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.4)
+      three:
+        specifier: ^0.183.2
+        version: 0.183.2
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -847,6 +853,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.183.1
+        version: 0.183.1
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
@@ -1075,7 +1084,7 @@ importers:
     dependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/app-ai:
     dependencies:
@@ -3152,6 +3161,9 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -7791,6 +7803,9 @@ packages:
     resolution: {integrity: sha512-mv4ZVMitAj5rl38Go2aUVbPt5YiLLaCFHUhINb1bLEjuiiwb8kCEQn0ghUZ1hJ2oNxXEd8aWtqNdX7lgdX5Nsw==}
     hasBin: true
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -8015,8 +8030,14 @@ packages:
   '@types/stack-trace@0.0.33':
     resolution: {integrity: sha512-O7in6531Bbvlb2KEsJ0dq0CHZvc3iWSR5ZYMtvGgnHA56VgriAN/AU2LorfmcvAl2xc9N5fbCTRyMRRl8nd74g==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
+  '@types/three@0.183.1':
+    resolution: {integrity: sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -8032,6 +8053,9 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -8406,6 +8430,9 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
@@ -10341,6 +10368,9 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
+  gsap@3.14.2:
+    resolution: {integrity: sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==}
+
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
@@ -11297,6 +11327,9 @@ packages:
 
   mermaid@11.12.0:
     resolution: {integrity: sha512-ZudVx73BwrMJfCFmSSJT84y6u5brEoV8DOItdHomNLz32uBjNrelm7mg95X7g+C6UoQH/W6mBLGDEDv73JdxBg==}
+
+  meshoptimizer@1.0.1:
+    resolution: {integrity: sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==}
 
   micro@9.3.5-canary.3:
     resolution: {integrity: sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==}
@@ -13010,6 +13043,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  three@0.183.2:
+    resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -14777,6 +14813,8 @@ snapshots:
     optional: true
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -19610,6 +19648,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -19873,9 +19913,21 @@ snapshots:
 
   '@types/stack-trace@0.0.33': {}
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 24.9.1
+
+  '@types/three@0.183.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.69
+      fflate: 0.8.2
+      meshoptimizer: 1.0.1
 
   '@types/through@0.0.33':
     dependencies:
@@ -19889,6 +19941,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/uuid@10.0.0': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -20121,31 +20175,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@vercel/microfrontends@2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@next/env': 16.0.10
-      '@types/md5': 2.3.6
-      ajv: 8.18.0
-      commander: 12.1.0
-      cookie: 1.0.2
-      fast-glob: 3.3.3
-      http-proxy: 1.18.1
-      jsonc-parser: 3.3.1
-      md5: 2.3.0
-      nanoid: 3.3.11
-      path-to-regexp: 6.3.0
-      semver: 7.7.3
-    optionalDependencies:
-      '@vercel/analytics': 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@vercel/speed-insights': 1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      next: 16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      vite: 7.1.10(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - debug
-
-  '@vercel/microfrontends@2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vercel/microfrontends@2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@next/env': 16.0.10
       '@types/md5': 2.3.6
@@ -20166,6 +20196,30 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       vite: 7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - debug
+
+  '@vercel/microfrontends@2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@vercel/speed-insights@1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@next/env': 16.0.10
+      '@types/md5': 2.3.6
+      ajv: 8.18.0
+      commander: 12.1.0
+      cookie: 1.0.2
+      fast-glob: 3.3.3
+      http-proxy: 1.18.1
+      jsonc-parser: 3.3.1
+      md5: 2.3.0
+      nanoid: 3.3.11
+      path-to-regexp: 6.3.0
+      semver: 7.7.3
+    optionalDependencies:
+      '@vercel/analytics': 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@vercel/speed-insights': 1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      vite: 7.1.10(@types/node@20.19.22)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - debug
 
@@ -20357,7 +20411,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.22)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@24.9.1)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -20426,7 +20480,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.22)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@20.19.22)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@1.21.7)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -20508,6 +20562,8 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  '@webgpu/types@0.1.69': {}
 
   '@xmldom/xmldom@0.9.8': {}
 
@@ -22269,7 +22325,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -22310,14 +22366,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  fumadocs-mdx@14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.1.10(@types/node@20.19.22)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -22340,7 +22396,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-openapi@10.3.16(72905e834892305f3d26cb758dfc1475):
+  fumadocs-openapi@10.3.16(bf91ca5af019d1af9184cb5492f81b75):
     dependencies:
       '@fumari/json-schema-ts': 0.0.2(json-schema-typed@8.0.2)
       '@fumari/stf': 1.0.3(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -22352,8 +22408,8 @@ snapshots:
       '@scalar/openapi-upgrader': 0.2.0
       ajv: 8.18.0
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
-      fumadocs-ui: 16.6.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+      fumadocs-core: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-ui: 16.6.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       github-slugger: 2.0.0
       hast-util-to-jsx-runtime: 2.3.6
       js-yaml: 4.1.1
@@ -22374,7 +22430,7 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  fumadocs-ui@16.6.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
+  fumadocs-ui@16.6.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.2.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -22388,7 +22444,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.10(@mdx-js/mdx@3.1.1)(@mixedbread/sdk@0.46.0)(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       lucide-react: 0.577.0(react@19.2.4)
       motion: 12.35.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -22557,6 +22613,8 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  gsap@3.14.2: {}
 
   gzip-size@6.0.0:
     dependencies:
@@ -23738,6 +23796,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  meshoptimizer@1.0.1: {}
+
   micro@9.3.5-canary.3:
     dependencies:
       arg: 4.1.0
@@ -24243,7 +24303,7 @@ snapshots:
 
   npm-to-yarn@3.0.1: {}
 
-  nuqs@2.8.9(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  nuqs@2.8.9(@tanstack/react-router@1.133.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.4
@@ -25784,7 +25844,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.17(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.25.0)):
+  terser-webpack-plugin@5.3.17(esbuild@0.25.0)(webpack@5.105.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -25820,6 +25880,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  three@0.183.2: {}
 
   throttleit@2.1.0: {}
 
@@ -26435,7 +26497,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0)(postcss@8.5.8))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@20.8.3(bufferutil@4.1.0))(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.1.0))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.1.10(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -26566,7 +26628,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.17(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.25.0))
+      terser-webpack-plugin: 5.3.17(esbuild@0.25.0)(webpack@5.105.0)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/thoughts/shared/plans/2026-03-24-manifesto-page-black-mode.md
+++ b/thoughts/shared/plans/2026-03-24-manifesto-page-black-mode.md
@@ -1,0 +1,540 @@
+# Manifesto Page — Full Black Background + GLSL Shader
+
+## Overview
+
+Create a `/manifesto` page under `apps/www/src/app/(app)/(internal)/manifesto/` with:
+1. A true black (`oklch(0 0 0)`) background mode scoped to the manifesto subtree
+2. A fullscreen animated GLSL shader (Three.js + GSAP) as the visual backdrop — adapted from `thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md`
+3. Content overlaid on top of the shader
+
+The page lives in `(internal)` — bypassing marketing chrome (AppNavbar, AppFooter, WaitlistCTA) — same pattern as pitch-deck.
+
+## Current State Analysis
+
+### Routing Structure
+- `(internal)` has no group-level layout — each child brings its own layout
+- `(internal)` inherits from `(app)/layout.tsx` (only CSS import + analytics)
+- Pitch-deck is the only existing `(internal)` page — fully custom layout
+
+### Theming System
+- Entire www site is locked to dark mode via `<html class="dark">` at `apps/www/src/app/layout.tsx:141`
+- CSS custom variant: `@custom-variant dark (&:is(.dark *))` at `packages/ui/src/globals.css:9`
+- Current dark background is `oklch(0.2178 0 0)` — dark gray, NOT black
+- True black requires CSS variable override scoped to the manifesto layout wrapper
+
+### Shader Research (`thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md`)
+- Source: Backhouse.com hero — directly decompiled from CDN bundle
+- Architecture: Three.js `ShaderMaterial` on a `PlaneGeometry(2,2)` quad, `OrthographicCamera(-1,1,1,-1)`
+- Animation: GSAP ticker drives `uTime` increment; `uReveal` uniform fades from black (0→1)
+- Interaction: mousedown/touchstart doubles amplitude + speed; lerped smoothly per frame
+- Deps: `three@0.160.1`, `gsap` — **neither installed anywhere in monorepo**
+
+### Key Discovery: Color Palette from Shader
+```
+uColors[0]  #000000  — Black (base/shadows)
+uColors[1]  #eff2c0  — Pale yellow-green (bright highlight)
+uColors[2]  #9feaf9  — Light cyan (cool)
+uColors[3]  #769ba2  — Muted teal (ambient)
+```
+These blend via radial cosine weighting to create organic, animated color movement on a black base — ideal for the manifesto aesthetic.
+
+## Desired End State
+
+- `/manifesto` renders on a pure black background
+- Fullscreen GLSL shader fills the viewport behind all content
+- Shader fades from black on page load (`uReveal` tween, 2s, 0.3s delay)
+- Hold-to-intensify interaction (mousedown/touchstart)
+- Content (`h1`, body text) overlaid on top of the canvas with `position: absolute`
+- No marketing chrome (navbar, footer, WaitlistCTA)
+- No changes to global theming
+
+### Verification
+- `/manifesto` → black background, shader animates on load
+- Hold click/touch → shader distortion visibly increases
+- Release → smoothly returns to base
+- `/blog` or `/` → standard dark gray unchanged
+- `pnpm typecheck` passes
+- `pnpm check` passes
+
+## What We're NOT Doing
+
+- Not adding a theme toggle
+- Not modifying shared `globals.css` token sets
+- Not creating a reusable "black mode" utility
+- Not writing manifesto copy/prose (scaffolded placeholder only)
+- Not adding navigation (follow-up)
+
+## Implementation Approach
+
+**Phase 1** (✅ complete): Layout with scoped CSS variable overrides + placeholder page scaffold.
+
+**Phase 2** (✅ complete): Install `three` + `gsap` into `apps/www`, create client-side `ManifestoShader` component, wire into the page as fullscreen background.
+
+**Phase 3** (current): Add a static rectangular "Hold" affordance element inside `ManifestoShader`. Driven by the same `onDown`/`onUp` event handlers already in the component — no new events, no prop drilling.
+
+---
+
+## Phase 1: Manifesto Layout with Black Mode ✅
+
+### Overview
+Manifesto route with a layout that overrides CSS variables to true black values.
+
+### Files Created:
+- `apps/www/src/app/(app)/(internal)/manifesto/layout.tsx`
+- `apps/www/src/app/(app)/(internal)/manifesto/page.tsx`
+
+### Layout — CSS Variable Override Pattern
+```tsx
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Manifesto",
+  description: "The Lightfast manifesto.",
+};
+
+export default function ManifestoLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="dark min-h-screen bg-background text-foreground"
+      style={
+        {
+          "--background": "oklch(0 0 0)",
+          "--foreground": "oklch(0.95 0 0)",
+          "--card": "oklch(0.06 0 0)",
+          "--card-foreground": "oklch(0.95 0 0)",
+          "--popover": "oklch(0 0 0)",
+          "--popover-foreground": "oklch(0.95 0 0)",
+          "--muted": "oklch(0.12 0 0)",
+          "--muted-foreground": "oklch(0.55 0 0)",
+          "--border": "oklch(0.2 0 0)",
+          "--accent": "oklch(0.12 0 0)",
+          "--accent-foreground": "oklch(0.95 0 0)",
+          "--input": "oklch(0.15 0 0)",
+          "--input-bg": "oklch(0.06 0 0)",
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+### Success Criteria:
+#### Automated Verification:
+- [x] Type checking passes: `pnpm typecheck`
+- [x] Linting passes: `pnpm check`
+- [ ] Build succeeds: `pnpm build:www`
+
+#### Manual Verification:
+- [x] Navigate to `/manifesto` → page renders on true black background
+- [x] Inspect the wrapper div's computed `--background` → `oklch(0 0 0)`
+- [x] Text is legible (white-ish on black)
+- [ ] Navigate to `/` or `/blog` → standard dark gray background is unchanged
+- [ ] No flash of wrong background color on page load
+
+---
+
+## Phase 2: GLSL Shader Background
+
+### Overview
+Add the Backhouse-derived animated GLSL shader as a fullscreen backdrop. The shader starts black and reveals color on load, making it indistinguishable from the black background until it blooms — an intentional reveal effect.
+
+### Changes Required:
+
+#### 1. Install Dependencies
+**File**: `apps/www/package.json` — add to `dependencies`
+
+Run from `apps/www/`:
+```bash
+pnpm add three gsap
+pnpm add -D @types/three
+```
+
+**Versions to use**: `three@^0.160.1` (matches research source), `gsap@^3`
+
+#### 2. Manifesto Shader Component
+**File**: `apps/www/src/app/(app)/(internal)/manifesto/_components/manifesto-shader.tsx` (new)
+**Purpose**: Client component wrapping the Three.js + GSAP animated canvas
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import gsap from "gsap";
+
+// Color palette from research: thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md
+const COLORS = ["#000000", "#eff2c0", "#9feaf9", "#769ba2"] as const;
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  precision mediump float;
+
+  uniform float uTime;
+  uniform float uAmplitude;
+  uniform vec3 uColors[4];
+  uniform float uReveal;
+
+  varying vec2 vUv;
+
+  void main() {
+    vec2 uv = vUv;
+    vec2 c = 2.0 * uv - 1.0;
+    float d = uAmplitude * uReveal;
+
+    // Four layered sine-wave distortions on swapped axes
+    c += d * 0.4 * sin(1.0 * c.yx + vec2(1.2, 3.4) + uTime);
+    c += d * 0.2 * sin(5.2 * c.yx + vec2(3.5, 0.4) + uTime);
+    c += d * 0.3 * sin(3.5 * c.yx + vec2(1.2, 3.1) + uTime);
+    c += d * 1.6 * sin(0.4 * c.yx + vec2(0.8, 2.4) + uTime);
+
+    // Blend 4 colors using radial cosine weight
+    vec3 color = uColors[0];
+    for (int i = 0; i < 4; i++) {
+      float r = cos(float(i) * length(c));
+      color = mix(color, uColors[i], r);
+    }
+
+    // Reveal: fade from black — gates both alpha and distortion
+    gl_FragColor = vec4(mix(vec3(0.0), color, uReveal), 1.0);
+  }
+`;
+
+export function ManifestoShader() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    // Renderer
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+
+    // Scene + camera (orthographic fullscreen quad)
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.z = 1;
+
+    // Uniforms
+    const uniforms = {
+      uTime: { value: 0 },
+      uAmplitude: { value: 0.65 },
+      uReveal: { value: 0 },
+      uColors: { value: COLORS.map((h) => new THREE.Color(h)) },
+    };
+
+    // Fullscreen quad
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 2),
+      new THREE.ShaderMaterial({ vertexShader, fragmentShader, uniforms }),
+    );
+    scene.add(mesh);
+
+    // Resize handler
+    const resize = () => {
+      renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    // Interaction: hold to intensify
+    let targetAmplitude = 0.65;
+    let currentAmplitude = 0.65;
+    let targetSpeed = 0.008;
+    let currentSpeed = 0.008;
+
+    const onDown = () => {
+      targetAmplitude = 1.3;
+      targetSpeed = 0.012;
+    };
+    const onUp = () => {
+      targetAmplitude = 0.65;
+      targetSpeed = 0.008;
+    };
+
+    canvas.addEventListener("mousedown", onDown);
+    canvas.addEventListener("mouseup", onUp);
+    canvas.addEventListener("mouseleave", onUp);
+    canvas.addEventListener("touchstart", onDown, { passive: true });
+    canvas.addEventListener("touchend", onUp);
+
+    // Render loop via GSAP ticker
+    const tick = () => {
+      currentAmplitude += (targetAmplitude - currentAmplitude) * 0.03;
+      currentSpeed += (targetSpeed - currentSpeed) * 0.03;
+      uniforms.uAmplitude.value = currentAmplitude;
+      uniforms.uTime.value += currentSpeed;
+      renderer.render(scene, camera);
+    };
+    gsap.ticker.add(tick);
+
+    // Reveal animation: black → full color + distortion
+    gsap.to(uniforms.uReveal, {
+      value: 1,
+      duration: 2,
+      delay: 0.3,
+      ease: "power2.inOut",
+    });
+
+    return () => {
+      gsap.ticker.remove(tick);
+      window.removeEventListener("resize", resize);
+      canvas.removeEventListener("mousedown", onDown);
+      canvas.removeEventListener("mouseup", onUp);
+      canvas.removeEventListener("mouseleave", onUp);
+      canvas.removeEventListener("touchstart", onDown);
+      canvas.removeEventListener("touchend", onUp);
+      renderer.dispose();
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 h-full w-full"
+      aria-hidden="true"
+    />
+  );
+}
+```
+
+**Notes:**
+- `"use client"` — required: uses `useEffect`, `useRef`, browser APIs
+- `pixelRatio` capped at 2 to avoid performance issues on retina displays
+- `mouseleave` added to `onUp` to prevent stuck-high amplitude if cursor leaves canvas
+- `{ passive: true }` on `touchstart` for scroll performance
+- `renderer.dispose()` on cleanup to release WebGL context
+
+#### 3. Updated Manifesto Page
+**File**: `apps/www/src/app/(app)/(internal)/manifesto/page.tsx` (update)
+**Purpose**: Layer content over the fullscreen shader canvas
+
+```tsx
+import { ManifestoShader } from "./_components/manifesto-shader";
+
+export default function ManifestoPage() {
+  return (
+    <main className="relative min-h-screen">
+      {/* Fullscreen shader backdrop */}
+      <ManifestoShader />
+
+      {/* Content overlay */}
+      <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6">
+        <div className="max-w-2xl space-y-8 text-center">
+          <h1 className="font-pp text-4xl font-medium tracking-tight sm:text-5xl md:text-6xl">
+            Manifesto
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Coming soon.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}
+```
+
+**Layout principle**: `main` is `relative`, shader canvas is `absolute inset-0`, content div is `relative z-10` — content sits above canvas in stacking context.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `three` and `gsap` appear in `apps/www/package.json`
+- [x] `@types/three` in devDependencies
+- [x] Type checking passes: `pnpm typecheck`
+- [x] Linting passes: `pnpm check`
+- [ ] Build succeeds: `pnpm build:www`
+
+#### Manual Verification:
+- [ ] Navigate to `/manifesto` → page starts pure black
+- [ ] After 0.3s, shader gradually blooms into animated color (cyan/teal/pale yellow)
+- [ ] Content text is readable over the shader
+- [ ] Hold click/touch on the page → distortion visibly increases
+- [ ] Release → smoothly returns to base animation
+- [ ] Resize browser window → canvas fills viewport without gaps
+- [ ] `/` and `/blog` → no shader, standard dark gray unchanged
+
+---
+
+## Phase 3: Hold Cursor Rect
+
+### Overview
+A fixed rectangular element that follows the mouse cursor via `gsap.quickTo`, signals the hold-to-intensify interaction. Appears when the cursor enters the canvas area, hides on leave. Scales down on mousedown synchronized with shader intensification. Rectangular shape (no border-radius) — Backhouse cursor pill aesthetic adapted to a rect.
+
+### Changes Required:
+
+#### 1. Updated `ManifestoShader` Component
+**File**: `apps/www/src/app/(app)/(internal)/manifesto/_components/manifesto-shader.tsx` (update)
+
+Add a `cursorRef`, `gsap.quickTo` for mouse following, and opacity/scale tweens into the existing `onDown`/`onUp`/`mouseleave` handlers:
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import gsap from "gsap";
+
+// ... (COLORS, vertexShader, fragmentShader unchanged)
+
+export function ManifestoShader() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const cursorRef = useRef<HTMLDivElement>(null);  // ← new
+
+  useEffect(() => {
+    // ... (renderer, scene, camera, uniforms, mesh, resize — unchanged)
+
+    // ── Cursor rect setup ────────────────────────────────────────────────
+    const cursor = cursorRef.current!;
+
+    // quickTo for smooth mouse following (0.3s lag, power3 ease)
+    const xTo = gsap.quickTo(cursor, "x", { duration: 0.3, ease: "power3" });
+    const yTo = gsap.quickTo(cursor, "y", { duration: 0.3, ease: "power3" });
+
+    const onMouseMove = (e: MouseEvent) => {
+      xTo(e.clientX);
+      yTo(e.clientY);
+    };
+
+    const onEnter = () => {
+      gsap.to(cursor, { opacity: 1, duration: 0.17 });
+    };
+
+    const onDown = () => {
+      targetAmplitude = 1.3;
+      targetSpeed = 0.012;
+      gsap.to(cursor, { scale: 0.82, duration: 0.4, ease: "power2.out" });  // ← new
+    };
+    const onUp = () => {
+      targetAmplitude = 0.65;
+      targetSpeed = 0.008;
+      gsap.to(cursor, { scale: 1, duration: 0.3, ease: "power2.out" });     // ← new
+    };
+    const onLeave = () => {
+      targetAmplitude = 0.65;
+      targetSpeed = 0.008;
+      gsap.to(cursor, { opacity: 0, scale: 1, duration: 0.17 });            // ← new
+    };
+
+    const wrapper = canvasRef.current!.parentElement!;
+    wrapper.addEventListener("mousemove", onMouseMove);
+    wrapper.addEventListener("mouseenter", onEnter);
+    wrapper.addEventListener("mousedown", onDown);
+    wrapper.addEventListener("mouseup", onUp);
+    wrapper.addEventListener("mouseleave", onLeave);
+    wrapper.addEventListener("touchstart", onDown, { passive: true });
+    wrapper.addEventListener("touchend", onUp);
+
+    // ... (tick, reveal — unchanged)
+
+    return () => {
+      // ... (existing cleanup)
+      wrapper.removeEventListener("mousemove", onMouseMove);
+      wrapper.removeEventListener("mouseenter", onEnter);
+      wrapper.removeEventListener("mousedown", onDown);
+      wrapper.removeEventListener("mouseup", onUp);
+      wrapper.removeEventListener("mouseleave", onLeave);
+      wrapper.removeEventListener("touchstart", onDown);
+      wrapper.removeEventListener("touchend", onUp);
+    };
+  }, []);
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="absolute inset-0 h-full w-full"
+        aria-hidden="true"
+      />
+      {/* Cursor rect — follows mouse, fixed positioned, driven by gsap.quickTo */}
+      <div
+        ref={cursorRef}
+        className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-1/2 border border-white/40 px-4 py-2 opacity-0"
+        aria-hidden="true"
+      >
+        <span className="text-[11px] font-medium uppercase tracking-widest text-white/60">
+          Hold
+        </span>
+      </div>
+    </>
+  );
+}
+```
+
+**Notes:**
+- `fixed` positioning — cursor must be in viewport space, not document flow
+- `-translate-x-1/2 -translate-y-1/2` — centers the rect on the cursor hotspot
+- `opacity-0` initial state — cursor rect is hidden until `mouseenter`
+- `gsap.quickTo` drives `x`/`y` CSS transforms with a 0.3s lag for smooth following
+- No `rounded-*` — rectangular shape per intent
+- `pointer-events-none` — all clicks/touches pass through to the canvas wrapper
+- Event listeners moved from `canvas` to `canvas.parentElement` (the `<main>` wrapper) to cover the full page area, consistent with existing shader interaction
+- `onLeave` resets scale to 1 in addition to hiding — prevents stuck scale if user releases outside canvas
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Type checking passes: `pnpm typecheck`
+- [x] Linting passes: `pnpm check`
+
+#### Manual Verification:
+- [ ] Navigate to `/manifesto` → no cursor rect visible on load
+- [ ] Move cursor over the page → rect appears and follows with smooth lag
+- [ ] Move cursor off the page → rect fades out
+- [ ] Hold click → rect scales to 0.82, shader distortion intensifies simultaneously
+- [ ] Release → rect returns to scale 1, shader returns to base
+- [ ] Cursor leaves canvas while held → rect fades + scale resets, shader resets
+- [ ] Touch devices → no cursor rect (touch has no hover), hold interaction still works via touchstart/touchend
+
+---
+
+## Technical Notes
+
+### Why Inline Style for CSS Variables?
+CSS custom properties cascade — overriding them on the layout wrapper scopes the black theme to the entire manifesto subtree. `as React.CSSProperties` cast needed since TypeScript doesn't recognise custom properties by default.
+
+### Why `absolute inset-0` on the Canvas?
+The canvas must fill the viewport without affecting document flow. `absolute inset-0 h-full w-full` inside a `relative min-h-screen` parent achieves this. The content div uses `relative z-10` to sit above the canvas in the stacking order.
+
+### Why GSAP Ticker Over `requestAnimationFrame`?
+Matches the source implementation and avoids manual RAF management. GSAP's ticker is already likely used elsewhere in the codebase (pitch-deck interactions) and batches well with other animations. If GSAP is ever removed from the project, replacing with `requestAnimationFrame` is a trivial swap.
+
+### `three` Version Pinning
+Research was extracted from `three@0.160.1`. Using `^0.160.1` rather than latest to avoid breaking shader API changes — Three.js minor versions occasionally change `ShaderMaterial` uniform handling.
+
+### Pixel Ratio Cap
+`Math.min(window.devicePixelRatio, 2)` prevents the renderer from drawing at 3× or 4× on ultra-retina displays — the shader is not pixel-perfect detail work and doesn't benefit from the extra samples.
+
+## Update Log
+
+### 2026-03-24 — Add Phase 3: Hold Cursor Rect
+- **Trigger**: Research doc `2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md` described the cursor pill interaction; user wanted the cursor follower as a rectangle (not pill-shaped)
+- **Changes**:
+  - Added Phase 3 inside `ManifestoShader` — `cursorRef` + `gsap.quickTo` mouse follower + opacity/scale tweens
+  - Rect is `fixed`, no rounding, hidden until `mouseenter`, follows cursor with 0.3s lag
+  - Scale sync: `0.82` on mousedown, `1` on mouseup/mouseleave — matches shader intensification
+  - Phase 2 marked complete in implementation overview
+- **Impact on remaining work**: Phase 3 is the final phase — no downstream changes
+
+---
+
+## References
+
+- Shader research: `thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md`
+- Root layout: `apps/www/src/app/layout.tsx:137-141` — hardcoded `dark` class
+- CSS tokens: `packages/ui/src/globals.css:139-170` — dark mode variable set
+- Dark variant: `packages/ui/src/globals.css:9` — `@custom-variant dark`
+- Pitch deck pattern: `apps/www/src/app/(app)/(internal)/pitch-deck/layout.tsx` — custom internal layout

--- a/thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md
+++ b/thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md
@@ -1,0 +1,666 @@
+---
+date: 2026-03-24T00:00:00+11:00
+researcher: claude-sonnet-4-6
+topic: "GLSL shader + pill UI + interaction extraction from backhouse.com hero section"
+tags: [research, web-analysis, glsl, three-js, shader, visual-fx, pill-button, custom-cursor, gsap]
+status: complete
+created_at: 2026-03-24
+confidence: high
+sources_count: 1
+---
+
+# Web Research: Backhouse.com GLSL Shader
+
+**Date**: 2026-03-24
+**Topic**: Extract the GLSL shader, component structure, and colors from https://www.backhouse.com/
+**Confidence**: High — shader source was directly decompiled from the live bundle
+
+---
+
+## Research Question
+
+Extract the full GLSL shader (vertex + fragment), color palette, and config from the animated gradient hero on backhouse.com. Document exact DOM/JS locations so the component is replicable.
+
+---
+
+## Executive Summary
+
+Backhouse.com's hero uses a fullscreen Three.js `ShaderMaterial` on a `PlaneGeometry(2,2)` quad. The fragment shader applies four layered sine-wave distortions to UV coordinates driven by `uTime`, then blends four palette colors using a radial cosine mix. The whole setup is roughly **120 lines of JS** inside a minified bundle at `cdn.odyn.dev`. A GSAP ticker drives the render loop and a mouse/touch hold interaction doubles the distortion amplitude.
+
+---
+
+## How to Find It (Replicable Process)
+
+### Step 1 — Identify the canvas element
+
+Open DevTools → Elements tab. The canvas sits inside a wrapper div with class `hero_home_shader`. The canvas itself has class `hero_home_canvas`.
+
+```html
+<!-- DOM location -->
+<div class="hero_home_shader">
+  <canvas class="hero_home_canvas"></canvas>
+</div>
+```
+
+### Step 2 — Find the JS bundle
+
+Open DevTools → Network tab → filter by JS. On page load a single CDN bundle is fetched:
+
+```
+https://cdn.odyn.dev/p/u8mh/bundle.js   (16,127 bytes, minified)
+```
+
+### Step 3 — Locate the shader in the bundle
+
+Search the bundle source for `gl_FragColor`. The shader code is stored as template literals inside the `ShaderMaterial` constructor call. Pattern to search:
+
+- `gl_FragColor` → fragment shader end
+- `gl_Position` → vertex shader end
+- `uColors` → uniform array declaration
+
+The relevant class/IIFE wraps a Three.js `WebGLRenderer`, an `OrthographicCamera`, and a `Mesh` with `ShaderMaterial`.
+
+---
+
+## Component Architecture
+
+### DOM structure
+
+```
+SECTION.hero_home_wrap
+  DIV.hero_home_contain  [display: grid, 12-col]
+    DIV.hero_bottom_shader_wrap  [position: relative, overflow: clip, data-cursor=""]
+      DIV.hero_home_shader       [pill container — clips the canvas]
+        CANVAS.hero_home_canvas  [WebGL surface, fills 100%/100%]
+        DIV.hero_home_overlay    [vignette + inset border, z-index: 2]
+```
+
+### Pill container CSS
+
+```css
+.hero_home_shader {
+  width: 100%;                      /* --max-width--full */
+  border-radius: 100vw;             /* --radius--round → 1426px computed */
+  height: max(15svh, 27svw);        /* fluid height, adapts to viewport */
+  max-height: 35svh;                /* cap — never taller than 35% of viewport */
+  position: relative;
+  overflow: clip;                   /* clips canvas corners to pill shape */
+}
+```
+
+`overflow: clip` is the key — the canvas has no border-radius of its own; the pill clipping comes entirely from the parent.
+
+### Canvas CSS
+
+```css
+.hero_home_canvas {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0%;
+  z-index: 1;
+}
+```
+
+### Overlay (vignette + inset border)
+
+```css
+.hero_home_overlay {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0%;
+  z-index: 2;
+  border-radius: 100vw;                         /* matches pill shape */
+  pointer-events: none;
+  box-shadow: rgb(0, 0, 0) 0px -2px 45px 30px inset;  /* dark edge vignette */
+  outline: rgb(0, 0, 0) solid 3px;             /* inset border around pill */
+  outline-offset: -1px;
+}
+```
+
+The overlay is what creates the dark vignette fade at the pill edges — a solid black `inset` box-shadow, plus a 3px black outline sitting flush inside the pill border. It sits above the canvas (z-index 2) but has `pointer-events: none` so it doesn't block shader interaction.
+
+### Dimensions at 1366px viewport
+
+| Property | Value |
+|----------|-------|
+| Width | 1366px (100% of container) |
+| Height | ~294px (`max(15svh, 27svw)` resolved) |
+| Aspect ratio | ~4.65:1 |
+| Canvas internal resolution | 2732 × 588px (2× DPR) |
+
+### Three.js setup (inside the canvas)
+
+```
+THREE.WebGLRenderer  (canvas: .hero_home_canvas)
+THREE.Scene
+THREE.OrthographicCamera  (-1, 1, 1, -1, 0.1, 10)
+THREE.Mesh
+  ├── THREE.PlaneGeometry(2, 2)         ← fullscreen quad
+  └── THREE.ShaderMaterial
+      ├── vertexShader   (passthrough)
+      ├── fragmentShader (distortion + color blend)
+      └── uniforms
+          ├── uTime       { value: 0 }
+          ├── uAmplitude  { value: 0.65 }
+          ├── uReveal     { value: 0 }       ← GSAP tween target
+          └── uColors     { value: [c1, c2, c3, c4] }
+```
+
+**Dependencies**:
+- `three@0.160.1`
+- `gsap@3.14.2` (ticker + reveal tween)
+
+---
+
+## Vertex Shader
+
+Standard Three.js UV passthrough — nothing custom here.
+
+```glsl
+varying vec2 vUv;
+
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+```
+
+---
+
+## Fragment Shader
+
+```glsl
+precision mediump float;
+
+uniform float uTime;
+uniform float uAmplitude;
+uniform vec3 uColors[4];
+uniform float uReveal;
+
+varying vec2 vUv;
+
+void main() {
+  vec2 uv = vUv;
+  vec2 centeredUv = 2.0 * uv - 1.0;
+  float distortionStrength = uAmplitude * uReveal;
+
+  // Four layered sine-wave distortions on swapped axes
+  centeredUv += distortionStrength * 0.4 * sin(1.0 * centeredUv.yx + vec2(1.2, 3.4) + uTime);
+  centeredUv += distortionStrength * 0.2 * sin(5.2 * centeredUv.yx + vec2(3.5, 0.4) + uTime);
+  centeredUv += distortionStrength * 0.3 * sin(3.5 * centeredUv.yx + vec2(1.2, 3.1) + uTime);
+  centeredUv += distortionStrength * 1.6 * sin(0.4 * centeredUv.yx + vec2(0.8, 2.4) + uTime);
+
+  // Blend 4 colors using radial cosine weight
+  vec3 color = uColors[0];
+  for (int i = 0; i < 4; i++) {
+    float r = cos(float(i) * length(centeredUv));
+    color = mix(color, uColors[i], r);
+  }
+
+  // Reveal: fade from black
+  gl_FragColor = vec4(mix(vec3(0.0), color, uReveal), 1.0);
+}
+```
+
+### How the distortion works
+
+1. UV remap to `[-1, 1]` centered space
+2. Four `sin()` passes each warp `centeredUv` using **swapped XY** (`centeredUv.yx`) — this creates diagonal/rotational flow
+3. Each pass has a different frequency (0.4, 5.2, 3.5, 0.4), phase offset vector, and amplitude weight (0.4, 0.2, 0.3, 1.6)
+4. All distortion is gated by `distortionStrength = uAmplitude * uReveal` — zero at page load, full at reveal complete
+
+### How the color blend works
+
+The `for` loop iterates 4 colors. For each color `i`, it computes `r = cos(i * length(centeredUv))` — a radial cosine function. Because `length(centeredUv)` varies across the screen, different colors dominate at different distances from center. The `mix()` chain progressively blends all 4 colors based on their radial distance weight.
+
+---
+
+## Color Palette
+
+```js
+// Three.js Color objects passed as uColors[4]
+const color1 = new THREE.Color('#000000'); // Black
+const color2 = new THREE.Color('#eff2c0'); // Pale yellow-green
+const color3 = new THREE.Color('#9feaf9'); // Light cyan
+const color4 = new THREE.Color('#769ba2'); // Muted teal
+```
+
+| Index | Hex | RGB | Role |
+|-------|-----|-----|------|
+| `uColors[0]` | `#000000` | `0, 0, 0` | Base / shadows |
+| `uColors[1]` | `#eff2c0` | `239, 242, 192` | Bright highlight band |
+| `uColors[2]` | `#9feaf9` | `159, 234, 249` | Cool cyan highlight |
+| `uColors[3]` | `#769ba2` | `118, 155, 162` | Ambient teal fill |
+
+---
+
+## Full Config / Uniforms
+
+| Parameter | Value | Purpose |
+|-----------|-------|---------|
+| `uAmplitude` | `0.65` | Base distortion intensity |
+| `uTime` | `+= timeSpeed` per frame | Animation clock |
+| `uReveal` | `0 → 1` via GSAP | Fade-in multiplier |
+| `timeSpeed` | `0.008` | Time increment per tick |
+| `holdAmplitudeMultiplier` | `2.0` | Amplitude on mousedown/touchstart |
+| `holdTimeSpeedMultiplier` | `1.5` | Speed multiplier on hold |
+| `lerpSpeed` | `0.03` | Lerp factor for smooth value transitions |
+| `revealDuration` | `2s` | GSAP reveal animation duration |
+| `revealDelay` | `0.3s` | GSAP reveal delay |
+| `revealEase` | `cubic-bezier(0.31, 0.75, 0.22, 1)` | Custom GSAP ease |
+
+---
+
+## Interaction System
+
+```js
+// On mousedown / touchstart
+targetAmplitude = baseAmplitude * holdAmplitudeMultiplier; // 0.65 * 2 = 1.3
+targetTimeSpeed = timeSpeed * holdTimeSpeedMultiplier;     // 0.008 * 1.5 = 0.012
+
+// On mouseup / touchend
+targetAmplitude = baseAmplitude; // back to 0.65
+targetTimeSpeed = timeSpeed;     // back to 0.008
+
+// Per-frame lerp (inside GSAP ticker)
+currentAmplitude += (targetAmplitude - currentAmplitude) * lerpSpeed;
+currentTimeSpeed += (targetTimeSpeed - currentTimeSpeed) * lerpSpeed;
+uniforms.uAmplitude.value = currentAmplitude;
+uniforms.uTime.value += currentTimeSpeed;
+```
+
+---
+
+## Reveal Animation
+
+```js
+gsap.to(uniforms.uReveal, {
+  value: 1,
+  duration: 2,
+  delay: 0.3,
+  ease: 'cubic-bezier(0.31, 0.75, 0.22, 1)',
+});
+```
+
+The `uReveal` uniform is both the fade-in alpha (`mix(vec3(0), color, uReveal)`) and the distortion gate (`distortionStrength = uAmplitude * uReveal`). So the effect starts still and black, then warps into full color simultaneously.
+
+---
+
+## Minimal Replication (React / Three.js)
+
+```tsx
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import gsap from 'gsap';
+
+const COLORS = ['#000000', '#eff2c0', '#9feaf9', '#769ba2'];
+
+const vertexShader = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = `
+  precision mediump float;
+  uniform float uTime;
+  uniform float uAmplitude;
+  uniform vec3 uColors[4];
+  uniform float uReveal;
+  varying vec2 vUv;
+
+  void main() {
+    vec2 uv = vUv;
+    vec2 c = 2.0 * uv - 1.0;
+    float d = uAmplitude * uReveal;
+
+    c += d * 0.4 * sin(1.0 * c.yx + vec2(1.2, 3.4) + uTime);
+    c += d * 0.2 * sin(5.2 * c.yx + vec2(3.5, 0.4) + uTime);
+    c += d * 0.3 * sin(3.5 * c.yx + vec2(1.2, 3.1) + uTime);
+    c += d * 1.6 * sin(0.4 * c.yx + vec2(0.8, 2.4) + uTime);
+
+    vec3 color = uColors[0];
+    for (int i = 0; i < 4; i++) {
+      float r = cos(float(i) * length(c));
+      color = mix(color, uColors[i], r);
+    }
+
+    gl_FragColor = vec4(mix(vec3(0.0), color, uReveal), 1.0);
+  }
+`;
+
+export function BackhouseShader() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.z = 1;
+
+    const uniforms = {
+      uTime: { value: 0 },
+      uAmplitude: { value: 0.65 },
+      uReveal: { value: 0 },
+      uColors: { value: COLORS.map(h => new THREE.Color(h)) },
+    };
+
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 2),
+      new THREE.ShaderMaterial({ vertexShader, fragmentShader, uniforms })
+    );
+    scene.add(mesh);
+
+    const resize = () => {
+      renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+      renderer.setPixelRatio(window.devicePixelRatio);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    let targetAmplitude = 0.65;
+    let currentAmplitude = 0.65;
+    let targetSpeed = 0.008;
+    let currentSpeed = 0.008;
+
+    const onDown = () => { targetAmplitude = 1.3; targetSpeed = 0.012; };
+    const onUp   = () => { targetAmplitude = 0.65; targetSpeed = 0.008; };
+    canvas.addEventListener('mousedown', onDown);
+    canvas.addEventListener('mouseup', onUp);
+    canvas.addEventListener('touchstart', onDown);
+    canvas.addEventListener('touchend', onUp);
+
+    const tick = () => {
+      currentAmplitude += (targetAmplitude - currentAmplitude) * 0.03;
+      currentSpeed     += (targetSpeed     - currentSpeed)     * 0.03;
+      uniforms.uAmplitude.value = currentAmplitude;
+      uniforms.uTime.value     += currentSpeed;
+      renderer.render(scene, camera);
+    };
+    gsap.ticker.add(tick);
+
+    gsap.to(uniforms.uReveal, { value: 1, duration: 2, delay: 0.3, ease: 'power2.inOut' });
+
+    return () => {
+      gsap.ticker.remove(tick);
+      window.removeEventListener('resize', resize);
+      renderer.dispose();
+    };
+  }, []);
+
+  return (
+    <div style={{ position: 'relative', overflow: 'clip' }}>
+      <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block' }} />
+      {/* vignette + inset border overlay */}
+      <div style={{
+        position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 2,
+        borderRadius: '100vw',
+        boxShadow: 'rgb(0,0,0) 0px -2px 45px 30px inset',
+        outline: 'rgb(0,0,0) solid 3px',
+        outlineOffset: '-1px',
+      }} />
+    </div>
+  );
+}
+
+// Usage — pill shape via Tailwind:
+// <div className="relative w-full overflow-clip rounded-[100vw]"
+//      style={{ height: 'max(15svh, 27svw)', maxHeight: '35svh' }}>
+//   <BackhouseShader />
+// </div>
+```
+
+---
+
+## Grain Effect
+
+**Technique**: Static noise PNG + CSS `transform: translate` with `steps()` timing. No SVG feTurbulence, no canvas, no JS.
+
+### DOM
+
+Direct child of `<body>`, highest z-index on the page:
+
+```html
+<div class="g_grain_overlay u-grain-animate">
+  <div class="w-embed">
+    <!-- inline <style> injected via Webflow w-embed -->
+  </div>
+</div>
+```
+
+### Full CSS
+
+```css
+.g_grain_overlay {
+  position: fixed;
+  width: 200%;              /* 2× viewport — prevents edges showing during translation */
+  height: 200vh;
+  inset: -50% 0% 0% -50%;  /* offset so translations have room in all directions */
+  z-index: 999999999;
+  opacity: 0.8;
+  pointer-events: none;
+  mix-blend-mode: normal;
+  background-image: url("https://cdn.prod.website-files.com/69733e404ee2e7c008f4d29a/6975ecc179fa2d60a979b232_download.png");
+  background-attachment: fixed; /* texture stays fixed to viewport, only transform moves it */
+  background-size: auto;
+  will-change: transform;
+}
+
+@keyframes grain-animation {
+  0%,  100% { transform: translate(0,     0);    }
+  17%        { transform: translate(-5%,  -10%); }
+  33%        { transform: translate(3%,   -15%); }
+  50%        { transform: translate(12%,  9%);   }
+  67%        { transform: translate(9%,   4%);   }
+  83%        { transform: translate(-1%,  7%);   }
+}
+
+.u-grain-animate {
+  animation: grain-animation 0.5s steps(6) infinite;
+}
+```
+
+### Key design decisions
+
+| Property | Value | Why |
+|----------|-------|-----|
+| `width: 200%` / `height: 200vh` | 2× viewport | Prevents edge gaps when translated |
+| `inset: -50% 0% 0% -50%` | Top-left offset | Centers the oversized div so all 6 positions stay within viewport |
+| `animation: 0.5s steps(6) infinite` | Stepped, not eased | Jumps discretely — no tween between positions. Mimics film grain flicker |
+| `mix-blend-mode: normal` | No blending | Grain sits on top at 0.8 opacity, darkening whatever is beneath |
+| `background-attachment: fixed` | Viewport-locked | Texture doesn't scroll — only the transform moves it |
+| `will-change: transform` | GPU layer | Compositor layer → smooth 60fps at near-zero CPU cost |
+| `pointer-events: none` | Passthrough | Invisible to all mouse/touch events |
+
+### Texture image
+
+```
+https://cdn.prod.website-files.com/69733e404ee2e7c008f4d29a/6975ecc179fa2d60a979b232_download.png
+```
+
+Monochrome noise PNG, ~2852 × 1682px, hosted on Webflow CDN. Any similar tileable noise texture works as a drop-in replacement.
+
+### Replication (Tailwind)
+
+```html
+<div class="grain-overlay grain-animate" />
+```
+
+```css
+.grain-overlay {
+  @apply fixed pointer-events-none;
+  width: 200%;
+  height: 200vh;
+  inset: -50% 0 0 -50%;
+  z-index: 9999;
+  opacity: 0.8;
+  background-image: url('/noise.png');
+  background-attachment: fixed;
+  background-size: auto;
+  will-change: transform;
+}
+
+@keyframes grain {
+  0%,  100% { transform: translate(0,    0);    }
+  17%        { transform: translate(-5%, -10%); }
+  33%        { transform: translate(3%,  -15%); }
+  50%        { transform: translate(12%, 9%);   }
+  67%        { transform: translate(9%,  4%);   }
+  83%        { transform: translate(-1%, 7%);   }
+}
+
+.grain-animate {
+  animation: grain 0.5s steps(6) infinite;
+}
+```
+
+---
+
+## Pill Elements & Click Effects
+
+Two distinct pill-shaped elements exist on the page. Both use `border-radius: 100vw` (resolved from `--radius--round`).
+
+---
+
+### 1. "Partner with us" CTA Button
+
+**DOM structure:**
+
+```html
+<div class="button_main_wrap">        <!-- visual pill shell -->
+  <div class="clickable_wrap">        <!-- absolute inset, captures pointer events -->
+    <button class="clickable_btn">    <!-- actual button (shown when link href="#") -->
+      <span class="button_main_text">Partner with us</span>
+    </button>
+  </div>
+</div>
+```
+
+**CSS (resolved):**
+
+```css
+.button_main_wrap {
+  border-radius: 100vw;               /* --radius--round */
+  background-color: #ececec;          /* --swatch--white */
+  color: #0b0b0b;                     /* --swatch--black */
+  padding: clamp(0.875rem, fluid, 1rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.button_main_wrap:hover {
+  background-color: #0b0b0b;          /* --button-primary--background-hover */
+  color: #ececec;                     /* inverted */
+}
+```
+
+**Design tokens:**
+
+| Token | Value |
+|-------|-------|
+| `--radius--round` | `100vw` |
+| `--swatch--white` | `#ececec` |
+| `--swatch--black` | `#0b0b0b` |
+
+**Click effect:** Opens a contact form panel via GSAP timeline:
+1. `.form_wrap` → `pointer-events: auto; opacity: 1`
+2. `.form_bg` → `opacity: 0 → 1` over `0.4s`
+3. `.form_contain` → `yPercent: 100 → 0` over `1.5s` (`ease-secondary: cubic-bezier(0.31, 0.75, 0.22, 1)`)
+4. Stops main Lenis scroll, starts form's own Lenis scroll instance
+
+No ripple, no scale, no color flash on click — purely a slide-in panel.
+
+---
+
+### 2. Custom Cursor Pill (`.cursor`)
+
+The cursor is a fixed pill that appears when hovering any `[data-cursor]` element. It says **"Hold"** — it is the visual affordance for the shader hold interaction.
+
+**DOM:**
+```html
+<div class="cursor">
+  <p class="cursor_text">Hold</p>
+</div>
+```
+
+**CSS:**
+```css
+.cursor {
+  border-radius: 100vw;
+  border: 0.6px solid #ececec;
+  background: transparent;
+  padding: 0.8rem 0.9rem;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  top: 0; left: 0;
+  z-index: 10;
+  transition: opacity 0.17s cubic-bezier(0.626, 0.011, 0.25, 1);
+}
+
+/* Becomes visible when hovering a [data-cursor] element */
+body:has([data-cursor]:hover) .cursor { opacity: 1; }
+```
+
+**JS behavior (GSAP):**
+
+```js
+// Mouse following — smooth lag via quickTo
+const xTo = gsap.quickTo(cursor, 'x', { duration: 0.3, ease: 'power3' });
+const yTo = gsap.quickTo(cursor, 'y', { duration: 0.3, ease: 'power3' });
+window.addEventListener('mousemove', e => { xTo(e.clientX); yTo(e.clientY); });
+
+// Appear/disappear with text slide on [data-cursor] hover
+// onMouseenter: cursor text slides in from y:15, duration 0.25s
+// onMouseleave: timeline.reverse()
+
+// Scale on hold
+canvas.addEventListener('mousedown', () => {
+  gsap.to(cursor, { scale: 0.82, duration: 0.4, ease: 'power2.out' });
+});
+window.addEventListener('mouseup', () => {
+  gsap.to(cursor, { scale: 1, duration: 0.3, ease: 'power2.out' });
+});
+```
+
+The canvas element itself has `data-cursor` attribute, so hovering the hero reveals the pill cursor. Clicking/holding it shrinks the pill (scale 0.82) — simultaneously triggering the shader distortion ramp-up.
+
+---
+
+### Shader ↔ Cursor Connection
+
+The `.cursor` pill and the GLSL `uAmplitude` uniform are driven by the **same `mousedown`/`mouseup` events** on the canvas:
+
+```
+mousedown on canvas
+  ├── GSAP: cursor pill → scale: 0.82
+  └── Shader: targetAmplitude = 0.65 * 2 = 1.3, targetSpeed = 0.012
+
+mouseup
+  ├── GSAP: cursor pill → scale: 1
+  └── Shader: targetAmplitude = 0.65, targetSpeed = 0.008
+```
+
+The cursor squish and the shader turbulence are intentionally synchronized — squeezing the cursor pill = squeezing the shader.
+
+---
+
+## Sources
+
+### Live extraction
+- [https://www.backhouse.com/](https://www.backhouse.com/) — Direct page analysis, 2026-03-24
+- Bundle: `https://cdn.odyn.dev/p/u8mh/bundle.js` — Minified JS, decompiled via browser DevTools
+
+---
+
+**Last Updated**: 2026-03-24
+**Confidence Level**: High — shader code was directly read from the decompiled bundle, not reconstructed
+**Next Steps**: Adapt `BackhouseShader` component above or swap in different `COLORS` and distortion coefficients


### PR DESCRIPTION
## Summary

- Adds `/manifesto` route under `(internal)` — no marketing chrome
- Black-mode layout via scoped CSS variable overrides (`oklch(0 0 0)`)
- Fullscreen-contained Three.js GLSL shader (4:3 aspect ratio, `max-w-2xl`, centered)
- Backhouse-derived palette: black / pale yellow-green / light cyan / muted teal
- Hold interaction: mousedown doubles amplitude + speed, lerped per frame via GSAP ticker
- Fixed cursor rect follows mouse via `gsap.quickTo`, scales on hold in sync with shader
- Vignette overlay: inset `box-shadow` + 3px `outline` border
- Installs `three`, `gsap`, `@types/three` into `apps/www`

## Test plan

- [ ] Navigate to `/manifesto` → pure black background, shader blooms from black after 0.3s
- [ ] Move cursor over shader box → cursor rect appears and follows with lag
- [ ] Hold click → rect scales to 0.82, shader distortion visibly intensifies
- [ ] Release → both return smoothly to base state
- [ ] Cursor leaves box while held → rect fades + scale resets, shader resets
- [ ] Resize window → shader canvas fills 4:3 container without gaps
- [ ] `/` and `/blog` → standard dark gray, no shader

🤖 Generated with [Claude Code](https://claude.com/claude-code)