### PR TITLE
fix(desktop/dev): auto-inject NODE_EXTRA_CA_CERTS for portless TLS trust

### DIFF
--- a/scripts/with-desktop-env.mjs
+++ b/scripts/with-desktop-env.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolvePortlessMfeUrl } from "@lightfastai/dev-proxy";
@@ -9,6 +11,8 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
+
+const PORTLESS_CA_PATH = path.join(homedir(), ".portless", "ca.pem");
 const args = process.argv.slice(2);
 
 if (args[0] === "--") {
@@ -43,10 +47,49 @@ child.on("exit", (code, signal) => {
 });
 
 function buildEnv() {
+  const appOrigin = resolveDesktopAppOrigin(process.env);
   return {
     ...process.env,
-    LIGHTFAST_APP_ORIGIN: resolveDesktopAppOrigin(process.env),
+    LIGHTFAST_APP_ORIGIN: appOrigin,
+    ...portlessNodeCaEnv(appOrigin, process.env),
   };
+}
+
+// Electron's main process inherits Node's undici fetch as the `fetch`
+// global, and Node's CA bundle does not include portless's local root
+// (~/.portless/ca.pem). Any HTTPS request from main against the dev
+// aggregate (https://*.localhost) therefore fails the TLS handshake
+// with SELF_SIGNED_CERT_IN_CHAIN. lightfast-dev's `proxy app-runtime`
+// already injects NODE_EXTRA_CA_CERTS for the next-dev child for the
+// same reason — mirror that here so a fresh contributor shell doesn't
+// need the env var pre-exported in shellrc.
+//
+// Longer-term, the more architecturally correct fix is to switch the
+// main-process fetch in apps/desktop/src/main/auth-flow.ts (and any
+// future Node fetches) to Electron's `net.fetch` from `electron`'s
+// `net` module, which routes through Chromium's networking and trusts
+// the macOS keychain. That removes the need for this env injection.
+// Tracked in
+// thoughts/shared/research/2026-05-06-desktop-exchange-tls-portless.md.
+function portlessNodeCaEnv(appOrigin, env) {
+  if (env.NODE_EXTRA_CA_CERTS) {
+    return {};
+  }
+  let hostname;
+  try {
+    hostname = new URL(appOrigin).hostname;
+  } catch {
+    return {};
+  }
+  const isLocalhost =
+    hostname === "localhost" || hostname.endsWith(".localhost");
+  if (!isLocalhost) {
+    return {};
+  }
+  if (!existsSync(PORTLESS_CA_PATH)) {
+    return {};
+  }
+  return { NODE_EXTRA_CA_CERTS: PORTLESS_CA_PATH };
 }
 
 function resolveDesktopAppOrigin(env) {
@@ -75,4 +118,7 @@ function toOrigin(rawUrl, label) {
 
 function printEnv(env) {
   console.log(`LIGHTFAST_APP_ORIGIN=${env.LIGHTFAST_APP_ORIGIN}`);
+  if (env.NODE_EXTRA_CA_CERTS) {
+    console.log(`NODE_EXTRA_CA_CERTS=${env.NODE_EXTRA_CA_CERTS}`);
+  }
 }

--- a/thoughts/shared/research/2026-05-06-desktop-exchange-tls-portless.md
+++ b/thoughts/shared/research/2026-05-06-desktop-exchange-tls-portless.md
@@ -1,0 +1,56 @@
+---
+date: 2026-05-06
+researcher: claude
+git_commit: bf1699fa5
+branch: fix/coderabbit-pr614-followup
+topic: Desktop /api/desktop/auth/exchange POST fails TLS verification against portless dev mesh
+tags: [desktop, auth, portless, tls, dev-experience]
+status: open
+related_pr: 627
+related_plans:
+  - thoughts/shared/plans/2026-05-06-pr627-merge-readiness.md
+---
+
+# Desktop exchange POST + portless TLS — DX follow-up
+
+Surfaced during PR 627 post-merge live verification on 2026-05-06.
+
+## Symptom
+
+`pnpm dev:desktop` (agent mode or interactive) signs the user in via the browser, dispatches `lightfast-dev://auth/callback?code=...&state=...`, the desktop receives it, then emits `auth_signin_failed{reason:"exchange_failed"}`. The `/api/desktop/auth/exchange` POST never reaches the dev:app server.
+
+## Cause
+
+Electron main's global `fetch` is Node's undici. It uses Node's bundled CA list, which does not include the portless local root at `~/.portless/ca.pem`. Direct repro:
+
+```
+node -e 'fetch("https://lightfast.localhost/api/desktop/auth/exchange",{method:"POST",headers:{"Content-Type":"application/json"},body:"{}"}).then(r=>console.log(r.status)).catch(e=>console.error(e.code,e.cause?.code))'
+# → undefined SELF_SIGNED_CERT_IN_CHAIN
+```
+
+`curl` and Chromium succeed because they trust the macOS keychain (where portless installs the root). Node does not.
+
+## Why it bit PR 627
+
+Commit `ad7d1641e` (PR 627) migrated `exchangeCode` from the legacy `http://localhost:3024` (no TLS) to `createAppUrl("/api/desktop/auth/exchange")` → `https://lightfast.localhost/...`. Sign-in URL composition (`createAppUrl(...)`) was already on portless but goes through Chromium (browser dispatch), not Node.
+
+The previous "Re-verified end-to-end with no LIGHTFAST_API_URL set" claim in `ad7d1641e` must have run with `NODE_EXTRA_CA_CERTS` exported in the shell. Without that env var, the exchange POST silently fails on every fresh dev shell.
+
+## Workaround (today)
+
+```sh
+NODE_EXTRA_CA_CERTS="$HOME/.portless/ca.pem" pnpm dev:desktop
+```
+
+Verified end-to-end on `bf1699fa5`: `auth_signed_in` event, token persisted to `auth.bin` (851 bytes).
+
+## Durable fixes (pick one)
+
+1. **`scripts/with-desktop-env.mjs` auto-injection.** When `LIGHTFAST_APP_ORIGIN` resolves to a `*.localhost` host AND `~/.portless/ca.pem` exists, set `NODE_EXTRA_CA_CERTS` on the spawned env. Easiest, narrowest blast radius. Doesn't touch desktop source. Does not help if a future Node-fetch call uses a different cert path.
+2. **Switch `auth-flow.ts:248` to Electron's `net.fetch`.** `net.fetch` from `electron`'s `net` module routes through Chromium's networking, which honors the macOS keychain — same trust path the bridge already uses. Architecturally correct (Electron-native), but slightly more invasive: changes return-type semantics in subtle ways and may need test adjustments.
+
+Recommendation: option 2 longer-term, option 1 as immediate unblock if option 2 proves disruptive in tests.
+
+## Out of scope
+
+Production builds use real public certs (Let's Encrypt or platform CA), so this is a dev-only path. Packaged Electron releases are unaffected.


### PR DESCRIPTION
## Summary

Auto-inject `NODE_EXTRA_CA_CERTS=$HOME/.portless/ca.pem` into the Electron child env when `LIGHTFAST_APP_ORIGIN` resolves to a `*.localhost` host and the CA file exists. Mirrors the injection `lightfast-dev proxy app-runtime` already does for the next-dev child.

## Why

Electron main inherits Node's undici fetch as the global `fetch`. Node's bundled CA list does not include portless's local root, so HTTPS calls from desktop main to the dev aggregate (`https://*.localhost`) fail TLS handshake with `SELF_SIGNED_CERT_IN_CHAIN`.

Concrete failure: the PKCE exchange POST in `apps/desktop/src/main/auth-flow.ts` (`/api/desktop/auth/exchange`) silently fails for any contributor running `pnpm dev:desktop` from a fresh shell with no `NODE_EXTRA_CA_CERTS` exported, surfacing only as `auth_signin_failed{reason:"exchange_failed"}` with no other diagnostic.

This was surfaced by PR #627 post-merge live verification (commit `bf1699fa5`). Standalone reproducer from a strictly scrubbed env:

```sh
env -i HOME=$HOME PATH=$PATH \
  node -e 'fetch("https://lightfast.localhost/...").catch(e => console.error(e.cause?.code))'
# → SELF_SIGNED_CERT_IN_CHAIN

env -i HOME=$HOME PATH=$PATH NODE_EXTRA_CA_CERTS=$HOME/.portless/ca.pem \
  node -e 'fetch("https://lightfast.localhost/...").then(r => console.log(r.status))'
# → 404 (TLS succeeded, request reached server)
```

## Behavior

`scripts/with-desktop-env.mjs --print` results across three cases:

| Parent env | Resolved origin | Output |
|---|---|---|
| empty | `https://lightfast.localhost` | injects `NODE_EXTRA_CA_CERTS=~/.portless/ca.pem` |
| `NODE_EXTRA_CA_CERTS=/tmp/x.pem` | `https://lightfast.localhost` | passes through `/tmp/x.pem` (no override) |
| empty | `https://app.lightfast.ai` | no-op (hostname not `*.localhost`) |

Also no-op when `~/.portless/ca.pem` does not exist (contributor without portless installed).

## Future work

The architecturally correct fix is to switch the desktop main-process `fetch` (currently only one call site, `auth-flow.ts:248`) to Electron's `net.fetch`, which routes through Chromium's networking and trusts the macOS keychain. That would obviate this env injection entirely. Tracked in `thoughts/shared/research/2026-05-06-desktop-exchange-tls-portless.md` (added in this PR).

## Test plan

- [x] `node scripts/with-desktop-env.mjs --print` from clean shell → injects
- [x] Same with `NODE_EXTRA_CA_CERTS` already set in parent → respects parent
- [x] Same with `LIGHTFAST_APP_ORIGIN=https://app.lightfast.ai` → no-op
- [ ] Live PKCE flow on a fresh shell without `NODE_EXTRA_CA_CERTS` exported reaches `auth_signed_in` (covered by PR 627 verification + this script change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)