### PR TITLE
fix(desktop): codesign pre-fixes for rc.1 ad-hoc dry-run

### DIFF
--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -6,8 +6,6 @@
   <true/>
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
   <true/>
-  <key>com.apple.security.cs.disable-library-validation</key>
-  <true/>
   <key>com.apple.security.inherit</key>
   <true/>
 </dict>

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -13,24 +13,21 @@ const BUNDLE_ID = "ai.lightfast.lightfast";
 
 const osxSign =
   process.env.APPLE_SIGNING_IDENTITY && process.env.APPLE_TEAM_ID
-    ? // TODO(apple-cert): kebab-case keys below are silently dropped by
-      // @electron/osx-sign@1.3.3 (camelCase only). Notarization will fail
-      // when secrets land. Rename to camelCase + move per-file ones into
-      // optionsForFile before exercising the dev-id path. Out of scope here
-      // because verification needs Apple secrets we don't have yet.
-      {
+    ? {
         identity: process.env.APPLE_SIGNING_IDENTITY,
-        "hardened-runtime": true,
-        "gatekeeper-assess": false,
         entitlements: resolve(
           import.meta.dirname,
           "build/entitlements.mac.plist"
         ),
-        "entitlements-inherit": resolve(
+        entitlementsInherit: resolve(
           import.meta.dirname,
           "build/entitlements.mac.inherit.plist"
         ),
-        "signature-flags": "library",
+        optionsForFile: () => ({
+          hardenedRuntime: true,
+          gatekeeperAssess: false,
+          signatureFlags: "library",
+        }),
       }
     : // Ad-hoc fallback used while waiting on Apple Developer enrollment.
       // identity:"-" alone produces an unsigned bundle: osx-sign defaults

--- a/thoughts/shared/plans/2026-05-06-desktop-rc1-ad-hoc-dry-run.md
+++ b/thoughts/shared/plans/2026-05-06-desktop-rc1-ad-hoc-dry-run.md
@@ -1,0 +1,372 @@
+---
+date: 2026-05-06
+owner: jp@jeevanpillay.com
+branch: main
+based_on:
+  - thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md
+  - thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
+  - thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md
+status: draft
+---
+
+# Desktop `0.1.0-rc.1` Ad-Hoc Dry-Run + Codesign Pre-Fixes
+
+## Overview
+
+Three things, in order: (1) append a 2026-05-06 status update to the original Codex-gap research file so the Status Tracker reflects today's reality (PR #621 + PR #637 landed; G-7 closed); (2) pre-fix the two known codesign correctness gaps (G-2 osxSign kebab-case keys; G-3 helper-inherit plist `disable-library-validation`) so the first signed cut doesn't ping-pong back to the codebase; (3) provision Sentry secrets only and cut `@lightfast/desktop@0.1.0-rc.1` in ad-hoc mode to exercise the entire release pipeline (~90% of it) before Apple Developer enrollment unblocks.
+
+This plan does **not** touch Apple Developer setup. The ad-hoc fallback added by PR #637 (`forge.config.ts:14-49` + `desktop-release.yml:120-124`) is the explicit Apple-blocked path and we use it.
+
+## Current State Analysis
+
+Verified against `main` at `ab634170e`:
+
+- PR #621 shipped Phases B–F of `2026-04-23-desktop-pre-release-batch.md`: env layer, source-map upload, signed-release workflow, desktop CI, contributor ergonomics. Workflow is wired but inert until first tag.
+- PR #637 shipped the unsigned-beta-distribution track: `signingMode: "ad-hoc" | "developer-id"` enum threaded through `package.json:72`, `src/shared/build-info-schema.ts:6-7,15`, build-info, Sentry tags, updater (gated off when ad-hoc, `updater.ts:87-89`), and the workflow (auto-flips signing mode based on whether `APPLE_SIGNING_IDENTITY` exists; auto-derives `prerelease=true` from any `-rc.N`/`-beta.N`/`-alpha.N` suffix).
+- Verification doc enumerates 7 gaps. G-7 (deep-link removal still holds after the custom-URL-scheme work in `b30d99975`) is verified **closed** — `grep` for `setAsDefaultProtocolClient`, `onDeepLink`, `open-url` across `apps/desktop/src/` returns zero matches; `protocol.ts` is gone.
+- Two code-side gaps remain that are cheap to land independently of Apple:
+  - **G-2** (`forge.config.ts:14-49` developer-id branch): `"hardened-runtime"`, `"gatekeeper-assess"`, `"entitlements-inherit"`, `"signature-flags"` are kebab-case and silently dropped by `@electron/osx-sign@1.3.3` (camelCase only). The in-source TODO already names this. Notarization will fail on first signed build until renamed.
+  - **G-3** (`entitlements.mac.inherit.plist:9-10`): main plist was trimmed in PR #614 to drop `com.apple.security.cs.disable-library-validation`, but the helper-process inherit plist (used by GPU/Renderer/Plugin helpers via `entitlements-inherit` in `forge.config.ts:29-32`) still carries it. Codex carries it in neither.
+- One pipeline gap: Sentry isn't provisioned yet, so even an ad-hoc tag would publish without symbolicated stack traces or a Sentry release.
+
+### Key Discoveries
+
+- The pipeline is fully self-contained on the ad-hoc path: `desktop-release.yml:120-124` flips `signingMode` based on `APPLE_SIGNING_IDENTITY` presence; the "Import Apple signing certificate" step at `desktop-release.yml:126` and "Write notarize API key" step are guarded by `if: env.APPLE_SIGNING_IDENTITY != ''`. With Apple secrets absent, the workflow runs end-to-end without touching codesign or notarization.
+- Sentry secrets are independent of Apple. Provisioning only the 2 Sentry secrets + 2 Sentry vars unblocks symbolicated stacks now; doing so before Apple lands means rc.1 already has working observability when the first signed cut happens.
+- `desktop-release.yml:32-40` auto-detects prerelease from any hyphen-suffix in the tag, so `0.1.0-rc.1` → `--prerelease` flag at draft creation. No workflow change needed for the rc cadence.
+- The `pnpm package` command exercises Forge's full sign path on ad-hoc — verified locally that the current `forge.config.ts:43-49` ad-hoc fallback (`identity: "-"`, `identityValidation: false`, `optionsForFile: () => ({ hardenedRuntime: false })`) produces a launchable `.app`. Pre-fixing G-2 in the developer-id branch must not regress the ad-hoc branch.
+
+## Desired End State
+
+1. The Codex-gap research at `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` carries an appended `## Status Update 2026-05-06` section that closes G-7 and explicitly lists G-1, G-2, G-3, G-4, G-5, G-6 as the remaining gates. Prior Status Tracker rows are unchanged (preserves historical truth of what was thought on 2026-04-24).
+2. `apps/desktop/forge.config.ts:14-49` developer-id branch uses camelCase keys throughout; per-file options live inside `optionsForFile`. The ad-hoc fallback branch is unchanged. The in-source TODO is removed.
+3. `apps/desktop/build/entitlements.mac.inherit.plist` no longer carries `com.apple.security.cs.disable-library-validation`.
+4. Sentry repo settings carry: secrets `SENTRY_DSN`, `SENTRY_AUTH_TOKEN`; variables `SENTRY_ORG`, `SENTRY_PROJECT`.
+5. `git tag @lightfast/desktop@0.1.0-rc.1 && git push origin '@lightfast/desktop@0.1.0-rc.1'` fires `desktop-release.yml`. Outcome:
+   - Workflow run is green (`prepare`, `build` matrix on arm64 + x64, `finalize`).
+   - Draft GitHub release (prerelease) carries 6 assets: arm64 + x64 × (`.zip`, `.dmg`) plus `latest-mac-arm64.json` and `latest-mac-x64.json`.
+   - Sentry release `@lightfast/desktop@0.1.0-rc.1+<runNumber>` exists with sourcemaps for both `.vite/build` and `.vite/renderer/main_window` uploaded.
+   - Build provenance attestation present on `out/make/**/*.zip`.
+6. The arm64 `.dmg` boots from a clean `/Applications` install via the documented "Open Anyway" path (per `apps/desktop/README.md:5-30`). Renderer signs in successfully via the loopback callback. A test-thrown error in main lands in Sentry with a fully symbolicated stack (file path + line number resolves back to `apps/desktop/src/...`).
+
+## What We're NOT Doing
+
+- Provisioning Apple Developer Program / App Store Connect API key. Out of scope; blocked.
+- Cutting `@lightfast/desktop@0.1.0` (without `-rc.N`). The first non-rc cut is a separate decision after rc.1 + Apple.
+- File-backed structured logger (graduating §2 of the Codex-gap research from DEFERRED). Punted to a follow-up; revisit when a beta user hits something Sentry doesn't surface.
+- Help menu "Check for updates" item. Punted; README already documents the manual reinstall path for ad-hoc beta.
+- Branch protection for `Desktop CI / Typecheck + package (unsigned)` — repo Settings UI, not automatable from code. Tracked as G-4; not in this plan.
+- Any change to `updater.ts:87-89` ad-hoc kill-switch. The auto-updater stays disabled on ad-hoc by design.
+- Sparkle-native, Linux makers, Windows MSIX, universal binary, SQLite, worker tier — all explicitly DEFERRED in the original tracker, unchanged here.
+
+## Implementation Approach
+
+Strict ordering on Phase 1 → Phase 2 → Phase 3a → Phase 3b. Phase 2 is independent of Phase 3 in principle (codesign pre-fix doesn't depend on Sentry), but landing them as separate commits keeps the rc.1 tag clean: tag a commit that has both pre-fix + Sentry secrets so the dry-run validates them simultaneously.
+
+Each phase is a halt point. After Phase 2 lands and CI is green, halt for human go-ahead before provisioning Sentry. After Sentry secrets land, halt for human go-ahead before cutting the rc tag (because the tag triggers a real GitHub Actions run that publishes a draft release).
+
+## Execution Protocol
+
+Phase boundaries halt execution. Automated checks passing is necessary but not sufficient — the next phase starts only on user go-ahead.
+
+---
+
+## Phase 1: Research file status update
+
+### Overview
+
+Append a `## Status Update 2026-05-06` section to `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`. Append-only — no edits to prior rows. The new section summarizes:
+- N-1 (PR #621, `aef1d3240`, 2026-04-24): pre-release-batch phases B–F.
+- N-2 (PR #637, `ab634170e`, 2026-05-06): unsigned-beta-distribution + `signingMode` enum.
+- N-3 mid-flight items (`2565270fa` floating settings, `b30d99975` custom URL scheme + PKCE).
+- G-7 closed (no `setAsDefaultProtocolClient` / `onDeepLink` / `open-url` references in `apps/desktop/src/`).
+- G-1..G-6 standing as the gates for first-class signed v0.1.0.
+
+### Changes Required
+
+#### 1. `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`
+
+**File**: `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`
+**Changes**: Append a new top-level section after the existing `## Status Update 2026-04-24` section. Update frontmatter `last_updated: 2026-05-06` and `last_updated_note` to reflect the new state. Add a `verifications:` field referencing `2026-05-06-desktop-prod-readiness-status-verification.md`.
+
+The appended section:
+
+```markdown
+## Status Update 2026-05-06
+
+Verification pass logged at [`thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md`](2026-05-06-desktop-prod-readiness-status-verification.md). Every prior **DONE** / **DROPPED** Status Tracker row remains true. The three rows previously **IN PROGRESS** all landed.
+
+### What landed since 2026-04-24
+
+- **PR #621** (`aef1d3240`, 2026-04-24) — pre-release-batch phases B–F. Closes IN PROGRESS rows in §2 (Sentry source-map upload), §6 (multi-arch matrix), §13 (build-metadata stamping). Source artifacts: `apps/desktop/src/env/{main,renderer}.ts`, `apps/desktop/scripts/upload-sourcemaps.mjs`, `.github/workflows/desktop-{release,ci}.yml`, `apps/desktop/.env.example`, `apps/desktop/package.json` `clean` script, `.changeset/config.json` ignore.
+- **PR #637** (`ab634170e`, 2026-05-06) — unsigned-beta-distribution. Adds a `signingMode: "ad-hoc" | "developer-id"` enum threaded through `apps/desktop/package.json:72`, `apps/desktop/src/shared/build-info-schema.ts:6-7,15`, build-info, Sentry tags, updater. `forge.config.ts:14-49` carries a two-branch osxSign (developer-id when `APPLE_SIGNING_IDENTITY` + `APPLE_TEAM_ID` set, else ad-hoc fallback `identity: "-"`). `desktop-release.yml:32-40` auto-derives `prerelease=true` from any hyphen-suffix in the tag; `desktop-release.yml:120-124` flips `signingMode` based on whether `APPLE_SIGNING_IDENTITY` exists. `apps/desktop/src/main/updater.ts:87-89` disables the auto-updater entirely when `signingMode === "ad-hoc"` (Squirrel.Mac requires the new build to satisfy the running app's Designated Requirement; ad-hoc DRs are content-bound).
+- **Mid-flight** — `2565270fa` (floating settings panel), `b30d99975` (custom URL scheme + PKCE). The custom-URL-scheme work does **not** reintroduce a deep-link handler in main: `grep` for `setAsDefaultProtocolClient`, `onDeepLink`, `open-url` across `apps/desktop/src/` returns zero matches. The deletion of `protocol.ts` and the lack of `CFBundleURLTypes` in `forge.config.ts:81-92` extendInfo both still hold. **§10 deep-link surface is genuinely gone.**
+
+### Tracker rows state at 2026-05-06
+
+| § | Finding | Prior state | Current state |
+|---|---|---|---|
+| 2 | Source-map upload / `@sentry/cli` | IN PROGRESS | **DONE** (PR #621) |
+| 6 | Multi-arch arm64+x64 | IN PROGRESS | **DONE** (PR #621) |
+| 13 | Non-empty version / buildNumber / sparkleFeedUrl | IN PROGRESS | **DONE** (PR #621 — workflow stamps via `npm pkg set`; placeholders in `package.json` are intentional) |
+| 13 | `signingMode` (new) | n/a | **DONE** (PR #637) |
+| 10 | Deep-link `console.log` / dispatcher | DEFERRED | **N/A** — surface removed; was never reintroduced |
+
+All other DEFERRED / RELEASE rows from the 2026-04-24 tracker remain unchanged.
+
+### Remaining gates for first-class signed v0.1.0
+
+- **G-1** — Apple Developer enrollment + Sentry secrets. External, partially blocked (Apple). Sentry can land independently.
+- **G-2** — `forge.config.ts:14-49` osxSign developer-id branch uses kebab-case keys silently dropped by `@electron/osx-sign@1.3.3`. Will fail signed-build path on first try. Pre-fix is cheap but unverifiable until Apple secrets exist.
+- **G-3** — `apps/desktop/build/entitlements.mac.inherit.plist:9-10` still carries `com.apple.security.cs.disable-library-validation`. Codex carries it in neither main nor inherit plist.
+- **G-4** — Branch protection for `Desktop CI / Typecheck + package (unsigned)` (UI-only, not automatable from code).
+- **G-5** — First end-to-end dry run: cut `@lightfast/desktop@0.1.0-rc.1`. Can be run in ad-hoc mode now without Apple — exercises ~90% of the pipeline (matrix, Forge ad-hoc fallback, Sentry release + sourcemaps, attestation, Sparkle JSON feed). Codesign + notarize remain unverified until Apple lands.
+- **G-6** — Auto-updater is intentionally disabled when `signingMode === "ad-hoc"`. Beta users reinstall manually until the first signed cut.
+
+G-7 from the verification doc (custom URL scheme audit) is **closed** — verified above.
+
+### Recommended order to clear the gates
+
+1. Pre-fix G-2 + G-3 in code (cheap, lands without Apple).
+2. Provision Sentry only (G-1 partial). Defers Apple to its own dependency chain.
+3. Cut `@lightfast/desktop@0.1.0-rc.1` ad-hoc dry-run (G-5 partial). Validates everything except codesign + notarize.
+4. When Apple unblocks: provision the remaining 8 secrets, cut `@lightfast/desktop@0.1.0-rc.2` (signed), verify codesign + notarize + stapled ticket. Promote to `@lightfast/desktop@0.1.0`.
+5. Branch protection (G-4) — repo Settings UI. Do this after rc.1 to confirm `Desktop CI` is the right check name to require.
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] `grep -c "Status Update 2026-05-06" thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` → `1`
+- [x] `grep -c "Status Update 2026-04-24" thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` → `1` (ensures the prior section was preserved, not overwritten)
+- [x] `head -20 thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md | grep "last_updated: 2026-05-06"` → match
+- [x] `git diff --stat ...` — N/A: file is untracked in main, so a tracked-diff is not meaningful. Manually inspected: prior body unchanged; frontmatter `last_updated`/`last_updated_note` updated + `verifications:` field added; new `## Status Update 2026-05-06` section appended.
+
+#### Human Review:
+- [ ] Open the file → confirm new section renders correctly in your markdown viewer; the row table is legible
+
+---
+
+## Phase 2: Codesign pre-fix (G-2 + G-3)
+
+### Overview
+
+Two file edits. Both are mechanical and verifiable today (the developer-id branch isn't reachable in CI without Apple secrets, but TypeScript still type-checks; ad-hoc-mode `pnpm package` still succeeds because the ad-hoc branch is untouched).
+
+### Changes Required
+
+#### 1. `apps/desktop/forge.config.ts` — osxSign camelCase rename
+
+**File**: `apps/desktop/forge.config.ts`
+**Changes**: Lines 14–49. Rename kebab-case keys in the developer-id branch to the camelCase forms `@electron/osx-sign@1.3.3` actually consumes. `hardened-runtime`, `gatekeeper-assess`, `signature-flags` are per-file options that must move into `optionsForFile`; `entitlements-inherit` is a top-level option (`entitlementsInherit`). Remove the in-source TODO. Leave the ad-hoc fallback branch (lines 35–49) untouched.
+
+```ts
+const osxSign =
+  process.env.APPLE_SIGNING_IDENTITY && process.env.APPLE_TEAM_ID
+    ? {
+        identity: process.env.APPLE_SIGNING_IDENTITY,
+        entitlements: resolve(
+          import.meta.dirname,
+          "build/entitlements.mac.plist"
+        ),
+        entitlementsInherit: resolve(
+          import.meta.dirname,
+          "build/entitlements.mac.inherit.plist"
+        ),
+        optionsForFile: () => ({
+          hardenedRuntime: true,
+          gatekeeperAssess: false,
+          signatureFlags: "library",
+        }),
+      }
+    : // Ad-hoc fallback used while waiting on Apple Developer enrollment.
+      // identity:"-" alone produces an unsigned bundle: osx-sign defaults
+      // identityValidation:true, runs `security find-identity -v -`, finds
+      // nothing, throws, forge swallows. Bundle then SIGKILLs at launch
+      // (Code Signature Invalid) once FusesPlugin patches the binary.
+      // hardenedRuntime must go through optionsForFile — mergeOptionsForFile
+      // ignores top-level hardenedRuntime. Library validation rejects sibling
+      // frameworks under hardened runtime because ad-hoc DRs are content-bound.
+      {
+        identity: "-",
+        identityValidation: false,
+        optionsForFile: () => ({ hardenedRuntime: false }),
+        preAutoEntitlements: false,
+        preEmbedProvisioningProfile: false,
+      };
+```
+
+The "Why" comment on the ad-hoc branch is unchanged. The TODO comment on the developer-id branch is dropped because the work is done.
+
+#### 2. `apps/desktop/build/entitlements.mac.inherit.plist` — drop disable-library-validation
+
+**File**: `apps/desktop/build/entitlements.mac.inherit.plist`
+**Changes**: Remove the `com.apple.security.cs.disable-library-validation` key + value (lines 9–10). The remaining three keys (`allow-jit`, `allow-unsigned-executable-memory`, `inherit`) match Codex's helper entitlements.
+
+Final file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] `pnpm --filter @lightfast/desktop typecheck` passes
+- [x] `pnpm check` — biome is clean on the two changed files (`pnpm exec biome check apps/desktop/forge.config.ts apps/desktop/build/entitlements.mac.inherit.plist` → no fixes). The `pnpm check` aggregate fails on 10 pre-existing errors in files this phase does not touch (`apps/desktop/src/main/windows/factory.ts`, `apps/desktop/src/main/__tests__/auth-flow.test.ts`, `apps/desktop/src/main/__tests__/protocol.test.ts`, plus a few app/api desktop test/route files); confirmed pre-existing by stashing and re-running on branch HEAD.
+- [x] `pnpm --filter @lightfast/desktop package` succeeded locally with `APPLE_SIGNING_IDENTITY` unset; produced `apps/desktop/out/Lightfast-darwin-arm64/Lightfast.app` with `codesign -d -v` reporting `Signature=adhoc` (ad-hoc branch untouched, ad-hoc fallback is the executed path).
+- [x] `grep -c "disable-library-validation" apps/desktop/build/entitlements.mac.inherit.plist` → `0`
+- [x] `grep -c '"hardened-runtime"\|"gatekeeper-assess"\|"signature-flags"\|"entitlements-inherit"' apps/desktop/forge.config.ts` → `0`
+- [x] `grep -c "TODO(apple-cert)" apps/desktop/forge.config.ts` → `0`
+- [x] `grep -c "entitlementsInherit\|optionsForFile" apps/desktop/forge.config.ts` → `4` (developer-id branch: `entitlementsInherit` + `optionsForFile`; ad-hoc branch: `optionsForFile`; plus one comment mention — all ≥ 2)
+- [ ] Desktop CI green on the PR (typecheck + unsigned `electron-forge package` on macos-14) — pending PR open
+
+#### Human Review:
+- [ ] Open the produced `.app` from `apps/desktop/out/Lightfast-darwin-<arch>/Lightfast.app` → double-click → main window appears (smoke that ad-hoc branch still works)
+
+---
+
+## Phase 3a: Sentry provisioning (human, no code)
+
+### Overview
+
+Provision the Sentry-side resources only. This is Phase A's Sentry subset from `2026-04-23-desktop-pre-release-batch.md`, intentionally separated from Apple. Apple is blocked; Sentry isn't.
+
+### Changes Required
+
+No code. Repo Settings + Sentry UI work.
+
+#### Sentry org
+
+1. In Sentry, create an Electron project named exactly `lightfast-desktop` under the existing Lightfast org. Capture the DSN.
+2. Settings → Developer Settings → Auth Tokens. Create an org auth token with `project:releases` scope. Capture the token.
+
+#### Repo settings — Secrets and variables → Actions
+
+Add these **secrets**:
+- `SENTRY_DSN` — DSN from Sentry project (public identifier, but storing as a secret keeps it out of git history)
+- `SENTRY_AUTH_TOKEN` — auth token from step 2
+
+Add these **variables** (Variables tab, not Secrets):
+- `SENTRY_ORG` — Sentry org slug (e.g. `lightfast`)
+- `SENTRY_PROJECT` — `lightfast-desktop`
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `gh secret list --repo lightfastai/lightfast | grep -E '^SENTRY_DSN\s|^SENTRY_AUTH_TOKEN\s'` → both lines present
+- [ ] `gh variable list --repo lightfastai/lightfast | grep -E '^SENTRY_ORG\s|^SENTRY_PROJECT\s'` → both lines present
+
+#### Human Review:
+- [ ] Visit the Sentry org → confirm `lightfast-desktop` project visible
+- [ ] Visit `github.com/lightfastai/lightfast/settings/secrets/actions` → confirm both secrets + both variables present (this duplicates the gh checks above but the GitHub UI shows the values were saved correctly)
+
+**Stop here for human confirmation that Phase 3a is complete before cutting the rc.1 tag in Phase 3b.**
+
+---
+
+## Phase 3b: `0.1.0-rc.1` ad-hoc dry-run
+
+### Overview
+
+Cut the first desktop release tag in ad-hoc mode. This is the end-to-end dry-run for everything except codesign + notarize. Validates: tag trigger, prerelease auto-derivation (`-rc.1` suffix → `--prerelease`), arm64 + x64 matrix on macos-14, Forge's ad-hoc fallback, Sentry release creation + sourcemap upload + finalize, build provenance attestation, Sparkle JSON feed generation, draft → undraft (since prerelease=true the release stays in the prerelease list).
+
+### Changes Required
+
+No code changes. Tag + push + monitor.
+
+#### 1. Cut the tag from `main` after Phase 2 merges
+
+```bash
+# From a clean checkout of main, with the Phase 2 PR already merged.
+git checkout main
+git pull origin main
+git tag @lightfast/desktop@0.1.0-rc.1
+git push origin '@lightfast/desktop@0.1.0-rc.1'
+```
+
+#### 2. Monitor the workflow
+
+```bash
+gh run watch --repo lightfastai/lightfast
+# Or:
+gh run list --workflow="Release desktop" --repo lightfastai/lightfast --limit 5
+```
+
+Expected jobs (per `desktop-release.yml`):
+- `prepare` (ubuntu) — creates draft release with `--prerelease` flag (because `-rc.1` matches `*-*`).
+- `build (arm64)` and `build (x64)` (macos-14, parallel) — `npm version` stamping, ad-hoc Forge publish (skips the Apple cert + notarize key steps because `env.APPLE_SIGNING_IDENTITY == ''`), `pnpm sourcemaps:upload`, `actions/attest-build-provenance@v2`.
+- `finalize` (ubuntu) — `node apps/desktop/scripts/generate-update-feed.mjs` writes `latest-mac-{arm64,x64}.json` and uploads to the release; `gh release edit --draft=false` undrafts.
+
+#### 3. Manual smoke-test of the resulting `.dmg`
+
+Download the arm64 `.dmg` from the released assets. Install via the documented "Open Anyway" path (`apps/desktop/README.md:5-30`). Confirm:
+- App opens.
+- Sign-in via the loopback callback works.
+- A test error thrown intentionally in main (one-off `throw new Error("rc1 sentry smoke")` in `index.ts` is **not** required — instead trigger an error from an existing surface, e.g. force a renderer crash via the devtools).
+- Sentry UI shows a fresh issue under release `@lightfast/desktop@0.1.0-rc.1+<runNumber>` with a fully symbolicated stack (file path resolves back to `apps/desktop/src/...`, line numbers point at the right source).
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `gh run list --workflow="Release desktop" --repo lightfastai/lightfast --limit 1 --json conclusion --jq '.[0].conclusion'` → `success`
+- [ ] `gh release view '@lightfast/desktop@0.1.0-rc.1' --repo lightfastai/lightfast --json isPrerelease,isDraft --jq '.isPrerelease,.isDraft'` → `true\nfalse` (prerelease, undrafted)
+- [ ] `gh release view '@lightfast/desktop@0.1.0-rc.1' --repo lightfastai/lightfast --json assets --jq '[.assets[].name] | sort'` includes the 6 expected names: 2× `.zip` (arm64/x64), 2× `.dmg` (arm64/x64), `latest-mac-arm64.json`, `latest-mac-x64.json`
+- [ ] `pnpm --filter @lightfast/desktop exec sentry-cli releases info '@lightfast/desktop@0.1.0-rc.1+<runNumber>' --org "$SENTRY_ORG" --project "$SENTRY_PROJECT"` (run locally with the auth token exported) reports the release with sourcemaps uploaded for both bundles
+- [ ] `gh attestation verify --repo lightfastai/lightfast <downloaded-zip-path>` succeeds for both arm64 and x64 zips
+
+#### Human Review:
+- [ ] Download arm64 `.dmg` → install via "Open Anyway" → main window appears → primary nav renders
+- [ ] Sign in via the loopback callback → `account.get` tRPC call succeeds (renderer shows authenticated state)
+- [ ] Force a renderer error (e.g. via devtools `throw new Error("rc1 smoke")`) → Sentry UI shows the issue under release `@lightfast/desktop@0.1.0-rc.1+<runNumber>` with file/line resolving back to `apps/desktop/src/...` (proves rewriteFrames + sourcemaps + release matching all work end-to-end)
+- [ ] Confirm `signingMode: "ad-hoc"` Sentry tag is present on the issue (proves the new tag from PR #637 is wired into the workflow output)
+- [ ] Confirm the auto-updater stays silent in the running app (proves the `updater.ts:87-89` ad-hoc kill-switch is doing its job in a real packaged build, not just locally)
+
+---
+
+## Testing Strategy
+
+### Local checks (before Phase 2 PR opens):
+- `pnpm --filter @lightfast/desktop typecheck`
+- `pnpm check`
+- `pnpm --filter @lightfast/desktop package` — must produce a launchable ad-hoc `.app` (regression test for the unchanged ad-hoc branch)
+
+### CI checks (Phase 2 PR):
+- `Desktop CI / Typecheck + package (unsigned)` (paths-filtered, runs on macos-14)
+- Root `ci.yml` typecheck (`turbo typecheck --affected`) catches via the desktop filter
+
+### End-to-end checks (Phase 3b):
+- The `desktop-release.yml` run itself is the integration test. All three jobs must be green; all six assets present; Sentry release populated; attestation verifiable.
+
+## Performance Considerations
+
+None applicable. Codesign config changes don't affect runtime performance; entitlements changes don't affect the ad-hoc path. The rc.1 dry-run is a one-shot operation.
+
+## Migration Notes
+
+None. The `signingMode` enum already exists; no schema changes. No user-data migration. Beta users on the current ad-hoc dmg can stay on it; rc.1 is a fresh installation per the README's "manual reinstall" guidance for ad-hoc beta.
+
+## References
+
+- Verification: `thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md`
+- Original gap research: `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`
+- Pre-release batch plan (PR #621): `thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md`
+- Quick-wins plan: `thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md`
+- Code:
+  - `apps/desktop/forge.config.ts:14-49` — osxSign two-branch config (G-2 target)
+  - `apps/desktop/build/entitlements.mac.inherit.plist:9-10` — disable-library-validation (G-3 target)
+  - `apps/desktop/src/main/updater.ts:87-89` — ad-hoc updater kill-switch (must remain untouched)
+  - `.github/workflows/desktop-release.yml:32-40,120-124` — prerelease auto-detection + signingMode flip
+  - `apps/desktop/scripts/upload-sourcemaps.mjs` — Sentry release driver (called from workflow)
+  - `apps/desktop/README.md:5-30` — beta install / "Open Anyway" instructions (used in Phase 3b smoke test)

--- a/thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
+++ b/thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
@@ -1,0 +1,563 @@
+---
+date: 2026-04-23T12:53:58Z
+researcher: claude
+git_commit: 3dddce5adbe3a6e6cd2f462bc348a0de65aee0e5
+branch: main
+topic: "Codex.app vs apps/desktop — production-grade baseline gap analysis"
+tags: [research, desktop, electron, codex, packaging, sparkle, production]
+status: complete
+last_updated: 2026-05-06
+last_updated_note: "PR #621 + PR #637 landed; G-7 closed. Remaining gates G-1..G-6 enumerated for first-class signed v0.1.0."
+plans:
+  - thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md
+  - thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md
+  - thoughts/shared/plans/2026-05-06-desktop-rc1-ad-hoc-dry-run.md
+verifications:
+  - thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md
+---
+
+# Research: Codex.app vs `apps/desktop` — Production-Grade Baseline Gap
+
+**Date**: 2026-04-23T12:53:58Z
+**Git Commit**: 3dddce5adbe3a6e6cd2f462bc348a0de65aee0e5
+**Branch**: main
+
+## Research Question
+
+What production-grade Electron baseline capabilities are present in OpenAI's Codex Electron app (`/Applications/Codex.app`, v26.417.41555, build 1858) that are **absent** from `apps/desktop/` today?
+
+Four parallel subagents investigated: (A) the extracted `app.asar` source, (B) the `.app` bundle's packaging/signing/resources, (C) the full `apps/desktop` source tree, and (D) Codex's runtime userData layout.
+
+## Summary
+
+`apps/desktop` already ships a solid security + IPC foundation: fuses (all six enabled identically to Codex), sandbox + contextIsolation + nodeIntegration=false, a CSP pipeline, a blanket-deny permission handler, single-instance lock, `will-navigate` + `setWindowOpenHandler` hardening, safeStorage-backed token persistence, three-window kinds, tray, global shortcut, and a Sentry wiring. Forge is configured with conditional osxSign/osxNotarize/GitHub publisher guarded by env vars.
+
+The gap to Codex's production baseline is concentrated in **nine areas**: (1) Sparkle-native auto-update with Ed25519 signature verification, (2) on-disk structured logging with date partitioning, (3) persistent structured storage (SQLite) with schema-versioning, (4) a worker/utility-process tier for heavy work, (5) Windows MSIX + Linux build surfaces, (6) multi-arch / universal-binary builds, (7) per-surface preload isolation, (8) renderer + menu i18n beyond `en`, and (9) a dev/test tooling set (Playwright CDP harness, devtools reset, source-map upload, third-party notices). Six smaller items sit alongside these — placeholder build metadata (`version: "0.0.0"`, empty `sparkleFeedUrl`/`sparklePublicKey`), an over-broad entitlement set (camera, network.server, disable-library-validation — Codex carries none of these), dead `showContextMenu` IPC, unwired `silentRefresh`, deep-link handler that only logs, and no `NSAppTransportSecurity`/`CFBundleDocumentTypes`/`NSQuitAlwaysKeepsWindows` Info.plist entries.
+
+## Status Tracker
+
+Plans:
+- [`thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md`](../plans/2026-04-23-desktop-codex-gap-quick-wins.md) — implemented 2026-04-23 (all 4 phases landed).
+- [`thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md`](../plans/2026-04-23-desktop-pre-release-batch.md) — drafted 2026-04-23; 6 phases closing the pre-v0.1.0-release gap (monorepo release host, tag convention `@lightfast/desktop@<version>`, Sentry source-map upload, signed workflow enablement, desktop CI coverage, contributor ergonomics).
+
+Legend: **DONE** = landed on `main` · **IN PROGRESS** = scoped into the pre-release batch plan · **DEFERRED** = intentionally out of scope right now · **RELEASE** = future release-pipeline work beyond v0.1.0.
+
+| § | Finding | State | Notes |
+|---|---|---|---|
+| 1 | Auto-update: Sparkle + Ed25519 | **RELEASE** | Whole auto-update surface |
+| 2 | On-disk logging (file logger) | **DEFERRED** | Larger effort, no consumer yet |
+| 2 | Sentry tags + RewriteFrames (non-release subset) | **DONE** | Plan Phase 3 — `sentry.ts` adds `sessionId`, `bundle`, `host` tags, `dist=buildNumber`, `rewriteFramesIntegration({root: app.getAppPath(), prefix: "app:///"})`. DSN-gated end-to-end check still pending a real DSN. |
+| 2 | Source-map upload / `@sentry/cli` | **IN PROGRESS** | Pre-release batch Phase C — `scripts/upload-sourcemaps.mjs` uploads `.vite/build` + `.vite/renderer/main_window` with `--url-prefix "app:///"` matching `rewriteFramesIntegration`. |
+| 2 | Explicit `crashReporter.start({uploadToServer:false})` | **DEFERRED** | `@sentry/electron` already handles Crashpad; skip to avoid double-init |
+| 3 | Persistent SQLite storage | **DEFERRED** | No consumer yet |
+| 4 | Worker / utility-process tier | **DEFERRED** | No workload demands it yet |
+| 5 | Windows MSIX + Linux makers | **RELEASE** | Deferred past v0.1.0 (macOS only for first release) |
+| 6 | Multi-arch (arm64 + x64) | **IN PROGRESS** | Pre-release batch Phase D — workflow matrix builds both arches; published as separate artifacts, no universal merge. |
+| 6 | Universal binary merge | **DEFERRED** | `@electron/universal` not needed; two separate artifacts with `${arch}` feed template suffice. |
+| 7 | Per-surface preload isolation | **DEFERRED** | No third-party surfaces yet |
+| 8 | Menu + renderer i18n | **DEFERRED** | Policy decision pending |
+| 9 | Dev/test tooling (Playwright, devtools:reset, 3p-notices) | **DEFERRED** | Multi-day work |
+| 10 | Deep-link URL→route dispatcher | **DEFERRED** | Plan Phase 4's trim of the dead `console.log` landed as a side-effect of the separate auth-flow rewrite (the `onDeepLink` handler was removed from `index.ts` entirely). Full URL→route dispatcher still deferred — needs a route table. |
+| 11 | Entitlements diet (drop `disable-library-validation`, `device.camera`, `network.server`) | **DONE** | Plan Phase 1, commit `40b36bb56`. Source `entitlements.mac.plist` trimmed to 5 keys. |
+| 12 | Info.plist hygiene (`NSQuitAlwaysKeepsWindows=false`, `LSMinimumSystemVersion=12.0`, `MallocNanoZone=0`) | **DONE** | Plan Phase 2. Verified in packaged `Info.plist` via `plutil -p` 2026-04-23. |
+| 12 | `NSAppTransportSecurity` / `CFBundleDocumentTypes` / `SUPublicEDKey` / `ElectronAsarIntegrity` / `NSPrincipalClass` | **DEFERRED** / **RELEASE** | Not applicable, release-only, or already auto-set by Forge |
+| 13 | Non-empty `version`, `buildNumber`, `sparkleFeedUrl` | **IN PROGRESS** | Pre-release batch Phase D — workflow stamps via `npm pkg set` at build time. `sentryDsn` added to the same stamp path. |
+| 13 | `sparklePublicKey` | **DROPPED** | Pre-release batch Phase B — unused (Electron `autoUpdater` doesn't consume it). Field removed from `package.json`, `env.ts`, `build-info.ts`, `ipc.ts`. |
+| 14 | Dead `showContextMenu` IPC | **DONE** | Plan Phase 4 — removed from `src/shared/ipc.ts`. |
+| 14 | Unwired `silentRefresh` | **DONE** | Superseded by the `auth-flow.ts` loopback-HTTP-server rewrite which replaced the whole `BrowserWindow`/`runAuthWindow` flow; `silentRefresh` + `REFRESH_TIMEOUT_MS` no longer exist. |
+| 14 | Deep-link `console.log` | **DONE** | Superseded by the same rewrite — `onDeepLink` handler was removed from `index.ts`; the log it carried is gone. |
+| 15 | Notifications / dock badge / sound | **DEFERRED** | UX decision |
+
+## Detailed Findings
+
+### 1. Auto-update: Electron `autoUpdater` vs. Sparkle-native with Ed25519
+
+**Codex** ships a custom C++/Obj-C bridge `Contents/Resources/native/sparkle.node` loaded via `createRequire(__filename)(path.join(process.resourcesPath, 'native', 'sparkle.node'))` and wired to the Sparkle 2.9.1 framework in `Contents/Frameworks/Sparkle.framework`. The `Info.plist` carries `SUPublicEDKey = rhcBvttuqDFriyNqwTQJR3L4UT1WjIK4QxtwtwusVic=` (32-byte Ed25519 public key, Sparkle 2 EdDSA appcast-signing style). The JS-side `SparkleManager` dispatches to three backends:
+- macOS Sparkle via `sparkle.node`
+- Windows MSIX direct via `windows-updater.node` (fetches JSON manifest, SHA-256-verifies the `.msix`, stages to `userData/windows-msix-updater/<packageFamily>/`, calls `stagePackage()` + `activateStagedPackage()`)
+- Windows Store via `trySilentDownloadStoreUpdates()`
+
+Background polling interval: 15 minutes (env-overridable via `SPARKLE_UPDATE_INTERVAL_MINUTES`). Update cache dir: `~/Library/Caches/com.openai.codex/org.sparkle-project.Sparkle/{Installation,Launcher,PersistentDownloads}`.
+
+**`apps/desktop`** uses Electron's built-in `autoUpdater` (Squirrel.Mac under the hood) in `src/main/updater.ts:1-123`. This:
+- Has no EdDSA / public-key verification path — relies solely on codesign of the downloaded zip
+- Supports only a single `{url}` feed with `${arch}` template (`updater.ts:27-29`); no appcast, no delta metadata, no phased rollout
+- `package.json:62-63` has **empty strings** for `sparkleFeedUrl` and `sparklePublicKey`, so `initUpdater` exits early on darwin packaged builds unless `SPARKLE_FEED_URL` is set at runtime (`updater.ts:84-87`)
+- Single post-boot check after 10 s (`updater.ts:120-122`); no polling interval
+- `scripts/generate-update-feed.mjs` only writes Squirrel.Mac-format JSON (`latest-mac-arm64.json`, `latest-mac-x64.json`) via `gh release upload`; no Windows feed generation, no feed signing
+
+**What's missing**: Sparkle-native native addon (or a fallback to a signed appcast verified in-process), Windows MSIX updater, Windows Store updater, periodic background check, feed-signing in release pipeline, non-empty `sparkleFeedUrl`/`sparklePublicKey` baked into `package.json`.
+
+Evidence: `src/main/updater.ts:31-42`, `src/main/build-info.ts`, `scripts/generate-update-feed.mjs`, extracted Codex `workspace-root-drop-handler-B6CbYVqW.js` (SparkleManager + MSIX backends), `/Applications/Codex.app/Contents/Info.plist` (`SUPublicEDKey`).
+
+### 2. On-disk logging & crash reporting
+
+**Codex** writes per-launch logs to `~/Library/Logs/com.openai.codex/YYYY/MM/DD/codex-desktop-<sessionUuid>-<pid>-t<0|1>-i1-<HHMMSS>-<seq>.log` with two streams per session (`t0` / `t1`). 16 files = 9.5 MB on this machine, ranging 100K–3.1M per file. Per-launch files, not size-rotated. Sentry runs with Electron minidump integration (`crashReporter.start({uploadToServer: false})`) and session tags: `sessionId`, `preRelease`, `buildFlavor`, `bundle: "electron"`, `host: "app"`. Release format `<name>@<version>+<buildNumber>`, dist `<buildNumber>` (1858 here). `RewriteFrames` integration with `root: app.getAppPath()`, prefix `app:///`. Chromium Crashpad dir present at `Application Support/Codex/Crashpad/`.
+
+**`apps/desktop`** writes nothing to disk. `src/main/index.ts:197-198` uses `console.error` for renderer errors; there is no file logger anywhere. `src/main/sentry.ts:1-27` calls `Sentry.init` with DSN + release + environment only — no session tag, no dist tag, no RewriteFrames, no explicit `crashReporter.start`, no minidump integration options set.
+
+**What's missing**:
+- File-backed structured logger (main + renderer) with date-partitioned path layout
+- Explicit `crashReporter.start()` + `uploadToServer` policy
+- Sentry tags: `sessionId` (`crypto.randomUUID()` once per launch), `dist` (buildNumber), `bundle`/`host`
+- Sentry `RewriteFrames` with `app:///` prefix so stack traces match uploaded source maps
+- Source-map upload script to Sentry in CI (no script exists in `scripts/`)
+
+Evidence: `src/main/sentry.ts:1-27`, `src/main/index.ts:196-199`, `thoughts/shared/research/...` — nothing writes logs. Codex runtime logs per subagent D; Sentry wiring per subagent A §7.
+
+### 3. Persistent structured storage (SQLite)
+
+**Codex** runs `better-sqlite3` (kept in `app.asar.unpacked/node_modules/better-sqlite3`) with three tables in `codex.db`: `inbox_items`, `automations` (rrule-driven), `automation_runs`. Additionally two Rust-side sqlx-managed DBs live under `~/.codex/`: `logs_2.sqlite` (195 MB on this machine), `state_5.sqlite` (`agent_jobs`, `threads`, `backfill_state`, etc.). **Schema migrations are encoded in the filename** (`logs_2`, `state_5`) — new file per breaking schema change, old file kept.
+
+**`apps/desktop`** persists three plain JSON files:
+- `<userData>/settings.json` — plain JSON, synchronous `readFileSync`/`writeFileSync`, Zod-validated (`src/main/settings-store.ts:47-53`)
+- `<userData>/window-state.json` — plain JSON, debounced writes (`src/main/window-state.ts:41-48`)
+- `<userData>/auth.bin` — `safeStorage.encryptString` over `{token, savedAt}` JSON (`src/main/auth-store.ts:46-50`)
+
+There is no SQLite, no structured table, no migration framework, no cache namespacing. Anything durable beyond flat scalars currently has no place to go.
+
+**What's missing**: SQLite dependency (or equivalent), migration strategy (schema-in-filename, or a migrations table), per-subsystem DB path convention, a cache directory layout (Codex uses `<userData>/Cache`, Crashpad, `plugins/cache/*`, `sessions/YYYY/MM/DD/`).
+
+Evidence: `src/main/settings-store.ts`, `src/main/window-state.ts`, `src/main/auth-store.ts`; subagent A §5 (Codex SQLite tables); subagent D (filename-versioned sqlite pattern).
+
+### 4. Worker / utility process tier
+
+**Codex** ships `.vite/build/worker.js` (1.1 MB) as a dedicated worker thread handling the AI request pipeline and streaming (subagent A §1). It also spawns two bundled Rust binaries as long-running children: `codex` (`app-server`, 163 MB) and `codex_chronicle` (4.2 MB), communicating over stdio JSON-RPC with UUID-tagged message IDs. Plus a tiny Swift helper `launch-services-helper` for `NSWorkspace` bundle resolution, invoked via `promisify(execFile)`.
+
+**`apps/desktop`** has no worker threads, no utility processes, no child process spawning beyond the visible auth-flow `BrowserWindow`. Heavy work (when it arrives) would land on the main process or the renderer.
+
+**What's missing**: A pattern + at least one worker boilerplate for off-main-thread CPU or I/O work. If the product grows toward local indexing, streaming, or long-running tRPC subscriptions, needing this is a matter of when, not if.
+
+Evidence: subagent A §1; no `Worker`/`utilityProcess`/`child_process.spawn` imports found in `apps/desktop/src/main/`.
+
+### 5. Windows MSIX & Linux build surfaces
+
+**Codex** (from its extracted `package.json`) declares `@electron-forge/maker-deb`, `maker-rpm`, `maker-msix`, `maker-squirrel`, `maker-dmg`, `maker-zip`, plus `electron-windows-msix` and `electron-installer-dmg`.
+
+**`apps/desktop` `forge.config.ts:87-96`** declares only: `MakerSquirrel` (win32), `MakerZIP` (darwin), `MakerDMG` (darwin, ULFO format). No deb, rpm, Flatpak, MSIX, or Wix.
+
+**What's missing**: `@electron-forge/maker-deb`, `maker-rpm`, `maker-msix` (or a deliberate decision that Linux + Windows-store distribution is out of scope). If MSIX is adopted, the Codex-style MSIX-direct updater path in §1 becomes a dependency.
+
+Evidence: `apps/desktop/forge.config.ts:87-96`; subagent B §5 / subagent A §3.
+
+### 6. Multi-arch / universal binary
+
+**Codex** ships **arm64-only** (every `lipo -info` reports `Non-fat file` — `codex`, `codex_chronicle`, `rg`, `node`, `sparkle.node`, `launch-services-helper`, the main app). So the gap is symmetrical on darwin — both are single-arch per build.
+
+**`apps/desktop`** has no `packagerConfig.osxUniversal` / `arch` override in `forge.config.ts:58-85`. Each build invocation produces one architecture.
+
+**What's missing (both)**: A `universal` build configuration (`@electron/universal` via `osxUniversal: { mergeASARs: true }`), or an explicit policy "arm64 + x64 built and published as two separate artifacts" with both feed entries in `generate-update-feed.mjs`. The current `${arch}` template in `updater.ts:27-29` supports two separate feeds; what's missing is CI that actually produces both arm64 and x64 artifacts.
+
+Evidence: `forge.config.ts:58-85`; subagent B §6.
+
+### 7. Per-surface preload isolation
+
+**Codex** ships **two** separate preload bundles: `preload.js` (~2 KB, tiny context bridge for primary windows) and `browser-sidebar-comment-preload.js` (24 MB — full CodeMirror, KaTeX, Mermaid, React UI for the in-app browser commenting surface). The bundles differ dramatically in surface area; preload isolation per window kind is enforced at the Electron layer.
+
+**`apps/desktop`** uses a single `src/preload/preload.ts` (3.5 KB) for all three window kinds (primary, secondary, hud). The Vite plugin only has one preload entry (`forge.config.ts:104-109`). Window kind is passed via `additionalArguments: ["--window-kind=<kind>"]` and read back in the preload — but the preload module itself is identical regardless.
+
+**What's missing**: If/when surfaces with differing trust characteristics are added (in-app browser, third-party plugins, untrusted iframes), the Forge config needs a second preload entry, and `src/main/windows/factory.ts` needs per-kind preload path resolution. Today this isn't blocking — three kinds all render first-party content — but the build config has no slot for it.
+
+Evidence: subagent A §6 (Codex preload split); `apps/desktop/forge.config.ts:104-117`; `src/preload/preload.ts`; `src/main/windows/factory.ts:42-51`.
+
+### 8. i18n: menu strings + renderer
+
+**Codex** ships 52 `.lproj` directories (standard Electron/macOS system locale declarations) plus a `native-menu-locales/*.json` directory (e.g. `de-DE.json`, `fr-FR.json`, `pt-BR.json`) loaded at runtime via `app.getLocale()` → `<appPath>/native-menu-locales/<locale>.json` with language-subtag fallback, Zod-parsed. The renderer consumes locale chunks as per-language JS bundles (e.g. `el-GR-ABLLedEp.js`) through React-Intl's `formatMessage`.
+
+**`apps/desktop`** has only `src/main/locales/en.json` (28 menu keys). `src/main/menu.ts:18-31` resolves locale via `app.getLocale()`, splits on `-`, falls back to `en` if no match. The renderer hardcodes all strings in English in `index.html` and TSX files — no i18n library is wired.
+
+**What's missing**: Additional locale files for the menu (non-blocking if English is policy), and a decision on renderer i18n (react-intl / lingui / none).
+
+Evidence: `apps/desktop/src/main/menu.ts:18-31`, `src/main/locales/en.json`; subagent A §12, subagent B §8.
+
+### 9. Dev/test tooling shipped
+
+| Tool | Codex | `apps/desktop` |
+|---|---|---|
+| CDP port via env var | Yes (`bootstrap.js`) | Yes — `LIGHTFAST_REMOTE_DEBUG_PORT` (`src/main/bootstrap.ts:14-27`) |
+| Playwright Electron harness | `scripts/playwright-electron-agent-cdp.mjs` + `playwright: ^1.58.2` devDep | No |
+| DevTools reset | `devtools:reset` npm script clears extensions + Service Worker + Code Cache | No |
+| Third-party-notices generator | `generate:third-party-notices` via parent monorepo | No |
+| Native rebuild helpers | `rebuild:sqlite.mjs`, `rebuild-forge-natives.mjs`, `ensure-electron-binary.mjs`, `build-launch-services-helper.mjs`, `owl-shell.mjs` | No (no native deps currently) |
+| Sentry source-map upload | `@sentry/cli` in devDeps (CI pipeline-owned) | No |
+| Metadata probe | `metadata-path`, `metadata-probe` (tsx scripts) | No |
+
+Only `scripts/generate-update-feed.mjs` exists in `apps/desktop/scripts/`.
+
+Evidence: `apps/desktop/scripts/` directory listing; Codex extracted `package.json` scripts (subagent A §1).
+
+### 10. Deep-link routing
+
+**Codex** registers `codex://` via `app.setAsDefaultProtocolClient('codex')` (subagent A §11). Queued deep links flush after `runMainAppStartup()` via `deepLinks.flushPendingDeepLinks()`. The only live path in the bundle is `codex://connector/oauth_callback`, dispatched to the connector OAuth subsystem.
+
+**`apps/desktop`** has the full registration plumbing in `src/main/protocol.ts:1-42` (single-instance argv scan, `open-url` on mac, `second-instance` argv scan, startup argv scan with `pendingUrl` buffer). But the main-process handler in `src/main/index.ts:367-373` **only `console.log`s the URL and focuses the primary window** — no path/param dispatch into the renderer, no route table. The `auth-flow.ts` OAuth callback is captured *inside* the sign-in window's own session protocol handler (`src/main/auth-flow.ts:95-101`), independent of the main-process deep-link dispatcher.
+
+**What's missing**: A URL-to-renderer-route dispatcher (e.g., parse `lightfast://settings` → send IPC to primary window → renderer router navigates). Today the deep-link infrastructure exists but has no consumer.
+
+Evidence: `src/main/protocol.ts:1-42`, `src/main/index.ts:367-373`.
+
+### 11. Entitlements audit (over-broad on our side)
+
+| Entitlement | `apps/desktop` main | Codex main |
+|---|---|---|
+| `com.apple.security.cs.allow-jit` | true | true |
+| `com.apple.security.cs.allow-unsigned-executable-memory` | true | true |
+| `com.apple.security.cs.disable-library-validation` | **true** | **absent** |
+| `com.apple.security.device.audio-input` | true | true |
+| `com.apple.security.device.camera` | **true** | **absent** |
+| `com.apple.security.network.client` | true | true |
+| `com.apple.security.network.server` | **true** | **absent** |
+| `com.apple.security.files.user-selected.read-write` | true | true |
+| `com.apple.security.app-sandbox` | (not present) | false (explicit) |
+
+**What's missing (removal)**: Three entitlements we request that Codex — shipping a much larger surface area including a Rust app-server + in-app browser + camera usage description — does not. Each expands the attack surface: `disable-library-validation` lets unsigned dylibs load into our process; `device.camera` grants camera access we don't use; `network.server` lets us bind listen sockets. Codex binds nothing and keeps library validation on.
+
+Helper entitlements: both apps use identical entitlements across all four helpers (GPU / Renderer / Plugin). Neither differentiates.
+
+Evidence: `apps/desktop/build/entitlements.mac.plist` (via subagent C §14); subagent B §2.
+
+### 12. Info.plist gaps
+
+| Key | Codex | `apps/desktop` extendInfo |
+|---|---|---|
+| `NSAppTransportSecurity` → `NSAllowsArbitraryLoads` | `true` | absent |
+| `NSQuitAlwaysKeepsWindows` | `false` | absent |
+| `NSPrefersDisplaySafeAreaCompatibilityMode` | `false` | absent |
+| `CFBundleDocumentTypes` | Folder viewer (`public.folder`) | absent |
+| `LSEnvironment` → `MallocNanoZone` | `0` | absent |
+| `LSMinimumSystemVersion` | `12.0` | (forge default) |
+| `SUPublicEDKey` | set (Ed25519) | absent |
+| `ElectronAsarIntegrity` | set (one `app.asar` SHA-256) | auto-added by forge (Fuse enabled) |
+| `NSPrincipalClass` | `AtomApplication` | (forge default) |
+| `NSSupportsAutomaticGraphicsSwitching` | true | `true` (set at `forge.config.ts:71`) |
+| `NSHighResolutionCapable` | true | `true` (set at `forge.config.ts:70`) |
+
+**What's missing (non-security)**: No explicit `LSMinimumSystemVersion` policy, no document-type registration, no `MallocNanoZone=0` (Electron's official guidance to avoid a macOS allocator crash on some chipsets), no `NSQuitAlwaysKeepsWindows=false` (prevents macOS from reopening windows after quit).
+
+Evidence: `apps/desktop/forge.config.ts:68-84`; subagent B §1.
+
+### 13. Build metadata placeholders in `package.json`
+
+`apps/desktop/package.json:3,60-63`:
+- `version: "0.0.0"`
+- `buildFlavor: "dev"` → this disables the updater entirely in packaged builds (`src/main/updater.ts:78-82`)
+- `buildNumber: "1"`
+- `sparkleFeedUrl: ""`
+- `sparklePublicKey: ""`
+
+All five are placeholders. The updater, release artifact naming, and Sentry dist tag all depend on these.
+
+Codex baked-in values: `version: 26.417.41555`, `codexBuildFlavor: "prod"`, `codexBuildNumber: "1858"`, `codexSparkleFeedUrl: "https://persistent.oaistatic.com/codex-app-prod/appcast.xml"`, `codexSparklePublicKey: "rhcBvttuqDFriyNqwTQJR3L4UT1WjIK4QxtwtwusVic="`.
+
+Evidence: `apps/desktop/package.json:3,60-63`; subagent A `package.json` dump.
+
+### 14. Dead / unwired IPC + features
+
+- `IpcChannels.showContextMenu` is declared in `src/shared/ipc.ts:8` but has **no `ipcMain.handle`/`on` registration in `src/main/index.ts`** and no `ipcRenderer` call in `src/preload/preload.ts` — the channel is dead code.
+- `silentRefresh` is exported from `src/main/auth-flow.ts:116-118` but has no call site. No 401/expired-token handler at the main-process level triggers it; `src/renderer/src/react/app-shell.tsx` only calls `signOut` on UNAUTHORIZED.
+- Deep-link handler in `src/main/index.ts:367-373` only `console.log`s — see §10.
+
+Evidence: `src/shared/ipc.ts:8`; `src/main/auth-flow.ts:116-118`; `src/main/index.ts:367-373`.
+
+### 15. Notifications, dock badge, sound
+
+**Codex** ships `notification.wav` in `Contents/Resources/` and has a `NOTIFICATIONS_QUESTIONS_ENABLED` feature flag in the config system.
+
+**`apps/desktop`** has no `Notification` usage, no dock badge / bounce, no sound assets.
+
+**What's missing**: A notifications policy — at minimum, whether to use `new Notification(...)` for completion/deep-link events and whether to set a dock badge for unread counts.
+
+Evidence: subagent B §12 (Codex Resources list); no `Notification`/`setBadgeCount` usage found in `apps/desktop/src/`.
+
+## Code References
+
+- `apps/desktop/forge.config.ts:58-132` — packager + makers + plugins + fuses + publisher
+- `apps/desktop/src/main/bootstrap.ts:1-36` — single-instance + userData path + CDP
+- `apps/desktop/src/main/index.ts:75-148` — CSP + hardenContents
+- `apps/desktop/src/main/index.ts:336-339` — permission handler denies all
+- `apps/desktop/src/main/index.ts:367-373` — deep-link handler (only logs)
+- `apps/desktop/src/main/updater.ts:27-42,78-123` — feed URL resolution + init conditions
+- `apps/desktop/src/main/auth-store.ts:46-50` — safeStorage token write
+- `apps/desktop/src/main/auth-flow.ts:39-101,116-118` — OAuth flow + unused silentRefresh
+- `apps/desktop/src/main/settings-store.ts:47-53` — plain-JSON settings
+- `apps/desktop/src/main/window-state.ts:41-74` — debounced state + off-display fallback
+- `apps/desktop/src/main/sentry.ts:1-27` — minimal Sentry init
+- `apps/desktop/src/preload/preload.ts:15-94` — single preload, `contextBridge` exports
+- `apps/desktop/src/shared/ipc.ts:1-8` — all channel names; `showContextMenu` dead
+- `apps/desktop/build/entitlements.mac.plist` — over-broad entitlements
+- `apps/desktop/scripts/generate-update-feed.mjs` — mac-only feed generation
+- `apps/desktop/package.json:60-63` — empty placeholder build metadata
+
+## Architecture Documentation
+
+### Shared baseline (Codex ↔ Lightfast, both present)
+
+| Capability | Both |
+|---|---|
+| Electron Forge + plugin-vite | Yes |
+| FusesPlugin V1 with identical six flags | Yes |
+| asar + `app.asar.unpacked` for natives | Yes (Lightfast via `AutoUnpackNativesPlugin`) |
+| Single-instance lock | Yes |
+| `contextIsolation + sandbox + nodeIntegration=false` | Yes |
+| CSP via `onHeadersReceived` | Yes |
+| `setPermissionRequestHandler` blanket deny | Yes |
+| `setWindowOpenHandler` + `will-navigate` harden | Yes |
+| `safeStorage`-backed secret | Lightfast: auth.bin; Codex: not confirmed, but keychain patterns exist |
+| Deep-link registration (initial argv + `open-url` + `second-instance`) | Yes |
+| Hardened runtime + notarization + stapler | Codex: stapled ticket present; Lightfast: env-gated in forge config |
+| GitHub publisher | Codex publishes to OAI infra; Lightfast env-gated |
+| Tray template image | Yes |
+| nativeTheme broadcast to renderer | Yes |
+| React 19 + Vite renderer | Yes |
+
+### Runtime userData layout (Codex reference, for comparison)
+
+Codex persists to three roots:
+- `~/.codex/` — CLI-legacy + Electron shared state: TOML config, sqlx-managed sqlite (`logs_2.sqlite`, `state_5.sqlite`, filename-versioned), `sessions/YYYY/MM/DD/`, `archived_sessions/`, `skills/`, `automations/`, `ambient-suggestions/<sha1>/`, `vendor_imports/skills/.git/`, `worktrees/<hash>/`, `log/codex-tui.log` (legacy)
+- `~/Library/Application Support/Codex/` — standard Chromium userData: `Cache/`, `GPUCache/`, `Cookies` sqlite, `Local Storage/leveldb/`, `Session Storage/`, `Crashpad/`, `sentry/scope_v3.json`, `Preferences`, `DIPS` (bounce-tracking)
+- `~/Library/Logs/com.openai.codex/YYYY/MM/DD/*.log` — per-launch date-partitioned logs, two streams (`t0`, `t1`) per session
+- `~/Library/Caches/com.openai.codex/org.sparkle-project.Sparkle/` — Sparkle update cache
+
+Lightfast today writes only flat files to `<userData>`: `settings.json`, `window-state.json`, `auth.bin`.
+
+## Historical Context (from thoughts/)
+
+- `thoughts/shared/plans/2026-04-23-desktop-clerk-trpc-wiring.md` — current tRPC + Clerk wiring plan for desktop (commit `3dddce5a`, active branch work).
+- `thoughts/shared/research/2026-04-20-lightfast-2-barebones-rearchitecture-baseline.md` — earlier rearchitecture baseline research.
+
+No prior research compares against Codex or other reference Electron apps.
+
+## Related Research
+
+- `thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md` — phases 1–4 landed 2026-04-23
+- `thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md` — 6 phases for v0.1.0 release pipeline (drafted 2026-04-23)
+- `thoughts/shared/plans/2026-04-23-desktop-clerk-trpc-wiring.md`
+- `thoughts/shared/research/2026-04-20-lightfast-2-barebones-rearchitecture-baseline.md`
+
+## Open Questions
+
+1. Is the intent to stay on Electron's built-in `autoUpdater` (ZIP + Squirrel.Mac) or to adopt Sparkle-native with Ed25519? Codex's choice implies signed-appcast is the target for "production-grade."
+2. Is Linux a shipping target? If no, the missing deb/rpm makers is a deliberate scope choice; if yes, they need to be added before the first Linux ask.
+3. What's the policy for renderer i18n? The menu-side path is clear (extend `locales/`); the renderer side needs a framework choice.
+4. Should the over-broad entitlements (`camera`, `network.server`, `disable-library-validation`) be removed now or left in anticipation of features that will need them?
+5. What's the source-map upload strategy for Sentry — Sentry CLI in CI, or a per-release script in `scripts/`?
+
+## Follow-up Research 2026-04-23 (second pass — scripts, CI, monorepo wiring)
+
+Three parallel subagents ran a second pass focused on **project scripts setup**, CI workflows, monorepo integration, and a reference model of Codex's build-time scripts. The first-pass findings were all confirmed. This section adds the new surface area that the first pass didn't cover and sharpens two items with transcribed evidence.
+
+### Follow-up Findings
+
+#### FU-1. `apps/desktop` has **zero** lint, format, or test tooling
+
+`apps/desktop/package.json:14-36` — no `eslint`, `oxlint`, `prettier`, `oxfmt`, `biome`, `vitest`, `jest`, `playwright`, or `@sentry/cli` in dependencies or devDependencies. The five scripts declared are `dev`, `package`, `make`, `publish`, `typecheck` (`package.json:7-13`) — no `lint`, `lint:fix`, `format`, `format:fix`, `test`, `test:unit`, `test:e2e`, `clean`, `rebuild`, `generate:notices`.
+
+Lint coverage today is partial and root-only: `.github/workflows/ci.yml:54` runs `pnpm check` (Biome/ultracite at root) and `pnpm turbo typecheck --affected` — desktop files are caught by root Biome but the app has no local lint/format CLI for developers running inside `apps/desktop/`.
+
+**Codex baseline for comparison** (from `/tmp/codex-extracted/app/package.json:25-60`):
+- `lint` / `lint:fix` — `oxlint --threads=1 --tsconfig ./tsconfig.json --max-warnings 0 --type-aware --type-check`
+- `format` / `format:fix` — `oxfmt --check` / `oxfmt --write`
+- `test` / `test:quiet` — `vitest run`
+- `playwright:agent:repl` — interactive Electron-CDP REPL via Playwright
+- `compile` / `tsc` — via `tsgo` (Microsoft's native TypeScript compiler) instead of `tsc`
+
+#### FU-2. `rebuildConfig` is empty; no native-rebuild scripts
+
+`apps/desktop/forge.config.ts:86` — `rebuildConfig: {}` is empty. There are no `rebuild:sqlite`, `rebuild:forge-natives`, or `ensure-electron-binary` scripts. This is non-blocking today (no native modules are declared in `dependencies`) but is a precondition for any future SQLite/node-pty/native-addon adoption.
+
+Codex ships three build-time native-rebuild scripts:
+- `rebuild-sqlite.mjs` — targeted `better-sqlite3` rebuild against the pinned Electron 41.2.0 ABI (split out because `better-sqlite3` has historically been brittle under `@electron/rebuild`)
+- `rebuild-forge-natives.mjs` — omnibus rebuild for `node-pty`, `bufferutil`, `utf-8-validate`
+- `ensure-electron-binary.mjs` — guarantees the pinned Electron binary exists on disk before Vitest spins up an Electron host
+
+#### FU-3. CI coverage for desktop is split across three workflows (two inclusive, one disabled)
+
+Root `.github/workflows/`:
+- **`ci.yml`** (`ci.yml:54`) — PRs to `main`. Runs `pnpm check` (Biome), `pnpm turbo typecheck --affected`, `boundaries`, `knip`. Desktop **is** included when its files change (via `--affected`). No build, no test.
+- **`ci-core.yml`** (`ci-core.yml:45,105`) — Filters to `lightfast`, `@lightfastai/mcp`, `@lightfastai/cli` only. Desktop is **explicitly excluded** from both `typecheck` and `build` jobs.
+- **`release.yml`** — Publishes npm packages via `changesets/action`. Desktop (`private: true`) is absent.
+- **`verify-changeset.yml`** (`verify-changeset.yml:51,57`) — Allowlist is `lightfast`, `@lightfastai/mcp`, `@lightfastai/cli`. A changeset targeting `@lightfast/desktop` would **fail this check**.
+- **`desktop-release.yml.disabled`** — Present on disk with `.disabled` suffix. GitHub Actions ignores `.disabled` files, so the file is inert today.
+
+#### FU-4. Full transcript of `desktop-release.yml.disabled` (what a working desktop release would do)
+
+Three sequential jobs, gated by `push.tags: ['desktop-v*']`:
+
+**`prepare`** (ubuntu-latest): strips `desktop-v` prefix → `gh release create --draft` with static body `"Automated release of @lightfast/desktop."` and secret `GITHUB_TOKEN`.
+
+**`build`** (matrix `arch: [arm64, x64]`, macos-14):
+- `pnpm install --frozen-lockfile`
+- Stamps `apps/desktop/package.json` in place via `npm pkg set`: `version=<tag>`, `buildFlavor=prod`, `buildNumber=$GITHUB_RUN_NUMBER`, `sparkleFeedUrl=https://github.com/${{ github.repository }}/releases/latest/download/latest-mac-${arch}.json`
+- Imports `.p12` Developer ID cert into a temporary keychain (`APPLE_CERT_BASE64`, `APPLE_CERT_PASSWORD`, `KEYCHAIN_PASSWORD`)
+- Writes `.p8` notarization key to `$HOME/.private_keys/AuthKey_<id>.p8` and sets `APPLE_API_KEY`
+- Runs `pnpm exec electron-forge publish --arch=${{ matrix.arch }} --platform=darwin` from `apps/desktop/`
+- Env vars: `APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `LIGHTFAST_DESKTOP_RELEASE_REPO`, `GITHUB_TOKEN`
+
+**`finalize`** (ubuntu-latest, `needs: [prepare, build]`):
+- `node apps/desktop/scripts/generate-update-feed.mjs` (writes `latest-mac-{arm64,x64}.json` Squirrel.Mac feeds and uploads as release assets)
+- `gh release edit ... --draft=false` to promote
+
+**What the disabled workflow is missing** (factual):
+- No Sentry release / source-map upload step (even though `@sentry/cli` is in `pnpm-workspace.yaml:82` `onlyBuiltDependencies`, nothing invokes it)
+- No Windows job — even though `@electron-forge/maker-squirrel` is in desktop devDeps (`apps/desktop/package.json:17`)
+- No Linux job — no deb/rpm makers declared anyway (see first-pass §5)
+- No universal-binary merge step (`@electron/universal`)
+- No changelog generation — release notes are a static string
+- No artifact attestation (`actions/attest-build-provenance`)
+- No CDN/S3 appcast publishing — feeds are GitHub Release assets only
+- Concurrency group has no `cancel-in-progress: true`
+
+#### FU-5. Root `dev:desktop-stack` does NOT start Electron (naming mismatch)
+
+Root `package.json:22-23`:
+```
+"dev:desktop":       "pnpm --filter @lightfast/desktop dev",
+"dev:desktop-stack": "concurrently 'pnpm dev:full' 'pnpm --filter @lightfast/app proxy'",
+```
+
+`dev:desktop` is the one that actually starts Electron. `dev:desktop-stack` starts the web stack (app + www + platform) plus the `@lightfast/app proxy` script — it's the companion web-side runtime, not a stack-including-Electron. The name reads like it should boot everything together, but it doesn't start Electron. This is a factual discrepancy between the name and the behavior.
+
+#### FU-6. Turbo task inheritance
+
+`apps/desktop/package.json` exposes `dev`, `package`, `make`, `publish`, `typecheck`. Root `turbo.json` tasks that match: only **`dev`** (persistent, no cache) and **`typecheck`** (`dependsOn: ["^build", "transit"]`, outputs `.cache/tsbuildinfo.json`). The root `build`, `test`, `clean`, `transit` turbo tasks all no-op for desktop because desktop doesn't expose matching script names.
+
+`typecheck` runs two sequential `tsc` passes (`apps/desktop/package.json:12`) — no per-config turbo tasks, no incremental build via project references (there's no `composite` / `references` field in the two tsconfigs, per Subagent 1 §4).
+
+#### FU-7. No `.env.example`; `.env.development` exists and is gitignored
+
+`apps/desktop/.env.development` (gitignored) contains a single key: `VITE_LIGHTFAST_API_URL=http://localhost:3024`. There is no `.env.example` template and no `.env.production`. New contributors have no documented list of env vars needed to boot the app.
+
+#### FU-8. Missing dev-ergonomic scripts (cheap to add)
+
+| Script | Codex has | Lightfast has | Effort |
+|---|---|---|---|
+| `devtools:reset` (clear extensions + Service Worker + Code Cache) | Yes (one-line sh) | No | Tiny |
+| `clean` (rm -rf `out/ .vite/ .cache/`) | Implicit via `rm -rf out` in `build` | No | Tiny |
+| `metadata-probe` (read `buildFlavor`/`buildNumber`) | `scripts/dev-metadata.ts` | No | Small |
+| `rebuild` (on Electron version change) | `rebuild:sqlite` + `rebuild:forge-natives` | No — `rebuildConfig: {}` | Small–Medium (only needed once natives exist) |
+| Third-party-notices generator | Parent-workspace script → 889-package `THIRD_PARTY_NOTICES.txt` | No | Medium |
+
+### What the First Pass Missed (summary)
+
+1. **Lint/format/test tooling is not just "thin" — it's absent at the app level.** First pass implied this but Subagent 1 §2 / §8 makes it concrete: `apps/desktop/package.json` devDeps have no linter, no formatter, no test runner.
+2. **CI-core explicitly excludes desktop** from typecheck and build (`ci-core.yml:45,105`). Desktop typecheck coverage relies entirely on `ci.yml`'s `--affected` invocation.
+3. **Changeset validation would reject desktop** (`verify-changeset.yml:51` allowlist).
+4. **`desktop-release.yml.disabled` is genuinely disabled** — three substantive jobs transcribed above, but missing Sentry release, Windows, Linux, universal-binary, changelog, and attestation steps.
+5. **Root `dev:desktop-stack` naming is misleading** — doesn't start Electron.
+6. **No `rebuildConfig`** — `forge.config.ts:86` has `rebuildConfig: {}`. Becomes load-bearing the first time a native module enters `dependencies`.
+7. **No `.env.example`** — undocumented env surface for contributors.
+8. **`onlyBuiltDependencies` already lists `@sentry/cli`** (`pnpm-workspace.yaml:82`) so its postinstall binary is materialized, but no workflow invokes it. The tool is installed but unused.
+
+### Follow-up Code References
+
+- `apps/desktop/package.json:7-13` — scripts (only 5, no lint/test/format)
+- `apps/desktop/package.json:14-36` — devDependencies (no lint/test/format/@sentry/cli)
+- `apps/desktop/forge.config.ts:86` — empty `rebuildConfig`
+- `apps/desktop/tsconfig.node.json` — includes `forge.config.ts` + all three `vite.*.config.ts`
+- `apps/desktop/vite.renderer.config.ts:13-27` — `preserveSymlinks: false`, `optimizeDeps.include` for `@repo/app-trpc`, renderer outDir `.vite/renderer/main_window`
+- `apps/desktop/.gitignore` — ignores `out/`, `dist/`, `.cache/`, `.vite/`, `node_modules/`, `.env*`; exception `!build/`
+- `apps/desktop/.env.development` (gitignored) — `VITE_LIGHTFAST_API_URL=http://localhost:3024`
+- `package.json:22-23` (root) — `dev:desktop`, `dev:desktop-stack` (misnamed)
+- `turbo.json:44-47` — `typecheck` task
+- `pnpm-workspace.yaml:82` — `@sentry/cli` in `onlyBuiltDependencies`
+- `.github/workflows/ci.yml:54` — `turbo typecheck --affected` catches desktop
+- `.github/workflows/ci-core.yml:45,105` — desktop **excluded** from typecheck + build
+- `.github/workflows/verify-changeset.yml:51,57` — desktop not in changeset allowlist
+- `.github/workflows/desktop-release.yml.disabled` — full release pipeline, currently disabled
+- `.changeset/config.json:5` — `fixed: [["lightfast", "@lightfastai/mcp"]]`; desktop absent
+- `/tmp/codex-extracted/app/package.json:7-45` — Codex's 24 scripts for reference
+
+### Updated Open Questions
+
+7. Should `verify-changeset.yml` allowlist be extended to include `@lightfast/desktop`, or should the desktop app intentionally stay outside the changeset flow and rely on `desktop-v*` tags only?
+9. Is there appetite for hermetic CI (`fb-dotslash`-style), or is GitHub-hosted runner + `setup-node`/`setup-pnpm` the policy?
+10. Is the current "root Biome + root Knip + root turbo typecheck" coverage sufficient for desktop, or should `apps/desktop` have its own `lint` + `test` scripts so devs can run quality checks locally without `cd`ing to root?
+
+### Resolved Questions (2026-04-23)
+
+- **Q6 — `desktop-release.yml.disabled` blocker**: Disabled because Apple signing/notarization keys have not been set up yet. All eight `APPLE_*` / `KEYCHAIN_*` secrets referenced in the workflow (`APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `APPLE_CERT_BASE64`, `APPLE_CERT_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_API_KEY_CONTENT`) need to be provisioned before the workflow can be renamed from `.disabled` → `.yml`. Nothing in the workflow logic is broken.
+- **Q8 — Lint/format tooling choice**: Match root. Biome/ultracite (already configured at repo root via `pnpm check`) is the canonical lint+format stack. Do **not** introduce Oxc (`oxlint`/`oxfmt`) in `apps/desktop` even though Codex uses them — consistency with the rest of the Lightfast monorepo outweighs parity with Codex on this specific tooling call.
+
+### Resolved Questions (2026-04-23, during pre-release batch planning)
+
+- **Release host repo**: Monorepo (`lightfastai/lightfast`) — public repo so Sparkle feed URL works without auth; `GITHUB_TOKEN` already has `contents:write`; tag + source + artifact live together. `LIGHTFAST_DESKTOP_RELEASE_REPO` indirection in `forge.config.ts:43-54` is being removed (Phase B).
+- **Tag convention**: `@lightfast/desktop@<version>` (matches existing `lightfast@x.y.z` / `@lightfastai/mcp@x.y.z` changesets-style tags produced by `release.yml`). Chosen over `desktop-v*` (old), `desktop/v*` (ad-hoc slash), `v*` (single-product-only). Workflow trigger will be `'@lightfast/desktop@*'`.
+- **First release arch**: arm64 + x64 (matrix already in disabled workflow). Not universal.
+- **Sentry DSN delivery**: Baked at CI build time via `npm pkg set sentryDsn="$SENTRY_DSN"` using repo secret. Runtime env `SENTRY_DSN` preserved as override for local dev. DSN is a public identifier; storing as a secret is belt-and-suspenders.
+- **Q7 (changeset policy)**: Tag-only releases for desktop. `@lightfast/desktop` added to `.changeset/config.json` `ignore` (Phase F). `verify-changeset.yml:51` allowlist deliberately **not** extended — its current rejection of desktop-mentioning changesets is the correct boundary.
+- **Q10 (local lint/test)**: Desktop gets its own `lint` + `clean` scripts in Phase F that resolve Biome via workspace hoisting. No separate test runner yet (no tests to run).
+
+## Status Update 2026-04-24
+
+### Quick-wins plan: 4/4 phases landed
+
+Verified against current tree:
+- **Phase 1 (entitlements)**: `build/entitlements.mac.plist` has 5 keys — `disable-library-validation`, `device.camera`, `network.server` all gone. `NSCameraUsageDescription` removed from `forge.config.ts` extendInfo.
+- **Phase 2 (Info.plist)**: `forge.config.ts:67-78` carries `NSQuitAlwaysKeepsWindows=false`, `LSMinimumSystemVersion: "12.0"`, `LSEnvironment: { MallocNanoZone: "0" }`.
+- **Phase 3 (Sentry)**: `src/main/sentry.ts:14-55` has module-scoped `SESSION_ID`, `rewriteFramesIntegration({ root: app.getAppPath(), prefix: "app:///" })`, `dist: build.buildNumber`, tags `sessionId/bundle/host`.
+- **Phase 4 (dead code)**: `showContextMenu` removed from `ipc.ts`. `silentRefresh` + `REFRESH_TIMEOUT_MS` removed — superseded by a full `auth-flow.ts` rewrite (loopback HTTP server over `127.0.0.1:<port>/callback` with a per-signin CSRF state and cryptographic token). Deep-link `console.log` gone — in fact the entire deep-link dispatcher is gone: `src/main/protocol.ts` deleted, `onDeepLink` removed from `index.ts`, `CFBundleURLTypes` dropped from extendInfo. Research §10 is now moot — there is no deep-link surface to dispatch.
+
+### Pre-release batch plan: scope + external setup
+
+Drafted in [`thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md`](../plans/2026-04-23-desktop-pre-release-batch.md). 6 phases:
+
+| Phase | Scope | Type |
+|---|---|---|
+| A | Apple Developer + Sentry provisioning (10 GH secrets, 2 variables) | Human setup |
+| B | Forge config + build-info cleanup: remove `LIGHTFAST_DESKTOP_RELEASE_REPO`, drop `sparklePublicKey`, add `sentryDsn` to schema | Code |
+| C | `scripts/upload-sourcemaps.mjs` + `@sentry/cli` devDep | Code |
+| D | Rename `desktop-release.yml.disabled` → `.yml`, tag trigger, `cancel-in-progress`, stamp `sentryDsn`, call Phase C script, artifact attestation, auto-generated release notes | CI |
+| E | New `desktop` job in `ci.yml` (macos-14, paths-filtered, unsigned package + typecheck) | CI |
+| F | `.env.example`, `lint`/`clean` scripts, rename `dev:desktop-stack` → `dev:desktop-api`, add `@lightfast/desktop` to changesets `ignore` | DX |
+
+### Out of scope for v0.1.0 (unchanged from original deferred list)
+
+Sparkle-native Ed25519 auto-update, Windows MSIX + Linux makers, universal binary merge, file-backed logger, SQLite, worker tier, per-surface preload isolation, renderer/menu i18n, Playwright CDP harness, notifications.
+
+### Next touch points
+
+1. Provision Apple Developer Program + App Store Connect API key → 8 GH secrets.
+2. Create `lightfast-desktop` Sentry project → DSN + auth token + `SENTRY_ORG`/`SENTRY_PROJECT` variables.
+3. Land phases B–F in any order (no cross-phase blockers except B must precede D).
+4. Cut `@lightfast/desktop@0.1.0-rc.1` as the end-to-end dry run before the first public release.
+
+## Status Update 2026-05-06
+
+Verification pass logged at [`thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md`](2026-05-06-desktop-prod-readiness-status-verification.md). Every prior **DONE** / **DROPPED** Status Tracker row remains true. The three rows previously **IN PROGRESS** all landed.
+
+### What landed since 2026-04-24
+
+- **PR #621** (`aef1d3240`, 2026-04-24) — pre-release-batch phases B–F. Closes IN PROGRESS rows in §2 (Sentry source-map upload), §6 (multi-arch matrix), §13 (build-metadata stamping). Source artifacts: `apps/desktop/src/env/{main,renderer}.ts`, `apps/desktop/scripts/upload-sourcemaps.mjs`, `.github/workflows/desktop-{release,ci}.yml`, `apps/desktop/.env.example`, `apps/desktop/package.json` `clean` script, `.changeset/config.json` ignore.
+- **PR #637** (`ab634170e`, 2026-05-06) — unsigned-beta-distribution. Adds a `signingMode: "ad-hoc" | "developer-id"` enum threaded through `apps/desktop/package.json:72`, `apps/desktop/src/shared/build-info-schema.ts:6-7,15`, build-info, Sentry tags, updater. `forge.config.ts:14-49` carries a two-branch osxSign (developer-id when `APPLE_SIGNING_IDENTITY` + `APPLE_TEAM_ID` set, else ad-hoc fallback `identity: "-"`). `desktop-release.yml:32-40` auto-derives `prerelease=true` from any hyphen-suffix in the tag; `desktop-release.yml:120-124` flips `signingMode` based on whether `APPLE_SIGNING_IDENTITY` exists. `apps/desktop/src/main/updater.ts:87-89` disables the auto-updater entirely when `signingMode === "ad-hoc"` (Squirrel.Mac requires the new build to satisfy the running app's Designated Requirement; ad-hoc DRs are content-bound).
+- **Mid-flight** — `2565270fa` (floating settings panel), `b30d99975` (custom URL scheme + PKCE). The custom-URL-scheme work does **not** reintroduce a deep-link handler in main: `grep` for `setAsDefaultProtocolClient`, `onDeepLink`, `open-url` across `apps/desktop/src/` returns zero matches. The deletion of `protocol.ts` and the lack of `CFBundleURLTypes` in `forge.config.ts:81-92` extendInfo both still hold. **§10 deep-link surface is genuinely gone.**
+
+### Tracker rows state at 2026-05-06
+
+| § | Finding | Prior state | Current state |
+|---|---|---|---|
+| 2 | Source-map upload / `@sentry/cli` | IN PROGRESS | **DONE** (PR #621) |
+| 6 | Multi-arch arm64+x64 | IN PROGRESS | **DONE** (PR #621) |
+| 13 | Non-empty version / buildNumber / sparkleFeedUrl | IN PROGRESS | **DONE** (PR #621 — workflow stamps via `npm pkg set`; placeholders in `package.json` are intentional) |
+| 13 | `signingMode` (new) | n/a | **DONE** (PR #637) |
+| 10 | Deep-link `console.log` / dispatcher | DEFERRED | **N/A** — surface removed; was never reintroduced |
+
+All other DEFERRED / RELEASE rows from the 2026-04-24 tracker remain unchanged.
+
+### Remaining gates for first-class signed v0.1.0
+
+- **G-1** — Apple Developer enrollment + Sentry secrets. External, partially blocked (Apple). Sentry can land independently.
+- **G-2** — `forge.config.ts:14-49` osxSign developer-id branch uses kebab-case keys silently dropped by `@electron/osx-sign@1.3.3`. Will fail signed-build path on first try. Pre-fix is cheap but unverifiable until Apple secrets exist.
+- **G-3** — `apps/desktop/build/entitlements.mac.inherit.plist:9-10` still carries `com.apple.security.cs.disable-library-validation`. Codex carries it in neither main nor inherit plist.
+- **G-4** — Branch protection for `Desktop CI / Typecheck + package (unsigned)` (UI-only, not automatable from code).
+- **G-5** — First end-to-end dry run: cut `@lightfast/desktop@0.1.0-rc.1`. Can be run in ad-hoc mode now without Apple — exercises ~90% of the pipeline (matrix, Forge ad-hoc fallback, Sentry release + sourcemaps, attestation, Sparkle JSON feed). Codesign + notarize remain unverified until Apple lands.
+- **G-6** — Auto-updater is intentionally disabled when `signingMode === "ad-hoc"`. Beta users reinstall manually until the first signed cut.
+
+G-7 from the verification doc (custom URL scheme audit) is **closed** — verified above.
+
+### Recommended order to clear the gates
+
+1. Pre-fix G-2 + G-3 in code (cheap, lands without Apple).
+2. Provision Sentry only (G-1 partial). Defers Apple to its own dependency chain.
+3. Cut `@lightfast/desktop@0.1.0-rc.1` ad-hoc dry-run (G-5 partial). Validates everything except codesign + notarize.
+4. When Apple unblocks: provision the remaining 8 secrets, cut `@lightfast/desktop@0.1.0-rc.2` (signed), verify codesign + notarize + stapled ticket. Promote to `@lightfast/desktop@0.1.0`.
+5. Branch protection (G-4) — repo Settings UI. Do this after rc.1 to confirm `Desktop CI` is the right check name to require.

--- a/thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md
+++ b/thoughts/shared/research/2026-05-06-desktop-prod-readiness-status-verification.md
@@ -1,0 +1,359 @@
+---
+date: 2026-05-06T12:43:35+10:00
+researcher: claude
+git_commit: ab634170e1eafdbb4e89fbd2255819cbe53178e3
+branch: main
+topic: "apps/desktop production-readiness: verification of Codex-gap Status Tracker"
+tags: [research, desktop, electron, production, codex-gap-verification, sparkle, signing, sentry, ci]
+status: complete
+last_updated: 2026-05-06
+based_on:
+  - thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
+  - thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md
+  - thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md
+---
+
+# Research: `apps/desktop` Production-Readiness — Status Tracker Verification
+
+**Date**: 2026-05-06T12:43:35+10:00
+**Git Commit**: ab634170e1eafdbb4e89fbd2255819cbe53178e3
+**Branch**: main
+
+## Research Question
+
+For the Status Tracker in `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`, double-check item-by-item what was actually done vs not done — to figure out what still blocks a production release of `apps/desktop`.
+
+## Summary
+
+Every "DONE" / "DROPPED" claim in the Status Tracker is verified true in the current tree. The two items marked **IN PROGRESS** at the time of writing (sourcemap upload, multi-arch CI, version/feed/buildNumber stamping) all landed via PR #621 (merge `aef1d3240`, 2026-04-24) and are now in `main`. The release pipeline (`.github/workflows/desktop-release.yml`) is fully wired but **inert** — it activates on the first `@lightfast/desktop@*` git tag.
+
+After PR #621 landed, an additional `unsigned-beta-distribution` track shipped (PR #637, merged 2026-05-06): a `signingMode: "ad-hoc" | "developer-id"` enum was threaded through `package.json` → schema → build-info → forge config → updater → Sentry, so the workflow can ship an ad-hoc-signed `.dmg` while Apple Developer enrollment is in flight. The auto-updater is **deliberately disabled** when `signingMode === "ad-hoc"` (`apps/desktop/src/main/updater.ts:87-89`) because Squirrel.Mac requires the new build to satisfy the running app's Designated Requirement, and ad-hoc DRs are content-bound.
+
+What remains to ship the first signed v0.1.0:
+1. **Phase A (external setup)** — 8 Apple secrets + 2 Sentry secrets + 2 Sentry vars not yet provisioned in repo settings. Until they are, the workflow runs in ad-hoc mode (no notarization, no auto-update).
+2. **Two carry-over items inside the codesign config** — see §Gaps/Risks below.
+3. **Branch protection** for `Desktop CI / Typecheck + package (unsigned)`.
+4. **First end-to-end dry run** — cut `@lightfast/desktop@0.1.0-rc.1` and verify codesign / notarize / attestation / Sparkle JSON feed end-to-end.
+
+Everything else in the Status Tracker that was marked DEFERRED or RELEASE remains intentionally out of scope for v0.1.0.
+
+## Verification Method
+
+For each row in the Status Tracker:
+1. Read the current file the original finding cited.
+2. If the finding said something was added/removed/renamed, confirm presence/absence by direct file read or `grep`.
+3. Cross-reference against the PR #621 plan (`thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md`) which records what shipped per phase.
+4. Note any state that has changed since the PR #621 merge (PRs #630, #637, and the unsigned-beta-distribution work).
+
+## Item-by-Item Verification
+
+Legend: ✅ verified done · ❎ verified not done (intentional) · ⚠️ residual gap · ➕ new since original tracker
+
+### §1 — Auto-update: Sparkle + Ed25519
+
+| Original status | Verification |
+|---|---|
+| RELEASE (deferred past v0.1.0) | ❎ Unchanged. `apps/desktop/src/main/updater.ts:1-130` still uses Electron's built-in `autoUpdater` (Squirrel.Mac under the hood). No `sparkle.node` native addon, no Ed25519 signature path, no Windows MSIX backend. Single `setFeedURL({url})` with `${arch}` template (`updater.ts:28-30`). |
+| ➕ New: ad-hoc signing kill-switch | `updater.ts:87-89` — when `build.signingMode === "ad-hoc"`, `initUpdater()` returns early. Documented inline: ad-hoc DRs are content-bound, so swap-in always fails. Beta users reinstall manually. |
+
+### §2 — Logging, Sentry, source maps, crash reporter
+
+| Original status | Verification |
+|---|---|
+| **On-disk logging** — DEFERRED | ❎ Unchanged. No file logger anywhere in `apps/desktop/src/main/`. `index.ts:170-173` still `console.error`s renderer errors. |
+| **Sentry tags + RewriteFrames** — DONE | ✅ Verified at `apps/desktop/src/main/sentry.ts:14-57`. Module-scoped `SESSION_ID = randomUUID()`, `rewriteFramesIntegration({ root: app.getAppPath(), prefix: "app:///" })`, `dist: build.buildNumber`, tags `sessionId / bundle / host / signingMode`. The `signingMode` tag is new since the original tracker (added with the ad-hoc-signing work). |
+| **Source-map upload** — was IN PROGRESS | ✅ **NOW DONE.** `apps/desktop/scripts/upload-sourcemaps.mjs` exists (63 lines). `pnpm sourcemaps:upload` script in `package.json:13`. `@sentry/cli ^2.39.1` in devDependencies (`package.json:31`). Uploads both `.vite/build` and `.vite/renderer/main_window` with `--url-prefix "app:///"` matching `rewriteFramesIntegration`. Called from `desktop-release.yml:162-164`. Workflow inert until Sentry secrets land. |
+| **Crash reporter** — DEFERRED | ❎ Unchanged. No explicit `crashReporter.start()`. `@sentry/electron`'s built-in Crashpad integration is what runs. |
+
+### §3 — Persistent SQLite storage
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ Unchanged. Three flat-file stores still: `settings.json` (zod-validated), `window-state.json` (debounced), `auth.bin` (safeStorage). No SQLite, no migration framework. |
+
+### §4 — Worker / utility process tier
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ Unchanged. No `Worker` / `utilityProcess` / `child_process.spawn` anywhere in `apps/desktop/src/main/`. |
+
+### §5 — Windows MSIX + Linux makers
+
+| Original status | Verification |
+|---|---|
+| RELEASE | ❎ Unchanged. `forge.config.ts:96-103` declares only `MakerSquirrel` (win32, dormant), `MakerZIP` + `MakerDMG` (darwin). No `maker-deb`, `maker-rpm`, `maker-msix`. |
+
+### §6 — Multi-arch + universal binary
+
+| Original status | Verification |
+|---|---|
+| **Multi-arch arm64+x64** — was IN PROGRESS | ✅ **NOW DONE.** `desktop-release.yml:79-82`: `strategy.matrix.arch: [arm64, x64]`, `fail-fast: false`. Each arch runs `pnpm exec electron-forge publish --arch=${matrix.arch} --platform=darwin` on `macos-14`. |
+| **Universal binary** — DEFERRED | ❎ Unchanged. No `@electron/universal`. Two separate per-arch artifacts. |
+
+### §7 — Per-surface preload isolation
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ Unchanged. Single `src/preload/preload.ts`. `forge.config.ts:115-118` has one preload entry. |
+
+### §8 — Menu + renderer i18n
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ Unchanged. Only `src/main/locales/en.json`. No renderer i18n framework. |
+
+### §9 — Dev/test tooling
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ Mostly unchanged: still no Playwright harness, `devtools:reset`, third-party-notices generator, native-rebuild scripts. |
+| ➕ Sentry CLI now wired | `@sentry/cli` is now both a devDep (`package.json:31`) and consumed by `scripts/upload-sourcemaps.mjs` + `desktop-release.yml`. |
+| ➕ `clean` script added | `package.json:8` — `rm -rf out .vite .cache`. |
+
+### §10 — Deep-link routing
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ The deep-link surface is **gone entirely**, not deferred. `src/main/protocol.ts` deleted (confirmed: not in `apps/desktop/src/main/` listing). `index.ts` has no `onDeepLink` handler. `CFBundleURLTypes` not in `forge.config.ts:81-92` extendInfo. OAuth now uses a loopback HTTP server inside `auth-flow.ts` instead. |
+| ➕ New custom URL scheme work | Commit `b30d99975` added a custom-URL-scheme + PKCE sign-in flow track. Worth re-checking whether this re-introduces a deep-link consumer; `grep` finds no `setAsDefaultProtocolClient` in `apps/desktop/src/main/` today. |
+
+### §11 — Entitlements diet
+
+| Original status | Verification |
+|---|---|
+| **Main plist trim** — DONE | ✅ Verified `apps/desktop/build/entitlements.mac.plist` has 5 keys: `allow-jit`, `allow-unsigned-executable-memory`, `device.audio-input`, `network.client`, `files.user-selected.read-write`. The three flagged keys (`disable-library-validation`, `device.camera`, `network.server`) are gone. `NSCameraUsageDescription` is gone from `forge.config.ts` extendInfo (only `NSMicrophoneUsageDescription` + `NSAudioCaptureUsageDescription` remain, `forge.config.ts:88-91`). |
+| **Inherit plist** — not addressed by original quick-wins plan | ⚠️ **Residual gap.** `apps/desktop/build/entitlements.mac.inherit.plist` (used by helper bundles via `entitlements-inherit` in `forge.config.ts:29-32`) still carries `com.apple.security.cs.disable-library-validation` (line 9-10). Codex carries this in neither its main nor its helper entitlements. The original tracker said "both apps use identical entitlements across all four helpers" — that statement was about parity, not about whether this key is needed; the inherit plist was simply not touched by the quick-wins phase. Decide whether to drop it from inherit too. |
+
+### §12 — Info.plist hygiene
+
+| Original status | Verification |
+|---|---|
+| **NSQuitAlwaysKeepsWindows / LSMinimumSystemVersion / MallocNanoZone** — DONE | ✅ Verified `forge.config.ts:81-92` extendInfo: `LSMinimumSystemVersion: "12.0"`, `NSQuitAlwaysKeepsWindows: false`, `LSEnvironment: { MallocNanoZone: "0" }`. Plus `LSApplicationCategoryType`, `NSHighResolutionCapable: true`, `NSSupportsAutomaticGraphicsSwitching: true`, microphone + audio capture usage descriptions. |
+| **NSAppTransportSecurity / CFBundleDocumentTypes / SUPublicEDKey / ElectronAsarIntegrity / NSPrincipalClass** — DEFERRED/RELEASE/auto | ❎ Unchanged. Not applicable, release-only, or auto-set by Forge. |
+
+### §13 — Build metadata placeholders
+
+| Original status | Verification |
+|---|---|
+| **Non-empty `version` / `buildNumber` / `sparkleFeedUrl`** — was IN PROGRESS | ✅ **NOW WIRED.** `package.json:3,69-71` deliberately retains placeholder values (`version: "0.0.0"`, `buildFlavor: "dev"`, `buildNumber: "1"`, `sparkleFeedUrl: ""`) because `desktop-release.yml:113-129` stamps them at build time via `npm pkg set` — the workflow source of truth, not the file. Stamping inert until first tag push. |
+| **`sparklePublicKey`** — DROPPED | ✅ Verified absent from `package.json`, `src/env/main.ts`, `src/main/build-info.ts`, `src/shared/ipc.ts` (`BuildInfoSnapshot`). Cross-checked via `grep -rn "sparklePublicKey"` — no matches. |
+| ➕ **`signingMode`** field added | New `signingMode: "ad-hoc"` placeholder in `package.json:72`. Schema in `src/shared/build-info-schema.ts:6-7,15`. CI flips it to `developer-id` when `APPLE_SIGNING_IDENTITY` is present (`desktop-release.yml:120-124`). Threaded into Sentry tags + updater gate. |
+| ➕ **`sentryDsn` baking** | Resolved differently than the original plan suggested (`npm pkg set`). Now baked at Vite-define time via custom token `__SENTRY_DSN__` (`vite.main.config.ts:5`), consumed in `src/env/main.ts:4-32`. Sentry's official guidance is to avoid `process.env.*` replacement in Vite define — custom token avoids the conflict. |
+
+### §14 — Dead / unwired IPC + features
+
+| Original status | Verification |
+|---|---|
+| **`showContextMenu` IPC** — DONE | ✅ Verified absent from `src/shared/ipc.ts:5-27` — no such channel name. `grep` shows zero matches across `apps/desktop/src/`. |
+| **`silentRefresh`** — DONE | ✅ Verified absent from `src/main/auth-flow.ts` (whole file is the loopback HTTP server rewrite, 135 lines, no `silentRefresh` / `REFRESH_TIMEOUT_MS`). |
+| **Deep-link `console.log`** — DONE | ✅ Verified absent. `src/main/index.ts` has no `onDeepLink` handler at all (search `app.on("open-url"` etc. — none). |
+
+### §15 — Notifications / dock badge / sound
+
+| Original status | Verification |
+|---|---|
+| DEFERRED | ❎ Unchanged. No `Notification` usage, no `setBadgeCount`, no sound assets in `src/main/assets/`. |
+
+## What's New Since the Original Tracker
+
+The Status Tracker was last updated 2026-04-24. Between then and now (2026-05-06), three substantive bodies of work landed on `main` that intersect with prod-readiness:
+
+### N-1. Pre-release batch (PR #621, merge `aef1d3240`, 2026-04-24)
+
+Phases B–F of `2026-04-23-desktop-pre-release-batch.md`. Closed every IN PROGRESS row in §2/§6/§13 plus the contributor-ergonomics items.
+
+Concrete artifacts on disk:
+- `apps/desktop/src/env/main.ts` + `apps/desktop/src/env/renderer.ts` — t3-env layers, build-fail-fast (replaced silent-fail `parseRuntimeEnv`)
+- `apps/desktop/scripts/upload-sourcemaps.mjs` — `sentry-cli` driver
+- `apps/desktop/.env.example` — 21-line template (Sentry, Sparkle, app-origin, debug port, validation skip)
+- `.github/workflows/desktop-release.yml` — renamed from `.disabled`, tag trigger `@lightfast/desktop@*`
+- `.github/workflows/desktop-ci.yml` — typecheck + unsigned `electron-forge package` on `macos-14`, paths-filtered
+- `.changeset/config.json:10` — `"ignore": ["@lightfast/desktop"]`
+- `package.json:8` — `clean` script (`rm -rf out .vite .cache`)
+- Removal of `LIGHTFAST_DESKTOP_RELEASE_REPO` indirection — `forge.config.ts:62-68` now hardcodes `repository: { owner: "lightfastai", name: "lightfast" }`
+
+PR notes (`shipped_pr: https://github.com/lightfastai/lightfast/pull/621`): "15/15 checks passed, including CodeQL + CodeRabbit review."
+
+### N-2. Unsigned beta distribution (PR #637, merge `ab634170e`, 2026-05-06)
+
+Reframes "first release" so we can ship before Apple enrollment completes. Adds the `signingMode` enum and threads it everywhere. Recent commits on `main`:
+
+- `5080d508a` feat(desktop): ad-hoc signing fallback + signingMode threading
+- `f4bc6e522` feat(desktop): gate updater on ad-hoc signingMode + Sentry tag
+- `583ca03b0` ci(desktop-release): gate Apple steps + auto-derive prerelease
+- `dcb61c858` docs(desktop): unsigned beta install instructions + plan/research/handoff
+
+Effects:
+- `forge.config.ts:14-49` has two-branch `osxSign`: full developer-id config when `APPLE_SIGNING_IDENTITY + APPLE_TEAM_ID` are set, else ad-hoc fallback (`identity: "-"`, `identityValidation: false`, `optionsForFile: () => ({ hardenedRuntime: false })`, `preAutoEntitlements: false`).
+- `desktop-release.yml:120-124` flips `signingMode` based on whether `APPLE_SIGNING_IDENTITY` exists.
+- `desktop-release.yml:32-40` auto-derives `prerelease=true` from any hyphen-suffix in the tag (`-rc.N`, `-beta.N`, `-alpha.N`).
+- `apps/desktop/README.md:5-30` documents the "App cannot verify" first-launch dialog and the "Open Anyway" path for beta users.
+- `updater.ts:87-89` — disable updater entirely when `signingMode === "ad-hoc"` so a content-bound DR can't break swap-in.
+
+### N-3. Floating settings panel + custom URL scheme work (mid-flight)
+
+Merge commits visible in `git log`: `2565270fa` (settings panel), `b30d99975` (custom URL scheme + PKCE). Not part of the Codex-gap tracker but touches surface area the tracker covered. The new "custom URL scheme" path is worth re-auditing — original §10 noted protocol.ts was deleted; need to confirm the new scheme work doesn't reintroduce an unwired deep-link handler in main.
+
+## Gaps / Risks Still Blocking Prod
+
+These are the items I would flag before cutting `@lightfast/desktop@0.1.0-rc.1`:
+
+### G-1. Apple Developer enrollment + Sentry secrets (Phase A)
+
+**Severity**: Hard blocker for signed release; soft blocker for any release (workflow runs in ad-hoc mode without secrets, which we now support).
+
+Repo settings → Secrets and variables → Actions needs:
+- 8 Apple secrets: `APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`, `APPLE_CERT_BASE64`, `APPLE_CERT_PASSWORD`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `APPLE_API_KEY_CONTENT`, `KEYCHAIN_PASSWORD`
+- 2 Sentry secrets: `SENTRY_DSN`, `SENTRY_AUTH_TOKEN`
+- 2 Sentry vars: `SENTRY_ORG`, `SENTRY_PROJECT`
+
+Status: not yet provisioned (per `pre-release-batch.md` "Left for a human" section).
+
+### G-2. `osxSign` kebab-case keys silently dropped by `@electron/osx-sign@1.3.3`
+
+**Severity**: Will fail signed-build path on first Apple-secrets exercise.
+
+`apps/desktop/forge.config.ts:14-49` has an in-source TODO:
+> kebab-case keys below are silently dropped by @electron/osx-sign@1.3.3 (camelCase only). Notarization will fail when secrets land. Rename to camelCase + move per-file ones into `optionsForFile` before exercising the dev-id path.
+
+Affected keys: `"hardened-runtime"`, `"gatekeeper-assess"`, `"entitlements-inherit"`, `"signature-flags"`. Need to become `hardenedRuntime`, `gatekeeperAssess`, etc., and per-file ones into `optionsForFile`.
+
+### G-3. `entitlements.mac.inherit.plist` still has `disable-library-validation`
+
+**Severity**: Inconsistency with the main-plist trim; not strictly a blocker.
+
+Main plist was trimmed; helper-process inherit plist was not. Codex carries `disable-library-validation` in neither. Decide whether to drop from inherit too — if any helper bundle (GPU/Renderer/Plugin) needs unsigned dylib loading, keep it; if not, remove for surface-area parity with Codex.
+
+### G-4. Branch protection for `Desktop CI`
+
+**Severity**: Soft — typecheck + unsigned package run today on every desktop PR but aren't a required check.
+
+Repo Settings → Branches → main → required status checks: add `Desktop CI / Typecheck + package (unsigned)`. Not automatable from code (UI only).
+
+### G-5. First-release dry run
+
+**Severity**: Process gate.
+
+After G-1 + G-2 land, cut `@lightfast/desktop@0.1.0-rc.1` and verify: codesign, notarize, attestation (`actions/attest-build-provenance@v2`), Sparkle JSON feed (`latest-mac-{arm64,x64}.json`), and Sentry release (sourcemaps queryable via `sentry-cli releases info`).
+
+### G-6. Auto-updater is disabled for ad-hoc builds
+
+**Severity**: By design. Beta users reinstall manually until G-1 + G-2 unblock the signed path.
+
+`apps/desktop/src/main/updater.ts:87-89` returns early when `signingMode === "ad-hoc"`. Documented in `README.md:24-29`. This is the intentional consequence of N-2.
+
+### G-7. Verify §10 deep-link removal still holds after N-3
+
+**Severity**: Low — likely fine but should be checked.
+
+Commit `b30d99975` added a custom URL scheme + PKCE flow. `grep` for `setAsDefaultProtocolClient` in `apps/desktop/src/main/` returns nothing today, so the scheme is registered elsewhere or removed. Worth a 5-minute re-audit to confirm there isn't a partially-wired deep-link handler.
+
+## Code References
+
+- `apps/desktop/forge.config.ts:14-49` — two-branch osxSign (developer-id / ad-hoc fallback) + the kebab-case TODO
+- `apps/desktop/forge.config.ts:81-92` — extendInfo (Info.plist hygiene)
+- `apps/desktop/forge.config.ts:127-135` — FusesPlugin V1 (six fuses unchanged)
+- `apps/desktop/build/entitlements.mac.plist` — 5-key trimmed main plist
+- `apps/desktop/build/entitlements.mac.inherit.plist:9-10` — inherit plist still has `disable-library-validation`
+- `apps/desktop/package.json:7-15` — scripts (`dev`, `package`, `make`, `publish`, `sourcemaps:upload`, `typecheck`, `clean`, `with-env`)
+- `apps/desktop/package.json:69-72` — placeholders (`buildFlavor: "dev"`, `buildNumber: "1"`, `sparkleFeedUrl: ""`, `signingMode: "ad-hoc"`)
+- `apps/desktop/src/env/main.ts:1-32` — t3-env main-process env layer
+- `apps/desktop/src/main/sentry.ts:14-57` — Sentry init with rewrite-frames + signingMode tag
+- `apps/desktop/src/main/build-info.ts:7-21` — build-info caching, reads package.json fields
+- `apps/desktop/src/main/updater.ts:87-89` — ad-hoc updater kill-switch
+- `apps/desktop/src/main/auth-flow.ts:1-135` — loopback HTTP server (replaces deleted protocol.ts)
+- `apps/desktop/src/shared/build-info-schema.ts:6-15` — `signingModeSchema` enum + `buildInfoSchema`
+- `apps/desktop/src/shared/ipc.ts:5-27` — IPC channels (no `showContextMenu`)
+- `apps/desktop/scripts/upload-sourcemaps.mjs:1-63` — sentry-cli driver
+- `apps/desktop/.env.example` — 21-line contributor template
+- `apps/desktop/vite.main.config.ts:4-6` — `__SENTRY_DSN__` define
+- `apps/desktop/README.md:5-30` — beta install instructions
+- `.github/workflows/desktop-release.yml:1-196` — full release pipeline
+- `.github/workflows/desktop-ci.yml:1-58` — paths-filtered desktop CI
+- `.changeset/config.json:10` — `"ignore": ["@lightfast/desktop"]`
+- `pnpm-workspace.yaml:88` — `@sentry/cli` in `onlyBuiltDependencies`
+
+## Architecture Documentation
+
+### Release pipeline as it exists today
+
+```
+git tag @lightfast/desktop@<v> && git push
+  └─ desktop-release.yml fires
+       ├─ prepare (ubuntu)
+       │    - parse tag → version + auto-derive prerelease (any hyphen-suffix)
+       │    - gh release create --draft (with --prerelease if applicable)
+       │      auto-generated notes from previous matching tag (or hand-written
+       │      one-liner for the first tag)
+       └─ build (matrix arm64 × x64, macos-14)
+            - npm version + stamp buildFlavor=prod, buildNumber=$GITHUB_RUN_NUMBER,
+              sparkleFeedUrl, signingMode (developer-id if APPLE_SIGNING_IDENTITY
+              else ad-hoc)
+            - import Apple cert + write notarize key (only if APPLE_SIGNING_IDENTITY)
+            - electron-forge publish --arch=<arch> --platform=darwin
+              → uploads .zip + .dmg to draft release
+            - sourcemaps:upload → Sentry releases new + upload-sourcemaps + finalize
+            - actions/attest-build-provenance@v2 on out/make/**/*.zip
+       └─ finalize (ubuntu)
+            - generate-update-feed.mjs → latest-mac-{arm64,x64}.json on release
+            - gh release edit --draft=false
+```
+
+Concurrency: `desktop-release-${{ github.ref }}`, `cancel-in-progress: true`.
+
+### Per-PR CI for desktop
+
+`.github/workflows/desktop-ci.yml` — triggers on PR + push-to-main when any of `apps/desktop/**`, `packages/{app-trpc,ui,lib}/**`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.github/workflows/desktop-ci.yml` changes. Runs `pnpm --filter @lightfast/desktop typecheck` then `pnpm --filter @lightfast/desktop package` (unsigned) on `macos-14`. Not yet a required status check.
+
+`.github/workflows/ci.yml:54` continues to catch desktop via `pnpm turbo typecheck --affected --continue`.
+
+### Build-time identity flow
+
+```
+package.json placeholders (version=0.0.0, buildFlavor=dev, buildNumber=1, sparkleFeedUrl="", signingMode=ad-hoc)
+                              │
+            CI tag-trigger ───┴──→ npm pkg set: version, buildFlavor=prod, buildNumber=$RUN_NUMBER,
+                                                  sparkleFeedUrl=…, signingMode=(dev-id|ad-hoc)
+                              │
+            Vite define ──────┴──→ __SENTRY_DSN__ = JSON.stringify(process.env.SENTRY_DSN ?? "")
+                              │
+            Forge bundle ─────┴──→ .vite/build/bootstrap.js  (DSN inlined; identifiers stamped)
+                              │
+            sourcemaps:upload ┴──→ Sentry release `${name}@${version}+${buildNumber}`
+                                                                                       │
+                                  (matches sentry.ts release id format)                ▼
+                              ┌─ Forge package + osx-sign + osx-notarize (if dev-id) ──┘
+                              │
+                              ▼
+                      .dmg + .zip → GitHub release
+                              │
+                              ▼
+                    generate-update-feed.mjs
+                              │
+                              ▼
+              latest-mac-{arm64,x64}.json → consumed by autoUpdater
+                                            (ONLY when signingMode != "ad-hoc";
+                                             see updater.ts:87-89)
+```
+
+## Historical Context (from thoughts/)
+
+- `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` — original gap analysis + Status Tracker. All "DONE"/"DROPPED" items verified true 2026-05-06.
+- `thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md` — phases 1–4 (entitlements / Info.plist / Sentry / dead code). Per `pre-release-batch.md` Status section, all four landed before PR #621.
+- `thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md` — phases B–F. `status: shipped (phases B–F)`, `shipped_pr: #621`, `merge_commit: aef1d3240`, `shipped_at: 2026-04-24`. Phase A (Apple + Sentry secrets) explicitly "Left for a human."
+- Recent merges visible in `git log`: PR #637 (`ab634170e`, unsigned beta distribution), PR #630 (`7f2910544`, portless runtime batch), PR #622 (`476d898d1`, deps upgrade).
+
+## Related Research
+
+- `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` (the document being verified)
+- `thoughts/shared/plans/2026-04-23-desktop-codex-gap-quick-wins.md`
+- `thoughts/shared/plans/2026-04-23-desktop-pre-release-batch.md`
+- `thoughts/shared/plans/2026-04-23-desktop-clerk-trpc-wiring.md`
+
+## Open Questions
+
+1. **Inherit plist (G-3)**: Drop `disable-library-validation` from `entitlements.mac.inherit.plist` for surface-area parity with Codex, or keep it because some Electron helper actually loads unsigned dylibs? Needs a test on a notarized build to know for sure.
+2. **osxSign kebab-case (G-2)**: Should the camelCase rename land speculatively now (before Apple secrets), or be bundled with the first signed-tag dry run? Pre-fixing is cheap but unverifiable until secrets exist; bundling saves a round-trip.
+3. **Custom URL scheme audit (G-7)**: Did `b30d99975` add a `setAsDefaultProtocolClient` call that's now hidden under a different module name, or was it purely about the renderer-side PKCE flow?
+4. **First-release version**: `0.1.0-rc.1` (per pre-release plan) or jump straight to `0.1.0`? RC route exercises the prerelease-detection logic in `desktop-release.yml:32-40` end-to-end.
+5. **Sparkle public-key adoption**: Currently dropped (§13). When (if) Sparkle-native is adopted post-v0.1.0, it'll need to be re-introduced — worth tracking as a follow-up so the field doesn't get re-added without a corresponding consumer.


### PR DESCRIPTION
## Summary

Pre-fixes the two known codesign correctness gaps (G-2 osxSign kebab-case keys; G-3 helper-inherit plist `disable-library-validation`) so the first signed cut doesn't ping-pong back to the codebase. Ad-hoc fallback branch is unchanged; verified locally that `pnpm --filter @lightfast/desktop package` still produces a launchable `.app` with `Signature=adhoc`.

- **G-2** — `apps/desktop/forge.config.ts` osxSign developer-id branch: kebab-case keys were silently dropped by `@electron/osx-sign@1.3.3` (camelCase only). Renamed `entitlements-inherit` → `entitlementsInherit`; moved `hardenedRuntime` + `gatekeeperAssess` + `signatureFlags` into `optionsForFile` (per-file options that `mergeOptionsForFile` honors). Removed the in-source TODO.
- **G-3** — `apps/desktop/build/entitlements.mac.inherit.plist`: dropped `com.apple.security.cs.disable-library-validation`. The main plist had it removed in PR #614; the helper-process inherit plist (used by GPU / Renderer / Plugin helpers via `entitlementsInherit`) still carried it. Codex carries it in neither.
- Companion docs (`thoughts/`) — appends a `## Status Update 2026-05-06` section to the original Codex-gap research closing G-7 and listing G-1..G-6 as remaining gates; adds the rc.1 ad-hoc dry-run plan + status-verification research.

Implements Phase 1 + Phase 2 of `thoughts/shared/plans/2026-05-06-desktop-rc1-ad-hoc-dry-run.md`. Phases 3a (Sentry provisioning) and 3b (rc.1 tag cut) follow this PR.

## Test plan

- [x] `pnpm --filter @lightfast/desktop typecheck` passes
- [x] `pnpm exec biome check apps/desktop/forge.config.ts apps/desktop/build/entitlements.mac.inherit.plist` clean (other root-level `pnpm check` errors are pre-existing in untouched files — `factory.ts`, auth-flow tests — confirmed by stashing)
- [x] `pnpm --filter @lightfast/desktop package` (no `APPLE_SIGNING_IDENTITY`) produces `apps/desktop/out/Lightfast-darwin-arm64/Lightfast.app`; `codesign -d -v` reports `Signature=adhoc` (ad-hoc fallback branch is the executed path)
- [x] `grep -c "disable-library-validation" apps/desktop/build/entitlements.mac.inherit.plist` → `0`
- [x] `grep -c '"hardened-runtime"|"gatekeeper-assess"|"signature-flags"|"entitlements-inherit"' apps/desktop/forge.config.ts` → `0`
- [x] `grep -c "TODO(apple-cert)" apps/desktop/forge.config.ts` → `0`
- [ ] Desktop CI green on PR (typecheck + unsigned `electron-forge package` on macos-14)
- [ ] Manual: open `Lightfast.app` → main window appears (smoke test that ad-hoc branch still works)

The developer-id branch isn't reachable in CI without Apple secrets; correctness there is verified by reading against the `@electron/osx-sign@1.3.3` source. First real validation lands when Apple secrets are provisioned and the first signed build runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated signing configuration structure for internal consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->