### PR TITLE
refactor(www): restore manifesto page layout and shader migration

### DIFF
--- a/apps/www/src/app/(app)/(internal)/manifesto/_components/manifesto-shader.tsx
+++ b/apps/www/src/app/(app)/(internal)/manifesto/_components/manifesto-shader.tsx
@@ -1,136 +1,120 @@
 "use client";
 
+import { ShaderMount } from "@paper-design/shaders-react";
 import gsap from "gsap";
-import { useEffect, useRef } from "react";
-import * as THREE from "three";
+import { type ComponentRef, useEffect, useRef } from "react";
 
 // Color palette from research: thoughts/shared/research/2026-03-24-web-analysis-backhouse-glsl-shader-extraction.md
-const COLORS = ["#000000", "#eff2c0", "#9feaf9", "#769ba2"] as const;
+// Passed as number[][] → ShaderMount flattens to uniform3fv for vec3[4]
+type Vec3 = [number, number, number];
+const COLORS: Vec3[] = [
+  [0.0, 0.0, 0.0],
+  [0.937, 0.949, 0.753],
+  [0.624, 0.918, 0.976],
+  [0.463, 0.608, 0.635],
+];
 
-const vertexShader = /* glsl */ `
-  varying vec2 vUv;
-  void main() {
-    vUv = uv;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+// Same GLSL logic as original Three.js shader — ported to WebGL2 / GLSL 300 ES.
+// Uses gl_FragCoord (equivalent to Three.js vUv since both use bottom-left origin).
+// u_time / u_resolution / u_pixelRatio are provided automatically by ShaderMount.
+const FRAGMENT_SHADER = /* glsl */ `#version 300 es
+precision mediump float;
+
+uniform float u_time;
+uniform vec2 u_resolution;
+uniform float u_pixelRatio;
+uniform float u_amplitude;
+uniform vec3 u_colors[4];
+
+out vec4 fragColor;
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / u_resolution;
+  vec2 c = 2.0 * uv - 1.0;
+  float d = u_amplitude;
+
+  c += d * 0.4 * sin(1.0 * c.yx + vec2(1.2, 3.4) + u_time);
+  c += d * 0.2 * sin(5.2 * c.yx + vec2(3.5, 0.4) + u_time);
+  c += d * 0.3 * sin(3.5 * c.yx + vec2(1.2, 3.1) + u_time);
+  c += d * 1.6 * sin(0.4 * c.yx + vec2(0.8, 2.4) + u_time);
+
+  vec3 color = u_colors[0];
+  for (int i = 0; i < 4; i++) {
+    float r = cos(float(i) * length(c));
+    color = mix(color, u_colors[i], r);
   }
-`;
 
-const fragmentShader = /* glsl */ `
-  precision mediump float;
+  fragColor = vec4(color, 1.0);
+}`;
 
-  uniform float uTime;
-  uniform float uAmplitude;
-  uniform vec3 uColors[4];
-  uniform float uReveal;
+// Stable initial uniforms — defined outside component so React never re-sets them.
+// u_amplitude is driven imperatively via GSAP; u_colors never changes.
+const INITIAL_UNIFORMS = { u_amplitude: 0.65, u_colors: COLORS };
 
-  varying vec2 vUv;
-
-  void main() {
-    vec2 uv = vUv;
-    vec2 c = 2.0 * uv - 1.0;
-    float d = uAmplitude * uReveal;
-
-    // Four layered sine-wave distortions on swapped axes
-    c += d * 0.4 * sin(1.0 * c.yx + vec2(1.2, 3.4) + uTime);
-    c += d * 0.2 * sin(5.2 * c.yx + vec2(3.5, 0.4) + uTime);
-    c += d * 0.3 * sin(3.5 * c.yx + vec2(1.2, 3.1) + uTime);
-    c += d * 1.6 * sin(0.4 * c.yx + vec2(0.8, 2.4) + uTime);
-
-    // Blend 4 colors using radial cosine weight
-    vec3 color = uColors[0];
-    for (int i = 0; i < 4; i++) {
-      float r = cos(float(i) * length(c));
-      color = mix(color, uColors[i], r);
-    }
-
-    // Reveal: fade from black — gates both alpha and distortion
-    gl_FragColor = vec4(mix(vec3(0.0), color, uReveal), 1.0);
-  }
-`;
+// ShaderMount speed maps to: u_time += (dt_ms * speed) * 0.001
+// Original: u_time += 0.008/frame at 60fps = 0.48/s → speed = 0.48
+// Mousedown: 0.012/frame = 0.72/s → speed = 0.72
 
 export function ManifestoShader() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const shaderRef = useRef<ComponentRef<typeof ShaderMount>>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const cursorRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
