### PR TITLE
fix(desktop): release-pipeline bugs caught by rc.1 ad-hoc dry-run

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -61,6 +61,11 @@ const githubPublisher = process.env.GITHUB_TOKEN
       repository: { owner: "lightfastai", name: "lightfast" },
       draft: true,
       prerelease: process.env.LIGHTFAST_DESKTOP_RELEASE_PRERELEASE === "true",
+      // Forge defaults tagPrefix to "v", which would create a parallel
+      // release at v<version>. The workflow's prepare job already created a
+      // draft at @lightfast/desktop@<version>; matching tagPrefix here makes
+      // Forge publish assets onto that release instead of a sibling.
+      tagPrefix: "@lightfast/desktop@",
     })
   : null;
 

--- a/apps/desktop/scripts/upload-sourcemaps.mjs
+++ b/apps/desktop/scripts/upload-sourcemaps.mjs
@@ -18,7 +18,14 @@ for (const name of required) {
   }
 }
 
-const release = `${pkg.name}@${pkg.version}+${pkg.buildNumber}`;
+// Sentry release versions reject `/` and certain whitespace, so the scoped
+// package name (`@lightfast/desktop`) cannot be used verbatim. Strip the
+// leading `@` and replace the scope separator with `-` to yield
+// `lightfast-desktop@<version>+<buildNumber>` — matches the Sentry project
+// slug. Must produce the same string as `getSentryInitOptions` in
+// `apps/desktop/src/main/sentry.ts`; keep both in sync.
+const releaseName = pkg.name.replace(/^@/, "").replace("/", "-");
+const release = `${releaseName}@${pkg.version}+${pkg.buildNumber}`;
 const urlPrefix = "app:///";
 const buildDir = resolve(desktopRoot, ".vite/build");
 const rendererDir = resolve(desktopRoot, ".vite/renderer/main_window");

--- a/apps/desktop/src/main/sentry.ts
+++ b/apps/desktop/src/main/sentry.ts
@@ -17,9 +17,13 @@ const SESSION_ID = randomUUID();
 export function getSentryInitOptions(): SentryInitOptions {
   const build = getBuildInfo();
   const dsn = mainEnv.SENTRY_DSN ?? "";
+  // Sentry release versions reject `/`. Mirror the transform in
+  // `apps/desktop/scripts/upload-sourcemaps.mjs` so the runtime release id
+  // matches the uploaded sourcemaps; both must stay in sync.
+  const releaseName = build.name.replace(/^@/, "").replace("/", "-");
   return {
     dsn,
-    release: `${build.name}@${build.version}+${build.buildNumber}`,
+    release: `${releaseName}@${build.version}+${build.buildNumber}`,
     environment: build.buildFlavor,
     enabled: Boolean(dsn) && build.buildFlavor !== "dev",
   };


### PR DESCRIPTION
## Summary

The first \`@lightfast/desktop@0.1.0-rc.1\` cut (workflow run [25415597890](https://github.com/lightfastai/lightfast/actions/runs/25415597890)) failed on two latent bugs from PR #621 that the dry-run was designed to surface. Both fixed here.

**Bug A — Sentry release id contained a slash.** \`scripts/upload-sourcemaps.mjs\` and \`src/main/sentry.ts\` both built the release as \`\${pkg.name}@\${pkg.version}+\${pkg.buildNumber}\` = \`@lightfast/desktop@0.1.0-rc.1+1\`. \`sentry-cli\` rejected it: *Invalid release version. Slashes and certain whitespace characters are not permitted.* Strip the leading \`@\` and replace the scope separator with \`-\` in both files → \`lightfast-desktop@0.1.0-rc.1+1\` (matches the Sentry project slug). Runtime release and uploaded sourcemap release must produce identical strings or stack traces won't symbolicate; cross-reference comments in both files.

**Bug B — Forge \`PublisherGithub\` used a different tag than the workflow.** \`forge.config.ts:60-72\` had no \`tagPrefix\`, so Forge defaulted to \`v\` and uploaded the four build assets to a parallel \`v0.1.0-rc.1\` release. The workflow's \`prepare\` job had already created a draft at \`@lightfast/desktop@0.1.0-rc.1\` (empty). Set \`tagPrefix: "@lightfast/desktop@"\` so Forge writes onto the workflow's release.

## Test plan

- [x] \`pnpm --filter @lightfast/desktop typecheck\` passes
- [x] \`pnpm exec biome check\` clean on the three changed files
- [x] \`node --check apps/desktop/scripts/upload-sourcemaps.mjs\` clean
- [x] Sanity simulated \`pkg.name = "@lightfast/desktop"\` → release id = \`lightfast-desktop@0.1.0-rc.1+1\`
- [ ] CI green (Desktop CI \`Typecheck + package (unsigned)\`)
- [ ] Re-cut \`@lightfast/desktop@0.1.0-rc.1\` after this lands; expect a single release with 6 assets and a Sentry release populated

This PR plus the cleanup of the two failed rc.1 draft releases unblocks Phase 3b of \`thoughts/shared/plans/2026-05-06-desktop-rc1-ad-hoc-dry-run.md\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release tagging and asset publishing configuration for GitHub releases.
  * Enhanced sourcemap upload and release naming consistency for error tracking integration to ensure better crash reporting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->