### PR TITLE
perf(www): compile workspace packages to JS to reduce Turbopack memory

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -76,14 +76,9 @@ const wwwConfig: NextConfig = {
   /** Enables hot reloading for local packages without a build step */
   transpilePackages: [
     "@repo/og",
-    "@repo/ui",
     "@vendor/seo",
-    "@vendor/security",
-    "@vendor/analytics",
     "@vendor/email",
     "@vendor/inngest",
-    "@vendor/observability",
-    "@vendor/next",
     "@vendor/cms",
   ],
 
@@ -126,5 +121,5 @@ if (process.env.ANALYZE === "true") {
 const withMDX = createMDX();
 
 export default withMicrofrontends(withMDX(config), {
-  debug: env.VERCEL_ENV !== "production",
+  debug: process.env.NODE_ENV === "development",
 });

--- a/internal/typescript/react-compiled.json
+++ b/internal/typescript/react-compiled.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./internal-package.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "dom", "dom.iterable"],
+    "jsx": "react-jsx",
+    "emitDeclarationOnly": false
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,21 +8,53 @@
     "*.css"
   ],
   "exports": {
-    "./components/*": "./src/components/*.tsx",
-    "./components/chat": "./src/components/chat/index.ts",
-    "./components/chat/*": "./src/components/chat/*.tsx",
-    "./components/ssr-code-block": "./src/components/ssr-code-block/index.tsx",
-    "./integration-icons": "./src/components/integration-icons.tsx",
-    "./framework-icons": "./src/components/framework-icons.tsx",
-    "./lib/brand": "./src/lib/brand/index.ts",
-    "./lib/*": "./src/lib/*.ts",
+    "./components/*": {
+      "types": "./dist/components/*.d.ts",
+      "default": "./dist/components/*.js"
+    },
+    "./components/chat": {
+      "types": "./dist/components/chat/index.d.ts",
+      "default": "./dist/components/chat/index.js"
+    },
+    "./components/chat/*": {
+      "types": "./dist/components/chat/*.d.ts",
+      "default": "./dist/components/chat/*.js"
+    },
+    "./components/ssr-code-block": {
+      "types": "./dist/components/ssr-code-block/index.d.ts",
+      "default": "./dist/components/ssr-code-block/index.js"
+    },
+    "./integration-icons": {
+      "types": "./dist/components/integration-icons.d.ts",
+      "default": "./dist/components/integration-icons.js"
+    },
+    "./framework-icons": {
+      "types": "./dist/components/framework-icons.d.ts",
+      "default": "./dist/components/framework-icons.js"
+    },
+    "./lib/brand": {
+      "types": "./dist/lib/brand/index.d.ts",
+      "default": "./dist/lib/brand/index.js"
+    },
+    "./lib/*": {
+      "types": "./dist/lib/*.d.ts",
+      "default": "./dist/lib/*.js"
+    },
+    "./hooks/*": {
+      "types": "./dist/hooks/*.d.ts",
+      "default": "./dist/hooks/*.js"
+    },
+    "./types/*": {
+      "types": "./dist/types/*.d.ts",
+      "default": "./dist/types/*.js"
+    },
     "./postcss.config": "./postcss.config.mjs",
     "./globals.css": "./src/globals.css",
-    "./shiki.css": "./src/shiki.css",
-    "./hooks/*": "./src/hooks/*.tsx",
-    "./types/*": "./src/types/*.ts"
+    "./shiki.css": "./src/shiki.css"
   },
   "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
     "ui": "pnpm dlx shadcn@canary",
     "generate:component": "turbo gen react-component",
     "clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "@repo/typescript-config/react-compiled.json",
   "compilerOptions": {
-    "outDir": "dist",
     "baseUrl": ".",
     "paths": {
       "@repo/ui/*": ["./src/*"]

--- a/vendor/analytics/package.json
+++ b/vendor/analytics/package.json
@@ -7,25 +7,32 @@
   "license": "MIT",
   "exports": {
     "./posthog-server": {
-      "types": "./src/providers/posthog/server.ts",
-      "default": "./src/providers/posthog/server.ts"
+      "types": "./dist/src/providers/posthog/server.d.ts",
+      "default": "./dist/src/providers/posthog/server.js"
     },
-    "./posthog-client": "./src/providers/posthog/client.tsx",
-    "./posthog-instrumentation-client": "./src/providers/posthog/instrumentation-client.ts",
+    "./posthog-client": {
+      "types": "./dist/src/providers/posthog/client.d.ts",
+      "default": "./dist/src/providers/posthog/client.js"
+    },
+    "./posthog-instrumentation-client": {
+      "types": "./dist/src/providers/posthog/instrumentation-client.d.ts",
+      "default": "./dist/src/providers/posthog/instrumentation-client.js"
+    },
     "./posthog": {
-      "types": "./src/providers/posthog/index.ts",
-      "default": "./src/providers/posthog/index.ts"
+      "types": "./dist/src/providers/posthog/index.d.ts",
+      "default": "./dist/src/providers/posthog/index.js"
     },
     "./vercel": {
-      "types": "./src/providers/vercel/index.ts",
-      "default": "./src/providers/vercel/index.ts"
+      "types": "./dist/src/providers/vercel/index.d.ts",
+      "default": "./dist/src/providers/vercel/index.js"
     },
     "./env": "./env.ts"
   },
   "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
-    "build": "tsc"
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/vendor/analytics/tsconfig.json
+++ b/vendor/analytics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "@repo/typescript-config/react-compiled.json",
   "compilerOptions": {
     "types": ["node"],
     "paths": {

--- a/vendor/next/package.json
+++ b/vendor/next/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
-    "dev": "tsc",
+    "dev": "tsc --watch",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "devDependencies": {

--- a/vendor/next/src/next-config-builder.ts
+++ b/vendor/next/src/next-config-builder.ts
@@ -89,7 +89,14 @@ export const config: NextConfig = withVercelToolbar()({
       dynamic: 30,
       static: 180,
     },
-    optimizePackageImports: ["@repo/ui", "lucide-react"],
+    optimizePackageImports: [
+      "@repo/ui",
+      "lucide-react",
+      "shiki",
+      "recharts",
+      "@tanstack/react-table",
+      "@tanstack/table-core",
+    ],
   },
 
   // This is required to support PostHog trailing slash API requests

--- a/vendor/observability/package.json
+++ b/vendor/observability/package.json
@@ -7,50 +7,50 @@
   "exports": {
     "./sentry-env": {
       "types": "./dist/env/sentry-env.d.ts",
-      "default": "./src/env/sentry-env.ts"
+      "default": "./dist/env/sentry-env.js"
     },
     "./sentry": {
       "types": "./dist/sentry.d.ts",
-      "default": "./src/sentry.ts"
+      "default": "./dist/sentry.js"
     },
     "./betterstack-env": {
       "types": "./dist/env/betterstack.d.ts",
-      "default": "./src/env/betterstack.ts"
+      "default": "./dist/env/betterstack.js"
     },
     "./betterstack-edge-env": {
       "types": "./dist/env/betterstack-edge.d.ts",
-      "default": "./src/env/betterstack-edge.ts"
+      "default": "./dist/env/betterstack-edge.js"
     },
     "./log/next": {
       "types": "./dist/log/next.d.ts",
-      "default": "./src/log/next.ts"
+      "default": "./dist/log/next.js"
     },
     "./log/edge": {
       "types": "./dist/log/edge.d.ts",
-      "default": "./src/log/edge.ts"
+      "default": "./dist/log/edge.js"
     },
     "./log/types": {
       "types": "./dist/log/types.d.ts",
-      "default": "./src/log/types.ts"
+      "default": "./dist/log/types.js"
     },
     "./error/next": {
       "types": "./dist/error/next.d.ts",
-      "default": "./src/error/next.ts"
+      "default": "./dist/error/next.js"
     },
     "./error/edge": {
       "types": "./dist/error/edge.d.ts",
-      "default": "./src/error/edge.ts"
+      "default": "./dist/error/edge.js"
     },
     "./print-routes": {
       "types": "./dist/print-routes.d.ts",
-      "default": "./src/print-routes.ts"
+      "default": "./dist/print-routes.js"
     }
   },
   "license": "MIT",
   "scripts": {
     "build": "tsc",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
-    "dev": "tsc",
+    "dev": "tsc --watch",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "devDependencies": {

--- a/vendor/observability/tsconfig.json
+++ b/vendor/observability/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false
+  },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vendor/security/package.json
+++ b/vendor/security/package.json
@@ -6,19 +6,28 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./env": "./env.ts",
-    "./middleware": "./src/middleware.ts",
-    "./clerk-nosecone": "./src/clerk-nosecone.ts",
-    "./csp": "./src/csp/index.ts"
+    "./middleware": {
+      "types": "./dist/src/middleware.d.ts",
+      "default": "./dist/src/middleware.js"
+    },
+    "./clerk-nosecone": {
+      "types": "./dist/src/clerk-nosecone.d.ts",
+      "default": "./dist/src/clerk-nosecone.js"
+    },
+    "./csp": {
+      "types": "./dist/src/csp/index.d.ts",
+      "default": "./dist/src/csp/index.js"
+    }
   },
   "license": "MIT",
   "scripts": {
     "build": "tsc",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
-    "dev": "tsc",
+    "dev": "tsc --watch",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "devDependencies": {

--- a/vendor/security/tsconfig.json
+++ b/vendor/security/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@repo/typescript-config/internal-package.json",
   "compilerOptions": {
+    "emitDeclarationOnly": false,
     "paths": {
       "~/env": ["./env.ts"]
     },


### PR DESCRIPTION
## Summary

- Compile `@repo/ui`, `@vendor/analytics`, `@vendor/observability`, `@vendor/security` from TypeScript source to pre-built JS in `dist/`; update their `exports` maps to point to `dist/` files
- Add `react-compiled.json` tsconfig preset (`internal-package.json` + `emitDeclarationOnly: false` + JSX/DOM libs) used by all compiled packages
- Trim `transpilePackages` in `apps/www` from 10 → 5 packages (removes the 5 packages now pre-compiled)
- Add `shiki`, `recharts`, `@tanstack/react-table`, `@tanstack/table-core` to `optimizePackageImports` for better tree-shaking
- Fix `@vercel/microfrontends` debug mode — was `env.VERCEL_ENV !== "production"` (always `true` locally since `VERCEL_ENV` is unset) → changed to `process.env.NODE_ENV === "development"`
- Remove unused `three` + `@types/three` from `apps/www`

**Root cause**: Turbopack was re-compiling 9 source-only workspace packages from raw TypeScript on every route visit, retaining the full module graph in memory with no eviction. This caused ~21GB RAM accumulation over ~1 hour of dev usage.

**Note**: `@vendor/next` intentionally kept as source — it's only imported from `next.config.ts` (loaded by jiti once at startup, not per-route by Turbopack), so it contributes zero to memory accumulation. Compiling it would hit a Node.js ESM extension resolution issue (`../env` without `.js`).

## Test plan

- [x] `pnpm --filter @repo/ui build` — `packages/ui/dist/` populated with `.js` + `.d.ts`
- [x] `@vendor/analytics`, `@vendor/observability`, `@vendor/security` all build cleanly
- [x] `pnpm typecheck` for `apps/www` passes
- [x] `pnpm dev:www` starts without module errors (`✓ Ready in 2.9s`)
- [x] `/` and `/manifesto` routes compile and return 200
- [ ] PostHog analytics still fires (verify in browser network tab)
- [ ] Sentry error boundary still active
- [ ] Security middleware headers present (Arcjet/nosecone)
- [ ] Memory stays below 3–4 GB after visiting 10+ routes for 30 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)