-    }
-
-    // Renderer
-    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-
-    // Scene + camera (orthographic fullscreen quad)
-    const scene = new THREE.Scene();
-    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
-    camera.position.z = 1;
-
-    // Uniforms
-    const uniforms = {
-      uTime: { value: 0 },
-      uAmplitude: { value: 0.65 },
-      uReveal: { value: 0 },
-      uColors: { value: COLORS.map((h) => new THREE.Color(h)) },
-    };
-
-    // Fullscreen quad
-    const mesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(2, 2),
-      new THREE.ShaderMaterial({ vertexShader, fragmentShader, uniforms })
-    );
-    scene.add(mesh);
-
-    // Resize handler
-    const resize = () => {
-      renderer.setSize(canvas.clientWidth, canvas.clientHeight);
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    };
-    resize();
-    window.addEventListener("resize", resize);
-
-    // ── Cursor rect setup ─────────────────────────────────────────────────
+    const wrapper = wrapperRef.current!;
     const cursor = cursorRef.current!;
-    // Center rect on cursor hotspot via GSAP percentage offset
-    gsap.set(cursor, { xPercent: -50, yPercent: -50 });
+    const overlay = overlayRef.current!;
 
+    // Center rect on cursor hotspot
+    gsap.set(cursor, { xPercent: -50, yPercent: -50 });
     const xTo = gsap.quickTo(cursor, "x", { duration: 0.3, ease: "power3" });
     const yTo = gsap.quickTo(cursor, "y", { duration: 0.3, ease: "power3" });
 
-    // ── Interaction state ─────────────────────────────────────────────────
-    let targetAmplitude = 0.65;
-    let currentAmplitude = 0.65;
-    let targetSpeed = 0.008;
-    let currentSpeed = 0.008;
+    // Reveal: black overlay fades out
+    gsap.to(overlay, {
+      opacity: 0,
+      duration: 2,
+      delay: 0.3,
+      ease: "power2.inOut",
+    });
+
+    // Animation state — lerped each GSAP tick, then pushed to shader imperatively
+    const cur = { amplitude: 0.65, speed: 0.48 };
+    const tgt = { amplitude: 0.65, speed: 0.48 };
+
+    const tick = () => {
+      cur.amplitude += (tgt.amplitude - cur.amplitude) * 0.03;
+      cur.speed += (tgt.speed - cur.speed) * 0.03;
+      const sm = shaderRef.current?.paperShaderMount;
+      if (sm) {
+        sm.setUniforms({ u_amplitude: cur.amplitude });
+        sm.setSpeed(cur.speed);
+      }
+    };
+    gsap.ticker.add(tick);
 
     const onMouseMove = (e: MouseEvent) => {
       xTo(e.clientX);
       yTo(e.clientY);
     };
-
-    const onEnter = () => {
-      gsap.to(cursor, { opacity: 1, duration: 0.17 });
-    };
-
+    const onEnter = () => gsap.to(cursor, { opacity: 1, duration: 0.17 });
     const onDown = () => {
-      targetAmplitude = 1.3;
-      targetSpeed = 0.012;
+      tgt.amplitude = 1.3;
+      tgt.speed = 0.72;
       gsap.to(cursor, { scale: 0.82, duration: 0.4, ease: "power2.out" });
     };
-
     const onUp = () => {
-      targetAmplitude = 0.65;
-      targetSpeed = 0.008;
+      tgt.amplitude = 0.65;
+      tgt.speed = 0.48;
       gsap.to(cursor, { scale: 1, duration: 0.3, ease: "power2.out" });
     };
