### PR TITLE
fix(coderabbit): nest tools and finishing_touches under reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -160,36 +160,36 @@ reviews:
     docstrings:
       mode: "warning"
 
-# ── Tools ──
-tools:
-  eslint:
-    enabled: false
-  biome:
-    enabled: true
-  ast-grep:
-    enabled: true
-    essential_rules: true
-  shellcheck:
-    enabled: true
-  actionlint:
-    enabled: true
-  markdownlint:
-    enabled: true
-  yamllint:
-    enabled: true
-  github-checks:
-    enabled: true
-  gitleaks:
-    enabled: true
+  # ── Tools ──
+  tools:
+    eslint:
+      enabled: false
+    biome:
+      enabled: true
+    ast-grep:
+      enabled: true
+      essential_rules: true
+    shellcheck:
+      enabled: true
+    actionlint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    github-checks:
+      enabled: true
+    gitleaks:
+      enabled: true
 
-# ── Finishing touches — one-click agentic actions in PR comments ──
-finishing_touches:
-  docstrings:
-    enabled: true
-  unit_tests:
-    enabled: true
-  simplify:
-    enabled: true
+  # ── Finishing touches — one-click agentic actions in PR comments ──
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+    simplify:
+      enabled: true
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary
- Move `tools:` and `finishing_touches:` blocks under `reviews:` to match CodeRabbit's v2 schema
- Fixes the "Unrecognized key(s) in object: 'tools', 'finishing_touches'" validation warning, which was causing our tool/finishing-touches config to be silently ignored on every review

## Test plan
- [x] `.coderabbit.yaml` parses as valid YAML
- [x] `reviews.tools` and `reviews.finishing_touches` resolve correctly under the v2 schema (verified against https://coderabbit.ai/integrations/schema.v2.json)
- [ ] Next CodeRabbit review on this PR does not emit the parsing warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration file structure has been reorganized. Tool and finishing touch settings have been relocated from the top level to be nested within the reviews section. The functionality and all options remain unchanged. Users with custom configuration files will need to update them accordingly to align with this new structural organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->