### PR TITLE
chore(next): enable browserToTerminal log forwarding

### DIFF
--- a/vendor/next/src/config.ts
+++ b/vendor/next/src/config.ts
@@ -88,6 +88,10 @@ export const baseConfig: NextConfig = {
 
   // Required to support PostHog trailing slash API requests
   skipTrailingSlashRedirect: true,
+
+  logging: {
+    browserToTerminal: true,
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Enable Next 16.2's stable `logging.browserToTerminal` in the shared `@vendor/next` baseConfig
- Forwards client `console.log/info/warn/error` to the dev terminal with `(file:line:col)` source locations
- Both `apps/app` and `apps/platform` inherit it via `lodash.merge(baseConfig, …)`

## Why
Next 16.2.0 promoted this from `experimental.browserDebugInfoInTerminal` to a stable `logging.browserToTerminal` key. Makes in-editor AI agents (Claude Code, Cursor) able to see client-side errors without tab-switching to devtools. Dev-only — no effect on `next start` or prod builds.

## Notes
- Sentry's `captureConsoleIntegration({ levels: ["error", "warn"] })` in `apps/app/src/instrumentation-client.ts` also patches `console.*`. Both will fire in dev — benign, but expect warn/error to show up in terminal AND in Sentry dev client. Scope the Sentry integration to non-dev only if it gets noisy.
- Official docs conflict on the default value (`'warn'` vs `'error'`), so the flag is set explicitly to `true`.

## Test plan
- [x] `pnpm dev:app` and trigger a `console.log` from a client component — verify it appears in terminal with `(path:line:col)`
- [x] Same for `pnpm dev:platform`
- [x] `pnpm build:app` + `pnpm build:platform` still succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled browser-to-terminal log forwarding in the configuration, allowing browser console output to be displayed in the terminal for enhanced visibility during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->