### PR TITLE
fix(deps): patch @hookform/resolvers phantom zod peer for Turbopack

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,8 @@ overrides:
   path-to-regexp: ^6.3.0
   fast-xml-parser: ^5.5.6
 
+packageExtensionsChecksum: sha256-2FPZBw94MFNppirrJdB4qikbdLGsOF45SnJk4YB2rYM=
+
 importers:
 
   .:
@@ -379,7 +381,7 @@ importers:
         version: link:../../db/app
       '@hookform/resolvers':
         specifier: 'catalog:'
-        version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
+        version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))(zod@4.3.6)
       '@lightfastai/ai-sdk':
         specifier: workspace:*
         version: link:../../core/ai-sdk
@@ -3846,6 +3848,10 @@ packages:
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
       react-hook-form: ^7.55.0
+      zod: '>=3.24.0'
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -14804,10 +14810,12 @@ snapshots:
     dependencies:
       hono: 4.12.14
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@19.2.5))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@19.2.5))(zod@4.3.6)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.72.1(react@19.2.5)
+    optionalDependencies:
+      zod: 4.3.6
 
   '@iconify/types@2.0.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,3 +90,11 @@ onlyBuiltDependencies:
 publicHoistPattern:
   - '*import-in-the-middle*'
   - '*require-in-the-middle*'
+
+packageExtensions:
+  '@hookform/resolvers':
+    peerDependencies:
+      zod: '>=3.24.0'
+    peerDependenciesMeta:
+      zod:
+        optional: true


### PR DESCRIPTION
## Summary
- Fixes failing Vercel production build: `Module not found: Can't resolve 'zod/v4/core'`
- Root cause: `@hookform/resolvers@5.2.2` imports `zod/v4/core` from its compiled output but only declares `react-hook-form` as a peer — leaving `zod` as a phantom dep. Webpack resolves it via pnpm hoisting; Turbopack's strict virtual-store resolution does not.
- Adds a `packageExtensions` entry to `pnpm-workspace.yaml` declaring `zod` as an optional peer. pnpm then generates a peer-aware virtual store key (`@hookform+resolvers@5.2.2_..._zod@4.3.6`) and places `zod` alongside the resolvers package.

## Failing deployment
https://vercel.com/lightfast/lightfast-app/4eKWDgLv52uyjk5ymCZRH16zzwDa

## Test plan
- [x] `pnpm install` regenerates lockfile with peer-aware virtual store key
- [x] `pnpm --filter=@lightfast/app build:prod` (Turbopack) compiles successfully
- [ ] Vercel preview deployment passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)