### PR TITLE
feat: API keys settings page — list, create, revoke, rotate, delete

### DIFF
--- a/apps/app/src/app/(app)/(org)/[slug]/(manage)/settings/_components/team-general-settings-client.tsx
+++ b/apps/app/src/app/(app)/(org)/[slug]/(manage)/settings/_components/team-general-settings-client.tsx
@@ -11,7 +11,6 @@ import {
   FormDescription,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
   useFormCompat,
 } from "@repo/ui/components/ui/form";
@@ -42,7 +41,7 @@ export function TeamGeneralSettingsClient({
 
   // Use cached organization list from app layout (avoids Clerk 404 timing issues)
   const { data: organizations } = useSuspenseQuery(
-    trpc.organization.listUserOrganizations.queryOptions(),
+    trpc.organization.listUserOrganizations.queryOptions()
   );
 
   // Find current organization from cached list by slug
@@ -79,8 +78,8 @@ export function TeamGeneralSettingsClient({
         const previousOrgs = queryClient.getQueryData(orgListQueryKey);
         queryClient.setQueryData(orgListQueryKey, (old: typeof previousOrgs) =>
           old?.map((org) =>
-            org.slug === input.slug ? { ...org, slug: input.name } : org,
-          ),
+            org.slug === input.slug ? { ...org, slug: input.name } : org
+          )
         );
         return { previousOrgs };
       },
@@ -120,7 +119,7 @@ export function TeamGeneralSettingsClient({
         void queryClient.invalidateQueries({ queryKey: orgListQueryKey });
         setIsUpdating(false);
       },
-    }),
+    })
   );
 
   const onSubmit = async (values: TeamSettingsFormValues) => {

--- a/apps/app/src/app/(app)/(org)/[slug]/(manage)/settings/api-keys/_components/org-api-key-list.tsx
+++ b/apps/app/src/app/(app)/(org)/[slug]/(manage)/settings/api-keys/_components/org-api-key-list.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useTRPC } from "@repo/app-trpc/react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@repo/ui/components/ui/alert-dialog";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@repo/ui/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/ui/dropdown-menu";
+import { Input } from "@repo/ui/components/ui/input";
+import { toast } from "@repo/ui/components/ui/sonner";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import {
+  Check,
+  Copy,
+  Key,
+  Loader2,
+  MoreHorizontal,
+  Plus,
+  RefreshCw,
+  ShieldOff,
+  Trash2,
+} from "lucide-react";
+import { useCallback, useState } from "react";
+
+export function OrgApiKeyList() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const listQueryKey = trpc.orgApiKeys.list.queryOptions().queryKey;
+
+  const { data: keys } = useSuspenseQuery({
+    ...trpc.orgApiKeys.list.queryOptions(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Create dialog state
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Alert dialog state
+  const [alertAction, setAlertAction] = useState<{
+    type: "revoke" | "rotate" | "delete";
+    keyId: string;
+    keyName: string;
+  } | null>(null);
+
+  const invalidateList = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: listQueryKey }),
+    [queryClient, listQueryKey]
+  );
+
+  // --- Mutations ---
+
+  const createMutation = useMutation(
+    trpc.orgApiKeys.create.mutationOptions({
+      meta: { errorTitle: "Failed to create API key" },
+      onSuccess: (data) => {
+        setCreatedKey(data.key);
+        setNewKeyName("");
+        void invalidateList();
+      },
+    })
+  );
+
+  const revokeMutation = useMutation(
+    trpc.orgApiKeys.revoke.mutationOptions({
+      meta: { errorTitle: "Failed to revoke API key" },
+      onSuccess: () => toast.success("API key revoked"),
+      onSettled: () => void invalidateList(),
+    })
+  );
+
+  const rotateMutation = useMutation(
+    trpc.orgApiKeys.rotate.mutationOptions({
+      meta: { errorTitle: "Failed to rotate API key" },
+      onSuccess: (data) => {
+        setCreatedKey(data.key);
+        setIsCreateOpen(true);
+        toast.success("API key rotated — copy your new key");
+      },
+      onSettled: () => void invalidateList(),
+    })
+  );
+
+  const deleteMutation = useMutation(
+    trpc.orgApiKeys.delete.mutationOptions({
+      meta: { errorTitle: "Failed to delete API key" },
+      onSuccess: () => toast.success("API key deleted"),
+      onSettled: () => void invalidateList(),
+    })
+  );
+
+  // --- Handlers ---
+
+  function handleCreate() {
+    if (!newKeyName.trim()) {
+      return;
+    }
+    createMutation.mutate({ name: newKeyName.trim() });
+  }
+
+  function handleConfirmAlert() {
+    if (!alertAction) {
+      return;
+    }
+    switch (alertAction.type) {
+      case "revoke":
+        revokeMutation.mutate({ keyId: alertAction.keyId });
+        break;
+      case "rotate":
+        rotateMutation.mutate({ keyId: alertAction.keyId });
+        break;
+      case "delete":
+        deleteMutation.mutate({ keyId: alertAction.keyId });
+        break;
+      default:
+        break;
+    }
+    setAlertAction(null);
+  }
+
+  function handleCopy() {
+    if (!createdKey) {
+      return;
+    }
+    navigator.clipboard.writeText(createdKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleDialogClose(open: boolean) {
+    if (open) {
+      setIsCreateOpen(true);
+    } else {
+      setIsCreateOpen(false);
+      setCreatedKey(null);
+      setNewKeyName("");
+      setCopied(false);
+      createMutation.reset();
+    }
+  }
+
+  // --- Render ---
+
+  return (
+    <>
+      {/* Header + Create Button */}
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          {keys.length} {keys.length === 1 ? "key" : "keys"}
+        </p>
+        <Dialog onOpenChange={handleDialogClose} open={isCreateOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" variant="secondary">
+              <Plus className="mr-1.5 h-4 w-4" />
+              Create Key
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                {createdKey ? "Copy Your API Key" : "Create API Key"}
+              </DialogTitle>
+              <DialogDescription>
+                {createdKey
+                  ? "This key will only be shown once. Copy it now and store it securely."
+                  : "Give your key a descriptive name to identify its purpose."}
+              </DialogDescription>
+            </DialogHeader>
+
+            {createdKey ? (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 rounded-lg bg-muted/50 p-3">
+                  <code className="flex-1 break-all font-mono text-sm">
+                    {createdKey}
+                  </code>
+                  <Button
+                    className="h-8 w-8 shrink-0"
+                    onClick={handleCopy}
+                    size="icon"
+                    variant="ghost"
+                  >
+                    {copied ? (
+                      <Check className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <Input
+                  autoFocus
+                  maxLength={100}
+                  onChange={(e) => setNewKeyName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      handleCreate();
+                    }
+                  }}
+                  placeholder="e.g. Production API, CI/CD Pipeline"
+                  value={newKeyName}
+                />
+                <DialogFooter>
+                  <Button
+                    disabled={!newKeyName.trim() || createMutation.isPending}
+                    onClick={handleCreate}
+                    variant="secondary"
+                  >
+                    {createMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                        Creating...
+                      </>
+                    ) : (
+                      "Create"
+                    )}
+                  </Button>
+                </DialogFooter>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Key List */}
+      {keys.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="mb-4 rounded-full bg-muted/20 p-3">
+            <Key className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <p className="font-semibold text-sm">No API keys yet</p>
+          <p className="mt-1 max-w-sm text-muted-foreground text-sm">
+            Create an API key to access your organization's resources
+            programmatically.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border/60">
+          {keys.map((key) => {
+            const isPending =
+              (revokeMutation.isPending &&
+                revokeMutation.variables?.keyId === key.id) ||
+              (deleteMutation.isPending &&
+                deleteMutation.variables?.keyId === key.id) ||
+              (rotateMutation.isPending &&
+                rotateMutation.variables?.keyId === key.id);
+
+            return (
+              <div
+                className={`flex items-center justify-between border-border/60 border-b px-4 py-4 last:border-b-0 ${
+                  isPending ? "opacity-60" : ""
+                } ${key.isActive ? "" : "opacity-50"}`}
+                key={key.id}
+              >
+                <div className="min-w-0 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium text-sm">{key.name}</p>
+                    {!key.isActive && (
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground text-xs">
+                        Revoked
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 text-muted-foreground text-xs">
+                    <code className="font-mono">{key.keyPreview}</code>
+                    <span>
+                      Created{" "}
+                      {formatDistanceToNow(new Date(key.createdAt), {
+                        addSuffix: true,
+                      })}
+                    </span>
+                    {key.lastUsedAt && (
+                      <span>
+                        Last used{" "}
+                        {formatDistanceToNow(new Date(key.lastUsedAt), {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    )}
+                    {key.expiresAt && (
+                      <span>
+                        Expires{" "}
+                        {formatDistanceToNow(new Date(key.expiresAt), {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      className="h-8 w-8 shrink-0 p-0"
+                      onClick={(e) => e.stopPropagation()}
+                      size="sm"
+                      variant="ghost"
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Actions</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {key.isActive && (
+                      <>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            setAlertAction({
+                              type: "rotate",
+                              keyId: key.id,
+                              keyName: key.name,
+                            })
+                          }
+                        >
+                          <RefreshCw className="mr-2 h-4 w-4" />
+                          Rotate
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            setAlertAction({
+                              type: "revoke",
+                              keyId: key.id,
+                              keyName: key.name,
+                            })
+                          }
+                        >
+                          <ShieldOff className="mr-2 h-4 w-4" />
+                          Revoke
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                      </>
+                    )}
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() =>
+                        setAlertAction({
+                          type: "delete",
+                          keyId: key.id,
+                          keyName: key.name,
+                        })
+                      }
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Confirmation AlertDialog */}
+      <AlertDialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setAlertAction(null);
+          }
+        }}
+        open={!!alertAction}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {alertAction?.type === "revoke" && "Revoke API Key?"}
+              {alertAction?.type === "rotate" && "Rotate API Key?"}
+              {alertAction?.type === "delete" && "Delete API Key?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {alertAction?.type === "revoke" &&
+                `"${alertAction.keyName}" will be deactivated immediately. Any requests using this key will fail.`}
+              {alertAction?.type === "rotate" &&
+                `"${alertAction.keyName}" will be revoked and replaced with a new key. Update your integrations with the new key.`}
+              {alertAction?.type === "delete" &&
+                `"${alertAction.keyName}" will be permanently deleted. This action cannot be undone.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={
+                alertAction?.type === "delete"
+                  ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  : ""
+              }
+              onClick={handleConfirmAlert}
+            >
+              {alertAction?.type === "revoke" && "Revoke"}
+              {alertAction?.type === "rotate" && "Rotate"}
+              {alertAction?.type === "delete" && "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/app/src/app/(app)/(org)/[slug]/(manage)/settings/api-keys/_components/security-notice.tsx
+++ b/apps/app/src/app/(app)/(org)/[slug]/(manage)/settings/api-keys/_components/security-notice.tsx
@@ -1,0 +1,26 @@
+import { ShieldCheck } from "lucide-react";
+
+export function SecurityNotice() {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/20 p-5">
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+        <h3 className="font-medium text-sm">Security Best Practices</h3>
+      </div>
+      <ul className="mt-3 list-inside list-disc space-y-1 text-muted-foreground text-sm">
+        <li>Never commit API keys to version control</li>
+        <li>Rotate keys regularly and after any suspected compromise</li>
+        <li>
+          Use separate keys for each environment (dev, staging, production)
+        </li>
+        <li>
+          Store keys in a secret manager or encrypted environment variables
+        </li>
+        <li>
+          Each key has full access to your organization's resources — treat them
+          like passwords
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/app/src/components/answer-interface.tsx
+++ b/apps/app/src/components/answer-interface.tsx
@@ -27,7 +27,7 @@ export function AnswerInterface({ clerkOrgId }: AnswerInterfaceProps) {
   const isClient = useSyncExternalStore(
     emptySubscribe,
     () => true,
-    () => false,
+    () => false
   );
   const formRef = useRef<PromptInputRef | null>(null);
 
@@ -86,15 +86,6 @@ export function AnswerInterface({ clerkOrgId }: AnswerInterfaceProps) {
     await Promise.resolve(); // Satisfy linter - function must be async for prop signature
     const text = promptMessage.text ?? "";
     const success = handleSendMessage(text);
-
-    // Clear form only if message was successfully queued
-    if (success && formRef.current) {
-      formRef.current.reset();
-    }
-  };
-
-  const handleSuggestionClick = (prompt: string) => {
-    const success = handleSendMessage(prompt);
 
     // Clear form only if message was successfully queued
     if (success && formRef.current) {

--- a/apps/app/src/components/answer-prompt-input.tsx
+++ b/apps/app/src/components/answer-prompt-input.tsx
@@ -23,7 +23,7 @@ interface AnswerPromptInputProps {
   isSubmitDisabled: boolean;
   onSubmit: (
     message: PromptInputMessage,
-    event: FormEvent<HTMLFormElement>,
+    event: FormEvent<HTMLFormElement>
   ) => Promise<void>;
   placeholder: string;
   status: ChatStatus;
@@ -47,14 +47,14 @@ export const AnswerPromptInput = forwardRef<
     submitDisabledReason,
     className,
   },
-  ref,
+  ref
 ) {
   return (
     <PromptInput
       className={cn(
         "w-full overflow-hidden rounded-xl border border-border/50 bg-card/40 shadow-sm backdrop-blur-md transition-all",
         "!divide-y-0",
-        className,
+        className
       )}
       onSubmit={onSubmit}
       ref={ref}
@@ -64,7 +64,7 @@ export const AnswerPromptInput = forwardRef<
           className={cn(
             "w-full resize-none whitespace-pre-wrap break-words rounded-none border-0 p-3 focus-visible:ring-0",
             "!bg-transparent focus:!bg-transparent hover:!bg-transparent disabled:!bg-transparent dark:!bg-transparent",
-            "min-h-0 min-h-[56px] outline-none",
+            "min-h-0 min-h-[56px] outline-none"
           )}
           placeholder={placeholder}
           style={{ lineHeight: "24px" }}
@@ -72,7 +72,7 @@ export const AnswerPromptInput = forwardRef<
       </PromptInputBody>
       <PromptInputToolbar
         className={cn(
-          "flex items-center justify-end gap-2 bg-transparent p-2 transition-[color,box-shadow]",
+          "flex items-center justify-end gap-2 bg-transparent p-2 transition-[color,box-shadow]"
         )}
       >
         <PromptInputTools className="flex items-center gap-2">

--- a/apps/app/src/components/settings-sidebar.tsx
+++ b/apps/app/src/components/settings-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@repo/ui/components/ui/button";
-import { cn } from "@repo/ui/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 

--- a/apps/www/src/styles/docs.css
+++ b/apps/www/src/styles/docs.css
@@ -15,7 +15,9 @@
  * Outside @layer so overrides beat fumadocs' unlayered component styles.
  */
 .dark {
-  --sidebar: var(--background); /* Docs sidebar should blend with page, not contrast */
+  --sidebar: var(
+    --background
+  ); /* Docs sidebar should blend with page, not contrast */
   --color-fd-background: var(--background);
   --color-fd-foreground: var(--foreground);
   --color-fd-card: var(--background);

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -107,7 +107,7 @@ export const usePromptInputAttachments = () => {
 
   if (!context) {
     throw new Error(
-      "usePromptInputAttachments must be used within a PromptInput",
+      "usePromptInputAttachments must be used within a PromptInput"
     );
   }
 
@@ -140,7 +140,7 @@ export function PromptInputAttachment({
             alt={data.filename ?? "attachment"}
             className={cn(
               "size-full rounded-md object-cover",
-              isUploading && "opacity-50",
+              isUploading && "opacity-50"
             )}
             height={56}
             src={data.url}
@@ -210,7 +210,7 @@ export function PromptInputAttachments({
       aria-live="polite"
       className={cn(
         "overflow-hidden transition-[height] duration-200 ease-out",
-        className,
+        className
       )}
       style={{ height: attachments.files.length ? height : 0 }}
       {...props}
@@ -291,12 +291,12 @@ export type PromptInputProps = Omit<
     message: string;
   }) => void;
   onAttachmentUpload?: (
-    file: File,
+    file: File
   ) => Promise<PromptInputAttachmentItem | null | undefined>;
   onAttachmentsChange?: (attachments: PromptInputAttachmentItem[]) => void;
   onSubmit: (
     message: PromptInputMessage,
-    event: FormEvent<HTMLFormElement>,
+    event: FormEvent<HTMLFormElement>
   ) => void;
 };
 
@@ -316,7 +316,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
       onSubmit,
       ...props
     },
-    ref,
+    ref
   ) => {
     const [items, setItems] = useState<PromptInputAttachmentItem[]>([]);
     const itemsRef = useRef<PromptInputAttachmentItem[]>(items);
@@ -362,7 +362,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           return false;
         });
       },
-      [accept],
+      [accept]
     );
 
     const add = useCallback(
@@ -445,7 +445,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
                   size: file.size,
                   uploadState: "pending" as const,
                 };
-              },
+              }
             );
 
             // Add pending items to UI immediately
@@ -463,7 +463,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
                 if (!uploaded) {
                   // Remove the pending item if upload returned null/undefined
                   setItems((prev) =>
-                    prev.filter((item) => item.id !== pendingItem.id),
+                    prev.filter((item) => item.id !== pendingItem.id)
                   );
                   revokeObjectURL(pendingItem.url);
                   continue;
@@ -490,8 +490,8 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
                           contentType: uploaded.contentType ?? mediaType,
                           uploadState: "complete" as const,
                         }
-                      : item,
-                  ),
+                      : item
+                  )
                 );
               } catch (error) {
                 const message =
@@ -502,7 +502,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
 
                 // Remove the failed pending item
                 setItems((prev) =>
-                  prev.filter((item) => item.id !== pendingItem.id),
+                  prev.filter((item) => item.id !== pendingItem.id)
                 );
                 revokeObjectURL(pendingItem.url);
               }
@@ -526,7 +526,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           }
         })();
       },
-      [matchesAccept, maxFiles, maxFileSize, onAttachmentUpload, onError],
+      [matchesAccept, maxFiles, maxFileSize, onAttachmentUpload, onError]
     );
 
     const remove = useCallback((id: string) => {
@@ -563,7 +563,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           clear();
         },
       }),
-      [clear],
+      [clear]
     );
 
     // Note: File input cannot be programmatically set for security reasons
@@ -656,7 +656,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           contentType: item.contentType,
           metadata: item.metadata ?? null,
           uploadState: item.uploadState,
-        }),
+        })
       );
 
       const messageEl = event.currentTarget.elements.namedItem("message");
@@ -665,7 +665,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
           text: messageEl instanceof HTMLTextAreaElement ? messageEl.value : "",
           attachments: attachmentsPayload,
         },
-        event,
+        event
       );
 
       // Don't clear automatically - let parent control via ref.reset() or ref.clear()
@@ -681,7 +681,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         openFileDialog,
         fileInputRef: inputRef,
       }),
-      [items, add, remove, clear, openFileDialog],
+      [items, add, remove, clear, openFileDialog]
     );
 
     return (
@@ -698,7 +698,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         <form
           className={cn(
             "w-full divide-y overflow-hidden rounded-xl border bg-background shadow-sm",
-            className,
+            className
           )}
           onSubmit={handleSubmit}
           ref={formRef}
@@ -706,7 +706,7 @@ export const PromptInput = forwardRef<PromptInputRef, PromptInputProps>(
         />
       </AttachmentsContext.Provider>
     );
-  },
+  }
 );
 
 PromptInput.displayName = "PromptInput";
@@ -777,7 +777,7 @@ export const PromptInputTextarea = ({
         "field-sizing-content bg-transparent dark:bg-transparent",
         "max-h-32 min-h-16",
         "focus-visible:ring-0",
-        className,
+        className
       )}
       name="message"
       onChange={(e) => {
@@ -813,7 +813,7 @@ export const PromptInputTools = ({
     className={cn(
       "flex items-center gap-1",
       "[&_button:first-child]:rounded-bl-xl",
-      className,
+      className
     )}
     {...props}
   />
@@ -833,7 +833,7 @@ export const PromptInputButton = ({
         "shrink-0 gap-1.5 rounded-full text-xs",
         "border-border/30 dark:border-border/50",
         variant === "ghost" && "text-muted-foreground",
-        className,
+        className
       )}
       size={size}
       type="button"
@@ -935,7 +935,7 @@ export const PromptInputClear = ({
       className={cn(
         "shrink-0 gap-1.5 rounded-full! text-xs",
         "border-border/30 dark:border-border/50",
-        className,
+        className
       )}
       size={size}
       type="button"
@@ -965,7 +965,7 @@ export const PromptInputModelSelectTrigger = ({
     className={cn(
       "border-none bg-transparent font-medium text-muted-foreground shadow-none transition-colors",
       'hover:bg-accent hover:text-foreground [&[aria-expanded="true"]]:bg-accent [&[aria-expanded="true"]]:text-foreground',
-      className,
+      className
     )}
     {...props}
   />


### PR DESCRIPTION
## Summary
- Rebuilt the org-scoped API key list client component with full CRUD: list, create (with one-time key display), revoke, rotate, and delete — all using AlertDialog confirmations and DropdownMenu per row
- Added static security best practices notice below the key list
- Removed unused imports and fixed trailing comma formatting across several files

## Test plan
- [ ] Navigate to `/{slug}/settings/api-keys` — page loads with skeleton then content
- [ ] Empty state renders when no keys exist
- [ ] Create a key via dialog, copy the one-time key
- [ ] Verify key list shows preview, status badges, and timestamps
- [ ] Revoke, rotate, and delete keys via dropdown menu with AlertDialog confirmation
- [ ] Security notice renders below the key list

🤖 Generated with [Claude Code](https://claude.com/claude-code)