### PR TITLE
ci(desktop-release): use package-style release title

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -67,7 +67,7 @@ jobs:
               --repo "${{ github.repository }}" \
               --draft \
               "${prerelease_flag[@]}" \
-              --title "Lightfast desktop v${{ steps.ver.outputs.version }}" \
+              --title "lightfast@${{ steps.ver.outputs.version }}" \
               "${notes_arg[@]}"
           fi
 


### PR DESCRIPTION
## Summary

Future \`@lightfast/desktop@*\` tag pushes will now produce GitHub release titles in the format \`lightfast@<version>\`, matching the convention I applied retrospectively to the four ad-hoc dry-run RCs (renamed via \`gh release edit\` to \`lightfast@0.1.0-alpha.1\` through \`lightfast@0.1.0-alpha.4\`).

Tag names are unchanged — only the human-facing title rendered on the release page.

## Test plan

- [x] Diff is one line in \`.github/workflows/desktop-release.yml\`
- [ ] Confirmed by next tag push: cutting \`@lightfast/desktop@0.1.0-alpha.5\` produces a release titled \`lightfast@0.1.0-alpha.5\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release naming format for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->