### PR TITLE
fix(desktop): create Sentry release before finalize

### DIFF
--- a/apps/desktop/scripts/upload-sourcemaps.mjs
+++ b/apps/desktop/scripts/upload-sourcemaps.mjs
@@ -38,11 +38,16 @@ function sentry(args) {
 }
 
 // Modern artifact-bundle flow with debug-id matching. `sourcemaps inject`
-// runs in `forge.config.ts`'s prePackage hook so the injected //# debugId=
-// comments land in the asar; here we only `upload`. Stack frames in Sentry
-// resolve via debug-id, which avoids URL-prefix mismatches between the
-// uploaded path (`assets/index-*.js`) and the runtime frame
+// runs in `forge.config.ts`'s `packageAfterCopy` hook so the injected
+// //# debugId= comments land in the asar; here we only `upload`. Stack
+// frames in Sentry resolve via debug-id, sidestepping URL-prefix mismatches
+// between the uploaded path (`assets/index-*.js`) and the runtime frame
 // (`app:///.vite/renderer/main_window/assets/index-*.js`).
+//
+// `sourcemaps upload --release` writes the artifact bundle but does NOT
+// create the release entity. `releases new` is required before finalize,
+// otherwise finalize errors with "Release not found".
+sentry(["releases", "new", release]);
 sentry(["sourcemaps", "upload", "--release", release, buildDir]);
 sentry(["sourcemaps", "upload", "--release", release, rendererDir]);
 sentry(["releases", "finalize", release]);


### PR DESCRIPTION
## Summary

PR #641 dropped \`sentry-cli releases new\` from the upload flow, assuming \`sourcemaps upload --release X\` would auto-create the release entity. It doesn't — it uploads the artifact bundle and tags it, but the release record itself stays absent. \`releases finalize\` then errors with **\"Release not found\"** and the workflow fails after sourcemaps have already uploaded.

Failed run: [25420266590](https://github.com/lightfastai/lightfast/actions/runs/25420266590)

## Fix

Restore \`sentry-cli releases new <release>\` as the first step. Full flow: new → upload (main) → upload (renderer) → finalize.

## Test plan

- [x] \`node --check apps/desktop/scripts/upload-sourcemaps.mjs\` clean
- [ ] CI green
- [ ] Re-cut rc.3: artifact bundles uploaded with debug-ids (proven in failing run); release entity exists; finalize succeeds; workflow undrafts the release; \`latest-mac-{arm64,x64}.json\` Sparkle feeds present in the 6-asset release