### PR TITLE
chore(ci): drop custom bot secret names; use defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.LIGHTFAST_RELEASE_BOT_GITHUB_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -68,8 +67,8 @@ jobs:
           publish: pnpm changeset publish
           setupGitUser: false
         env:
-          GITHUB_TOKEN: ${{ secrets.LIGHTFAST_RELEASE_BOT_GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.LIGHTFAST_RELEASE_BOT_NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Verify published versions match


### PR DESCRIPTION
## Summary

Aligns with the parallel changes on [`lightfastai/dev-harness`](https://github.com/lightfastai/dev-harness) (main) and [`lightfastai/ai-sdk` PR #1](https://github.com/lightfastai/ai-sdk/pull/1) so all three repos share the same CI surface. Two renames in \`release.yml\`:

- **\`LIGHTFAST_RELEASE_BOT_GITHUB_TOKEN\` → \`${{ secrets.GITHUB_TOKEN }}\`** (auto-injected, no setup needed). The custom bot PAT has been returning 401 \`Bad credentials\` org-wide — every \`Release\` run since 2026-04-06 has failed at the checkout step on this token. Switching to the default GITHUB_TOKEN unblocks the workflow today.
- **\`LIGHTFAST_RELEASE_BOT_NPM_TOKEN\` → \`NPM_TOKEN\`** (conventional, org-level). To be paired with a new automation token issued out of band so the actual publish step can also succeed.

## Trade-off

With the default GITHUB_TOKEN, bot-pushed commits on the "Version Packages" PR no longer auto-trigger CI runs — humans re-trigger via \`gh workflow run\` when needed. This is a known limitation; if/when a working bot PAT becomes available, swapping back is a one-line change.

## Test plan

- [ ] Confirm CI is green on this PR
- [ ] After merge, verify the next push that touches \`.changeset/\*\*\` no longer fails at checkout (it will still need \`NPM_TOKEN\` set to publish — that's a separate manual step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow security by updating authentication credentials to use standard GitHub-provided tokens instead of custom credentials, enhancing the overall release process safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->