### PR TITLE
fix(desktop): emit Vite sourcemaps so Sentry can symbolicate stacks

### DIFF
--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN ?? ""),
   },
   build: {
+    // Required for Sentry stack-trace symbolication. Sourcemaps land in
+    // .vite/build/ alongside the bundles and are uploaded to Sentry by
+    // scripts/upload-sourcemaps.mjs. rewriteFramesIntegration in src/main/sentry.ts
+    // binds runtime frames (`app:///bootstrap.js`) to these maps.
+    sourcemap: true,
     lib: {
       entry: "src/main/bootstrap.ts",
       formats: ["cjs"],

--- a/apps/desktop/vite.preload.config.ts
+++ b/apps/desktop/vite.preload.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: "src/preload/preload.ts",
       formats: ["cjs"],

--- a/apps/desktop/vite.renderer.config.ts
+++ b/apps/desktop/vite.renderer.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     ],
   },
   build: {
+    sourcemap: true,
     outDir: resolve(import.meta.dirname, ".vite/renderer/main_window"),
     emptyOutDir: true,
     rollupOptions: {


### PR DESCRIPTION
## Summary

Third latent bug from PR #621 surfaced by the rc.1 ad-hoc dry-run (run [25418656753](https://github.com/lightfastai/lightfast/actions/runs/25418656753)). Sentry's sourcemap-upload script ran clean, but the report showed every uploaded JS file as \`(no sourcemap found)\` because Vite library mode defaults \`build.sourcemap\` to \`false\` and none of the three configs override it. The full symbolication pipeline — \`rewriteFramesIntegration({ root, prefix: 'app:///' })\` in \`src/main/sentry.ts\`, \`scripts/upload-sourcemaps.mjs\` with \`--ext js --ext map\`, the \`SENTRY_AUTH_TOKEN\` org token — is correctly wired. It just had no \`.map\` files to bind frames to.

Set \`build.sourcemap: true\` in all three Vite configs:
- \`apps/desktop/vite.main.config.ts\`
- \`apps/desktop/vite.preload.config.ts\`
- \`apps/desktop/vite.renderer.config.ts\`

## Test plan

- [x] \`pnpm --filter @lightfast/desktop typecheck\` passes
- [x] \`pnpm exec biome check\` clean on all three Vite configs
- [x] \`pnpm --filter @lightfast/desktop package\` succeeds; \`find apps/desktop/.vite -name '*.map'\` returns 5 files (\`bootstrap.js.map\`, \`preload.js.map\`, two \`main-*.js.map\` chunks, renderer \`assets/index-*.js.map\`).
- [ ] CI green
- [ ] After merge: re-cut as \`@lightfast/desktop@0.1.0-rc.2\`. Expected outcome — sentry-cli upload report shows each JS file paired with a \`.map\`, no \`(no sourcemap found)\` warnings; manual smoke test produces a symbolicated stack in the Sentry UI.

## Related

- rc.1 ([release](https://github.com/lightfastai/lightfast/releases/tag/@lightfast/desktop@0.1.0-rc.1)) shipped clean for everything except symbolication.
- Plan: \`thoughts/shared/plans/2026-05-06-desktop-rc1-ad-hoc-dry-run.md\` Phase 3b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled source maps across desktop application builds to improve debugging capabilities and error tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->