### PR TITLE
fix(desktop): observability hardening — IPC routing + debug-id symbolication

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { MakerDMG } from "@electron-forge/maker-dmg";
@@ -69,7 +71,43 @@ const githubPublisher = process.env.GITHUB_TOKEN
     })
   : null;
 
+// Inject sentry debug-ids into the staged Vite output AFTER electron-packager
+// has copied it to its temp build path. We can't use prePackage because
+// Forge runs user hooks before plugin-vite's build, so .vite/ doesn't exist
+// yet. We can't use any earlier post-Vite hook because plugin-vite doesn't
+// expose one. packageAfterCopy fires once per platform/arch with `buildPath`
+// pointing at the staging dir whose contents will be sealed into the asar;
+// inject there, then mirror the modified files back to the source `.vite/`
+// so `scripts/upload-sourcemaps.mjs` uploads sourcemaps with debug-ids that
+// match what got packed.
+function injectSentryDebugIds(buildPath: string, sourceRoot: string): void {
+  if (!process.env.SENTRY_AUTH_TOKEN) {
+    return;
+  }
+  const targets = [".vite/build", ".vite/renderer/main_window"];
+  for (const t of targets) {
+    const stagingDir = resolve(buildPath, t);
+    const sourceDir = resolve(sourceRoot, t);
+    if (!existsSync(stagingDir)) {
+      continue;
+    }
+    execFileSync(
+      "pnpm",
+      ["exec", "sentry-cli", "sourcemaps", "inject", stagingDir],
+      { cwd: sourceRoot, stdio: "inherit" }
+    );
+    if (existsSync(sourceDir)) {
+      cpSync(stagingDir, sourceDir, { recursive: true, force: true });
+    }
+  }
+}
+
 const config: ForgeConfig = {
+  hooks: {
+    packageAfterCopy: async (_forgeConfig, buildPath) => {
+      injectSentryDebugIds(buildPath, import.meta.dirname);
+    },
+  },
   packagerConfig: {
     name: "Lightfast",
     executableName: "lightfast",

--- a/apps/desktop/scripts/upload-sourcemaps.mjs
+++ b/apps/desktop/scripts/upload-sourcemaps.mjs
@@ -26,7 +26,6 @@ for (const name of required) {
 // `apps/desktop/src/main/sentry.ts`; keep both in sync.
 const releaseName = pkg.name.replace(/^@/, "").replace("/", "-");
 const release = `${releaseName}@${pkg.version}+${pkg.buildNumber}`;
-const urlPrefix = "app:///";
 const buildDir = resolve(desktopRoot, ".vite/build");
 const rendererDir = resolve(desktopRoot, ".vite/renderer/main_window");
 
@@ -38,33 +37,14 @@ function sentry(args) {
   });
 }
 
-sentry(["releases", "new", release]);
-sentry([
-  "releases",
-  "files",
-  release,
-  "upload-sourcemaps",
-  "--url-prefix",
-  urlPrefix,
-  "--ext",
-  "js",
-  "--ext",
-  "map",
-  buildDir,
-]);
-sentry([
-  "releases",
-  "files",
-  release,
-  "upload-sourcemaps",
-  "--url-prefix",
-  urlPrefix,
-  "--ext",
-  "js",
-  "--ext",
-  "map",
-  rendererDir,
-]);
+// Modern artifact-bundle flow with debug-id matching. `sourcemaps inject`
+// runs in `forge.config.ts`'s prePackage hook so the injected //# debugId=
+// comments land in the asar; here we only `upload`. Stack frames in Sentry
+// resolve via debug-id, which avoids URL-prefix mismatches between the
+// uploaded path (`assets/index-*.js`) and the runtime frame
+// (`app:///.vite/renderer/main_window/assets/index-*.js`).
+sentry(["sourcemaps", "upload", "--release", release, buildDir]);
+sentry(["sourcemaps", "upload", "--release", release, rendererDir]);
 sentry(["releases", "finalize", release]);
 
 console.log(`Uploaded sourcemaps for release ${release}`);

--- a/apps/desktop/src/main/windows/factory.ts
+++ b/apps/desktop/src/main/windows/factory.ts
@@ -1,5 +1,4 @@
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import {
   BrowserWindow,
   type BrowserWindowConstructorOptions,
@@ -12,7 +11,13 @@ import { loadWindowState, trackWindowState } from "../window-state";
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
-const factoryDir = dirname(fileURLToPath(import.meta.url));
+// Vite emits the main bundle as CJS and Rollup does not polyfill
+// `import.meta` — both `.url` and `.dirname` get stripped to `{}.<prop>` =
+// undefined, which crashes downstream `fileURLToPath(undefined)`. `__dirname`
+// is CJS-native and the only reliable way to get the bundle directory inside
+// the asar at runtime.
+// biome-ignore lint/correctness/noGlobalDirnameFilename: Vite CJS output strips import.meta.*; __dirname is the only working option here.
+const factoryDir = __dirname;
 const PRELOAD_PATH = join(factoryDir, "preload.js");
 const RENDERER_DIST = join(factoryDir, `../renderer/${MAIN_WINDOW_VITE_NAME}`);
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,3 +1,8 @@
+// Installs the @sentry/electron IPC bridge on the contextBridge so the
+// renderer-side SDK routes events through main via `sentry-ipc:` instead of
+// fetching the ingest URL directly (which the renderer CSP blocks). Pair:
+// src/main/sentry.ts (main init) and src/renderer/src/main.ts (renderer init).
+import "@sentry/electron/preload";
 import { contextBridge, type IpcRendererEvent, ipcRenderer } from "electron";
 import type { AcceleratorName } from "../shared/accelerators";
 import {

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -1,4 +1,9 @@
-import * as Sentry from "@sentry/browser";
+// @sentry/electron/renderer routes events through `sentry-ipc:` (CSP-bypass
+// scheme registered by @sentry/electron/main + bridged by the
+// `@sentry/electron/preload` import in src/preload/preload.ts). The plain
+// @sentry/browser SDK fetches the ingest URL directly, which the renderer
+// CSP blocks — events silently drop.
+import * as Sentry from "@sentry/electron/renderer";
 import "./react/entry";
 import {
   ACCELERATORS,


### PR DESCRIPTION
## Summary

The rc.2 ad-hoc dry-run smoke test surfaced three latent issues that together prevented Sentry from receiving and symbolicating any renderer events. All fixed here so rc.3 can produce real symbolicated stacks end-to-end.

### F1 — Renderer SDK was bypassing the IPC bridge

\`apps/desktop/src/renderer/src/main.ts\` imported \`@sentry/browser\` and called \`Sentry.init\` directly. The browser SDK fetches \`https://o…ingest.us.sentry.io/api/…/envelope\`, which the renderer CSP blocks → events silently drop. Console showed \`Fetch API cannot load https://…ingest.us.sentry.io/…\` for every uncaught error.

**Fix:** swap to \`@sentry/electron/renderer\` and add \`import \"@sentry/electron/preload\"\` to \`apps/desktop/src/preload/preload.ts\`. The preload import installs the IPC bridge on \`contextBridge\`; the renderer SDK detects the bridge and routes events through main via the \`sentry-ipc:\` scheme (registered by \`@sentry/electron/main\` with \`bypassCsp: true\`). Main's Node HTTP transport has no CSP. Events deliver.

### E — No debug-ids in the shipped bundle

\`scripts/upload-sourcemaps.mjs\` used the legacy \`releases files upload-sourcemaps --url-prefix app:///\` flow, which relies on Sentry matching runtime frame URLs to uploaded asset URLs. The runtime URL was \`app:///.vite/renderer/main_window/assets/index-*.js\` but the upload was \`app:///assets/index-*.js\` — mismatch, no symbolication. Worse: \`grep debugId\` against the rc.2 asar returned 0 matches in every JS file — the bundles had no \`//# debugId=\` comments at all, so even the modern artifact-bundle path had nothing to match on.

**Fix:** switch to the modern \`sourcemaps inject\` + \`sourcemaps upload --release\` flow. A new Forge \`packageAfterCopy\` hook calls \`sentry-cli sourcemaps inject\` on the staging dir (after plugin-vite's build, before asar pack), then mirrors the modified files back to source \`.vite/\` so the workflow's later upload step uploads debug-id-bearing maps. Sentry resolves stack frames by debug-id, sidestepping URL conventions entirely.

\`prePackage\` was the wrong hook — Forge runs user hooks before plugin-vite's build, so \`.vite/\` doesn't exist yet at that point. \`packageAfterCopy\` fires after staging, with the temp build path passed in.

### Crash regression — main bundle threw on launch

Verifying the local build I hit \`TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string … Received undefined\` at \`fileURLToPath\` before \`app.ready\`. Source was \`apps/desktop/src/main/windows/factory.ts:15\` — \`dirname(fileURLToPath(import.meta.url))\`. In our Vite CJS output, Rollup strips \`import.meta\` to \`{}\`, so \`fileURLToPath({}.url) === fileURLToPath(undefined)\` throws. (rc.2 worked because Rollup polyfilled \`import.meta.url\` to \`typeof document>"u"?require("./bootstrap.js").url:document.currentScript.url\`; something between rc.2 and now stopped that — likely fallout from \`sourcemap: true\` in PR #640.)

**Fix:** \`__dirname\` (CJS-native, reliable) with a \`biome-ignore\` for \`noGlobalDirnameFilename\`. Biome's suggested fix \`import.meta.dirname\` gets stripped to \`{}.dirname\` the same way — also broken.

## Test plan

- [x] \`pnpm --filter @lightfast/desktop typecheck\` clean
- [x] \`pnpm exec biome check\` clean on all five changed files
- [x] Local \`pnpm package\` (with \`SENTRY_AUTH_TOKEN\` set) emits 5 .map files, all with matching \`//# debugId=<uuid>\` comments + \`debug_id\` keys in \`.map\` JSON; the packaged \`Lightfast.app\`'s asar carries the SAME debug-ids (verified UUID-by-UUID).
- [x] Installed local build launches cleanly (no \`fileURLToPath\` crash); CDP binds via \`--remote-debugging-port=9222\`.
- [ ] CI green
- [ ] Cut \`@lightfast/desktop@0.1.0-rc.3\` after merge. Expected: sentry-cli upload report shows each \`.js\` paired with \`.map\` (was already true post-PR #640 but now also with debug-ids); manual smoke test produces a Sentry issue with a fully symbolicated stack frame resolving to \`apps/desktop/src/...\`; \`signingMode: ad-hoc\` tag wired.

## Bug-trail

Tracking the dry-run finds:

| # | Surface | Status |
|---|---|---|
| A | Sentry release id contained \`/\` | ✅ fixed (#639) |
| B | Forge tagPrefix defaulted to \`v\` | ✅ fixed (#639) |
| C | Vite emitted no \`.map\` files | ✅ fixed (#640) |
| F | Renderer SDK CSP-blocked (this PR) | ✅ |
| E | No debug-id injection (this PR) | ✅ |
| Regression | factory.ts \`fileURLToPath(import.meta.url)\` crash (this PR) | ✅ |
| D (latent) | \`LIGHTFAST_REMOTE_DEBUG_PORT\` env doesn't bind CDP in packaged build | follow-up |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Sentry error tracking integration for the desktop application with improved sourcemap handling.

* **Chores**
  * Updated build configuration for better error tracking and debugging capabilities.
  * Optimized sourcemap upload workflow for improved error resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->