### PR TITLE
chore: fix pnpm check failures

### DIFF
--- a/api/app/src/inngest/index.ts
+++ b/api/app/src/inngest/index.ts
@@ -6,8 +6,7 @@ import { serve } from "inngest/next";
 import { inngest } from "./client/client";
 import { recordActivity } from "./workflow/infrastructure/record-activity";
 
-export { inngest };
-export { recordActivity };
+export { inngest, recordActivity };
 
 /**
  * Create the route context for Next.js API routes

--- a/api/platform/src/inngest/functions/platform-event-store.ts
+++ b/api/platform/src/inngest/functions/platform-event-store.ts
@@ -197,23 +197,23 @@ export const platformEventStore = inngest.createFunction(
       switch (sourceEvent.provider) {
         case "github":
           resourceId =
-            attributes.repoId != null ? String(attributes.repoId) : undefined;
+            attributes.repoId == null ? undefined : String(attributes.repoId);
           break;
         case "vercel":
           resourceId =
-            attributes.projectId != null
-              ? String(attributes.projectId)
-              : undefined;
+            attributes.projectId == null
+              ? undefined
+              : String(attributes.projectId);
           break;
         case "sentry":
           resourceId =
-            attributes.projectId != null
-              ? String(attributes.projectId)
-              : undefined;
+            attributes.projectId == null
+              ? undefined
+              : String(attributes.projectId);
           break;
         case "linear":
           resourceId =
-            attributes.teamId != null ? String(attributes.teamId) : undefined;
+            attributes.teamId == null ? undefined : String(attributes.teamId);
           break;
         default:
           resourceId = undefined;

--- a/api/platform/src/inngest/index.ts
+++ b/api/platform/src/inngest/index.ts
@@ -31,20 +31,20 @@ import { platformEventStore } from "./functions/platform-event-store";
 import { platformRepoIndexSync } from "./functions/platform-repo-index-sync";
 import { tokenRefresh } from "./functions/token-refresh";
 
-export { inngest };
 export {
-  ingestDelivery,
-  platformEventStore,
-  platformEntityGraph,
-  platformEntityEmbed,
-  platformBackfillOrchestrator,
-  platformEntityWorker,
   connectionLifecycle,
-  healthCheck,
-  tokenRefresh,
   deliveryRecovery,
-  platformRepoIndexSync,
+  healthCheck,
+  ingestDelivery,
+  inngest,
   platformAgentTriage,
+  platformBackfillOrchestrator,
+  platformEntityEmbed,
+  platformEntityGraph,
+  platformEntityWorker,
+  platformEventStore,
+  platformRepoIndexSync,
+  tokenRefresh,
 };
 
 /**

--- a/api/platform/src/lib/entity-extraction-patterns.ts
+++ b/api/platform/src/lib/entity-extraction-patterns.ts
@@ -62,7 +62,7 @@ const EXTRACTION_PATTERNS: ExtractionPattern[] = [
     category: "reference",
     pattern: /\b([a-f0-9]{7,40})\b/g,
     confidence: 0.7,
-    keyExtractor: (m) => m[1]?.substring(0, 7) ?? "",
+    keyExtractor: (m) => m[1]?.slice(0, 7) ?? "",
     valueExtractor: (m) => m[1] ?? "",
   },
 
@@ -107,7 +107,7 @@ function extractEvidence(
   const start = Math.max(0, matchIndex - contextSize);
   const end = Math.min(text.length, matchIndex + matchLength + contextSize);
 
-  let evidence = text.substring(start, end);
+  let evidence = text.slice(start, end);
   if (start > 0) {
     evidence = `...${evidence}`;
   }
@@ -185,7 +185,7 @@ export function extractFromRelations(
     switch (rel.entityType) {
       case "commit":
         category = "commit";
-        key = rel.entityId.substring(0, 7);
+        key = rel.entityId.slice(0, 7);
         break;
       case "branch":
         category = "branch";

--- a/apps/app/src/app/(api)/lib/with-api-key-auth.ts
+++ b/apps/app/src/app/(api)/lib/with-api-key-auth.ts
@@ -136,7 +136,7 @@ export async function withApiKeyAuth(
       .update(orgApiKeys)
       .set({
         lastUsedAt: sql`CURRENT_TIMESTAMP`,
-        lastUsedFromIp: clientIp.substring(0, 45),
+        lastUsedFromIp: clientIp.slice(0, 45),
       })
       .where(eq(orgApiKeys.id, foundKey.id))
       .catch((err: unknown) => {

--- a/apps/app/src/components/answer-tool-results.tsx
+++ b/apps/app/src/components/answer-tool-results.tsx
@@ -42,7 +42,7 @@ export function SearchToolResult({ data }: { data: SearchResponse }) {
                 </div>
               </div>
               <span className="text-muted-foreground/70 text-xs">
-                {resultCount} result{resultCount !== 1 ? "s" : ""}
+                {resultCount} result{resultCount === 1 ? "" : "s"}
               </span>
             </div>
           </AccordionTrigger>

--- a/apps/app/src/components/app-header.tsx
+++ b/apps/app/src/components/app-header.tsx
@@ -33,13 +33,13 @@ export function AppHeader() {
       return `${firstName[0]}${lastName[0]}`.toUpperCase();
     }
     if (firstName) {
-      return firstName.substring(0, 2).toUpperCase();
+      return firstName.slice(0, 2).toUpperCase();
     }
     if (lastName) {
-      return lastName.substring(0, 2).toUpperCase();
+      return lastName.slice(0, 2).toUpperCase();
     }
     if (username) {
-      return username.substring(0, 2).toUpperCase();
+      return username.slice(0, 2).toUpperCase();
     }
     return "LF";
   })();

--- a/apps/app/src/components/jobs-table.tsx
+++ b/apps/app/src/components/jobs-table.tsx
@@ -77,7 +77,7 @@ function getEventType(jobName: string): string {
   if (colonIndex === -1) {
     return jobName;
   }
-  return jobName.substring(0, colonIndex).trim();
+  return jobName.slice(0, colonIndex).trim();
 }
 
 interface JobRowProps {
@@ -178,7 +178,7 @@ function JobRow({ job }: JobRowProps) {
             <div className="flex items-center gap-2">
               <GitCommit className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
               <span className="font-mono text-muted-foreground text-xs">
-                {commitSha?.substring(0, 7) ?? ""}
+                {commitSha?.slice(0, 7) ?? ""}
               </span>
               <span className="truncate text-muted-foreground text-xs">
                 {commitMessage ?? job.name}

--- a/apps/app/src/components/jobs-table.tsx
+++ b/apps/app/src/components/jobs-table.tsx
@@ -159,11 +159,11 @@ function JobRow({ job }: JobRowProps) {
               <span className="text-sm capitalize">{job.status}</span>
             </div>
             <span className="text-muted-foreground text-xs">
-              {job.durationMs !== null
-                ? formatDuration(Number.parseInt(job.durationMs, 10))
-                : job.status === "running"
+              {job.durationMs === null
+                ? job.status === "running"
                   ? "In progress"
-                  : "—"}
+                  : "—"
+                : formatDuration(Number.parseInt(job.durationMs, 10))}
             </span>
           </div>
 

--- a/apps/app/src/components/user-page-header.tsx
+++ b/apps/app/src/components/user-page-header.tsx
@@ -43,13 +43,13 @@ export function UserPageHeader() {
       return `${firstName[0]}${lastName[0]}`.toUpperCase();
     }
     if (firstName) {
-      return firstName.substring(0, 2).toUpperCase();
+      return firstName.slice(0, 2).toUpperCase();
     }
     if (lastName) {
-      return lastName.substring(0, 2).toUpperCase();
+      return lastName.slice(0, 2).toUpperCase();
     }
     if (username) {
-      return username.substring(0, 2).toUpperCase();
+      return username.slice(0, 2).toUpperCase();
     }
     return "LF";
   })();

--- a/apps/app/src/lib/api-client.ts
+++ b/apps/app/src/lib/api-client.ts
@@ -15,7 +15,7 @@ export type ApiClient = JsonifiedClient<
  */
 export function createApiClient(clerkOrgId: string): ApiClient {
   const link = new OpenAPILink(apiContract, {
-    url: typeof window !== "undefined" ? window.location.origin : "",
+    url: typeof window === "undefined" ? "" : window.location.origin,
     headers: { "x-org-id": clerkOrgId },
     fetch: (request, init) =>
       fetch(request, { ...init, credentials: "include" }),

--- a/apps/app/src/lib/search.ts
+++ b/apps/app/src/lib/search.ts
@@ -134,9 +134,9 @@ export async function searchLogic(
       type: String(meta?.entityType ?? ""),
       url: null as string | null,
       occurredAt:
-        meta?.occurredAt != null
-          ? new Date(Number(meta.occurredAt)).toISOString()
-          : null,
+        meta?.occurredAt == null
+          ? null
+          : new Date(Number(meta.occurredAt)).toISOString(),
     };
   });
 

--- a/apps/www/src/app/(app)/(marketing)/(content)/blog/(listing)/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/blog/(listing)/page.tsx
@@ -160,9 +160,7 @@ export default function BlogPage() {
                 className="block"
                 href={`/blog/${page.slugs[0]}` as Route}
               >
-                <h2 className="mb-1 font-base text-md">
-                  {page.data.title}
-                </h2>
+                <h2 className="mb-1 font-base text-md">{page.data.title}</h2>
                 <p className="mb-4 text-muted-foreground text-sm leading-relaxed">
                   {page.data.description}
                 </p>
@@ -172,7 +170,7 @@ export default function BlogPage() {
                   <time dateTime={page.data.publishedAt}>
                     {new Date(page.data.publishedAt).toLocaleDateString(
                       "en-US",
-                      { year: "numeric", month: "short", day: "numeric" },
+                      { year: "numeric", month: "short", day: "numeric" }
                     )}
                   </time>
                 </div>

--- a/apps/www/src/app/(app)/(marketing)/(content)/blog/(listing)/topic/[category]/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/blog/(listing)/topic/[category]/page.tsx
@@ -98,9 +98,7 @@ export default async function BlogCategoryPage({ params }: Props) {
                 className="block"
                 href={`/blog/${page.slugs[0]}` as Route}
               >
-                <h2 className="mb-1 font-base text-md">
-                  {page.data.title}
-                </h2>
+                <h2 className="mb-1 font-base text-md">{page.data.title}</h2>
                 <p className="mb-4 text-muted-foreground text-sm leading-relaxed">
                   {page.data.description}
                 </p>

--- a/apps/www/src/app/(app)/(marketing)/(content)/blog/[slug]/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/blog/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function BlogPostPage({ params }: Props) {
 
           {/* Featured image */}
           {featuredImage && (
-            <div className="-mx-24 relative aspect-16/9 overflow-hidden rounded-lg bg-card">
+            <div className="relative -mx-24 aspect-16/9 overflow-hidden rounded-lg bg-card">
               <Image
                 alt={title}
                 className="h-full w-full object-cover"

--- a/apps/www/src/app/(app)/(marketing)/(content)/changelog/[slug]/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/changelog/[slug]/page.tsx
@@ -93,12 +93,12 @@ export default async function ChangelogEntryPage({ params }: Props) {
 
         <h2 className="pb-8 font-medium font-pp text-2xl">{title}</h2>
 
-        <p className="font-mono hidden text-muted-foreground text-xs uppercase tracking-wider">
+        <p className="hidden font-mono text-muted-foreground text-xs uppercase tracking-wider">
           {type}
         </p>
 
         {featuredImage && (
-          <div className="-mx-24 relative aspect-16/9 overflow-hidden rounded-lg bg-card">
+          <div className="relative -mx-24 aspect-16/9 overflow-hidden rounded-lg bg-card">
             <Image
               alt={title}
               className="h-full w-full object-cover"
@@ -154,7 +154,7 @@ export default async function ChangelogEntryPage({ params }: Props) {
         )}
 
         {description && (
-          <p className="pt-4 hidden text-muted-foreground text-sm leading-relaxed">
+          <p className="hidden pt-4 text-muted-foreground text-sm leading-relaxed">
             {description}
           </p>
         )}

--- a/apps/www/src/app/(app)/(marketing)/(content)/integrations/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/integrations/page.tsx
@@ -72,9 +72,7 @@ export const metadata: Metadata = createMetadata({
 });
 
 export default function IntegrationsIndexPage() {
-  const pages = getIntegrationPages().filter(
-    (p) => p.data.status === "live"
-  );
+  const pages = getIntegrationPages().filter((p) => p.data.status === "live");
 
   const structuredData: GraphContext = {
     "@context": "https://schema.org",

--- a/apps/www/src/app/(app)/(marketing)/(content)/pricing/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(content)/pricing/page.tsx
@@ -358,7 +358,7 @@ export default function PricingPage() {
                         : "",
                       "md:col-span-2 lg:col-span-1",
                       plan.plan === "business" &&
-                        "md:col-start-2 lg:col-start-auto",
+                        "md:col-start-2 lg:col-start-auto"
                     )}
                     key={plan.plan}
                   >
@@ -499,7 +499,7 @@ export default function PricingPage() {
                       <AccordionTrigger
                         className={cn(
                           "flex w-full items-center justify-between py-6 text-left",
-                          "group hover:no-underline",
+                          "group hover:no-underline"
                         )}
                       >
                         <span className="pr-4 font-medium text-base text-foreground">

--- a/apps/www/src/app/(app)/(marketing)/(landing)/_components/flow-field.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(landing)/_components/flow-field.tsx
@@ -12,24 +12,28 @@ const SEED = 1337;
 function mulberry32(seed: number) {
   let a = seed >>> 0;
   return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
+    a = (a + 0x6d_2b_79_f5) >>> 0;
     let t = a;
     t = Math.imul(t ^ (t >>> 15), t | 1);
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
   };
 }
 
 const PERM = (() => {
   const rand = mulberry32(SEED);
   const p = new Uint8Array(256);
-  for (let i = 0; i < 256; i++) p[i] = i;
+  for (let i = 0; i < 256; i++) {
+    p[i] = i;
+  }
   for (let i = 255; i > 0; i--) {
     const j = Math.floor(rand() * (i + 1));
     [p[i], p[j]] = [p[j]!, p[i]!];
   }
   const ext = new Uint8Array(512);
-  for (let i = 0; i < 512; i++) ext[i] = p[i & 255]!;
+  for (let i = 0; i < 512; i++) {
+    ext[i] = p[i & 255]!;
+  }
   return ext;
 })();
 
@@ -66,7 +70,7 @@ function perlin2(x: number, y: number) {
   return lerp(
     lerp(grad(PERM[A]!, xf, yf), grad(PERM[B]!, xf - 1, yf), u),
     lerp(grad(PERM[A + 1]!, xf, yf - 1), grad(PERM[B + 1]!, xf - 1, yf - 1), u),
-    v,
+    v
   );
 }
 

--- a/apps/www/src/app/(app)/(marketing)/(landing)/_components/isometric-hero.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(landing)/_components/isometric-hero.tsx
@@ -38,7 +38,7 @@ const topZB = BOX.z + BOX.d;
 const rightCorner = isoToCanvas(project(BOX.x + BOX.w, BOX.y, bottomZ));
 const topCorner = isoToCanvas(project(BOX.x, BOX.y, topZB));
 const bottomCorner = isoToCanvas(
-  project(BOX.x + BOX.w, BOX.y + BOX.h, bottomZ),
+  project(BOX.x + BOX.w, BOX.y + BOX.h, bottomZ)
 );
 
 // Box SVG position within the canvas
@@ -53,11 +53,11 @@ const lissajousProjected: Vec2[] = computeLissajousPoints(
   LOGO_CURVE.a,
   LOGO_CURVE.b,
   LOGO_CURVE.delta,
-  STEPS,
+  STEPS
 )
   .slice(0, STEPS)
   .map(([px, py]) =>
-    project(cx + LISSAJOUS_RADIUS * px, cy + LISSAJOUS_RADIUS * py, topZ),
+    project(cx + LISSAJOUS_RADIUS * px, cy + LISSAJOUS_RADIUS * py, topZ)
   );
 
 const lissajousPath = `${lissajousProjected
@@ -77,7 +77,7 @@ export const HAIRLINE_X_PCT = (topCorner[0] / CANVAS_W) * 100;
 
 export function IsometricHero() {
   return (
-    <div className="aspect-video w-full overflow-hidden rounded-md bg-">
+    <div className="bg- aspect-video w-full overflow-hidden rounded-md">
       <svg
         className="h-full w-full"
         viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`}

--- a/apps/www/src/app/(app)/(marketing)/(landing)/_components/isometric-hero.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(landing)/_components/isometric-hero.tsx
@@ -18,8 +18,6 @@ const bounds = shapeBounds(shape);
 const PAD = 4;
 const vx = bounds.minX - PAD;
 const vy = bounds.minY - PAD;
-const vw = bounds.maxX - bounds.minX + PAD * 2;
-const vh = bounds.maxY - bounds.minY + PAD * 2;
 
 // Golden-ratio framing — focal point at upper-RIGHT power point
 const PHI_INV_SQ = 0.381_966_011_250_105_1;

--- a/apps/www/src/app/(app)/(marketing)/(landing)/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(landing)/page.tsx
@@ -80,33 +80,7 @@ export const metadata: Metadata = {
 
 export const revalidate = 3600;
 
-async function getLatestCommit(): Promise<{ hash: string; url: string }> {
-  try {
-    const res = await fetch(
-      "https://api.github.com/repos/lightfastai/.lightfast/commits?per_page=1",
-      {
-        headers: { Accept: "application/vnd.github.v3+json" },
-        next: { revalidate: 3600 },
-      }
-    );
-    if (!res.ok) {
-      throw new Error(`GitHub API ${res.status}`);
-    }
-    const [commit] = (await res.json()) as [{ sha: string }];
-    return {
-      hash: commit.sha.slice(0, 7),
-      url: `https://github.com/lightfastai/.lightfast/commit/${commit.sha}`,
-    };
-  } catch {
-    return {
-      hash: "unknown",
-      url: "https://github.com/lightfastai/.lightfast",
-    };
-  }
-}
-
 export default async function HomePage() {
-  const { hash, url } = await getLatestCommit();
   // Build organization entity
   const organizationEntity: Organization = {
     "@type": "Organization",

--- a/apps/www/src/app/(app)/(marketing)/(landing)/page.tsx
+++ b/apps/www/src/app/(app)/(marketing)/(landing)/page.tsx
@@ -10,9 +10,9 @@ import type {
 import { JsonLd } from "@vendor/seo/json-ld";
 import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import type { Metadata } from "next";
-import { LatestContentPreview } from "~/app/(app)/_components/latest-content-preview";
 import { FAQSection, faqs } from "~/app/(app)/_components/faq-section";
 import { HeroChangelogBadge } from "~/app/(app)/_components/hero-changelog-badge";
+import { LatestContentPreview } from "~/app/(app)/_components/latest-content-preview";
 import { WaitlistCTA } from "~/app/(app)/_components/waitlist-cta";
 import {
   HAIRLINE_BOTTOM_X_PCT,
@@ -20,7 +20,6 @@ import {
   HAIRLINE_Y_PCT,
   IsometricHero,
 } from "./_components/isometric-hero";
-import { FlowField } from "./_components/flow-field";
 
 // SEO metadata for the landing page
 export const metadata: Metadata = {
@@ -211,14 +210,14 @@ export default async function HomePage() {
               />
               {/* Vertical extension lines — from card edges to section edges */}
               <div
-                className="absolute bottom-full w-px h-[100vh]"
+                className="absolute bottom-full h-[100vh] w-px"
                 style={{
                   left: `${HAIRLINE_X_PCT}%`,
                   backgroundColor: "var(--border)",
                 }}
               />
               <div
-                className="absolute top-full w-px h-[100vh]"
+                className="absolute top-full h-[100vh] w-px"
                 style={{
                   left: `${HAIRLINE_BOTTOM_X_PCT}%`,
                   backgroundColor: "var(--border)",

--- a/apps/www/src/app/(app)/_components/faq-section.tsx
+++ b/apps/www/src/app/(app)/_components/faq-section.tsx
@@ -6,7 +6,7 @@ import dynamic from "next/dynamic";
 // The FAQ is below the fold — no need to block the critical path with
 // @radix-ui/react-accordion + its shared primitives on initial load.
 const FaqAccordion = dynamic<{ faqs: (typeof faqs)[number][] }>(() =>
-  import("./faq-accordion").then((m) => ({ default: m.FaqAccordion })),
+  import("./faq-accordion").then((m) => ({ default: m.FaqAccordion }))
 );
 
 export const faqs = [
@@ -63,7 +63,7 @@ export function FAQSection() {
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-16">
         {/* Left: Badge */}
         <div>
-          <span className="inline-flex h-7 bg-card/40 items-center rounded-md border border-border px-3 text-muted-foreground text-sm">
+          <span className="inline-flex h-7 items-center rounded-md border border-border bg-card/40 px-3 text-muted-foreground text-sm">
             FAQ
           </span>
         </div>

--- a/apps/www/src/app/(app)/_components/hero-changelog-badge.tsx
+++ b/apps/www/src/app/(app)/_components/hero-changelog-badge.tsx
@@ -6,7 +6,7 @@ export async function HeroChangelogBadge() {
   const pages = getChangelogPages().sort(
     (a, b) =>
       new Date(b.data.publishedAt).getTime() -
-      new Date(a.data.publishedAt).getTime(),
+      new Date(a.data.publishedAt).getTime()
   );
   const latest = pages[0];
 
@@ -19,7 +19,7 @@ export async function HeroChangelogBadge() {
     {
       month: "short",
       day: "numeric",
-    },
+    }
   );
 
   return (

--- a/apps/www/src/app/(health)/api/health/route.ts
+++ b/apps/www/src/app/(health)/api/health/route.ts
@@ -87,7 +87,7 @@ export function GET(request: NextRequest) {
       ...(isLikelyBetterStack && {
         monitor: {
           detected: true,
-          userAgent: userAgent.substring(0, 100), // Truncate for security
+          userAgent: userAgent.slice(0, 100), // Truncate for security
         },
       }),
     },

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -139,7 +139,7 @@ export default function RootLayout({
         geistSans.variable,
         geistMono.variable,
         ppNeueMontreal.variable,
-        "dark scrollbar-thin touch-manipulation font-sans antialiased",
+        "dark scrollbar-thin touch-manipulation font-sans antialiased"
       )}
       lang="en"
       suppressHydrationWarning

--- a/apps/www/src/lib/builders/blog.ts
+++ b/apps/www/src/lib/builders/blog.ts
@@ -67,7 +67,6 @@ function buildBlogPostEntity(
 }
 
 function buildHowToEntity(data: BlogPostData, url: BlogPostUrl): HowTo {
-  // biome-ignore lint/style/noNonNullAssertion: caller guards on howToSteps presence
   const steps = data.howToSteps!;
   return {
     "@type": "HowTo",

--- a/apps/www/src/lib/builders/integrations.ts
+++ b/apps/www/src/lib/builders/integrations.ts
@@ -35,7 +35,9 @@ function buildIntegratedAppEntity(
   data: IntegrationPageData,
   url: IntegrationUrl
 ): SoftwareApplication | null {
-  if (data.status === "planned") return null;
+  if (data.status === "planned") {
+    return null;
+  }
   const display = PROVIDER_DISPLAY[data.providerId];
   return {
     "@type": "SoftwareApplication",

--- a/apps/www/src/lib/content-schemas.ts
+++ b/apps/www/src/lib/content-schemas.ts
@@ -86,7 +86,6 @@ export const LegalPageSchema = BasePageSchema.extend({
   effectiveAt: z.iso.datetime(),
 });
 
-const IntegrationStatusSchema = z.enum(["live", "beta", "planned"]);
 const IntegrationCategorySchema = z.enum([
   "dev-tools",
   "monitoring",

--- a/packages/app-embed/src/utils.ts
+++ b/packages/app-embed/src/utils.ts
@@ -2,11 +2,11 @@
  * Embedding utilities with environment-aware configuration and provider selection.
  */
 
-import { EMBEDDING_CONFIG } from "./config";
 import type { CohereEmbeddingModel } from "@repo/app-validation";
 import type { CohereInputType, EmbeddingProvider } from "@vendor/embed";
 import { createCohereEmbedding } from "@vendor/embed";
 import { embedEnv } from "@vendor/embed/env";
+import { EMBEDDING_CONFIG } from "./config";
 
 /**
  * Default embedding configuration

--- a/packages/app-pinecone/src/client.ts
+++ b/packages/app-pinecone/src/client.ts
@@ -5,7 +5,6 @@
  */
 
 import type { RecordMetadata } from "@pinecone-database/pinecone";
-import { PINECONE_CONFIG } from "./config";
 import { PineconeClient as VendorPineconeClient } from "@vendor/pinecone/client";
 import type {
   FetchResponse,
@@ -15,6 +14,7 @@ import type {
   UpsertRequest,
   UpsertResponse,
 } from "@vendor/pinecone/types";
+import { PINECONE_CONFIG } from "./config";
 
 /**
  * Lightfast Pinecone client with injected configuration

--- a/packages/app-providers/src/providers/github/index.ts
+++ b/packages/app-providers/src/providers/github/index.ts
@@ -261,7 +261,7 @@ export const github = defineWebhookProvider({
   getBaseEventType: (sourceType) => {
     const dotIndex = sourceType.indexOf(".");
     if (dotIndex > 0) {
-      const base = sourceType.substring(0, dotIndex);
+      const base = sourceType.slice(0, dotIndex);
       const configBase = base.replace(/-/g, "_");
       return configBase === "issue" ? "issues" : configBase;
     }

--- a/packages/app-providers/src/providers/linear/index.ts
+++ b/packages/app-providers/src/providers/linear/index.ts
@@ -288,7 +288,7 @@ export const linear = defineWebhookProvider({
   getBaseEventType: (sourceType) => {
     const dotIndex = sourceType.indexOf(".");
     if (dotIndex > 0) {
-      const base = sourceType.substring(0, dotIndex);
+      const base = sourceType.slice(0, dotIndex);
       return base
         .split("-")
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -366,7 +366,7 @@ export const linear = defineWebhookProvider({
         subtitle: t.description ?? null,
         badge: t.key,
         iconColor: t.color ?? null,
-        iconLabel: t.key.substring(0, 2),
+        iconLabel: t.key.slice(0, 2),
       }));
     },
 

--- a/packages/app-remotion/src/compositions/blog-why-we-built-featured/blog-why-we-built-featured.tsx
+++ b/packages/app-remotion/src/compositions/blog-why-we-built-featured/blog-why-we-built-featured.tsx
@@ -2,12 +2,12 @@ import {
   lissajousPoints as computeLissajousPoints,
   LOGO_CURVE,
 } from "@repo/ui/lib/brand";
+import type { Box3D, Vec2 } from "@repo/ui/lib/iso";
+import { createBox, facePath, project, shapeBounds } from "@repo/ui/lib/iso";
 import { AbsoluteFill, continueRender, delayRender } from "@vendor/remotion";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { ensureFontsLoaded } from "../landing-hero/shared/fonts";
-import type { Box3D, Vec2 } from "@repo/ui/lib/iso";
-import { createBox, facePath, project, shapeBounds } from "@repo/ui/lib/iso";
 
 const CANVAS_W = 1200;
 const CANVAS_H = 675;
@@ -48,7 +48,9 @@ const bottomZ = BOX.z;
 const topZB = BOX.z + BOX.d;
 const leftCorner = isoToCanvas(project(BOX.x, BOX.y + BOX.h, bottomZ));
 const rightCorner = isoToCanvas(project(BOX.x + BOX.w, BOX.y, bottomZ));
-const bottomCorner = isoToCanvas(project(BOX.x + BOX.w, BOX.y + BOX.h, bottomZ));
+const bottomCorner = isoToCanvas(
+  project(BOX.x + BOX.w, BOX.y + BOX.h, bottomZ)
+);
 const topCorner = isoToCanvas(project(BOX.x, BOX.y, topZB));
 
 // Pixel offset for the box SVG so its focal point lands on the anchor.

--- a/packages/app-remotion/src/compositions/changelog-v010-events/changelog-v010-events.tsx
+++ b/packages/app-remotion/src/compositions/changelog-v010-events/changelog-v010-events.tsx
@@ -4,9 +4,6 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import { ensureFontsLoaded } from "../landing-hero/shared/fonts";
 
-const CANVAS_W = 1200;
-const CANVAS_H = 675;
-
 interface FeedEvent {
   detail: string;
   extra?: string[];

--- a/packages/app-remotion/src/compositions/landing-hero/sections/logo-animation.tsx
+++ b/packages/app-remotion/src/compositions/landing-hero/sections/logo-animation.tsx
@@ -2,10 +2,10 @@ import {
   lissajousPoints as computeLissajousPoints,
   LOGO_CURVE,
 } from "@repo/ui/lib/brand";
-import { useCurrentFrame } from "@vendor/remotion";
-import type React from "react";
 import type { Box3D, Vec2 } from "@repo/ui/lib/iso";
 import { createBox, facePath, project, shapeBounds } from "@repo/ui/lib/iso";
+import { useCurrentFrame } from "@vendor/remotion";
+import type React from "react";
 
 const FACE_FILL: Record<string, string> = {
   top: "var(--background)",

--- a/packages/app-remotion/src/compositions/landing-hero/sections/stream-events.tsx
+++ b/packages/app-remotion/src/compositions/landing-hero/sections/stream-events.tsx
@@ -31,7 +31,11 @@ const FEED_EVENTS: FeedEvent[] = [
     label: "Issue Updated",
     detail: "MEM-302 ranking threshold",
   },
-  { source: "Vercel", label: "Deployment Ready", detail: "lightfast-app — Production" },
+  {
+    source: "Vercel",
+    label: "Deployment Ready",
+    detail: "lightfast-app — Production",
+  },
   { source: "GitHub", label: "PR Merged", detail: "#839 edge cache warmup" },
   {
     source: "Sentry",

--- a/packages/app-remotion/src/render.ts
+++ b/packages/app-remotion/src/render.ts
@@ -99,7 +99,21 @@ async function main() {
       for (const output of entry.outputs) {
         const filename = output.filename ?? `${id}.${output.format}`;
 
-        if (output.frame !== undefined) {
+        if (output.frame === undefined) {
+          // Full video render
+          const tmpPath = path.join(tmpDir, filename);
+          console.log(
+            `Rendering ${id} (${entry.width}×${entry.height} @ ${entry.fps}fps)...`
+          );
+          await renderMedia({
+            composition,
+            serveUrl: bundled,
+            outputLocation: tmpPath,
+            ...entry.renderProfile,
+          });
+          await distribute(tmpPath, [output], filename);
+          console.log(`  ✔ ${filename} → ${output.dest}`);
+        } else {
           // Still frame extraction from video
           const tmpPath = path.join(tmpDir, filename);
           console.log(`Rendering ${id} poster (frame ${output.frame})...`);
@@ -111,20 +125,6 @@ async function main() {
             imageFormat: output.format as "webp" | "png",
             scale: output.scale ?? 1,
             overwrite: true,
-          });
-          await distribute(tmpPath, [output], filename);
-          console.log(`  ✔ ${filename} → ${output.dest}`);
-        } else {
-          // Full video render
-          const tmpPath = path.join(tmpDir, filename);
-          console.log(
-            `Rendering ${id} (${entry.width}×${entry.height} @ ${entry.fps}fps)...`
-          );
-          await renderMedia({
-            composition,
-            serveUrl: bundled,
-            outputLocation: tmpPath,
-            ...entry.renderProfile,
           });
           await distribute(tmpPath, [output], filename);
           console.log(`  ✔ ${filename} → ${output.dest}`);

--- a/packages/app-test-data/datasets/webhook-schema.json
+++ b/packages/app-test-data/datasets/webhook-schema.json
@@ -53,10 +53,7 @@
               "description": "GitHub event types (X-GitHub-Event header values)"
             },
             {
-              "enum": [
-                "deployment.created",
-                "deployment.succeeded"
-              ],
+              "enum": ["deployment.created", "deployment.succeeded"],
               "description": "Vercel event types"
             },
             {

--- a/packages/app-test-data/src/cli/verify-event-filtering.ts
+++ b/packages/app-test-data/src/cli/verify-event-filtering.ts
@@ -43,7 +43,7 @@ function normalizeEventType(source: string, eventType: string): string {
   if (source === "github") {
     const dotIndex = eventType.indexOf(".");
     if (dotIndex > 0) {
-      const base = eventType.substring(0, dotIndex);
+      const base = eventType.slice(0, dotIndex);
       const configBase = base.replace(/-/g, "_");
       return configBase === "issue" ? "issues" : configBase;
     }
@@ -64,7 +64,7 @@ function normalizeEventType(source: string, eventType: string): string {
   if (source === "linear") {
     const colonIndex = eventType.indexOf(":");
     if (colonIndex > 0) {
-      return eventType.substring(0, colonIndex);
+      return eventType.slice(0, colonIndex);
     }
     return eventType;
   }

--- a/packages/app-test-data/src/loader/transform.ts
+++ b/packages/app-test-data/src/loader/transform.ts
@@ -18,7 +18,7 @@ export interface WebhookPayload {
  * Generate a unique delivery ID for test webhooks
  */
 const generateDeliveryId = (): string => {
-  return `test-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+  return `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 };
 
 /**

--- a/packages/dotlightfast/src/index.ts
+++ b/packages/dotlightfast/src/index.ts
@@ -1,15 +1,15 @@
-export { SkillFrontmatterSchema, type SkillFrontmatter } from "./schema";
 export { parseDotLightfast } from "./parse";
+export { type SkillFrontmatter, SkillFrontmatterSchema } from "./schema";
 export {
-  TriageDecisionSchema,
-  type TriageDecision,
-  type TriageEventContext,
   buildTriageSystemPrompt,
   buildTriageUserPrompt,
+  type TriageDecision,
+  TriageDecisionSchema,
+  type TriageEventContext,
 } from "./triage";
 export {
-  DotLightfastParseError,
   type DotLightfastConfig,
+  DotLightfastParseError,
   type Fetcher,
   type FetcherResult,
   type SkillManifest,

--- a/packages/dotlightfast/src/parse.test.ts
+++ b/packages/dotlightfast/src/parse.test.ts
@@ -18,7 +18,7 @@ const skillFile = (frontmatter: string, body = ""): FetcherResult => ({
 });
 
 const dir = (
-  entries: { name: string; type: "file" | "dir" }[] = [],
+  entries: { name: string; type: "file" | "dir" }[] = []
 ): FetcherResult => ({ type: "dir", entries });
 
 describe("parseDotLightfast — happy path / shape", () => {
@@ -29,11 +29,11 @@ describe("parseDotLightfast — happy path / shape", () => {
       { name: "beta", type: "dir" },
     ]),
     "skills/alpha/SKILL.md": skillFile(
-      "name: alpha\ndescription: The alpha skill",
+      "name: alpha\ndescription: The alpha skill"
     ),
     "skills/alpha/command/alpha.md": { type: "file", content: "" },
     "skills/beta/SKILL.md": skillFile(
-      "name: beta\ndescription: The beta skill",
+      "name: beta\ndescription: The beta skill"
     ),
   });
 
@@ -85,7 +85,7 @@ describe("parseDotLightfast — happy path / shape", () => {
         "skills/alpha/command/alpha.md",
         "skills/beta/SKILL.md",
         "skills/beta/command/beta.md",
-      ]),
+      ])
     );
   });
 });
@@ -101,7 +101,7 @@ describe("parseDotLightfast — missing-config branches", () => {
     const result = await parseDotLightfast(
       makeFetcher({
         "SPEC.md": { type: "file", content: "# Spec" },
-      }),
+      })
     );
     expect(result.spec).not.toBeNull();
     expect(result.skills).toEqual([]);
@@ -112,7 +112,7 @@ describe("parseDotLightfast — SPEC edge cases", () => {
   it("throws DotLightfastParseError with path='SPEC.md' when SPEC.md resolves to a directory", async () => {
     const fetcher = makeFetcher({ "SPEC.md": dir() });
     await expect(parseDotLightfast(fetcher)).rejects.toThrowError(
-      DotLightfastParseError,
+      DotLightfastParseError
     );
     await expect(parseDotLightfast(fetcher)).rejects.toMatchObject({
       path: "SPEC.md",
@@ -122,7 +122,7 @@ describe("parseDotLightfast — SPEC edge cases", () => {
   it("truncates SPEC longer than MAX_SPEC_BYTES (32_000) to exactly 32_000 chars", async () => {
     const input = "x".repeat(40_000);
     const result = await parseDotLightfast(
-      makeFetcher({ "SPEC.md": { type: "file", content: input } }),
+      makeFetcher({ "SPEC.md": { type: "file", content: input } })
     );
     expect(result.spec).not.toBeNull();
     expect(result.spec!.length).toBe(32_000);
@@ -132,7 +132,7 @@ describe("parseDotLightfast — SPEC edge cases", () => {
   it("does not truncate SPEC at exactly MAX_SPEC_BYTES", async () => {
     const input = "y".repeat(32_000);
     const result = await parseDotLightfast(
-      makeFetcher({ "SPEC.md": { type: "file", content: input } }),
+      makeFetcher({ "SPEC.md": { type: "file", content: input } })
     );
     expect(result.spec).toBe(input);
   });
@@ -147,9 +147,9 @@ describe("parseDotLightfast — skills filtering and caps", () => {
           { name: "alpha", type: "dir" },
         ]),
         "skills/alpha/SKILL.md": skillFile(
-          "name: alpha\ndescription: alpha skill",
+          "name: alpha\ndescription: alpha skill"
         ),
-      }),
+      })
     );
     expect(result.skills).toHaveLength(1);
     expect(result.skills[0]?.name).toBe("alpha");
@@ -162,12 +162,12 @@ describe("parseDotLightfast — skills filtering and caps", () => {
       const name = `skill-${i.toString().padStart(2, "0")}`;
       entries.push({ name, type: "dir" });
       skillFiles[`skills/${name}/SKILL.md`] = skillFile(
-        `name: ${name}\ndescription: skill ${i}`,
+        `name: ${name}\ndescription: skill ${i}`
       );
     }
 
     const result = await parseDotLightfast(
-      makeFetcher({ skills: dir(entries), ...skillFiles }),
+      makeFetcher({ skills: dir(entries), ...skillFiles })
     );
     expect(result.skills).toHaveLength(50);
     expect(result.skills[49]?.name).toBe("skill-49");
@@ -182,9 +182,9 @@ describe("parseDotLightfast — skills filtering and caps", () => {
           { name: "bravo", type: "dir" },
         ]),
         "skills/alpha/SKILL.md": skillFile(
-          "name: alpha\ndescription: alpha skill",
+          "name: alpha\ndescription: alpha skill"
         ),
-      }),
+      })
     );
     expect(result.skills).toHaveLength(1);
     expect(result.skills[0]?.name).toBe("alpha");
@@ -197,7 +197,7 @@ describe("parseDotLightfast — frontmatter resilience", () => {
       makeFetcher({
         skills: dir([{ name: "broken", type: "dir" }]),
         "skills/broken/SKILL.md": { type: "file", content: skillContent },
-      }),
+      })
     );
     expect(result.skills).toEqual([]);
   };
@@ -225,7 +225,7 @@ describe("parseDotLightfast — frontmatter resilience", () => {
       makeFetcher({
         skills: dir([{ name: "alpha", type: "dir" }]),
         "skills/alpha/SKILL.md": { type: "file", content },
-      }),
+      })
     );
     expect(result.skills).toHaveLength(1);
     expect(result.skills[0]).toMatchObject({
@@ -240,32 +240,29 @@ describe("parseDotLightfast — command probe branching", () => {
     ["file", { type: "file", content: "" }, true],
     ["dir", dir(), false],
     ["missing", { type: "missing" }, false],
-  ])(
-    "hasCommand is true only when probe resolves to a file (probe=%s)",
-    async (_label, commandResult, expected) => {
-      const result = await parseDotLightfast(
-        makeFetcher({
-          skills: dir([{ name: "alpha", type: "dir" }]),
-          "skills/alpha/SKILL.md": skillFile(
-            "name: alpha\ndescription: alpha skill",
-          ),
-          "skills/alpha/command/alpha.md": commandResult,
-        }),
-      );
-      expect(result.skills).toHaveLength(1);
-      expect(result.skills[0]?.hasCommand).toBe(expected);
-    },
-  );
+  ])("hasCommand is true only when probe resolves to a file (probe=%s)", async (_label, commandResult, expected) => {
+    const result = await parseDotLightfast(
+      makeFetcher({
+        skills: dir([{ name: "alpha", type: "dir" }]),
+        "skills/alpha/SKILL.md": skillFile(
+          "name: alpha\ndescription: alpha skill"
+        ),
+        "skills/alpha/command/alpha.md": commandResult,
+      })
+    );
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]?.hasCommand).toBe(expected);
+  });
 
   it("probes skills/<dirName>/command/<frontmatter.name>.md when dirName differs from name", async () => {
     const fetcher = vi.fn(
       makeFetcher({
         skills: dir([{ name: "alpha-v2", type: "dir" }]),
         "skills/alpha-v2/SKILL.md": skillFile(
-          "name: alpha\ndescription: alpha skill",
+          "name: alpha\ndescription: alpha skill"
         ),
         "skills/alpha-v2/command/alpha.md": { type: "file", content: "" },
-      }),
+      })
     );
 
     const result = await parseDotLightfast(fetcher);

--- a/packages/dotlightfast/src/parse.test.ts
+++ b/packages/dotlightfast/src/parse.test.ts
@@ -199,6 +199,7 @@ describe("parseDotLightfast — frontmatter resilience", () => {
         "skills/broken/SKILL.md": { type: "file", content: skillContent },
       })
     );
+    // biome-ignore lint/suspicious/noMisplacedAssertion: expectSkipped is a test helper invoked from each it()
     expect(result.skills).toEqual([]);
   };
 

--- a/packages/dotlightfast/src/parse.ts
+++ b/packages/dotlightfast/src/parse.ts
@@ -2,8 +2,8 @@ import { parse as parseYaml } from "yaml";
 
 import { SkillFrontmatterSchema } from "./schema";
 import {
-  DotLightfastParseError,
   type DotLightfastConfig,
+  DotLightfastParseError,
   type Fetcher,
   type SkillManifest,
 } from "./types";
@@ -15,7 +15,9 @@ const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 function extractFrontmatter(source: string): Record<string, unknown> | null {
   const match = FRONTMATTER_RE.exec(source);
-  if (!match?.[1]) return null;
+  if (!match?.[1]) {
+    return null;
+  }
   try {
     const parsed = parseYaml(match[1]);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
@@ -28,7 +30,7 @@ function extractFrontmatter(source: string): Record<string, unknown> | null {
 }
 
 export async function parseDotLightfast(
-  fetcher: Fetcher,
+  fetcher: Fetcher
 ): Promise<DotLightfastConfig> {
   const specResult = await fetcher("SPEC.md");
   let spec: string | null = null;
@@ -40,7 +42,7 @@ export async function parseDotLightfast(
   } else if (specResult.type !== "missing") {
     throw new DotLightfastParseError(
       "SPEC.md path resolved to a directory",
-      "SPEC.md",
+      "SPEC.md"
     );
   }
 
@@ -53,7 +55,9 @@ export async function parseDotLightfast(
 
     for (const entry of dirEntries) {
       const skill = await loadSkill(fetcher, entry.name);
-      if (skill) skills.push(skill);
+      if (skill) {
+        skills.push(skill);
+      }
     }
   }
 
@@ -62,20 +66,26 @@ export async function parseDotLightfast(
 
 async function loadSkill(
   fetcher: Fetcher,
-  dirName: string,
+  dirName: string
 ): Promise<SkillManifest | null> {
   const skillPath = `skills/${dirName}/SKILL.md`;
   const skillFile = await fetcher(skillPath);
-  if (skillFile.type !== "file") return null;
+  if (skillFile.type !== "file") {
+    return null;
+  }
 
   const raw = extractFrontmatter(skillFile.content);
-  if (!raw) return null;
+  if (!raw) {
+    return null;
+  }
 
   const parsed = SkillFrontmatterSchema.safeParse(raw);
-  if (!parsed.success) return null;
+  if (!parsed.success) {
+    return null;
+  }
 
   const commandProbe = await fetcher(
-    `skills/${dirName}/command/${parsed.data.name}.md`,
+    `skills/${dirName}/command/${parsed.data.name}.md`
   );
 
   return {

--- a/packages/dotlightfast/src/triage.ts
+++ b/packages/dotlightfast/src/triage.ts
@@ -11,14 +11,14 @@ export const TriageDecisionSchema = z.object({
 export type TriageDecision = z.infer<typeof TriageDecisionSchema>;
 
 export interface TriageEventContext {
-  externalId: string;
-  source: string;
-  sourceType: string;
-  observationType: string;
-  title: string;
   content: string;
+  externalId: string;
+  observationType: string;
   occurredAt: string;
   significanceScore: number;
+  source: string;
+  sourceType: string;
+  title: string;
 }
 
 export function buildTriageSystemPrompt(config: DotLightfastConfig): string {
@@ -27,7 +27,7 @@ export function buildTriageSystemPrompt(config: DotLightfastConfig): string {
   parts.push(
     "You are Lightfast's triage agent. For each event you receive, decide whether any configured skill should run.",
     "Output one of: skip (no skill is appropriate) or invoke (select exactly one skill by name).",
-    "Be decisive. If no skill clearly applies, pick skip.",
+    "Be decisive. If no skill clearly applies, pick skip."
   );
 
   if (config.spec) {
@@ -48,7 +48,7 @@ export function buildTriageSystemPrompt(config: DotLightfastConfig): string {
     "## Output rules",
     "- If you choose invoke, skillName MUST exactly match one of the skill names above.",
     "- If you choose skip, omit skillName.",
-    "- reasoning must be one or two short sentences explaining your choice.",
+    "- reasoning must be one or two short sentences explaining your choice."
   );
 
   return parts.join("\n");

--- a/packages/dotlightfast/src/types.ts
+++ b/packages/dotlightfast/src/types.ts
@@ -1,13 +1,13 @@
 export interface SkillManifest {
-  name: string;
   description: string;
   hasCommand: boolean;
+  name: string;
   path: string;
 }
 
 export interface DotLightfastConfig {
-  spec: string | null;
   skills: SkillManifest[];
+  spec: string | null;
 }
 
 export type FetcherResult =
@@ -21,7 +21,7 @@ export class DotLightfastParseError extends Error {
   constructor(
     message: string,
     public readonly path: string,
-    public readonly cause?: unknown,
+    public readonly cause?: unknown
   ) {
     super(message);
     this.name = "DotLightfastParseError";

--- a/packages/ui/src/components/chat/chat-input.tsx
+++ b/packages/ui/src/components/chat/chat-input.tsx
@@ -51,7 +51,7 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     // Use controlled value if provided, otherwise use internal state
     const message = value ?? internalMessage;
     const setMessage =
-      value !== undefined ? (onChange ?? noop) : setInternalMessage;
+      value === undefined ? setInternalMessage : (onChange ?? noop);
     const [isSending, setIsSending] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 

--- a/packages/ui/src/components/lightfast-custom-grid-background.tsx
+++ b/packages/ui/src/components/lightfast-custom-grid-background.tsx
@@ -489,5 +489,5 @@ export const LightfastCustomGridBackground = {
 };
 
 // Export types for external use
-export type { LightfastCustomGridBackgroundProps, ContainerProps, ItemProps };
-export { gridRootVariants, containerVariants };
+export type { ContainerProps, ItemProps, LightfastCustomGridBackgroundProps };
+export { containerVariants, gridRootVariants };

--- a/packages/webhook-schemas/fixtures/github/push.json
+++ b/packages/webhook-schemas/fixtures/github/push.json
@@ -180,9 +180,7 @@
       },
       "added": [],
       "removed": [],
-      "modified": [
-        "README.md"
-      ]
+      "modified": ["README.md"]
     }
   ],
   "head_commit": {
@@ -206,8 +204,6 @@
     },
     "added": [],
     "removed": [],
-    "modified": [
-      "README.md"
-    ]
+    "modified": ["README.md"]
   }
 }

--- a/packages/webhook-schemas/fixtures/vercel/deployment.created.json
+++ b/packages/webhook-schemas/fixtures/vercel/deployment.created.json
@@ -11,9 +11,7 @@
     "user": {
       "id": "8siqQqUqQWIYEvIAVe0Y0frQ"
     },
-    "installationIds": [
-      "icfg_inW7GGIU7ZpPC6qOQfPmknj1"
-    ],
+    "installationIds": ["icfg_inW7GGIU7ZpPC6qOQfPmknj1"],
     "integrations": [
       {
         "installationId": "icfg_inW7GGIU7ZpPC6qOQfPmknj1"
@@ -56,11 +54,7 @@
     },
     "name": "lightfast-app",
     "plan": "pro",
-    "regions": [
-      "iad1",
-      "syd1",
-      "fra1"
-    ],
+    "regions": ["iad1", "syd1", "fra1"],
     "target": null,
     "type": "LAMBDAS",
     "url": "lightfast-7y7n1r6ea-lightfast.vercel.app"

--- a/packages/webhook-schemas/fixtures/vercel/deployment.succeeded.json
+++ b/packages/webhook-schemas/fixtures/vercel/deployment.succeeded.json
@@ -11,9 +11,7 @@
     "user": {
       "id": "8siqQqUqQWIYEvIAVe0Y0frQ"
     },
-    "installationIds": [
-      "icfg_inW7GGIU7ZpPC6qOQfPmknj1"
-    ],
+    "installationIds": ["icfg_inW7GGIU7ZpPC6qOQfPmknj1"],
     "integrations": [
       {
         "installationId": "icfg_inW7GGIU7ZpPC6qOQfPmknj1"
@@ -54,9 +52,7 @@
     },
     "name": "lightfast-platform",
     "plan": "pro",
-    "regions": [
-      "iad1"
-    ],
+    "regions": ["iad1"],
     "target": null,
     "type": "LAMBDAS",
     "url": "lightfast-platform-q8yh6opzj-lightfast.vercel.app"

--- a/packages/webhook-schemas/src/capture.ts
+++ b/packages/webhook-schemas/src/capture.ts
@@ -170,7 +170,7 @@ async function main() {
     mkdirSync(dir, { recursive: true });
 
     const filePath = join(dir, `${eventAction}.json`);
-    writeFileSync(filePath, JSON.stringify(payload, null, 2) + "\n");
+    writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
   }
 
   // Summary

--- a/packages/webhook-schemas/src/capture.ts
+++ b/packages/webhook-schemas/src/capture.ts
@@ -8,10 +8,10 @@
  *   cd packages/webhook-schemas && pnpm capture
  */
 
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { db } from "@db/app/client";
 import { gatewayWebhookDeliveries } from "@db/app/schema";
-import { writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
 import { and, isNotNull, sql } from "drizzle-orm";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -26,11 +26,7 @@ type JsonValue =
 
 // ── PII Sanitization ────────────────────────────────────────────────────────
 
-const AUTHOR_CONTEXT_KEYS = new Set([
-  "author",
-  "committer",
-  "co-authored-by",
-]);
+const AUTHOR_CONTEXT_KEYS = new Set(["author", "committer", "co-authored-by"]);
 
 function isAuthorContext(key: string): boolean {
   const lower = key.toLowerCase();
@@ -39,7 +35,7 @@ function isAuthorContext(key: string): boolean {
 
 function walk(
   obj: Record<string, JsonValue>,
-  parentKey: string = ""
+  parentKey = ""
 ): Record<string, JsonValue> {
   for (const [key, value] of Object.entries(obj)) {
     if (key === "avatar_url" && typeof value === "string") {
@@ -80,7 +76,9 @@ function walk(
   return obj;
 }
 
-function sanitize(payload: Record<string, JsonValue>): Record<string, JsonValue> {
+function sanitize(
+  payload: Record<string, JsonValue>
+): Record<string, JsonValue> {
   const clone = structuredClone(payload);
   return walk(clone);
 }
@@ -137,13 +135,17 @@ async function main() {
   const providerCounts: Record<string, number> = {};
 
   for (const row of rows) {
-    if (!row.payload) continue;
+    if (!row.payload) {
+      continue;
+    }
 
     let parsed: Record<string, JsonValue>;
     try {
       parsed = JSON.parse(row.payload) as Record<string, JsonValue>;
     } catch {
-      console.log(`  Skipping unparseable payload for ${row.provider}/${row.eventType}`);
+      console.log(
+        `  Skipping unparseable payload for ${row.provider}/${row.eventType}`
+      );
       continue;
     }
 

--- a/packages/webhook-schemas/src/report.ts
+++ b/packages/webhook-schemas/src/report.ts
@@ -36,8 +36,7 @@ function deepKeys(obj: unknown, prefix = ""): Set<string> {
   }
 
   if (Array.isArray(obj)) {
-    for (let i = 0; i < obj.length; i++) {
-      const item = obj[i];
+    for (const item of obj) {
       if (item !== null && typeof item === "object") {
         for (const k of deepKeys(item, `${prefix}[]`)) {
           keys.add(k);
@@ -229,7 +228,7 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
         }
 
         const allSmallInts = values.every(
-          (v) => /^\d+$/.test(v) && Number.parseInt(v) < 100_000
+          (v) => /^\d+$/.test(v) && Number.parseInt(v, 10) < 100_000
         );
         return allSmallInts
           ? `PR number (small integer as string) — values: [${values.join(", ")}]`

--- a/packages/webhook-schemas/src/report.ts
+++ b/packages/webhook-schemas/src/report.ts
@@ -8,28 +8,27 @@
  *   cd packages/webhook-schemas && pnpm report
  */
 
-import {
-  preTransformVercelWebhookPayloadSchema,
-  preTransformGitHubPullRequestEventSchema,
-  preTransformGitHubIssuesEventSchema,
-  preTransformGitHubIssueCommentEventSchema,
-} from "@repo/app-providers";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  preTransformGitHubIssueCommentEventSchema,
+  preTransformGitHubIssuesEventSchema,
+  preTransformGitHubPullRequestEventSchema,
+} from "@repo/app-providers";
 import type { ZodType } from "zod";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
 interface Fixture {
-  provider: string;
+  data: Record<string, unknown>;
   eventType: string;
   path: string;
-  data: Record<string, unknown>;
+  provider: string;
 }
 
 // ── Deep key extraction (shared with validate) ──────────────────────────────
 
-function deepKeys(obj: unknown, prefix: string = ""): Set<string> {
+function deepKeys(obj: unknown, prefix = ""): Set<string> {
   const keys = new Set<string>();
 
   if (obj === null || obj === undefined || typeof obj !== "object") {
@@ -94,14 +93,15 @@ function loadFixtures(provider: string): Fixture[] {
 
 // ── Safely navigate nested objects ──────────────────────────────────────────
 
-function getNestedValue(
-  obj: Record<string, unknown>,
-  path: string
-): unknown {
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   const parts = path.split(".");
   let current: unknown = obj;
   for (const part of parts) {
-    if (current === null || current === undefined || typeof current !== "object") {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object"
+    ) {
       return undefined;
     }
     current = (current as Record<string, unknown>)[part];
@@ -152,13 +152,17 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
 
   for (const fixture of fixtures) {
     const meta = getNestedValue(fixture.data, "payload.deployment.meta");
-    if (!meta || typeof meta !== "object") continue;
+    if (!meta || typeof meta !== "object") {
+      continue;
+    }
 
     const metaObj = meta as Record<string, unknown>;
     for (const field of VERCEL_META_GITHUB_FIELDS) {
       const value = metaObj[field];
       const stats = fieldStats.get(field);
-      if (!stats) continue;
+      if (!stats) {
+        continue;
+      }
 
       if (value !== undefined && value !== null) {
         stats.present++;
@@ -199,7 +203,11 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
         const total = fixtures.length;
         const withPrId = fixtures.filter((f) => {
           const meta = getNestedValue(f.data, "payload.deployment.meta");
-          return meta && typeof meta === "object" && (meta as Record<string, unknown>).githubPrId;
+          return (
+            meta &&
+            typeof meta === "object" &&
+            (meta as Record<string, unknown>).githubPrId
+          );
         }).length;
         return `${withPrId}/${total} fixtures have githubPrId`;
       },
@@ -216,10 +224,12 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
           })
           .filter((v): v is string => typeof v === "string");
 
-        if (values.length === 0) return "No githubPrId values found";
+        if (values.length === 0) {
+          return "No githubPrId values found";
+        }
 
         const allSmallInts = values.every(
-          (v) => /^\d+$/.test(v) && parseInt(v) < 100000
+          (v) => /^\d+$/.test(v) && Number.parseInt(v) < 100_000
         );
         return allSmallInts
           ? `PR number (small integer as string) — values: [${values.join(", ")}]`
@@ -238,7 +248,9 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
           })
           .filter((v): v is string => typeof v === "string");
 
-        if (shas.length === 0) return "No githubCommitSha values found";
+        if (shas.length === 0) {
+          return "No githubCommitSha values found";
+        }
 
         const allFull = shas.every((s) => /^[a-f0-9]{40}$/.test(s));
         return allFull
@@ -251,7 +263,9 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
       answer: () => {
         const withShaNopr = fixtures.filter((f) => {
           const meta = getNestedValue(f.data, "payload.deployment.meta");
-          if (!meta || typeof meta !== "object") return false;
+          if (!meta || typeof meta !== "object") {
+            return false;
+          }
           const m = meta as Record<string, unknown>;
           return m.githubCommitSha && !m.githubPrId;
         });
@@ -269,12 +283,15 @@ function analyzeVercelFixtures(fixtures: Fixture[]) {
 // ── Section B: GitHub Field Coverage ────────────────────────────────────────
 
 function getSchema(eventType: string): ZodType | null {
-  if (eventType.startsWith("pull_request"))
+  if (eventType.startsWith("pull_request")) {
     return preTransformGitHubPullRequestEventSchema;
-  if (eventType.startsWith("issues"))
+  }
+  if (eventType.startsWith("issues")) {
     return preTransformGitHubIssuesEventSchema;
-  if (eventType.startsWith("issue_comment"))
+  }
+  if (eventType.startsWith("issue_comment")) {
     return preTransformGitHubIssueCommentEventSchema;
+  }
   return null;
 }
 
@@ -301,17 +318,25 @@ function analyzeGitHubFixtures(fixtures: Fixture[]) {
   };
 
   function categorize(field: string): string {
-    if (field.match(/\bid\b|_id|node_id|number/i)) return "identifiers";
-    if (field.match(/\bat\b|_at|date|time/i)) return "timestamps";
-    if (field.match(/url|href|link/i)) return "urls";
-    if (field.match(/user|author|owner|sender|assignee|reviewer|committer/i))
+    if (field.match(/\bid\b|_id|node_id|number/i)) {
+      return "identifiers";
+    }
+    if (field.match(/\bat\b|_at|date|time/i)) {
+      return "timestamps";
+    }
+    if (field.match(/url|href|link/i)) {
+      return "urls";
+    }
+    if (field.match(/user|author|owner|sender|assignee|reviewer|committer/i)) {
       return "users";
+    }
     if (
       field.match(
         /label|milestone|description|permissions|events|type|state|locked|active_lock_reason/i
       )
-    )
+    ) {
       return "metadata";
+    }
     return "other";
   }
 
@@ -334,18 +359,24 @@ function analyzeGitHubFixtures(fixtures: Fixture[]) {
     const captured = [...inputKeys].filter((k) => outputKeys.has(k));
 
     console.log(`\x1b[36m${fixture.path}\x1b[0m`);
-    console.log(`  Captured: ${captured.length}  |  Dropped: ${dropped.length}\n`);
+    console.log(
+      `  Captured: ${captured.length}  |  Dropped: ${dropped.length}\n`
+    );
 
     // Group dropped fields by category
     const grouped: Record<string, string[]> = {};
     for (const field of dropped) {
       const cat = categorize(field);
-      if (!grouped[cat]) grouped[cat] = [];
+      if (!grouped[cat]) {
+        grouped[cat] = [];
+      }
       grouped[cat].push(field);
     }
 
     for (const [cat, fields] of Object.entries(grouped)) {
-      if (fields.length === 0) continue;
+      if (fields.length === 0) {
+        continue;
+      }
       console.log(`  \x1b[33m${cat}\x1b[0m (${fields.length}):`);
       for (const field of fields.slice(0, 15)) {
         console.log(`    - ${field}`);
@@ -369,7 +400,9 @@ function analyzeGitHubFixtures(fixtures: Fixture[]) {
   // Global summary
   console.log("─── Dropped Fields Summary (across all GitHub fixtures) ──\n");
   for (const [cat, fields] of Object.entries(categories)) {
-    if (fields.length === 0) continue;
+    if (fields.length === 0) {
+      continue;
+    }
     console.log(`  ${cat}: ${fields.length} unique field(s)`);
   }
   const totalUnique = Object.values(categories).reduce(

--- a/packages/webhook-schemas/src/validate.ts
+++ b/packages/webhook-schemas/src/validate.ts
@@ -9,28 +9,28 @@
  *   cd packages/webhook-schemas && pnpm validate
  */
 
-import {
-  preTransformVercelWebhookPayloadSchema,
-  preTransformGitHubPullRequestEventSchema,
-  preTransformGitHubIssuesEventSchema,
-  preTransformGitHubIssueCommentEventSchema,
-} from "@repo/app-providers";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  preTransformGitHubIssueCommentEventSchema,
+  preTransformGitHubIssuesEventSchema,
+  preTransformGitHubPullRequestEventSchema,
+  preTransformVercelWebhookPayloadSchema,
+} from "@repo/app-providers";
 import type { ZodType } from "zod";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
 interface Fixture {
-  provider: string;
+  data: Record<string, unknown>;
   eventType: string;
   path: string;
-  data: Record<string, unknown>;
+  provider: string;
 }
 
 // ── Deep key extraction ─────────────────────────────────────────────────────
 
-function deepKeys(obj: unknown, prefix: string = ""): Set<string> {
+function deepKeys(obj: unknown, prefix = ""): Set<string> {
   const keys = new Set<string>();
 
   if (obj === null || obj === undefined || typeof obj !== "object") {
@@ -66,14 +66,19 @@ function deepKeys(obj: unknown, prefix: string = ""): Set<string> {
 // ── Schema mapping ──────────────────────────────────────────────────────────
 
 function getSchema(provider: string, eventType: string): ZodType | null {
-  if (provider === "vercel") return preTransformVercelWebhookPayloadSchema;
+  if (provider === "vercel") {
+    return preTransformVercelWebhookPayloadSchema;
+  }
   if (provider === "github") {
-    if (eventType.startsWith("pull_request"))
+    if (eventType.startsWith("pull_request")) {
       return preTransformGitHubPullRequestEventSchema;
-    if (eventType.startsWith("issues"))
+    }
+    if (eventType.startsWith("issues")) {
       return preTransformGitHubIssuesEventSchema;
-    if (eventType.startsWith("issue_comment"))
+    }
+    if (eventType.startsWith("issue_comment")) {
       return preTransformGitHubIssueCommentEventSchema;
+    }
   }
   return null;
 }
@@ -152,9 +157,7 @@ function main() {
     } else {
       console.log(`\x1b[31m✗\x1b[0m ${fixture.path} — PARSE FAILED`);
       for (const issue of result.error.issues) {
-        console.log(
-          `    ${issue.path.join(".")}: ${issue.message}`
-        );
+        console.log(`    ${issue.path.join(".")}: ${issue.message}`);
       }
       failCount++;
     }

--- a/packages/webhook-schemas/src/validate.ts
+++ b/packages/webhook-schemas/src/validate.ts
@@ -38,8 +38,7 @@ function deepKeys(obj: unknown, prefix = ""): Set<string> {
   }
 
   if (Array.isArray(obj)) {
-    for (let i = 0; i < obj.length; i++) {
-      const item = obj[i];
+    for (const item of obj) {
       if (item !== null && typeof item === "object") {
         for (const k of deepKeys(item, `${prefix}[]`)) {
           keys.add(k);

--- a/thoughts/shared/plans/2026-04-19-fix-pnpm-check.md
+++ b/thoughts/shared/plans/2026-04-19-fix-pnpm-check.md
@@ -1,0 +1,258 @@
+# Fix `pnpm check` Failures Implementation Plan
+
+## Overview
+
+`pnpm check` (runs `npx ultracite@latest check`, a Biome wrapper) reports **96 errors + 1 warning across 23 files** on `main`. The vast majority are auto-fixable formatter/style diagnostics; a small tail (~6 errors) needs manual judgment — most caused by commit `e11213c6e` which commented out three landing-page sections, orphaning imports and vars.
+
+## Current State Analysis
+
+- `pnpm check` → `ultracite check` (biome) — exit 1, 96 errors, 77 diagnostics truncated in default output.
+- `pnpm fix` → `ultracite fix` — already wired in `package.json`, applies every "Safe fix" diagnostic in place.
+- No TypeScript or test failures are in scope — `pnpm typecheck` and tests are separate pipelines (per `CLAUDE.md`).
+- Error distribution (verified via `--max-diagnostics=300`):
+
+| Rule | Count | Auto-fixable |
+|---|---|---|
+| `lint/style/useBlockStatements` | 29 | ✅ |
+| `assist/source/organizeImports` | 11 | ✅ |
+| `lint/nursery/useSortedClasses` | 8 | ✅ |
+| `lint/correctness/noUnusedVariables` | 7 | 5 ✅ / 2 ⚠️ |
+| `assist/source/useSortedInterfaceMembers` | 5 | ✅ |
+| `lint/style/useNumericSeparators` | 3 | ✅ |
+| `lint/style/noInferrableTypes` | 3 | ✅ |
+| `lint/style/useForOf` | 2 | ⚠️ manual |
+| `lint/correctness/noUnusedImports` | 2 | ✅ |
+| `lint/style/useTemplate`, `useNumberNamespace`, `useParseIntRadix` | 3 | ✅ |
+| `lint/suspicious/noMisplacedAssertion` | 1 | ⚠️ manual |
+| `suppressions/unused` | 1 | ⚠️ manual |
+| Formatter (whitespace/trailing commas) | ~20 files | ✅ |
+
+## Desired End State
+
+`pnpm check` exits 0 with no errors and no warnings. Every diagnostic above is resolved — either auto-applied by `pnpm fix` or handled by the targeted manual edits in Phase 2. Verified by: `pnpm check` returns clean.
+
+### Key Discoveries
+
+- `package.json:9` — `"check": "npx ultracite@latest check"`, `"fix": "npx ultracite@latest fix"`. One command fixes most issues.
+- `apps/www/src/app/(app)/(marketing)/(landing)/page.tsx:23,110` — `FlowField` import and `{ hash, url }` destructure both orphaned by commit `e11213c6e` (manifesto/self-driving/full-understanding sections commented out).
+- `apps/www/src/app/(app)/(marketing)/(landing)/_components/isometric-hero.tsx:21-22` — `vw`/`vh` computed but unused (likely intended for a viewBox that was never wired).
+- `packages/app-remotion/src/compositions/changelog-v010-events/changelog-v010-events.tsx:7-8` — `CANVAS_W`/`CANVAS_H` constants unused (composition size lives elsewhere in Remotion Root).
+- `apps/www/src/lib/content-schemas.ts:89` — `IntegrationStatusSchema` declared and unused.
+- `apps/www/src/lib/builders/blog.ts:70` — `// biome-ignore lint/style/noNonNullAssertion` comment no longer needed (rule no longer fires at `howToSteps!`).
+- `packages/dotlightfast/src/parse.test.ts:202` — `expect(result.skills).toEqual([])` inside helper `expectSkipped` defined at `describe` level, not inside an `it()`. Legitimate helper pattern — suppress with a targeted `biome-ignore`.
+- `packages/webhook-schemas/src/report.ts:40` and `packages/webhook-schemas/src/validate.ts:41` — index-only `for` loops where `i` is used solely to index `obj[i]`; safe mechanical conversion to `for (const item of obj)`.
+
+## What We're NOT Doing
+
+- Not disabling any Biome rules in `biome.json`/`.biomerc` (including the nursery `useSortedClasses` — eight real hits, just fix them).
+- Not touching `pnpm typecheck`, tests, or build — out of scope.
+- Not restoring the commented landing sections. They stay hidden; we only clean up orphaned code they leave behind.
+- Not upgrading `ultracite`/Biome — we fix against the pinned version.
+- Not introducing new `biome-ignore` comments except for the one genuinely overreaching rule (`noMisplacedAssertion`).
+- Not touching the `thoughts/` directory (agent-authored research/plan files should not be linted by ultracite — and aren't, confirmed by diagnostic list).
+
+## Implementation Approach
+
+Two phases:
+1. Run `pnpm fix` to clear everything marked **Safe fix** (~90 of 96 errors). Verify, then commit.
+2. Manually edit the ~6 remaining diagnostics with targeted changes listed below. Verify, then commit.
+
+Keeping the phases separate keeps the auto-fix diff reviewable in isolation from semantic edits.
+
+---
+
+## Phase 1: Apply `pnpm fix`
+
+### Overview
+
+Single-command pass that resolves every **Safe fix** diagnostic: block statements, import ordering, Tailwind class sorting, inferrable types, numeric separators, sorted interface members, and all formatter whitespace/trailing-comma issues. Also auto-removes trivially-unused imports (`noUnusedImports`) and simple unused-variable cases where deletion is safe.
+
+### Changes Required
+
+#### 1. Run the fixer
+
+```bash
+pnpm fix
+```
+
+Expected side effects (approximate, to spot-check in the diff):
+- Imports reordered in `apps/www/src/app/(app)/(marketing)/(landing)/page.tsx`, `packages/webhook-schemas/src/validate.ts`, `vendor/clerk/src/server.ts`, etc.
+- `if (x) return y;` → `if (x) { return y; }` across `packages/webhook-schemas/src/report.ts` and `validate.ts`.
+- Tailwind class reordering in landing page and `faq-section.tsx`.
+- Interface members alphabetized in `packages/dotlightfast/src/types.ts`, `validate.ts`, `changelog-v010-events.tsx`, `app-embed/src/utils.ts`.
+- Trailing commas / line-wrap normalization across ~20 files including `packages/webhook-schemas/fixtures/**.json`.
+- Simple `noInferrableTypes`, `useNumericSeparators`, `useTemplate`, `useNumberNamespace`, `useParseIntRadix` fixes.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `pnpm check 2>&1 | grep -E "Found [0-9]+ error" | tail -1` reports ≤ 10 errors remaining (the manual tail). _Note: 31 errors remained after Phase 1; plan underestimated because codebase accumulated more diagnostics (mostly `noSubstr`) since plan was written. See Phase 2 for full list._
+- [ ] `pnpm typecheck` still passes (sanity check — class/import reordering should not break types).
+- [ ] `git diff --stat` shows only the files listed under "Expected side effects" (no accidental scope creep).
+
+#### Manual Verification
+
+- [ ] Spot-check 2–3 reordered-import files compile and behave unchanged.
+- [ ] Confirm no JSON fixture payloads were semantically altered (the formatter should only touch whitespace in `packages/webhook-schemas/fixtures/**.json`).
+- [ ] Confirm `apps/www` dev server still renders the landing page — run `pnpm dev:www` and hit `http://localhost:4101`.
+
+**Implementation Note**: Pause after Phase 1 for a commit (`fix(chore): apply ultracite safe fixes`) before starting Phase 2. Keeps the mechanical vs. semantic diffs separate and easy to review.
+
+---
+
+## Phase 2: Manual edits for remaining diagnostics
+
+### Overview
+
+Six diagnostics `pnpm fix` cannot handle safely. Each has a specific, small edit.
+
+### Changes Required
+
+#### 1. Landing page — drop orphaned import and destructure
+
+**File**: `apps/www/src/app/(app)/(marketing)/(landing)/page.tsx`
+
+**Changes**: Remove the `FlowField` import (line ~23 after Phase 1 reorders) and drop the unused destructure on line 110. `getLatestCommit()` can still be called for its side-effect-free behavior, but nothing reads its return value, so drop the whole `await` expression too.
+
+Before:
+```tsx
+import { FlowField } from "./_components/flow-field";
+// ...
+export default async function HomePage() {
+  const { hash, url } = await getLatestCommit();
+  // Build organization entity
+  const organizationEntity: Organization = { /* ... */ };
+```
+
+After:
+```tsx
+// (FlowField import line removed)
+// ...
+export default async function HomePage() {
+  // Build organization entity
+  const organizationEntity: Organization = { /* ... */ };
+```
+
+Also: if `getLatestCommit` becomes unused project-wide after this edit, remove the function definition itself (lines ~90-107 in current file) and its imports. Confirm with `grep -rn "getLatestCommit" apps/www/src` before deleting.
+
+#### 2. Isometric hero — drop unused `vw`/`vh`
+
+**File**: `apps/www/src/app/(app)/(marketing)/(landing)/_components/isometric-hero.tsx`
+
+**Changes**: Delete lines 21-22 (`vw`, `vh`). `vx`/`vy` stay (still referenced).
+
+```tsx
+// Remove:
+const vw = bounds.maxX - bounds.minX + PAD * 2;
+const vh = bounds.maxY - bounds.minY + PAD * 2;
+```
+
+If `PAD` was only used by the removed lines, verify via `grep -n "PAD" isometric-hero.tsx` and drop it too.
+
+#### 3. Remotion changelog composition — drop unused canvas constants
+
+**File**: `packages/app-remotion/src/compositions/changelog-v010-events/changelog-v010-events.tsx`
+
+**Changes**: Delete lines 7-8 (`CANVAS_W`, `CANVAS_H`). Before deleting, `grep -n "CANVAS_[WH]" packages/app-remotion/src` to confirm no sibling files consume them via barrel export.
+
+#### 4. Integration schema — drop unused schema
+
+**File**: `apps/www/src/lib/content-schemas.ts`
+
+**Changes**: Delete the `IntegrationStatusSchema` declaration on line ~89. Confirm no external importer first: `grep -rn "IntegrationStatusSchema" apps packages`.
+
+#### 5. Blog builder — remove stale suppression
+
+**File**: `apps/www/src/lib/builders/blog.ts:70`
+
+**Changes**: Delete the single line:
+```ts
+// biome-ignore lint/style/noNonNullAssertion: caller guards on howToSteps presence
+```
+Biome reports the comment has no effect — the rule no longer fires on the line below.
+
+#### 6. dotlightfast tests — suppress over-strict `noMisplacedAssertion`
+
+**File**: `packages/dotlightfast/src/parse.test.ts:202`
+
+**Changes**: The `expectSkipped` helper is a legitimate test utility called from inside every `it()` in the `describe` block. Add a targeted suppression directly above line 202:
+
+```ts
+// biome-ignore lint/suspicious/noMisplacedAssertion: expectSkipped is a test helper invoked from each it()
+expect(result.skills).toEqual([]);
+```
+
+#### 7. `webhook-schemas` — convert two index loops to `for-of`
+
+**File**: `packages/webhook-schemas/src/report.ts:40` and `packages/webhook-schemas/src/validate.ts:41`
+
+Both files have the identical pattern in `deepKeys()`:
+
+Before:
+```ts
+for (let i = 0; i < obj.length; i++) {
+  const item = obj[i];
+  if (item !== null && typeof item === "object") {
+    // ...
+  }
+}
+```
+
+After:
+```ts
+for (const item of obj) {
+  if (item !== null && typeof item === "object") {
+    // ...
+  }
+}
+```
+
+`i` is unused aside from indexing, so the conversion is mechanical and semantics-preserving.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `pnpm check` exits 0, reports `Found 0 errors`.
+- [ ] `pnpm typecheck` still passes. _Not run in worktree (no node_modules); edits are mechanical/semantics-preserving._
+- [ ] `pnpm --filter @repo/webhook-schemas test` — `deepKeys` still behaves on arrays after the `for-of` conversion. _Not run in worktree; `for-of` over array is semantics-preserving._
+- [ ] `pnpm --filter @lightfast/dotlightfast test` — `parse.test.ts` passes with the new suppression comment. _Not run in worktree; only added a biome-ignore comment, no code change._
+
+#### Manual Verification
+
+- [ ] Landing page renders identically at `http://localhost:4101` (run `pnpm dev:www`).
+- [ ] Remotion compositions still render — `pnpm --filter @repo/app-remotion dev` if a preview exists; otherwise eyeball the Root config to confirm `CANVAS_W/H` were only module-local.
+- [ ] `git grep` confirms none of the deleted identifiers (`FlowField`, `IntegrationStatusSchema`, `CANVAS_W`, `CANVAS_H`, `vw`, `vh`, `getLatestCommit`) are referenced elsewhere after the edits.
+
+**Implementation Note**: Commit Phase 2 separately (`chore: resolve remaining ultracite diagnostics`). Final `pnpm check` run should be green.
+
+---
+
+## Testing Strategy
+
+### Automated Checks
+
+- `pnpm check` — primary acceptance signal.
+- `pnpm typecheck` — guard against ordering/removal breaking types.
+- Package-scoped tests for `webhook-schemas` and `dotlightfast` — the only areas where semantic edits land.
+
+### Manual Testing Steps
+
+1. Start `pnpm dev:www`; visit `/` and verify the visible sections (hero, FAQ, latest content preview) still render correctly.
+2. Inspect the `git diff` for Phase 1 — confirm it is purely whitespace / reordering / brace-wrapping with no logic changes.
+3. Inspect the `git diff` for Phase 2 — confirm each deletion maps 1:1 to the list above and no unrelated code was touched.
+
+## Performance Considerations
+
+None. Every change is syntactic cleanup or removal of dead code. The two `for-of` conversions are hot-path-neutral (index loop vs. iterator on a small array, schema-capture time only).
+
+## Migration Notes
+
+None — no runtime, schema, or API surface changes.
+
+## References
+
+- Root command: `package.json` → `"check": "npx ultracite@latest check"`, `"fix": "npx ultracite@latest fix"`
+- Root-cause commit for orphaned imports: `e11213c6e chore(www): hide unfinished landing sections`
+- Ultracite / Biome diagnostic docs: the error output itself links to each rule's page (e.g. `biomejs.dev/linter/#nursery`)

--- a/vendor/clerk/src/server.ts
+++ b/vendor/clerk/src/server.ts
@@ -1,8 +1,5 @@
 import "server-only";
 
-export { getUserOrgMemberships } from "./membership";
-export type { UserOrgMembership } from "./membership";
-
 export type {
   AllowlistIdentifier,
   ClerkMiddlewareAuth,
@@ -62,3 +59,5 @@ export {
   reverificationErrorResponse,
   verifyToken,
 } from "@clerk/nextjs/server";
+export type { UserOrgMembership } from "./membership";
+export { getUserOrgMemberships } from "./membership";

--- a/vendor/db/src/utils/create-drizzle-config.ts
+++ b/vendor/db/src/utils/create-drizzle-config.ts
@@ -10,7 +10,7 @@ export const createDrizzleConfig = (opts: {
 }): Config => {
   // Construct DATABASE_URL for PlanetScale
   const database =
-    (opts.database?.trim() !== "" ? opts.database : undefined) ?? "lightfast";
+    (opts.database?.trim() === "" ? undefined : opts.database) ?? "lightfast";
   // Remove any quotes from all values if they exist
   const cleanHost = opts.host.replace(/^["']|["']$/g, "");
   const cleanUsername = opts.username.replace(/^["']|["']$/g, "");

--- a/vendor/mcp/src/index.ts
+++ b/vendor/mcp/src/index.ts
@@ -73,7 +73,7 @@ export function registerContractTools(
           // With inputSchema: args = [parsedInput, extra]
           // Without inputSchema: args = [extra]
           const input = def.inputSchema ? args[0] : undefined;
-          const result = input !== undefined ? await fn(input) : await fn();
+          const result = input === undefined ? await fn() : await fn(input);
           return {
             structuredContent: result as Record<string, unknown>,
           };

--- a/vendor/security/src/csp/compose.ts
+++ b/vendor/security/src/csp/compose.ts
@@ -158,7 +158,7 @@ export function composeCspOptions(...configs: PartialCspDirectives[]): Options {
     } else if (userValue) {
       // MERGE: other directives merge with defaults (extends them)
       mergedDirectives[key] = mergeDirectives(
-        safeDefault != null ? ([...safeDefault] as Source[]) : [],
+        safeDefault == null ? [] : ([...safeDefault] as Source[]),
         userValue
       );
     } else if (safeDefault != null) {

--- a/vendor/seo/src/json-ld.tsx
+++ b/vendor/seo/src/json-ld.tsx
@@ -37,9 +37,6 @@ export const JsonLd = ({ code }: JsonLdProps) => (
   />
 );
 
-// Export types for use in components
-export type { GraphContext, JsonLdData };
-
 // Re-export commonly used schema types for convenience
 export type {
   Answer,
@@ -78,3 +75,5 @@ export type {
   WebSite,
   WithContext,
 } from "schema-dts";
+// Export types for use in components
+export type { GraphContext, JsonLdData };


### PR DESCRIPTION
## Summary
- Resolve 96 Biome/ultracite errors reported by `pnpm check` so CI is green again
- Phase 1: auto-apply `pnpm fix` for formatter, import/class/interface sorting, block statements, and simple rule fixes (45 files)
- Phase 2: manual cleanup of orphaned imports/vars left by e11213c6e, stale biome-ignore, for-of conversions, plus ~20 noSubstr drift fixes (19 files)

## Test plan
- [ ] `pnpm check` → 0 errors, 0 warnings (verified in worktree)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm --filter @repo/webhook-schemas test` passes (for-of conversion)
- [ ] `pnpm --filter @lightfast/dotlightfast test` passes (biome-ignore in parse.test.ts)
- [ ] Landing page renders at localhost:4101