### PR TITLE
fix(desktop): set MakerDeb/MakerRpm bin to lightfast

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -155,6 +155,13 @@ const config: ForgeConfig = {
       {
         options: {
           name: "lightfast",
+          // electron-installer-common defaults `bin` to `pkg.name`, which
+          // becomes `@lightfast/desktop` after the release workflow runs
+          // `npm version`. The actual binary on disk is `lightfast` (set via
+          // `packagerConfig.executableName` above). Without this override the
+          // maker fails: "could not find the Electron app binary at
+          // .../Lightfast-linux-<arch>/@lightfast/desktop".
+          bin: "lightfast",
           productName: "Lightfast",
           genericName: "Developer Tool",
           maintainer: "Lightfast <releases@lightfast.ai>",
@@ -169,6 +176,9 @@ const config: ForgeConfig = {
       {
         options: {
           name: "lightfast",
+          // Same `bin` override as MakerDeb above — electron-installer-redhat
+          // shares the same `getDefaultsFromPackageJSON` helper.
+          bin: "lightfast",
           productName: "Lightfast",
           genericName: "Developer Tool",
           license: "MIT",


### PR DESCRIPTION
## Summary

Surfaced by the [`@lightfast/desktop@0.1.0-rc.5`](https://github.com/lightfastai/lightfast/actions/runs/25435980406) dry-run after PR #650 merged: both `Build Linux x64` and `Build Linux arm64` legs failed identically at the maker step:

> could not find the Electron app binary at `.../Lightfast-linux-x64/@lightfast/desktop`

## Root cause

`electron-installer-common`'s [`getDefaultsFromPackageJSON`](https://github.com/electron-userland/electron-installer-common/blob/v0.10.4/src/defaults.js#L15) defaults `options.bin` to `pkg.name`. After the release workflow runs `npm version`, that field is `@lightfast/desktop` (the npm package name) — not the executable name. The actual binary on disk is `lightfast`, set via `packagerConfig.executableName` in `forge.config.ts:114`. The makers don't read `executableName` — they have their own `bin` option which I didn't set in PR #650.

`MakerRpm` shares the same default via `electron-installer-redhat`, so both makers fail the same way.

## Fix

Set `options.bin: "lightfast"` on both `MakerDeb` and `MakerRpm` (one line each + a comment explaining the override). No other changes.

## Why local builds missed this

`pnpm make --platform=darwin --arch=arm64` (the Phase 1 verification) only exercises mac makers. Local Linux make wasn't in the verification path; the rc dry-run was the integration test for "Linux release path produces installable artifacts" — pattern from `feedback_release_pipeline_dryrun.md` (rc.1 → rc.4 surfaced 7 bugs invisible to local builds; this is bug #1 of the rc.5 round).

## Test plan

- [x] `pnpm --filter @lightfast/desktop typecheck` passes locally
- [ ] Desktop CI matrix (`macos-14` + `ubuntu-22.04`) goes green on this PR
- [ ] After merge, push `@lightfast/desktop@0.1.0-rc.6` and confirm:
  - Both `build_linux` arch legs go green
  - Draft release shows 4 Linux binaries: `lightfast_<v>_amd64.deb`, `lightfast_<v>_arm64.deb`, `lightfast-<v>.x86_64.rpm`, `lightfast-<v>.aarch64.rpm`
  - `finalize` job runs (was skipped in rc.5)
  - Mac legs continue to pass — verify `.dmg` attestation glob extension still works (PR #650 bundled change)

## Notes for reviewer

The mac legs in rc.5 succeeded — confirms PR #650's `build` → `build_macos` rename and the `.dmg` attestation extension don't regress. The only failure was the Linux maker `bin` default, which this PR fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected binary naming in Linux package distributions (DEB and RPM) to ensure consistent executable naming across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->