-
     const onLeave = () => {
-      targetAmplitude = 0.65;
-      targetSpeed = 0.008;
+      tgt.amplitude = 0.65;
+      tgt.speed = 0.48;
       gsap.to(cursor, { opacity: 0, scale: 1, duration: 0.17 });
     };
 
-    const wrapper = canvas.parentElement!;
     wrapper.addEventListener("mousemove", onMouseMove);
     wrapper.addEventListener("mouseenter", onEnter);
     wrapper.addEventListener("mousedown", onDown);
@@ -139,27 +123,8 @@ export function ManifestoShader() {
     wrapper.addEventListener("touchstart", onDown, { passive: true });
     wrapper.addEventListener("touchend", onUp);
 
-    // Render loop via GSAP ticker
-    const tick = () => {
-      currentAmplitude += (targetAmplitude - currentAmplitude) * 0.03;
-      currentSpeed += (targetSpeed - currentSpeed) * 0.03;
-      uniforms.uAmplitude.value = currentAmplitude;
-      uniforms.uTime.value += currentSpeed;
-      renderer.render(scene, camera);
-    };
-    gsap.ticker.add(tick);
-
-    // Reveal animation: black → full color + distortion
-    gsap.to(uniforms.uReveal, {
-      value: 1,
-      duration: 2,
-      delay: 0.3,
-      ease: "power2.inOut",
-    });
-
     return () => {
       gsap.ticker.remove(tick);
-      window.removeEventListener("resize", resize);
       wrapper.removeEventListener("mousemove", onMouseMove);
       wrapper.removeEventListener("mouseenter", onEnter);
       wrapper.removeEventListener("mousedown", onDown);
@@ -167,13 +132,13 @@ export function ManifestoShader() {
       wrapper.removeEventListener("mouseleave", onLeave);
       wrapper.removeEventListener("touchstart", onDown);
       wrapper.removeEventListener("touchend", onUp);
-      renderer.dispose();
     };
   }, []);
 
   return (
     <>
       <div
+        ref={wrapperRef}
         style={{
           position: "relative",
           overflow: "clip",
@@ -181,13 +146,14 @@ export function ManifestoShader() {
           height: "100%",
         }}
       >
-        <canvas
-          aria-hidden="true"
-          ref={canvasRef}
-          style={{ width: "100%", height: "100%", display: "block" }}
-          tabIndex={-1}
+        <ShaderMount
+          fragmentShader={FRAGMENT_SHADER}
+          ref={shaderRef}
+          speed={0.48}
+          style={{ width: "100%", height: "100%" }}
+          uniforms={INITIAL_UNIFORMS}
         />
-        {/* Vignette + inset border overlay */}
+        {/* Vignette + inset border */}
         <div
           aria-hidden="true"
           style={{
@@ -200,8 +166,20 @@ export function ManifestoShader() {
             outlineOffset: "-1px",
           }}
         />
+        {/* Reveal overlay: starts opaque, GSAP fades to transparent */}
+        <div
+          aria-hidden="true"
+          ref={overlayRef}
+          style={{
+            position: "absolute",
+            inset: 0,
+            background: "#000",
+            pointerEvents: "none",
+            zIndex: 3,
+          }}
+        />
       </div>
-      {/* Cursor rect — fixed, follows mouse via gsap.quickTo, xPercent/yPercent centers on hotspot */}
+      {/* Cursor rect — fixed, follows mouse via gsap.quickTo */}
       <div
         aria-hidden="true"
         className="pointer-events-none fixed top-0 left-0 z-50 border border-white/40 px-4 py-2 opacity-0"

--- a/apps/www/src/app/(app)/(internal)/manifesto/page.tsx
+++ b/apps/www/src/app/(app)/(internal)/manifesto/page.tsx
@@ -1,11 +1,89 @@
+import { Icons } from "@repo/ui/components/icons";
+import NextLink from "next/link";
+import { execSync } from "node:child_process";
 import { ManifestoShader } from "./_components/manifesto-shader";
 
+function getGitCommit(): { hash: string; url: string } {
+  try {
+    if (process.env.VERCEL_GIT_COMMIT_SHA) {
+      const hash = process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7);
+      const owner = process.env.VERCEL_GIT_REPO_OWNER;
+      const slug = process.env.VERCEL_GIT_REPO_SLUG;
+      return {
+        hash,
+        url: `https://github.com/${owner}/${slug}/commit/${process.env.VERCEL_GIT_COMMIT_SHA}`,
+      };
+    }
+    const full = execSync("git log -1 --format=%H", { encoding: "utf8" }).trim();
+    return {
+      hash: full.slice(0, 7),
+      url: `https://github.com/lightfastai/lightfast/commit/${full}`,
+    };
+  } catch {
+    return { hash: "unknown", url: "https://github.com/lightfastai/lightfast" };
+  }
+}
+
 export default function ManifestoPage() {
+  const { hash } = getGitCommit();
+
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <div className="relative aspect-[4/3] w-full max-w-2xl">
+    <main className="flex h-screen flex-col">
+      {/* Top (50%) */}
+      <section className="relative flex-[5]">
+        <header className="relative flex items-start justify-between px-6 pt-6">
+          <NextLink href="/">
+            <Icons.logoShort className="h-4 w-4 text-foreground" />
+          </NextLink>
+
+          <div className="font-pp absolute left-[50%] max-w-sm space-y-4 text-lg lg:text-2xl">
+            <p className="font-medium text-foreground">
+              This is our specification.
+            </p>
+            <p className="font-medium text-foreground">
+              We are building the runtime that executes Programs — the substrate
+              where organisational intelligence runs autonomously, accumulates
+              memory, and compounds over time.
+            </p>
+            <p className="font-medium text-foreground">
+              We believe a company should be expressible as a Program. We
+              believe a founder's highest leverage is writing that Program
+              clearly. We believe everything else — the orchestration, the
+              memory, the execution, the intelligence — is the runtime's job.
+            </p>
+          </div>
+        </header>
+
+        {/* Bottom row — CTA left, last sentence at same level */}
+        <div className="absolute bottom-6 left-0 right-0 flex items-start px-6">
+          <div className="flex items-center gap-4">
+            <span className="font-mono text-foreground text-sm uppercase">
+              Read the Program →
+            </span>
+            <NextLink
+              className="font-mono text-foreground text-sm uppercase hover:underline"
+              href="https://github.com/lightfastai/.lightfast"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              @{hash}
+            </NextLink>
+          </div>
+          <p className="font-pp absolute left-[50%] font-semibold text-foreground text-lg lg:text-2xl">
+            We are building the runtime.
+          </p>
+        </div>
+      </section>
+
+      {/* Middle — shader (30%) */}
+      <section className="relative flex-[3]">
         <ManifestoShader />
-      </div>
+      </section>
+
+      {/* Bottom — footer (20%) */}
+      <footer className="flex flex-[2] items-center justify-center px-6">
+        {/* placeholder */}
+      </footer>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

PR #538 was merged at `620dec12b` (the Three.js shader version), but the branch had 2 commits on top that never made it in:

- `231251a7d` — restructure manifesto page layout + improve shader types
- `b557e2653` — rework manifesto page layout and copy

This PR restores both to `main` by checking out the final branch state directly.

**Changes:**
- `manifesto-shader.tsx` — migrated from Three.js to `@paper-design/shaders-react` (`ShaderMount` with GLSL 300 ES fragment shader, `Vec3[]` color palette)
- `page.tsx` — full manifesto layout: top half (logo + manifesto copy at `left-[50%]`), middle shader strip, bottom footer; git commit hash CTA linking to `@lightfastai/.lightfast`

## Test plan

- [ ] `/manifesto` loads with black background, shader blooms in middle strip
- [ ] Manifesto copy appears in top half, aligned left of center
- [ ] "Read the Program →" + `@{hash}` CTA visible at bottom of top section
- [ ] `@{hash}` links to the correct GitHub commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)