### PR TITLE
chore(ci): tune coderabbit config to match repo reality

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
-early_access: true
+early_access: false
 
 tone_instructions: "Be direct, concise, no pleasantries. Categorize: [blocker] must fix, [warning] should fix with trade-offs, [nit] optional. Cite files or CLAUDE.md sections. Explain WHY changes matter, don't restate what changed."
 
@@ -18,9 +18,10 @@ reviews:
   # Link tracking
   assess_linked_issues: true
 
-  # Auto-review triggers (disabled — use @coderabbitai in PR comments to trigger)
+  # Auto-review triggers — runs on non-draft PRs targeting main/develop unless title opts out.
+  # Incremental reviews run automatically on each push so pre-merge checks stay fresh.
   auto_review:
-    enabled: false
+    enabled: true
     drafts: false
     auto_incremental_review: true
     ignore_title_keywords:
@@ -154,13 +155,17 @@ reviews:
       requirements: "PR title should follow conventional commits format (feat:, fix:, chore:, etc.) and be under 70 characters"
     description:
       mode: "warning"
+    issue_assessment:
+      mode: "warning"
+    docstrings:
+      mode: "warning"
 
 # ── Tools ──
 tools:
   eslint:
-    enabled: true
-  biome:
     enabled: false
+  biome:
+    enabled: true
   ast-grep:
     enabled: true
     essential_rules: true
@@ -182,6 +187,8 @@ finishing_touches:
   docstrings:
     enabled: true
   unit_tests:
+    enabled: true
+  simplify:
     enabled: true
 
 chat:


### PR DESCRIPTION
## Summary

Aligns `.coderabbit.yaml` with how this repo actually lints, reviews, and merges — instead of the stock settings from initial setup.

- **Tool flip (correctness bug):** `eslint: off`, `biome: on`. Repo lints via `biome.jsonc` + ultracite (`pnpm check`); there is **zero** ESLint config anywhere in the tree, so ESLint-based comments were noise.
- **Auto-review enabled** with `auto_incremental_review: true`. Previously required a manual `@coderabbitai` ping per PR; `drafts: false` + `ignore_title_keywords` + `base_branches: [main, develop]` keep it gated.
- **`early_access: false`** — prefer stable review behavior over experimental features on the shared config.
- **Pre-merge checks expanded:** added `issue_assessment` (pairs with existing `assess_linked_issues: true`) and `docstrings`, both in `warning` mode — signal, not block.
- **Finishing touches:** added `simplify` recipe alongside docstrings + unit_tests.

`knowledge_base.code_guidelines.enabled: true` already auto-ingests `CLAUDE.md` + `AGENTS.md` via default `filePatterns`, so `path_instructions` are retained as belt-and-suspenders review emphasis rather than the sole source of project rules.

## Test plan

- [ ] Next PR opened triggers an auto-review without `@coderabbitai` ping
- [ ] Review comments no longer reference ESLint rules (biome only)
- [ ] Pre-merge checklist surfaces title, description, issue_assessment, docstrings
- [ ] `@coderabbitai run simplify` in a PR comment produces a suggestion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled automated PR reviews for improved code quality assurance
  * Enhanced pre-merge checks with issue assessment and docstring validation
  * Activated Biome code formatter and linter
  * Extended PR finishing touches workflow with simplification features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->