### PR TITLE
feat(desktop): linux makers + ci matrix; also extend mac attestation to .dmg

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -30,9 +30,13 @@ permissions:
 
 jobs:
   package:
-    name: Typecheck + package (unsigned)
-    runs-on: macos-14
+    name: Typecheck + package (unsigned, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, ubuntu-22.04]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -48,10 +52,20 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Install Linux maker prerequisites
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y rpm fakeroot
+          # Fail fast if the runner image (x64 or arm) is missing any tool
+          which dpkg-deb fakeroot rpm rpmbuild
+
       - run: pnpm install --frozen-lockfile
 
       - name: Typecheck
         run: pnpm --filter @lightfast/desktop typecheck
 
       - name: Package (unsigned)
+        # electron-forge defaults to host platform: macOS leg packages darwin
+        # via MakerZIP/MakerDMG, Linux leg packages linux via MakerDeb/MakerRpm.
+        # Each maker's platform filter (forge.config.ts:143-152) does the routing.
         run: pnpm --filter @lightfast/desktop package

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -71,8 +71,8 @@ jobs:
               "${notes_arg[@]}"
           fi
 
-  build:
-    name: Build ${{ matrix.arch }}
+  build_macos:
+    name: Build macOS ${{ matrix.arch }}
     needs: prepare
     runs-on: macos-14
     timeout-minutes: 60
@@ -166,11 +166,83 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'apps/desktop/out/make/**/*.zip'
+          subject-path: |
+            apps/desktop/out/make/**/*.zip
+            apps/desktop/out/make/**/*.dmg
+
+  build_linux:
+    name: Build Linux ${{ matrix.arch }}
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Intentionally no Sentry env vars: sourcemap upload runs on the mac
+      # leg only. Sentry's debug-id system dedupes server-side and the
+      # renderer/main JS source is identical across platforms, so a second
+      # upload would be duplicated work, not added coverage.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Linux maker prerequisites
+        run: |
+          sudo apt-get update && sudo apt-get install -y rpm fakeroot
+          # Fail fast if the runner image (x64 or arm) is missing any tool
+          which dpkg-deb fakeroot rpm rpmbuild
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Stamp version, buildFlavor, buildNumber, signingMode, prerelease env
+        working-directory: apps/desktop
+        run: |
+          npm version "${{ needs.prepare.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm pkg set buildFlavor=prod
+          npm pkg set buildNumber="$GITHUB_RUN_NUMBER"
+          # `signingMode=ad-hoc` keeps build-info shape platform-uniform.
+          # `updater.ts:32-42` returns null on Linux today, so this field is
+          # not yet load-bearing. The future Linux Sparkle PR will read it as
+          # the safe-default guard (same pattern as the mac path). Delete this
+          # line if/when Linux Sparkle introduces a Linux-specific signing scheme.
+          npm pkg set signingMode=ad-hoc
+          echo "LIGHTFAST_DESKTOP_RELEASE_PRERELEASE=${{ needs.prepare.outputs.prerelease }}" >> "$GITHUB_ENV"
+
+      - name: Publish (forge)
+        working-directory: apps/desktop
+        run: pnpm exec electron-forge publish --arch=${{ matrix.arch }} --platform=linux
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            apps/desktop/out/make/**/*.deb
+            apps/desktop/out/make/**/*.rpm
 
   finalize:
     name: Finalize release
