### PR TITLE
chore(config): align .npmrc with pnpm 10 defaults; fix CLAUDE.md drift

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,26 +1,7 @@
-# Core settings
-auto-install-peers=true
+# Pre/post scripts (off by default since pnpm 7; required for postinstall hooks)
 enable-pre-post-scripts=true
 
-# Workspace settings (monorepo)
-link-workspace-packages=true
-prefer-workspace-packages=true
-shared-workspace-lockfile=true
-
-# Use pnpm's default isolated mode for better dependency isolation
-# node-linker=isolated  # This is the default, no need to set explicitly
-
-# Performance: Better retry strategy
+# Slightly more tolerant fetches for flaky networks / CI
 fetch-retries=3
 fetch-retry-mintimeout=10000
 fetch-retry-maxtimeout=60000
-
-# Performance: Cache install scripts
-side-effects-cache=true
-side-effects-cache-readonly=false
-
-# Performance: Cache node_modules for 7 days
-modules-cache-max-age=604800
-
-# Note: Use --frozen-lockfile flag in CI instead of setting globally
-# Note: Use --prefer-offline flag when needed instead of setting globally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,13 +88,8 @@ Note: ngrok and inngest automatically runs with `pnpm dev:app`. You can test ngr
 
 ## Environment
 
-- **Node.js** >= 22.0.0 | **pnpm** 10.5.2
+- **Node.js** >= 22.0.0 | **pnpm** 10.32.1 (pinned via `packageManager` in root `package.json` — that's the source of truth)
 - **Env files**: `apps/<app>/.vercel/.env.development.local`
-
-## Workflows
-
-- **External repos**: Clone to `/tmp/repos/<repo-name>`
-- **Dependencies**: Check root `node_modules/` (hoisted with `node-linker=hoisted`)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Trim `.npmrc` 27 → 6 lines by removing pnpm 10 defaults (`auto-install-peers`, `link/prefer-workspace-packages`, `shared-workspace-lockfile`, `side-effects-cache*`).
- Fix `modules-cache-max-age=604800` bug — unit is **minutes**, so it was setting ~420 days, not 7. Default (`10080`) is already 7 days.
- Update `CLAUDE.md` pnpm version (`10.5.2` → `10.32.1`) and point at `packageManager` in root `package.json` as the source of truth so future drift is self-correcting.
- Remove stale Workflows section that claimed `node-linker=hoisted` — repo is on `isolated` (pnpm default), which actually enforces the vendor abstraction rule (packages can't import third-party SDKs directly through `@vendor/*`).

## Test plan
- [ ] `pnpm install` runs cleanly with no lockfile churn (only removed defaults)
- [ ] CI green