-    needs: [prepare, build]
+    needs: [prepare, build_macos, build_linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -27,6 +27,28 @@ auto-update is disabled on ad-hoc builds because Squirrel.Mac requires the
 new build to match the running app's designated requirement, and ad-hoc DRs
 are content-bound (they change with every build).
 
+### Linux
+
+Download the artifact for your distribution and architecture from the latest
+[Pre-release](https://github.com/lightfastai/lightfast/releases?q=prerelease%3Atrue):
+
+- **Debian / Ubuntu**: `lightfast_<version>_amd64.deb` (Intel/AMD) or
+  `lightfast_<version>_arm64.deb` (ARM)
+- **Fedora / RHEL / openSUSE**: `lightfast-<version>.x86_64.rpm` (Intel/AMD) or
+  `lightfast-<version>.aarch64.rpm` (ARM)
+
+Install via your package manager:
+
+```bash
+# Debian/Ubuntu
+sudo apt install ./lightfast_<version>_amd64.deb
+
+# Fedora/RHEL
+sudo dnf install ./lightfast-<version>.x86_64.rpm
+```
+
+Linux auto-update is not yet wired — re-download manually for new versions.
+
 ## Run
 
 ```bash
@@ -155,10 +177,17 @@ The `Release desktop` workflow then:
 1. Creates a draft GitHub Release for the tag.
 2. Builds signed+notarized ZIP and DMG artifacts for both `arm64` and `x64`
    via `electron-forge publish` on `macos-14`.
-3. Generates `latest-mac-<arch>.json` (Squirrel.Mac feed format) and uploads
-   them to the release. The app's updater points at
-   `releases/latest/download/latest-mac-${arch}.json`.
-4. Undrafts the release.
+3. Builds `.deb` and `.rpm` artifacts for both `arm64` and `x64` via
+   `electron-forge publish` on `ubuntu-22.04` / `ubuntu-22.04-arm`.
+4. Generates `latest-mac-<arch>.json` (Squirrel.Mac feed). Linux auto-update
+   is deferred, so no Linux feed is emitted yet — Linux users re-download
+   manually for new versions.
+5. Undrafts the release.
+
+We ship per-arch artifacts (no universal-binary merge on macOS) — users pick
+the matching arch. Rationale: the merge doubles download size, Linux has no
+universal concept, and the per-arch `.deb`/`.rpm` packages already encode the
+right architecture for `apt`/`dnf`.
 
 ### Required GitHub secrets
 

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -2,7 +2,9 @@ import { execFileSync } from "node:child_process";
 import { cpSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
+import { MakerDeb } from "@electron-forge/maker-deb";
 import { MakerDMG } from "@electron-forge/maker-dmg";
+import { MakerRpm } from "@electron-forge/maker-rpm";
 import { MakerSquirrel } from "@electron-forge/maker-squirrel";
 import { MakerZIP } from "@electron-forge/maker-zip";
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
@@ -149,6 +151,34 @@ const config: ForgeConfig = {
     new MakerDMG({
       format: "ULFO",
     }),
+    new MakerDeb(
+      {
+        options: {
+          name: "lightfast",
+          productName: "Lightfast",
+          genericName: "Developer Tool",
+          maintainer: "Lightfast <releases@lightfast.ai>",
+          homepage: "https://lightfast.ai",
+          categories: ["Development", "Utility"],
+          icon: resolve(import.meta.dirname, "build/icon.png"),
+        },
+      },
+      ["linux"]
+    ),
+    new MakerRpm(
+      {
+        options: {
+          name: "lightfast",
+          productName: "Lightfast",
+          genericName: "Developer Tool",
+          license: "MIT",
+          homepage: "https://lightfast.ai",
+          categories: ["Development", "Utility"],
+          icon: resolve(import.meta.dirname, "build/icon.png"),
+        },
+      },
+      ["linux"]
+    ),
   ],
   plugins: [
     new AutoUnpackNativesPlugin({}),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,7 +17,9 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
+    "@electron-forge/maker-deb": "^7.11.1",
     "@electron-forge/maker-dmg": "^7.11.1",
+    "@electron-forge/maker-rpm": "^7.11.1",
     "@electron-forge/maker-squirrel": "^7.11.1",
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -747,7 +747,13 @@ importers:
       '@electron-forge/cli':
         specifier: ^7.11.1
         version: 7.11.1(encoding@0.1.13)(esbuild@0.27.3)
+      '@electron-forge/maker-deb':
+        specifier: ^7.11.1
+        version: 7.11.1
       '@electron-forge/maker-dmg':
+        specifier: ^7.11.1
+        version: 7.11.1
+      '@electron-forge/maker-rpm':
         specifier: ^7.11.1
         version: 7.11.1
       '@electron-forge/maker-squirrel':
@@ -3191,8 +3197,16 @@ packages:
     resolution: {integrity: sha512-yhZrCGoN6bDeiB5DHFaueZ1h84AReElEj+f0hl2Ph4UbZnO0cnLpbx+Bs+XfMLAiA+beC8muB5UDK5ysfuT9BQ==}
     engines: {node: '>= 16.4.0'}
 
+  '@electron-forge/maker-deb@7.11.1':
+    resolution: {integrity: sha512-QTYiryQLYPDkq6pIfBmx0GQ6D8QatUkowH7rTlW5MnCUa0uumX0Xu7yGIjesuwW37fxT3Lv4xi+FSXMCm2eC1w==}
+    engines: {node: '>= 16.4.0'}
+
   '@electron-forge/maker-dmg@7.11.1':
     resolution: {integrity: sha512-7zs5/Ewz1PcOl4N1102stFgBiFGWxU18+UPFUSd/fgf9MErBl4HBWuVNMIHyeJ/56rdfkcmTxTqE+9TBEYrZcg==}
+    engines: {node: '>= 16.4.0'}
+
+  '@electron-forge/maker-rpm@7.11.1':
+    resolution: {integrity: sha512-iEfJPRQQyaTqk2EbUfZgulChNWvxGXeYUH0xBX/r5cj1pL4vcJXt3jLMQBVn3mk/0Ytv9UWRs8R/XuNWX6sf2w==}
     engines: {node: '>= 16.4.0'}
 
   '@electron-forge/maker-squirrel@7.11.1':
@@ -4654,6 +4668,10 @@ packages:
     peerDependencies:
       next: '>=15.0'
       react: ^19.2.5
+
+  '@malept/cross-spawn-promise@1.1.1':
+    resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
+    engines: {node: '>= 10'}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -8631,6 +8649,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/fs-extra@9.0.13':
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -9672,6 +9693,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -10393,9 +10417,25 @@ packages:
     resolution: {integrity: sha512-USiB9816d2JzKv0LiSbreRfTg5lDk3lWh0vlx/gugCO92ZIJkHVH0UM18EHvKeadErP6Xn4yiTphWzYfbA2Ong==}
     engines: {node: '>=18'}
 
+  electron-installer-common@0.10.4:
+    resolution: {integrity: sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q==}
+    engines: {node: '>= 10.0.0'}
+
+  electron-installer-debian@3.2.0:
+    resolution: {integrity: sha512-58ZrlJ1HQY80VucsEIG9tQ//HrTlG6sfofA3nRGr6TmkX661uJyu4cMPPh6kXW+aHdq/7+q25KyQhDrXvRL7jw==}
+    engines: {node: '>= 10.0.0'}
+    os: [darwin, linux]
+    hasBin: true
+
   electron-installer-dmg@5.0.1:
     resolution: {integrity: sha512-qOa1aAQdX57C+vzhDk3549dd/PRlNL4F8y736MTD1a43qptD+PvHY97Bo9gSf+OZ8iUWE7BrYSpk/FgLUe40EA==}
     engines: {node: '>= 16'}
+    hasBin: true
+
+  electron-installer-redhat@3.4.0:
+    resolution: {integrity: sha512-gEISr3U32Sgtj+fjxUAlSDo3wyGGq6OBx7rF5UdpIgbnpUvMN4W5uYb0ThpnAZ42VEJh/3aODQXHbFS4f5J3Iw==}
+    engines: {node: '>= 10.0.0'}
+    os: [darwin, linux]
     hasBin: true
 
   electron-is-dev@3.0.1:
@@ -11149,6 +11189,10 @@ packages:
     resolution: {integrity: sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==}
     engines: {node: '>= 12'}
 
+  gar@1.0.4:
+    resolution: {integrity: sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
@@ -11187,6 +11231,10 @@ packages:
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
+
+  get-folder-size@2.0.1:
+    resolution: {integrity: sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==}
+    hasBin: true
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -14265,6 +14313,9 @@ packages:
     resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
     engines: {node: '>=10'}
 
+  tiny-each-async@2.0.3:
+    resolution: {integrity: sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -14296,9 +14347,16 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
+  tmp-promise@3.0.3:
+    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   tn1150@0.1.0:
     resolution: {integrity: sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==}
@@ -14878,6 +14936,10 @@ packages:
   wildcard-match@5.1.4:
     resolution: {integrity: sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==}
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -14982,6 +15044,10 @@ packages:
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -16158,6 +16224,16 @@ snapshots:
       - bluebird
       - supports-color
 
+  '@electron-forge/maker-deb@7.11.1':
+    dependencies:
+      '@electron-forge/maker-base': 7.11.1
+      '@electron-forge/shared-types': 7.11.1
+    optionalDependencies:
+      electron-installer-debian: 3.2.0
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   '@electron-forge/maker-dmg@7.11.1':
     dependencies:
       '@electron-forge/maker-base': 7.11.1
@@ -16165,6 +16241,16 @@ snapshots:
       fs-extra: 10.1.0
     optionalDependencies:
       electron-installer-dmg: 5.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  '@electron-forge/maker-rpm@7.11.1':
+    dependencies:
+      '@electron-forge/maker-base': 7.11.1
+      '@electron-forge/shared-types': 7.11.1
+    optionalDependencies:
+      electron-installer-redhat: 3.4.0
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -17464,6 +17550,11 @@ snapshots:
       react: 19.2.5
       use-deep-compare: 1.3.0(react@19.2.5)
       whatwg-fetch: 3.6.20
+
+  '@malept/cross-spawn-promise@1.1.1':
+    dependencies:
+      cross-spawn: 7.0.6
+    optional: true
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -21856,6 +21947,11 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/fs-extra@9.0.13':
+    dependencies:
+      '@types/node': 25.3.3
+    optional: true
+
   '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
@@ -23098,6 +23194,13 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    optional: true
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -23743,6 +23846,37 @@ snapshots:
       pupa: 3.3.0
       unused-filename: 4.0.1
 
+  electron-installer-common@0.10.4:
+    dependencies:
+      '@electron/asar': 3.4.1
+      '@malept/cross-spawn-promise': 1.1.1
+      debug: 4.4.3
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      lodash: 4.18.1
+      parse-author: 2.0.0
+      semver: 7.7.4
+      tmp-promise: 3.0.3
+    optionalDependencies:
+      '@types/fs-extra': 9.0.13
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  electron-installer-debian@3.2.0:
+    dependencies:
+      '@malept/cross-spawn-promise': 1.1.1
+      debug: 4.4.3
+      electron-installer-common: 0.10.4
+      fs-extra: 9.1.0
+      get-folder-size: 2.0.1
+      lodash: 4.18.1
+      word-wrap: 1.2.5
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   electron-installer-dmg@5.0.1:
     dependencies:
       '@types/appdmg': 0.5.5
@@ -23750,6 +23884,19 @@ snapshots:
       minimist: 1.2.8
     optionalDependencies:
       appdmg: 0.6.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  electron-installer-redhat@3.4.0:
+    dependencies:
+      '@malept/cross-spawn-promise': 1.1.1
+      debug: 4.4.3
+      electron-installer-common: 0.10.4
+      fs-extra: 9.1.0
+      lodash: 4.18.1
+      word-wrap: 1.2.5
+      yargs: 16.2.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -24674,6 +24821,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gar@1.0.4:
+    optional: true
+
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
@@ -24713,6 +24863,12 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
+
+  get-folder-size@2.0.1:
+    dependencies:
+      gar: 1.0.4
+      tiny-each-async: 2.0.3
+    optional: true
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -28514,6 +28670,9 @@ snapshots:
     dependencies:
       convert-hrtime: 3.0.0
 
+  tiny-each-async@2.0.3:
+    optional: true
+
   tiny-invariant@1.3.3: {}
 
   tiny-warning@1.0.3:
@@ -28540,9 +28699,17 @@ snapshots:
       tldts-core: 7.0.28
     optional: true
 
+  tmp-promise@3.0.3:
+    dependencies:
+      tmp: 0.2.5
+    optional: true
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
+
+  tmp@0.2.5:
+    optional: true
 
   tn1150@0.1.0:
     dependencies:
@@ -29247,6 +29414,9 @@ snapshots:
 
   wildcard-match@5.1.4: {}
 
+  word-wrap@1.2.5:
+    optional: true
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -29314,6 +29484,17 @@ snapshots:
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+    optional: true
 
   yargs@17.7.2:
     dependencies:

--- a/thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
+++ b/thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
@@ -53,7 +53,8 @@ Legend: **DONE** = landed on `main` · **DEFERRED** = intentionally out of scope
 | 2 | Explicit `crashReporter.start({uploadToServer:false})` | **DEFERRED** | `@sentry/electron` already handles Crashpad; skip to avoid double-init |
 | 3 | Persistent SQLite storage | **DEFERRED** | No consumer yet |
 | 4 | Worker / utility-process tier | **DEFERRED** | No workload demands it yet |
-| 5 | Windows MSIX + Linux makers | **RELEASE** | Deferred past v0.1.0 (macOS only for first release) |
+| 5 | Linux makers (deb/rpm) + CI matrix | **DONE** | W3 — `MakerDeb`/`MakerRpm` registered with `["linux"]` gating in `forge.config.ts`; `desktop-ci.yml` runs `[macos-14, ubuntu-22.04]` matrix; `desktop-release.yml` adds `build_linux` job on `[ubuntu-22.04, ubuntu-22.04-arm]` for x64+arm64 with `.deb`/`.rpm` attestation. Linux Sparkle / `latest-linux-*.json` deferred to the macOS Sparkle PR (§1). |
+| 5 | Windows MSIX + EV-cert signing | **RELEASE** | Separate external-blocker track (Windows EV cert procurement); not part of W3. |
 | 6 | Multi-arch (arm64 + x64) | **DONE** | PR #621 — `desktop-release.yml` matrix builds both arches on `macos-14`, publishes as separate `.dmg`/`.zip` per arch with separate Sparkle feeds (`latest-mac-{arm64,x64}.json`). No universal merge. |
 | 6 | Universal binary merge | **DEFERRED** | `@electron/universal` not needed; two separate artifacts with `${arch}` feed template suffice. |
 | 7 | Per-surface preload isolation | **DEFERRED** | No third-party surfaces yet |


### PR DESCRIPTION
## Summary

- W3 implementation per [`thoughts/shared/plans/2026-05-06-desktop-w3-linux-makers.md`](../blob/feat/desktop-linux-makers/thoughts/shared/plans/2026-05-06-desktop-w3-linux-makers.md). Adds Linux `.deb`/`.rpm` production paths (per-arch x64 + arm64) so we can ship to Linux while macOS signing remains Apple-blocked.
- Three sequential phases, one commit each:
  - **Phase 1** — `MakerDeb` + `MakerRpm` registered in `forge.config.ts` with explicit `["linux"]` platform gating; devDeps + lockfile updated.
  - **Phase 2** — `desktop-ci.yml` expands to a `[macos-14, ubuntu-22.04]` matrix so Linux maker regressions surface on PRs.
  - **Phase 3** — `desktop-release.yml` splits `build` into `build_macos` (rename, no behavior change) + new `build_linux` job on `[ubuntu-22.04, ubuntu-22.04-arm]`. README + parent-doc Status Tracker updated.
- **Bundled mac-side change (called out per plan §3):** the existing mac attestation glob is extended from `*.zip` alone to `*.zip + *.dmg`. The DMG is a release artifact too and should carry the same provenance attestation the ZIP already does.
- **Intentional non-changes:** `generate-update-feed.mjs` stays mac-only — Linux Sparkle is FULL DEFER per parent doc §1, and `updater.ts` returns `null` on Linux, so there is no in-app consumer for a `latest-linux-*.json` feed yet. The future Linux Sparkle PR will define the real consumer contract.
- **Out of scope (see `What We're NOT Doing` in the plan):** Windows MSIX, Linux package signing, hosted apt/yum repository, Linux Sparkle, Linux Sentry sourcemap upload (mac leg already uploads via debug-id; server-side dedupes).

## Local verification

- Phase 1: `pnpm install --frozen-lockfile` ✓ · `typecheck` ✓ · `test` ✓ (38 tests across 3 files) · `pnpm package` ✓ · `pnpm make --platform=darwin --arch=arm64` produced exactly `Lightfast-0.0.0-arm64.dmg` + `zip/darwin/arm64/Lightfast-darwin-arm64-0.0.0.zip` — zero Linux artifacts leaked into the mac path despite `MakerSquirrel`/`MakerDMG` lacking explicit platform filters.
- Phase 2 + 3 workflows: parsed cleanly via `js-yaml`. `build_macos.matrix` unchanged; `build_linux.matrix` uses `include:` form pairing `x64↔ubuntu-22.04` and `arm64↔ubuntu-22.04-arm`. `finalize.needs = [prepare, build_macos, build_linux]`.

## Branch protection note

The `build` → `build_macos` rename changes the required-status-check name. **Before merging, verify** `Desktop release / build` is not currently a required check on `main` — if it is, update the rule to `Desktop release / build_macos` (and add `Desktop release / build_linux`). Memory state suggests only `Desktop CI / Typecheck + package (unsigned)` is required, so no rule update is expected, but verify.

## Test plan

- [ ] **Desktop CI matrix (this PR)** — both `Typecheck + package (unsigned, macos-14)` and `Typecheck + package (unsigned, ubuntu-22.04)` legs go green; the Linux leg's package log shows electron-forge selecting `MakerDeb` + `MakerRpm`.
- [ ] **Release pipeline rc dry-run (post-merge)** — push `@lightfast/desktop@0.1.0-rc.5`; workflow goes green on `prepare`, both `build_macos` arch legs, both `build_linux` arch legs, and `finalize`.
- [ ] **Linux artifact set** — draft release shows 4 new Linux binaries: `lightfast_<version>_amd64.deb`, `lightfast_<version>_arm64.deb`, `lightfast-<version>.x86_64.rpm`, `lightfast-<version>.aarch64.rpm`. No `latest-linux-*.json` files (intentional).
- [ ] **Attestations** — `gh attestation list --owner lightfastai` shows attestations for the 4 Linux binaries and (now) the 2 mac `.dmg` artifacts.
- [ ] **No-install metadata** — `dpkg-deb -I lightfast_<version>_amd64.deb` shows `Maintainer: Lightfast <releases@lightfast.ai>`, `Homepage: https://lightfast.ai`. `rpm -qpi lightfast-<version>.x86_64.rpm` shows `License : MIT`, `URL : https://lightfast.ai`.
- [ ] **Linux install (real VM, needs DISPLAY)** — `sudo apt install ./lightfast_<version>_amd64.deb` on Ubuntu 22.04 launches the primary window; `sudo dnf install ./lightfast-<version>.x86_64.rpm` on Fedora launches the primary window.
- [ ] **Sign-in flow on Linux** — `lightfast://` deep-link / PKCE callback completes on at least one Linux install; primary window flips to signed-in.

## Follow-up

- After rc dry-run passes: flip the W3 row in [`thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md`](../blob/main/thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md) to "landed" (intentionally deferred from this PR per the plan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Linux support to the desktop application with platform-specific packaging.
  * Enhanced build and release processes to automatically generate packages for both macOS and Linux platforms.

* **Documentation**
  * Added Linux installation instructions and package management guidance to the desktop application guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->