### PR TITLE
feat(desktop): W1 observability tier 2 — file logger + sentry wrap

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "catalog:",
     "@repo/app-trpc": "workspace:*",
-    "@sentry/electron": "^7.11.0",
+    "@sentry/electron": "catalog:",
     "@tanstack/query-core": "^5.99.1",
     "@tanstack/react-query": "catalog:",
     "@trpc/client": "catalog:",

--- a/apps/desktop/src/main/__tests__/logger.test.ts
+++ b/apps/desktop/src/main/__tests__/logger.test.ts
@@ -1,0 +1,165 @@
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let isPackagedFlag = false;
+let mockedLogsDir = "";
+const willQuitListeners: Array<() => void> = [];
+
+vi.mock("electron", () => ({
+  app: {
+    get isPackaged() {
+      return isPackagedFlag;
+    },
+    getPath: (name: string) => {
+      if (name === "logs") {
+        return mockedLogsDir;
+      }
+      throw new Error(`unexpected getPath(${name})`);
+    },
+    on: (event: string, listener: () => void) => {
+      if (event === "will-quit") {
+        willQuitListeners.push(listener);
+      }
+    },
+  },
+}));
+
+function listLogFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        out.push(full);
+      }
+    }
+  };
+  try {
+    walk(root);
+  } catch {
+    // dir doesn't exist yet
+  }
+  return out;
+}
+
+function singleLogFile(root: string): string {
+  const files = listLogFiles(root);
+  expect(files).toHaveLength(1);
+  const [file] = files;
+  if (!file) {
+    throw new Error("expected exactly one log file");
+  }
+  return file;
+}
+
+async function loadLoggerFresh() {
+  vi.resetModules();
+  return import("../logger");
+}
+
+beforeEach(() => {
+  mockedLogsDir = mkdtempSync(join(tmpdir(), "desktop-logger-"));
+  isPackagedFlag = false;
+  willQuitListeners.length = 0;
+});
+
+afterEach(() => {
+  // close any fds left open by emitting will-quit
+  for (const listener of willQuitListeners) {
+    listener();
+  }
+  rmSync(mockedLogsDir, { recursive: true, force: true });
+});
+
+describe("logger", () => {
+  it("initLogger() opens exactly one file under logs/YYYY/MM/DD/", async () => {
+    const { initLogger } = await loadLoggerFresh();
+    initLogger();
+    const file = singleLogFile(mockedLogsDir);
+    const rel = file.slice(mockedLogsDir.length + 1);
+    expect(rel).toMatch(/^\d{4}\/\d{2}\/\d{2}\/desktop-\d+-\d{9}\.log$/);
+  });
+
+  it("initLogger() is idempotent: second call is a no-op", async () => {
+    const { initLogger } = await loadLoggerFresh();
+    initLogger();
+    const firstFiles = listLogFiles(mockedLogsDir);
+    initLogger();
+    const secondFiles = listLogFiles(mockedLogsDir);
+    expect(secondFiles).toEqual(firstFiles);
+    expect(secondFiles).toHaveLength(1);
+  });
+
+  it("minLevel is debug in dev (app.isPackaged === false)", async () => {
+    isPackagedFlag = false;
+    const { initLogger, logger } = await loadLoggerFresh();
+    initLogger();
+    logger.debug("dev-debug-line");
+    const contents = readFileSync(singleLogFile(mockedLogsDir), "utf8");
+    expect(contents).toContain("dev-debug-line");
+  });
+
+  it("minLevel is info in packaged builds; debug is dropped, error is written", async () => {
+    isPackagedFlag = true;
+    const { initLogger, logger } = await loadLoggerFresh();
+    initLogger();
+    logger.debug("should-be-dropped");
+    logger.error("should-be-written");
+    const contents = readFileSync(singleLogFile(mockedLogsDir), "utf8");
+    expect(contents).not.toContain("should-be-dropped");
+    expect(contents).toContain("should-be-written");
+  });
+
+  it("emits valid JSON lines with ts, level, pid, message", async () => {
+    isPackagedFlag = true;
+    const { initLogger, logger } = await loadLoggerFresh();
+    initLogger();
+    logger.info("hello", { count: 3 });
+    const lines = readFileSync(singleLogFile(mockedLogsDir), "utf8")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const [first] = lines;
+    if (!first) {
+      throw new Error("expected one line");
+    }
+    const parsed = JSON.parse(first) as Record<string, unknown>;
+    expect(parsed.level).toBe("info");
+    expect(parsed.pid).toBe(process.pid);
+    expect(typeof parsed.ts).toBe("string");
+    expect(new Date(parsed.ts as string).toString()).not.toBe("Invalid Date");
+    expect(parsed.message).toBe('hello {"count":3}');
+  });
+
+  it("serializes Error arguments as name: message\\nstack", async () => {
+    isPackagedFlag = true;
+    const { initLogger, logger } = await loadLoggerFresh();
+    initLogger();
+    const err = new Error("boom");
+    logger.error("call failed", err);
+    const line = readFileSync(singleLogFile(mockedLogsDir), "utf8").trim();
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const msg = parsed.message as string;
+    expect(msg).toContain("Error: boom");
+    expect(msg).toContain("call failed");
+    expect(msg).not.toContain("[object Object]");
+  });
+
+  it("file is non-empty after a single emit", async () => {
+    isPackagedFlag = true;
+    const { initLogger, logger } = await loadLoggerFresh();
+    initLogger();
+    logger.error("anything");
+    expect(statSync(singleLogFile(mockedLogsDir)).size).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/main/auth-flow.ts
+++ b/apps/desktop/src/main/auth-flow.ts
@@ -7,6 +7,7 @@ import { shell } from "electron";
 import { z } from "zod";
 import { createAppUrl } from "./app-url";
 import { getToken, setToken } from "./auth-store";
+import { logger } from "./logger";
 import { getProtocolScheme, onProtocolUrl } from "./protocol";
 
 const DEFAULT_SIGNIN_TIMEOUT_MS = 5 * 60_000;
@@ -207,7 +208,7 @@ async function runSignIn(): Promise<string | null> {
         emitAgentEvent({ event: "auth_signed_in" });
         settle(token);
       } catch (error) {
-        console.error("[auth-flow] callback handler error", error);
+        logger.error("[auth-flow] callback handler error", error);
         captureException(error, {
           tags: { scope: "auth-flow.handler_error" },
         });
@@ -231,7 +232,7 @@ async function runSignIn(): Promise<string | null> {
     }
 
     shell.openExternal(signinUrl.toString()).catch((error) => {
-      console.error("[auth-flow] shell.openExternal failed", error);
+      logger.error("[auth-flow] shell.openExternal failed", error);
       captureException(error, {
         tags: { scope: "auth-flow.open_external" },
       });

--- a/apps/desktop/src/main/auth-store.ts
+++ b/apps/desktop/src/main/auth-store.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { captureException } from "@vendor/observability/sentry-electron-main";
 import { app, safeStorage } from "electron";
 import { z } from "zod";
+import { logger } from "./logger";
 
 const persistedSchema = z.object({
   token: z.string().min(1),
@@ -26,7 +27,7 @@ function purgePersisted(filePath: string, scope: string): boolean {
     rmSync(filePath, { force: true });
     return true;
   } catch (err) {
-    console.warn("[auth-store] purge failed", err);
+    logger.warn("[auth-store] purge failed", err);
     captureException(err, { tags: { scope } });
     return false;
   }
@@ -48,7 +49,7 @@ function load(): string | null {
     const plain = safeStorage.decryptString(buf);
     const parsed = persistedSchema.safeParse(JSON.parse(plain));
     if (!parsed.success) {
-      console.error("[auth-store] invalid persisted payload", parsed.error);
+      logger.error("[auth-store] invalid persisted payload", parsed.error);
       captureException(parsed.error, {
         tags: { scope: "auth-store.load.schema" },
       });
@@ -58,7 +59,7 @@ function load(): string | null {
     memory = parsed.data.token;
     return memory;
   } catch (err) {
-    console.error("[auth-store] failed to load; purging", err);
+    logger.error("[auth-store] failed to load; purging", err);
     captureException(err, { tags: { scope: "auth-store.load" } });
     purgePersisted(path, "auth-store.load.purge");
     return null;
@@ -67,7 +68,7 @@ function load(): string | null {
 
 function persist(token: string): boolean {
   if (!safeStorage.isEncryptionAvailable()) {
-    console.error(
+    logger.error(
       "[auth-store] safeStorage unavailable; refusing to write plaintext"
     );
     return false;
@@ -79,7 +80,7 @@ function persist(token: string): boolean {
     memory = token;
     return true;
   } catch (err) {
-    console.error("[auth-store] failed to persist", err);
+    logger.error("[auth-store] failed to persist", err);
     captureException(err, { tags: { scope: "auth-store.persist" } });
     return false;
   }

--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -11,6 +11,9 @@ const productName = app.isPackaged ? "Lightfast" : "Lightfast Dev";
 app.setName(productName);
 app.setPath("userData", join(app.getPath("appData"), productName));
 
+// Bootstrap runs before `./index` is dynamically imported, so the logger
+// module isn't loaded yet. These two console.* calls intentionally stay
+// pre-logger; everything inside ./index goes through src/main/logger.ts.
 if (!app.isPackaged) {
   const port = mainEnv.LIGHTFAST_REMOTE_DEBUG_PORT;
   if (port !== undefined) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,7 @@ import {
   signOut as signOutAuth,
 } from "./auth-store";
 import { getBuildInfo } from "./build-info";
+import { initLogger, logger } from "./logger";
 import { buildApplicationMenu } from "./menu";
 import { registerProtocolHandler } from "./protocol";
 import { getRuntimeConfig } from "./runtime-config";
@@ -205,8 +206,7 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.on(IpcChannels.rendererError, (_event, payload: unknown) => {
-    // eslint-disable-next-line no-console
-    console.error("[renderer]", payload);
+    logger.error("renderer error", payload);
     forwardRendererErrorToSentry(payload);
   });
 
@@ -342,6 +342,7 @@ function broadcastSettings(snapshot: SettingsSnapshot): void {
   }
 }
 
+initLogger();
 initSentry();
 
 // Register the custom-scheme handler synchronously, before app.whenReady().

--- a/apps/desktop/src/main/logger.ts
+++ b/apps/desktop/src/main/logger.ts
@@ -1,0 +1,105 @@
+import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { app } from "electron";
+
+type Level = "debug" | "info" | "warn" | "error";
+const LEVEL_ORDER: Record<Level, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// initLogger() must run before any logger.* call. Top-level *imports* of this
+// module are safe (no fd is opened until init); what's unsafe is calling
+// logger.* at module-init time before initLogger() runs in index.ts.
+let fd: number | null = null;
+let minLevel: Level = "info";
+
+function pad(n: number, width = 2): string {
+  return n.toString().padStart(width, "0");
+}
+
+function computeLogPath(): string {
+  const now = new Date();
+  const yyyy = now.getFullYear().toString();
+  const mm = pad(now.getMonth() + 1);
+  const dd = pad(now.getDate());
+  const hms = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}${pad(now.getMilliseconds(), 3)}`;
+  return join(
+    app.getPath("logs"),
+    yyyy,
+    mm,
+    dd,
+    `desktop-${process.pid}-${hms}.log`
+  );
+}
+
+function formatArg(a: unknown): string {
+  if (typeof a === "string") {
+    return a;
+  }
+  if (a instanceof Error) {
+    return `${a.name}: ${a.message}${a.stack ? `\n${a.stack}` : ""}`;
+  }
+  try {
+    return JSON.stringify(a);
+  } catch {
+    return String(a);
+  }
+}
+
+function emit(level: Level, args: unknown[]): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel]) {
+    return;
+  }
+  const record = `${JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    pid: process.pid,
+    message: args.map(formatArg).join(" "),
+  })}\n`;
+  if (fd !== null) {
+    try {
+      writeSync(fd, record);
+    } catch {
+      // Disk full / fd closed during quit. Logging must never crash the app.
+    }
+  }
+  if (!app.isPackaged) {
+    const sink =
+      level === "error"
+        ? console.error
+        : level === "warn"
+          ? console.warn
+          : console.log;
+    sink(...args);
+  }
+}
+
+export function initLogger(): void {
+  if (fd !== null) {
+    return;
+  }
+  const filePath = computeLogPath();
+  mkdirSync(dirname(filePath), { recursive: true });
+  fd = openSync(filePath, "a");
+  minLevel = app.isPackaged ? "info" : "debug";
+  app.on("will-quit", () => {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // fd already gone
+      }
+      fd = null;
+    }
+  });
+}
+
+export const logger = {
+  debug: (...args: unknown[]) => emit("debug", args),
+  info: (...args: unknown[]) => emit("info", args),
+  warn: (...args: unknown[]) => emit("warn", args),
+  error: (...args: unknown[]) => emit("error", args),
+};

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { app } from "electron";
 import { z } from "zod";
+import { logger } from "./logger";
 
 export const themeSourceSchema = z.enum(["system", "light", "dark"]);
 export type ThemeSource = z.infer<typeof themeSourceSchema>;
@@ -48,7 +49,7 @@ function write(snapshot: SettingsSnapshot): void {
   try {
     writeFileSync(storePath(), JSON.stringify(snapshot, null, 2), "utf8");
   } catch (error) {
-    console.error("[settings] failed to write", error);
+    logger.error("[settings] failed to write", error);
   }
 }
 

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -17,13 +17,15 @@ declare global {
   }
 }
 
-// Renderer errors are forwarded over IPC to main, which calls
-// captureException via `@vendor/observability/sentry-electron-main`. Single
-// SDK init in main keeps the bundle small and avoids per-process Sentry
-// config; the renderer doesn't need to know about Sentry. Trade-off: no
-// automatic renderer-side breadcrumbs / page-navigation tracking / future
-// replay — to add those, expose a `sentry-electron-renderer` re-export from
-// `@vendor/observability` and call `init` here.
+// Renderer errors are forwarded over IPC to main, which calls captureException
+// via `@vendor/observability/sentry-electron-main`. The renderer wrap at
+// `@vendor/observability/sentry-electron-renderer` exists as the canonical
+// import path for renderer-side Sentry; to enable a renderer Sentry SDK
+// (breadcrumbs, page-nav tracking, replay), call `init({ dsn, ... })` here.
+// Currently disabled to keep the renderer bundle small and Sentry config
+// single-source-of-truth in main. Note: the no-restricted-imports lint guard
+// against direct `@sentry/electron/renderer` imports is intentionally deferred
+// — there is currently no renderer Sentry usage to police.
 installErrorBoundary(window.lightfastBridge.reportError);
 
 const { buildInfo, platform } = window.lightfastBridge;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.49.0
       version: 10.49.0
     '@sentry/electron':
-      specifier: ^7.11.0
-      version: 7.11.0
+      specifier: ^7.13.0
+      version: 7.13.0
     '@sentry/nextjs':
       specifier: ^10.49.0
       version: 10.49.0
@@ -696,8 +696,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/app-trpc
       '@sentry/electron':
-        specifier: ^7.11.0
-        version: 7.11.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))
+        specifier: 'catalog:'
+        version: 7.13.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))
       '@tanstack/query-core':
         specifier: ^5.99.1
         version: 5.99.1
@@ -2340,7 +2340,7 @@ importers:
         version: 10.49.0
       '@sentry/electron':
         specifier: 'catalog:'
-        version: 7.11.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))
+        version: 7.13.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))
       '@sentry/nextjs':
         specifier: 'catalog:'
         version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4)
@@ -5250,12 +5250,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/instrumentation-express@0.62.0':
-    resolution: {integrity: sha512-Tvx+vgAZKEQxU3Rx+xWLiR0mLxHwmk69/8ya04+VsV9WYh8w6Lhx5hm5yAMvo1wy0KqWgFKBLwSeo3sHCwdOww==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@opentelemetry/instrumentation-fastify@0.57.0':
     resolution: {integrity: sha512-D+rwRtbiOediYocpKGvY/RQTpuLsLdCVwaOREyqWViwItJGibWI7O/wgd9xIV63pMP0D9IdSy27wnARfUaotKg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -7639,48 +7633,48 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
-  '@sentry-internal/browser-utils@10.47.0':
-    resolution: {integrity: sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==}
-    engines: {node: '>=18'}
-
   '@sentry-internal/browser-utils@10.49.0':
     resolution: {integrity: sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.47.0':
-    resolution: {integrity: sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==}
+  '@sentry-internal/browser-utils@10.50.0':
+    resolution: {integrity: sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==}
     engines: {node: '>=18'}
 
   '@sentry-internal/feedback@10.49.0':
     resolution: {integrity: sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.47.0':
-    resolution: {integrity: sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==}
+  '@sentry-internal/feedback@10.50.0':
+    resolution: {integrity: sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==}
     engines: {node: '>=18'}
 
   '@sentry-internal/replay-canvas@10.49.0':
     resolution: {integrity: sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.47.0':
-    resolution: {integrity: sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==}
+  '@sentry-internal/replay-canvas@10.50.0':
+    resolution: {integrity: sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==}
     engines: {node: '>=18'}
 
   '@sentry-internal/replay@10.49.0':
     resolution: {integrity: sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/replay@10.50.0':
+    resolution: {integrity: sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==}
+    engines: {node: '>=18'}
+
   '@sentry/babel-plugin-component-annotate@5.2.0':
     resolution: {integrity: sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==}
     engines: {node: '>= 18'}
 
-  '@sentry/browser@10.47.0':
-    resolution: {integrity: sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==}
-    engines: {node: '>=18'}
-
   '@sentry/browser@10.49.0':
     resolution: {integrity: sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.50.0':
+    resolution: {integrity: sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==}
     engines: {node: '>=18'}
 
   '@sentry/bundler-plugin-core@5.2.0':
@@ -7739,18 +7733,18 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@sentry/core@10.47.0':
-    resolution: {integrity: sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==}
-    engines: {node: '>=18'}
-
   '@sentry/core@10.49.0':
     resolution: {integrity: sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==}
     engines: {node: '>=18'}
 
-  '@sentry/electron@7.11.0':
-    resolution: {integrity: sha512-AKz66R/o/tULOg23zJyQZU2RK2uyV7PRYEWxDeyGDIfJeg+tXN1Zwjf/WuPcpoVE3xsXcCGBReboqMLgff587Q==}
+  '@sentry/core@10.50.0':
+    resolution: {integrity: sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==}
+    engines: {node: '>=18'}
+
+  '@sentry/electron@7.13.0':
+    resolution: {integrity: sha512-zW/1c9fKafCZsvhRRp9mIDH9bSvzBiIUwoN087zDDHc0vatVsqqai8nUk0bUewwYZY4Inia7r5w+kPWi8LXZzg==}
     peerDependencies:
-      '@sentry/node-native': 10.47.0
+      '@sentry/node-native': 10.50.0
     peerDependenciesMeta:
       '@sentry/node-native':
         optional: true
@@ -7760,36 +7754,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
-
-  '@sentry/node-core@10.47.0':
-    resolution: {integrity: sha512-qv6LsqHbkQmd0aQEUox/svRSz26J+l4gGjFOUNEay2armZu9XLD+Ct89jpFgZD5oIPNAj2jraodTRqydXiwS5w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
-      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
-      '@opentelemetry/instrumentation': '>=0.57.1 <1'
-      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-      '@opentelemetry/semantic-conventions': ^1.39.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/context-async-hooks':
-        optional: true
-      '@opentelemetry/core':
-        optional: true
-      '@opentelemetry/exporter-trace-otlp-http':
-        optional: true
-      '@opentelemetry/instrumentation':
-        optional: true
-      '@opentelemetry/resources':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-      '@opentelemetry/semantic-conventions':
-        optional: true
 
   '@sentry/node-core@10.49.0':
     resolution: {integrity: sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA==}
@@ -7815,26 +7779,49 @@ packages:
       '@opentelemetry/semantic-conventions':
         optional: true
 
-  '@sentry/node@10.47.0':
-    resolution: {integrity: sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw==}
+  '@sentry/node-core@10.50.0':
+    resolution: {integrity: sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
 
   '@sentry/node@10.49.0':
     resolution: {integrity: sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ==}
     engines: {node: '>=18'}
 
-  '@sentry/opentelemetry@10.47.0':
-    resolution: {integrity: sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g==}
+  '@sentry/node@10.50.0':
+    resolution: {integrity: sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.49.0':
+    resolution: {integrity: sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
 
-  '@sentry/opentelemetry@10.49.0':
-    resolution: {integrity: sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w==}
+  '@sentry/opentelemetry@10.50.0':
+    resolution: {integrity: sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': 1.9.1
@@ -18276,15 +18263,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-express@0.62.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-fastify@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -20645,51 +20623,43 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@sentry-internal/browser-utils@10.47.0':
-    dependencies:
-      '@sentry/core': 10.47.0
-
   '@sentry-internal/browser-utils@10.49.0':
     dependencies:
       '@sentry/core': 10.49.0
 
-  '@sentry-internal/feedback@10.47.0':
+  '@sentry-internal/browser-utils@10.50.0':
     dependencies:
-      '@sentry/core': 10.47.0
+      '@sentry/core': 10.50.0
 
   '@sentry-internal/feedback@10.49.0':
     dependencies:
       '@sentry/core': 10.49.0
 
-  '@sentry-internal/replay-canvas@10.47.0':
+  '@sentry-internal/feedback@10.50.0':
     dependencies:
-      '@sentry-internal/replay': 10.47.0
-      '@sentry/core': 10.47.0
+      '@sentry/core': 10.50.0
 
   '@sentry-internal/replay-canvas@10.49.0':
     dependencies:
       '@sentry-internal/replay': 10.49.0
       '@sentry/core': 10.49.0
 
-  '@sentry-internal/replay@10.47.0':
+  '@sentry-internal/replay-canvas@10.50.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.47.0
-      '@sentry/core': 10.47.0
+      '@sentry-internal/replay': 10.50.0
+      '@sentry/core': 10.50.0
 
   '@sentry-internal/replay@10.49.0':
     dependencies:
       '@sentry-internal/browser-utils': 10.49.0
       '@sentry/core': 10.49.0
 
-  '@sentry/babel-plugin-component-annotate@5.2.0': {}
-
-  '@sentry/browser@10.47.0':
+  '@sentry-internal/replay@10.50.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.47.0
-      '@sentry-internal/feedback': 10.47.0
-      '@sentry-internal/replay': 10.47.0
-      '@sentry-internal/replay-canvas': 10.47.0
-      '@sentry/core': 10.47.0
+      '@sentry-internal/browser-utils': 10.50.0
+      '@sentry/core': 10.50.0
+
+  '@sentry/babel-plugin-component-annotate@5.2.0': {}
 
   '@sentry/browser@10.49.0':
     dependencies:
@@ -20698,6 +20668,14 @@ snapshots:
       '@sentry-internal/replay': 10.49.0
       '@sentry-internal/replay-canvas': 10.49.0
       '@sentry/core': 10.49.0
+
+  '@sentry/browser@10.50.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.50.0
+      '@sentry-internal/feedback': 10.50.0
+      '@sentry-internal/replay': 10.50.0
+      '@sentry-internal/replay-canvas': 10.50.0
+      '@sentry/core': 10.50.0
 
   '@sentry/bundler-plugin-core@5.2.0(encoding@0.1.13)':
     dependencies:
@@ -20756,15 +20734,15 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/core@10.47.0': {}
-
   '@sentry/core@10.49.0': {}
 
-  '@sentry/electron@7.11.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))':
+  '@sentry/core@10.50.0': {}
+
+  '@sentry/electron@7.13.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@sentry/browser': 10.47.0
-      '@sentry/core': 10.47.0
-      '@sentry/node': 10.47.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))
+      '@sentry/browser': 10.50.0
+      '@sentry/core': 10.50.0
+      '@sentry/node': 10.50.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
@@ -20819,21 +20797,6 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/node-core@10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
-    dependencies:
-      '@sentry/core': 10.47.0
-      '@sentry/opentelemetry': 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      import-in-the-middle: 3.0.1
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-
   '@sentry/node-core@10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@sentry/core': 10.49.0
@@ -20847,46 +20810,18 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@sentry/node@10.47.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
-      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.50.0
+      '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-express': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-undici': 0.24.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
-      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
-      '@sentry/core': 10.47.0
-      '@sentry/node-core': 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      '@sentry/opentelemetry': 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      import-in-the-middle: 3.0.1
-    transitivePeerDependencies:
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
 
   '@sentry/node@10.49.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -20926,14 +20861,42 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/node@10.50.0(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))':
     dependencies:
+      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
-      '@sentry/core': 10.47.0
+      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.50.0
+      '@sentry/node-core': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
   '@sentry/opentelemetry@10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
@@ -20942,6 +20905,14 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@sentry/core': 10.49.0
+
+  '@sentry/opentelemetry@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.50.0
 
   '@sentry/react@10.49.0(react@19.2.5)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ catalog:
   '@radix-ui/react-dropdown-menu': ^2.1.15
   '@sentry/browser': ^10.49.0
   '@sentry/core': ^10.49.0
-  '@sentry/electron': ^7.11.0
+  '@sentry/electron': ^7.13.0
   '@sentry/nextjs': ^10.49.0
   '@t3-oss/env-core': ^0.13.11
   '@t3-oss/env-nextjs': ^0.13.11

--- a/thoughts/shared/plans/2026-05-06-desktop-w1-observability-tier-2.md
+++ b/thoughts/shared/plans/2026-05-06-desktop-w1-observability-tier-2.md
@@ -1,0 +1,496 @@
+---
+date: 2026-05-06
+author: claude (with jp@jeevanpillay.com)
+git_commit: 1bc77e573905d405c2f48fb81b0c019cab569204
+branch: docs/codex-gap-status-tracker-callout
+tags: [plan, desktop, electron, observability, sentry, logger, codex-gap-followup, w1]
+status: draft-revised-2026-05-06
+parents:
+  - thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md
+  - thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
+  - thoughts/shared/2026-05-06-desktop-rc1-ad-hoc-dry-run-report.md
+---
+
+# W1 — Desktop Observability Tier 2: file logger + Sentry vendor wrap + SDK bump
+
+## Overview
+
+Land the W1 worktree slice from `thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md`: a file-backed structured logger for the desktop main process, a vendored renderer-Sentry re-export to close the vendor-abstraction policy, a `@sentry/electron` catalog bump 7.11.0 → 7.13.0, and the parent-doc §10 drift correction. The primary motive is the dry-run finding that we are over-reliant on Sentry to see anything from a packaged build — a local file log is the floor under that reliance, especially while the Sentry org is over its free-tier quota and the issues stream is closed.
+
+## Current State Analysis
+
+Verified against tree at commit `1bc77e573905d405c2f48fb81b0c019cab569204`.
+
+- **No file logger.** Grep for `electron-log`, `pino`, `winston`, `bunyan`, `fs.appendFile` under `apps/desktop/src/main/` returns zero matches (`thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md:58`). All diagnostic output is `console.*` only.
+- **11 `console.*` sites in `src/main/`** (verified via grep): `settings-store.ts:51` (1), `auth-store.ts:29,51,61,70,82` (5), `auth-flow.ts:210,234` (2), `index.ts:209` (1), `bootstrap.ts:19,28` (2). Six sites already pair `console.error` with `captureException` from `@vendor/observability/sentry-electron-main`; five do not.
+- **Vendor wraps for Sentry are partial.** `vendor/observability/src/sentry-electron-main.ts` (re-exports `init`/`captureException`/`captureMessage`/`rewriteFramesIntegration` from `@sentry/electron/main`) and `vendor/observability/src/sentry-browser.ts` (re-exports `init`/`captureException` from `@sentry/browser`) exist. There is **no `sentry-electron-renderer.ts` wrap** despite `@sentry/electron/renderer` being the appropriate entry point for renderer-side init.
+- **Renderer Sentry is bridged via IPC, not initialized.** `apps/desktop/src/renderer/src/main.ts:23-27` calls `installErrorBoundary(window.lightfastBridge.reportError)` and the comment block at `:20-26` explicitly anticipates the missing wrap: "to add those, expose a `sentry-electron-renderer` re-export from `@vendor/observability` and call `init` here." Renderer errors travel over `IpcChannels.rendererError` to `index.ts:207-211` where `forwardRendererErrorToSentry` calls `captureException` against the main-process SDK (PR #643, G-12 closure).
+- **Catalog vs literal mismatch on `@sentry/electron`.** `pnpm-workspace.yaml:28` has `'@sentry/electron': ^7.11.0`. `vendor/observability/package.json:80` consumes via `"@sentry/electron": "catalog:"`. `apps/desktop/package.json:48` consumes via literal `"@sentry/electron": "^7.11.0"` — bypassing the catalog. NPM registry confirms `7.13.0` is the current latest; both `vendor/observability` and `apps/desktop` should track the catalog.
+- **Parent doc §10 is stale.** `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md:502,536` claim the deep-link surface "is genuinely gone." PR #627 (`d4f0cb4b2`, merged 2026-05-06) reintroduced `apps/desktop/src/main/protocol.ts` and `forge.config.ts:133-138` `CFBundleURLTypes` for the PKCE callback (`lightfast://auth/callback`). The §10 broader gap (general URL→route dispatcher) is still open, but the literal "gone" claim is wrong.
+- **Codex baseline reference (verified 2026-05-06 via local asar inventory; path is non-reproducible — evidence inlined here).** `/Applications/Codex.app/Contents/Resources/app.asar` has six top-level `node_modules` entries (`better-sqlite3, bindings, file-uri-to-path, node-addon-api, node-pty, tslib`) — **no `electron-log`, no `pino`, no `winston`**. Codex hand-rolls its file logger over Node `fs` with date-partitioned `~/Library/Logs/com.openai.codex/YYYY/MM/DD/...` paths and dual streams per session. **We are matching Codex's hand-rolled approach** — a ~50-LOC `node:fs` module rather than a library dependency. The original draft of this plan picked `electron-log` for its renderer↔main IPC bridge, then explicitly disabled that bridge in scope; the bridge was the only feature library-overhead bought us. Hand-roll keeps the dep tree thin and aligns with the Codex baseline.
+
+## Desired End State
+
+After W1 lands:
+
+- `vendor/observability/src/sentry-electron-renderer.ts` exists as a re-export wrap (one-line file mirroring `sentry-electron-main.ts`), exported via `vendor/observability/package.json` `exports` map, and importable as `@vendor/observability/sentry-electron-renderer`.
+- `pnpm-workspace.yaml` catalog floor for `@sentry/electron` is `^7.13.0`. `apps/desktop/package.json` consumes via `catalog:` (no literal pin).
+- `apps/desktop/src/main/logger.ts` exists as a ~50-LOC `node:fs`-backed module exporting `logger` (`{ debug, info, warn, error }`) and `initLogger()`. **No new runtime dependency** — written against Node built-ins to match Codex's hand-rolled approach.
+- Logger writes per-launch JSON-line files under `app.getPath('logs')/YYYY/MM/DD/desktop-<pid>-<HHMMSSsss>.log`, structurally aligned with Codex's pattern. Uses `fs.openSync` + `fs.writeSync` for crash-safe append-on-write (no JS-level buffering to lose).
+- 9 of 11 `console.*` call sites in `src/main/` use the new logger. `bootstrap.ts:19,28` retain `console.*` with an explanatory comment (logger module not loaded yet).
+- `apps/desktop/src/renderer/src/main.ts:20-26` comment block updated to reflect that the wrap now exists as pre-positioning; the trade-off explanation stays (renderer SDK still not initialized — wrap-only is the W1 scope; eslint enforcement of the import boundary is also deferred).
+- Parent research doc §10 corrections landed: line 502 "§10 is now moot" → updated to note PKCE-only reintroduction; line 536 "**§10 deep-link surface is genuinely gone.**" → updated to "single-purpose PKCE callback; general dispatcher still absent."
+
+### Verification
+
+```bash
+# Vendor wrap exists at the expected path (re-export resolved at import time, not require time)
+test -f vendor/observability/src/sentry-electron-renderer.ts && echo OK
+
+# Catalog version is current
+pnpm why @sentry/electron | grep -A1 "@sentry/electron"
+
+# Logger writes a file per launch
+pnpm --filter @lightfast/desktop dev   # observe a log file appears under app.getPath('logs')
+
+# Type & test green
+pnpm --filter @lightfast/desktop typecheck
+pnpm --filter @lightfast/desktop test
+pnpm --filter @vendor/observability typecheck
+pnpm check
+```
+
+### Key Discoveries
+
+- `app.setName(productName)` runs at `bootstrap.ts:11` before `./index` is dynamically imported, so `app.getPath('logs')` is reliably resolvable from the moment `index.ts` imports the logger module. We do not need to log anything from inside `bootstrap.ts` itself.
+- `vitest.config.ts` already runs Node-environment tests under `apps/desktop/src/**/*.{test,spec}.ts` — logger tests slot in at `apps/desktop/src/main/__tests__/logger.test.ts`. The mock pattern to follow is `auth-flow.test.ts:13-24` (`vi.mock("electron", () => ({ app: { get isPackaged() { return flag } } }))`); `auth-focus-gate.test.ts` does not mock `electron` and is the wrong reference.
+- The forge build pipeline already stamps `version`/`buildNumber`/`sparkleFeedUrl`/`sentryDsn` via `npm pkg set` on packaged builds (parent doc); no W1 change needed there.
+- `fs.openSync` + `fs.writeSync` is the simplest crash-safe write path for low-volume diagnostic logs. Each call lands in the OS-level write buffer immediately; we don't manage a JS-level stream buffer that could lose tail data on a hard crash. This is also how Codex's hand-roll works.
+
+## What We're NOT Doing
+
+- **Renderer Sentry SDK init.** Wrap-only scope. `init()` is not called from the renderer. The IPC bridge via `IpcChannels.rendererError` and `lightfastBridge.reportError` remains the renderer→Sentry path. Future worktree.
+- **Auto-forward from logger to Sentry.** `logger.error()` does not call `captureException`. Existing explicit `captureException` call sites at `auth-store.ts:32,53,62,83`, `auth-flow.ts:211,235`, and `index.ts:93` (in `forwardRendererErrorToSentry`) are unchanged. No coupling between the file-logger and the Sentry SDK; each call site decides.
+- **Migrating `bootstrap.ts:19,28`.** Bootstrap runs before `index.ts` is dynamically imported and before the logger module is loaded. We leave both `console.*` calls in place with a one-line comment explaining why. Forcing logger init inside bootstrap turns logger init failure into an app-fatal — not worth it.
+- **Removing existing `captureException` calls.** Even at sites where `console.error` and `captureException` currently both fire, we keep the `captureException` call. The new logger replaces only the `console.*` half.
+- **Log rotation, retention, or upload.** No size cap, no `.old` rolling, no retention sweep, no upload to Sentry/Logtail. Per-launch files are bounded by process lifetime. Future worktree if disk usage becomes a concern.
+- **Renderer-process logger.** Renderer logging stays as `console.*` plus the existing IPC error bridge. No renderer→main log channel is built. Future scope decides whether renderer logs land on disk.
+- **§10 broader fix (URL→route dispatcher).** The doc fix corrects the literal "gone" claim only. The general deep-link route table is still in the deferred list and is not part of W1.
+
+## Implementation Approach
+
+Land in 4 phases on a single feature branch (`feat/desktop-observability-tier2`). Each phase is a clean phase-boundary halt; review can stop and resume between phases. Phase ordering puts the smallest, most independent diffs first — the SDK bump and vendor wrap are reviewable on their own; the logger module is additive (no callers); the call-site swaps are the behavior change; the doc fix is zero-risk cleanup.
+
+## Execution Protocol
+
+Phase boundaries halt execution. Automated checks passing is necessary but not sufficient — the next phase starts only on user go-ahead.
+
+---
+
+## Phase 1: SDK bump + vendor renderer wrap + catalog normalization
+
+### Overview
+
+Bump `@sentry/electron` 7.11.0 → 7.13.0 in the catalog. Create the missing `sentry-electron-renderer` vendor re-export. Normalize `apps/desktop/package.json` to consume `@sentry/electron` via `catalog:` (matching `vendor/observability`). Update the renderer comment block now that the wrap exists. Pure config + 1-line file additions; no runtime behavior change.
+
+### Changes Required
+
+#### 1. Bump catalog floor
+
+**File**: `pnpm-workspace.yaml`
+**Change**: line 28 `'@sentry/electron': ^7.11.0` → `'@sentry/electron': ^7.13.0`.
+
+#### 2. Vendor renderer-Sentry wrap
+
+**File**: `vendor/observability/src/sentry-electron-renderer.ts` (new)
+**Change**: One-line re-export, mirroring `sentry-electron-main.ts`.
+
+```ts
+export {
+  captureException,
+  captureMessage,
+  init,
+} from "@sentry/electron/renderer";
+```
+
+#### 3. Vendor package exports map
+
+**File**: `vendor/observability/package.json`
+**Change**: add a new `./sentry-electron-renderer` entry to the `exports` block (alphabetical neighbor of `./sentry-electron-main`).
+
+```json
+"./sentry-electron-renderer": {
+  "types": "./src/sentry-electron-renderer.ts",
+  "default": "./src/sentry-electron-renderer.ts"
+},
+```
+
+#### 4. Normalize apps/desktop sentry pin
+
+**File**: `apps/desktop/package.json`
+**Change**: line 48 `"@sentry/electron": "^7.11.0"` → `"@sentry/electron": "catalog:"`.
+
+#### 5. Renderer comment update (now that wrap exists)
+
+**File**: `apps/desktop/src/renderer/src/main.ts:20-26`
+**Change**: Replace the comment block that anticipates the missing wrap with one that states the wrap exists and the renderer SDK init is intentionally deferred.
+
+```ts
+// Renderer errors are forwarded over IPC to main, which calls captureException
+// via `@vendor/observability/sentry-electron-main`. The renderer wrap at
+// `@vendor/observability/sentry-electron-renderer` exists as the canonical
+// import path for renderer-side Sentry; to enable a renderer Sentry SDK
+// (breadcrumbs, page-nav tracking, replay), call `init({ dsn, ... })` here.
+// Currently disabled to keep the renderer bundle small and Sentry config
+// single-source-of-truth in main. Note: the no-restricted-imports lint guard
+// against direct `@sentry/electron/renderer` imports is intentionally deferred
+// — there is currently no renderer Sentry usage to police.
+installErrorBoundary(window.lightfastBridge.reportError);
+```
+
+#### 6. Lockfile regen
+
+**File**: `pnpm-lock.yaml`
+**Change**: regenerate via `pnpm install`. Expect new resolution entries for `@sentry/electron@7.13.0` plus its transitive deps; expect removal of `7.11.x` entries that no longer have any consumer.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `pnpm install` succeeds, no peer-dep warnings introduced
+- [x] `pnpm why @sentry/electron` shows resolved version 7.13.0 for both `@vendor/observability` and `@lightfast/desktop`
+- [x] `pnpm --filter @vendor/observability typecheck` passes
+- [x] `pnpm --filter @lightfast/desktop typecheck` passes
+- [x] `pnpm --filter @lightfast/desktop test` passes (existing 3 vitest files, no new coverage in this phase)
+- [x] `pnpm check` passes
+- [x] `test -f vendor/observability/src/sentry-electron-renderer.ts` succeeds (TS source resolution; runtime require will fail until a consumer compiles it, which is acceptable for W1)
+
+#### Human Review
+
+- [x] Open the renderer comment block in `apps/desktop/src/renderer/src/main.ts:20-26` → wording reads cleanly and points at the new wrap path
+
+---
+
+## Phase 2: Hand-rolled file logger via node:fs
+
+### Overview
+
+Create `apps/desktop/src/main/logger.ts` as a ~50-LOC `node:fs`-backed module — no new runtime dependency. Date-partitioned per-launch path matching Codex's structural pattern (`<logs>/YYYY/MM/DD/desktop-<pid>-<HHMMSSsss>.log`), JSON-lines format, sync writes via `fs.writeSync`, dev-only stdout mirror. Module is purely additive in this phase — no call sites use it yet.
+
+The original draft of this plan picked `electron-log` for its renderer↔main IPC bridge, then explicitly disabled that bridge in scope. Hand-rolling removes ~80 KB + 1 dep and aligns with Codex's actual approach (verified via asar inventory: no logger lib).
+
+### Changes Required
+
+#### 1. Logger module
+
+**File**: `apps/desktop/src/main/logger.ts` (new)
+**Change**: New module. Exports `logger` (`{ debug, info, warn, error }`) and `initLogger()`. `initLogger()` is called once from `index.ts` before any other logger usage.
+
+Key design decisions baked into the file:
+
+- **Path computation**: `app.getPath('logs')` is the canonical Electron logs dir (macOS `~/Library/Logs/<App Name>`, Linux `~/.config/<App Name>/logs`, Win `%USERPROFILE%/AppData/Roaming/<App Name>/logs`). We append `YYYY/MM/DD/desktop-<pid>-<HHMMSSsss>.log`. Date + millisecond timestamp is computed once at `initLogger()` so all messages from one launch land in one file; the millisecond suffix avoids same-second filename collision.
+- **Format**: JSON lines, one record per call. Fields: `ts` (ISO8601), `level`, `pid`, `message`. grep/jq-friendly; matches the structured-logging contract referenced in the parent gap doc.
+- **Levels**: `debug` in dev (`!app.isPackaged`), `info` in packaged builds. Records below `minLevel` are dropped before format.
+- **Writes**: `fs.openSync` + `fs.writeSync` (sync). For low-volume diagnostic logging this is fine — no JS-level buffer to lose on hard crash, no stream backpressure to manage. `app.on("will-quit")` closes the fd; on hard crash the OS cleans it up.
+- **Stdout mirror**: only in dev (`!app.isPackaged`). Packaged builds have no terminal attached, so console mirror is wasted work.
+- **Renderer logging**: NOT routed through this module. Renderer continues using `console.*` and the existing IPC error bridge. (Same scope as the original electron-log draft.)
+
+```ts
+import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { app } from "electron";
+
+type Level = "debug" | "info" | "warn" | "error";
+const LEVEL_ORDER: Record<Level, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+// initLogger() must run before any logger.* call. Top-level *imports* of this
+// module are safe (no fd is opened until init); what's unsafe is calling
+// logger.* at module-init time before initLogger() runs in index.ts.
+let fd: number | null = null;
+let minLevel: Level = "info";
+
+function pad(n: number, width = 2): string {
+  return n.toString().padStart(width, "0");
+}
+
+function computeLogPath(): string {
+  const now = new Date();
+  const yyyy = now.getFullYear().toString();
+  const mm = pad(now.getMonth() + 1);
+  const dd = pad(now.getDate());
+  const hms = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}${pad(now.getMilliseconds(), 3)}`;
+  return join(app.getPath("logs"), yyyy, mm, dd, `desktop-${process.pid}-${hms}.log`);
+}
+
+function formatArg(a: unknown): string {
+  if (typeof a === "string") return a;
+  if (a instanceof Error) return `${a.name}: ${a.message}${a.stack ? `\n${a.stack}` : ""}`;
+  try {
+    return JSON.stringify(a);
+  } catch {
+    return String(a);
+  }
+}
+
+function emit(level: Level, args: unknown[]): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel]) return;
+  const record = JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    pid: process.pid,
+    message: args.map(formatArg).join(" "),
+  }) + "\n";
+  if (fd !== null) {
+    try {
+      writeSync(fd, record);
+    } catch {
+      // Disk full / fd closed during quit. Logging must never crash the app.
+    }
+  }
+  if (!app.isPackaged) {
+    const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+    sink(...args);
+  }
+}
+
+export function initLogger(): void {
+  if (fd !== null) return;
+  const filePath = computeLogPath();
+  mkdirSync(dirname(filePath), { recursive: true });
+  fd = openSync(filePath, "a");
+  minLevel = app.isPackaged ? "info" : "debug";
+  app.on("will-quit", () => {
+    if (fd !== null) {
+      try { closeSync(fd); } catch { /* fd already gone */ }
+      fd = null;
+    }
+  });
+}
+
+export const logger = {
+  debug: (...args: unknown[]) => emit("debug", args),
+  info: (...args: unknown[]) => emit("info", args),
+  warn: (...args: unknown[]) => emit("warn", args),
+  error: (...args: unknown[]) => emit("error", args),
+};
+```
+
+#### 2. Logger unit tests
+
+**File**: `apps/desktop/src/main/__tests__/logger.test.ts` (new)
+**Change**: vitest coverage for path computation, double-init idempotency, level filtering, and JSON format. Mocks `electron.app.getPath`, `electron.app.isPackaged`, and `electron.app.on` per the existing mocking pattern in `auth-flow.test.ts:13-24` (NOT `auth-focus-gate.test.ts` — that file does not mock electron). Real fs is used against an `os.tmpdir()` directory cleaned up between tests.
+
+Coverage:
+
+- `initLogger()` is idempotent (second call is a no-op; no second `openSync`)
+- `computeLogPath()` produces a path under the mocked `getPath('logs')` with shape `YYYY/MM/DD/desktop-<pid>-<HHMMSSsss>.log`
+- `minLevel === "debug"` when `app.isPackaged === false`; `"info"` otherwise
+- `logger.debug(...)` is dropped at info-level minLevel; `logger.error(...)` is always written
+- One log line is valid JSON with keys `ts`, `level`, `pid`, `message`
+- `Error` arguments serialize as `name: message\nstack`, not `[object Object]`
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `pnpm --filter @lightfast/desktop test` passes (4 vitest files now: existing 3 + logger.test.ts)
+- [x] `pnpm --filter @lightfast/desktop typecheck` passes
+- [x] `pnpm check` passes
+
+#### Human Review
+
+- [x] Open `apps/desktop/src/main/logger.ts` → JSON output is valid for representative inputs (string, object, Error with stack); pad/date logic is timezone-stable; sync writes don't visibly block startup at the call sites we care about. Verified 2026-05-06 by code read + the 7 unit tests covering string/object/Error inputs against a real tmp fs; date logic uses local-tz path partitioning + UTC `ts` (intentional split); business call sites all live on error paths so cold-start writes nothing.
+
+---
+
+## Phase 3: Migrate 9 console.* call sites
+
+### Overview
+
+Replace `console.error` / `console.warn` / `console.log` calls under `src/main/` with `logger.error` / `logger.warn` / `logger.info` calls, except for the two pre-init bootstrap sites which stay as `console.*` with an explanatory comment. Existing `captureException` calls are unchanged.
+
+`initLogger()` is called once from `index.ts` at the very top of module load (before `initSentry()`).
+
+### Changes Required
+
+#### 1. Logger init in main entry
+
+**File**: `apps/desktop/src/main/index.ts`
+**Change**:
+
+- Add `import { initLogger, logger } from "./logger";` (alphabetical, after `runtime-config`).
+- Insert `initLogger();` as the first statement in the side-effect block, immediately above the existing `initSentry();` at line 345.
+- Replace `console.error("[renderer]", payload);` at line 209 with `logger.error("renderer error", payload);`. Drop the `eslint-disable-next-line no-console` directive since it's no longer needed.
+
+#### 2. settings-store call-site swap
+
+**File**: `apps/desktop/src/main/settings-store.ts`
+**Change**:
+
+- Add `import { logger } from "./logger";` at the top.
+- Line 51: `console.error("[settings] failed to write", error);` → `logger.error("[settings] failed to write", error);`.
+
+#### 3. auth-store call-site swaps (5 sites)
+
+**File**: `apps/desktop/src/main/auth-store.ts`
+**Change**:
+
+- Add `import { logger } from "./logger";` at the top.
+- Line 29: `console.warn("[auth-store] purge failed", err);` → `logger.warn("[auth-store] purge failed", err);`
+- Line 51: `console.error("[auth-store] invalid persisted payload", parsed.error);` → `logger.error("[auth-store] invalid persisted payload", parsed.error);`
+- Line 61: `console.error("[auth-store] failed to load; purging", err);` → `logger.error("[auth-store] failed to load; purging", err);`
+- Lines 70-72: `console.error("[auth-store] safeStorage unavailable; refusing to write plaintext")` → `logger.error("[auth-store] safeStorage unavailable; refusing to write plaintext")`.
+- Line 82: `console.error("[auth-store] failed to persist", err);` → `logger.error("[auth-store] failed to persist", err);`
+
+Existing `captureException` calls at lines 32, 53, 62, 83 are unchanged.
+
+#### 4. auth-flow call-site swaps (2 sites)
+
+**File**: `apps/desktop/src/main/auth-flow.ts`
+**Change**:
+
+- Add `import { logger } from "./logger";` at the top.
+- Line 210: `console.error("[auth-flow] callback handler error", error);` → `logger.error("[auth-flow] callback handler error", error);`
+- Line 234: `console.error("[auth-flow] shell.openExternal failed", error);` → `logger.error("[auth-flow] shell.openExternal failed", error);`
+
+Existing `captureException` calls at lines 211, 235 are unchanged.
+
+#### 5. bootstrap.ts deliberate-stay sites
+
+**File**: `apps/desktop/src/main/bootstrap.ts`
+**Change**: NO `logger` import. Keep `console.log` at line 19 and `console.error` at line 28. Add a single comment above the file's first `console.*` (at line 18) explaining why:
+
+```ts
+// Bootstrap runs before `./index` is dynamically imported, so the logger
+// module isn't loaded yet. These two console.* calls intentionally stay
+// pre-logger; everything inside ./index goes through src/main/logger.ts.
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `pnpm --filter @lightfast/desktop test` passes (no test changes needed; existing tests don't depend on console.* output)
+- [x] `pnpm --filter @lightfast/desktop typecheck` passes
+- [x] `pnpm check` passes
+- [x] `grep -rn --exclude=logger.ts "console\.\(error\|warn\|log\|info\)" apps/desktop/src/main/` returns exactly 2 matches, both in `bootstrap.ts`. (Logger.ts itself uses `console.*` as the dev stdout mirror — that's the intended sink, not a stray call site, hence the exclusion. Recursive `-r` is required — without it the search misses subdirs and would silently pass.)
+
+#### Human Review
+
+- [x] Run `pnpm dev:desktop`, trigger settings write to disk → watch terminal: settings logger line appears with structured prefix (no raw `[settings]` console line); inspect `app.getPath('logs')/YYYY/MM/DD/desktop-<pid>-<HHMMSS>.log` → file exists, contains JSON lines for the launch — TODO: automate via Playwright Electron CDP harness once W5 lands. Verified 2026-05-06 via standalone Electron probe (the sandboxed Bash environment terminates `electron-forge start` when the parent shell exits, so a sustained dev:desktop session was infeasible). Probe used the real `electron@41.5.0` binary with `app.setName("Lightfast Dev")` matching `bootstrap.ts:10` and `app.getPath("logs")` resolved to `~/Library/Logs/Lightfast Dev`. Three logger.error invocations (renderer error, auth-store decrypt failure, settings EACCES) wrote to `~/Library/Logs/Lightfast Dev/2026/05/06/desktop-<pid>-<HHMMSSsss>.log`; all three lines were valid JSON with `ts`/`level`/`pid`/`message`; Error stacks serialized inline. Probe + log file cleaned up post-verification.
+- [x] Trigger an auth-store error path (delete `auth.bin` mid-session, sign out, sign in) → confirm both the file logger line AND a Sentry event are emitted (Sentry side requires DSN-equipped build; in dev the `enabled` branch in `sentry.ts:30` returns false and only the file log fires) — TODO: automate via mocked Sentry transport in vitest. File-log half verified by the same probe above (auth-store decrypt-failure scenario produced a structurally correct JSON line). Sentry-side verification deferred to packaged-build manual smoke; in dev the SDK is disabled by `enabled` branch in `sentry.ts:30` so only the file log fires, which is what the probe simulates.
+- [ ] Inspect a single packaged `.dmg` build → confirm `app.getPath('logs')` resolves to `~/Library/Logs/Lightfast/...` and a launch-file lands there. **Deferred** — out of phase-boundary scope per the Improvement Log decision to drop `pnpm package` from automated checks; first signed `.dmg` is blocked on Apple enrollment per `memory/project_desktop_release_state.md`. Dev-mode probe above confirms `app.getPath("logs")` integration works; the only delta in packaged mode is `productName = "Lightfast"` (vs `"Lightfast Dev"`) — `bootstrap.ts:10`.
+
+---
+
+## Phase 4: Doc fix — parent §10 drift correction [DONE]
+
+### Overview
+
+Update the parent gap doc's two stale assertions about §10 deep-link surface being "genuinely gone", which became inaccurate after PR #627 reintroduced `protocol.ts` for the PKCE custom URL scheme. Doc-only; zero code touched.
+
+### Changes Required
+
+#### 1. Phase 4 dead-code paragraph correction
+
+**File**: `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`
+**Change**: Around line 502, the sentence "Deep-link `console.log` gone — in fact the entire deep-link dispatcher is gone: `src/main/protocol.ts` deleted, `onDeepLink` removed from `index.ts`, `CFBundleURLTypes` dropped from extendInfo. Research §10 is now moot — there is no deep-link surface to dispatch." — replace with a corrected version noting the PKCE-only reintroduction.
+
+Suggested replacement:
+
+> Deep-link `console.log` gone; the original deep-link dispatcher was deleted (`src/main/protocol.ts`, `onDeepLink`, `CFBundleURLTypes`) — then PR #627 (2026-05-06) reintroduced `protocol.ts` and `CFBundleURLTypes` for the PKCE auth callback (`lightfast://auth/callback`) only. The general URL→renderer-route dispatcher §10 originally described is still absent.
+
+#### 2. Mid-flight section correction
+
+**File**: `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`
+**Change**: Around line 536, the sentence ending "**§10 deep-link surface is genuinely gone.**" — replace.
+
+Suggested replacement:
+
+> The 2026-04-25 deletion of `protocol.ts` was reversed by PR #627 (2026-05-06) for PKCE only: `setAsDefaultProtocolClient`, `open-url`, `second-instance`, `CFBundleURLTypes` all back in tree. **§10 surface is single-purpose (PKCE auth callback only); the general URL→route dispatcher remains absent.**
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `grep -n "genuinely gone\|now moot" thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` returns no matches
+- [x] `grep -n "PR #627\|PKCE auth callback" thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` returns matches in both updated paragraphs
+
+#### Human Review
+
+- [ ] Read the two updated paragraphs end-to-end → both read coherently with the surrounding context; cross-references to §10 elsewhere in the doc still resolve
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- New: `apps/desktop/src/main/__tests__/logger.test.ts` — initLogger idempotency, path shape, level selection, JSON format function output (Phase 2).
+- Unchanged: `auth-flow.test.ts`, `auth-focus-gate.test.ts`, `protocol.test.ts` — no behavior depends on `console.*` output, so call-site swaps don't require test updates.
+
+### Integration Tests
+
+W1 doesn't add Playwright/E2E coverage — that's W5's scope (`thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md:188-216`). Behavior verification in W1 happens through the Phase 3 Human Review steps and the Phase 1/2 automated checks. Once W5 lands, the "boot → log file appears → contents valid JSON" assertion graduates to an automated E2E check.
+
+## Performance Considerations
+
+- Zero new runtime dependency. Logger is ~50 LOC of `node:fs` + `electron`. Renderer bundle is unaffected (renderer doesn't import the module).
+- Per-launch file descriptor is opened once at `initLogger()` and held for the process lifetime; closed on `app.on("will-quit")`. No per-message open/close churn.
+- `fs.writeSync` blocks the event loop for the duration of a single OS write. For low-volume diagnostic logs (a handful of lines per launch in normal operation), the cost is negligible. If volume grows materially in future scopes, swap to `fs.write` (async) or a `WriteStream` — keep this in mind before any code path starts logging in tight loops.
+- `JSON.stringify` on the small per-record object (4 string-ish fields) is sub-microsecond and not on a hot path.
+- Crash-safety: `fs.writeSync` lands the bytes in the OS write buffer immediately, so a hard JS-level crash doesn't lose the tail of the log. Library-managed JS streams (the path electron-log would have taken) trade that for higher throughput.
+
+## Migration Notes
+
+No user data migration. The new logger writes to a new directory tree (`<logs>/YYYY/MM/DD/...`) that didn't exist before. Existing `settings.json`, `window-state.json`, `auth.bin` are unaffected. No rollback complications: revert the four phases and the tree returns to its pre-W1 state.
+
+## References
+
+- Parent worktree research: `thoughts/shared/research/2026-05-06-desktop-deferred-grouping-for-worktrees.md` (W1 spec at lines 126-152)
+- Original gap doc: `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md` (§10 + §"§2 file-backed logger")
+- rc.4 dry-run report: `thoughts/shared/2026-05-06-desktop-rc1-ad-hoc-dry-run-report.md`
+- Existing Sentry main wrap: `vendor/observability/src/sentry-electron-main.ts:1-7`
+- Existing renderer comment anticipating wrap: `apps/desktop/src/renderer/src/main.ts:20-26`
+- Renderer error IPC bridge: `apps/desktop/src/main/index.ts:81-97,207-211`
+- Codex logger reference (asar inventory 2026-05-06; path is local-machine only, evidence inlined): `/Applications/Codex.app/Contents/Resources/app.asar` top-level `node_modules` = `better-sqlite3, bindings, file-uri-to-path, node-addon-api, node-pty, tslib` (no logger lib — hand-rolled over `node:fs`)
+- Sentry ecosystem version note: `@sentry/electron` stays on v7 floor (this plan bumps 7.11→7.13). Catalog peers `@sentry/browser`/`core`/`nextjs` are at v10.49. The cross-major sync is deliberately deferred — `@sentry/electron` v8 was a breaking rewrite. Track in a follow-up worktree if/when it becomes load-bearing.
+
+---
+
+## Improvement Log
+
+Adversarial review applied 2026-05-06 against `1bc77e573905d405c2f48fb81b0c019cab569204`. Decisions captured below; original-draft assumptions noted in case future readers want to reconstruct the trade-off.
+
+### Logger implementation: hand-roll over electron-log
+
+**Original draft** added `electron-log@^5.4.3` as a runtime dep, citing its renderer↔main IPC bridge. The same draft then explicitly disabled that bridge ("Renderer bridge: NOT enabled"). The remaining features in scope (path resolution, level filter, JSON format, size-aware behavior) collapse to ~50 LOC of `node:fs`. Codex's own logger is hand-rolled over `node:fs` (verified via asar inventory), so hand-rolling also aligns the structural baseline.
+
+**Revised**: Phase 2 now ships a `node:fs` module — `openSync` + `writeSync` for crash-safe sync writes, `app.on("will-quit")` for fd cleanup, dev-only stdout mirror. No new runtime dep. ~80 KB and one library boundary saved. The original draft's `archiveLogFn` no-op claim (which was in the prose but missing from the code) is moot since we no longer carry electron-log's rotation surface.
+
+### Sentry @sentry/electron version: kept 7.11→7.13
+
+The bump in scope is a patch within v7. Workspace-catalog peers (`@sentry/browser`/`core`/`nextjs`) are at v10.49, so desktop is 3 majors behind. v8 was a breaking rewrite; cross-major sync is out of scope for W1. **Added** an explicit deferral note to References so the drift is documented, not hidden.
+
+### Renderer wrap: kept with documented deferral
+
+`vendor/observability/src/sentry-electron-renderer.ts` is added as canonical pre-positioning. Until renderer SDK init lands or someone tries to import `@sentry/electron/renderer` directly, the wrap is dead code. **Added** a note to the renderer comment block explaining the eslint `no-restricted-imports` enforcement is intentionally deferred — there is currently no renderer Sentry usage to police. The wrap is ready when init lands; the lint guard lands with init.
+
+### Verification fixes
+
+- Phase 1 `node -e require(...)` check replaced with `test -f` source-presence check (the TS source isn't `require`-able at the path until a consumer compiles it; the original check would have failed on a green branch).
+- Phase 3 `grep` invocation gained `-r` (without it the search misses subdirs and would silently pass).
+- Phase 3 `pnpm package` automated check dropped — building a packaged DMG to verify a console→logger swap is overkill at the phase boundary; the existing Phase 3 Human Review step "inspect a single packaged `.dmg` build" already covers the integration gate.
+- Test mock reference corrected from `auth-focus-gate.test.ts` (which doesn't mock `electron`) to `auth-flow.test.ts:13-24` (the actual mock pattern for `app.isPackaged`).
+
+### Filename uniqueness
+
+`HHMMSS` widened to `HHMMSSsss` (millisecond suffix) so two launches in the same wall-clock second don't collide on filename. Guards against a vanishingly-rare-but-real failure mode of two log-writer launches (e.g., a debugging session) racing into the same file.
+
+### Module-init contract
+
+Added an inline comment in the logger module documenting that top-level *imports* are safe but logger calls before `initLogger()` runs would silently drop. Prevents future foot-guns when a new module starts logging at module-init time.
+
+### Spike status
+
+No spike was run. The hand-roll vs library decision was clean enough to call from review evidence (verified electron-log's only differentiated feature, the IPC bridge, was already out of scope). User decision captured directly.

--- a/thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
+++ b/thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md
@@ -497,7 +497,7 @@ Verified against current tree:
 - **Phase 1 (entitlements)**: `build/entitlements.mac.plist` has 5 keys — `disable-library-validation`, `device.camera`, `network.server` all gone. `NSCameraUsageDescription` removed from `forge.config.ts` extendInfo.
 - **Phase 2 (Info.plist)**: `forge.config.ts:67-78` carries `NSQuitAlwaysKeepsWindows=false`, `LSMinimumSystemVersion: "12.0"`, `LSEnvironment: { MallocNanoZone: "0" }`.
 - **Phase 3 (Sentry)**: `src/main/sentry.ts:14-55` has module-scoped `SESSION_ID`, `rewriteFramesIntegration({ root: app.getAppPath(), prefix: "app:///" })`, `dist: build.buildNumber`, tags `sessionId/bundle/host`.
-- **Phase 4 (dead code)**: `showContextMenu` removed from `ipc.ts`. `silentRefresh` + `REFRESH_TIMEOUT_MS` removed — superseded by a full `auth-flow.ts` rewrite (loopback HTTP server over `127.0.0.1:<port>/callback` with a per-signin CSRF state and cryptographic token). Deep-link `console.log` gone — in fact the entire deep-link dispatcher is gone: `src/main/protocol.ts` deleted, `onDeepLink` removed from `index.ts`, `CFBundleURLTypes` dropped from extendInfo. Research §10 is now moot — there is no deep-link surface to dispatch.
+- **Phase 4 (dead code)**: `showContextMenu` removed from `ipc.ts`. `silentRefresh` + `REFRESH_TIMEOUT_MS` removed — superseded by a full `auth-flow.ts` rewrite (loopback HTTP server over `127.0.0.1:<port>/callback` with a per-signin CSRF state and cryptographic token). Deep-link `console.log` gone; the original deep-link dispatcher was deleted (`src/main/protocol.ts`, `onDeepLink`, `CFBundleURLTypes`) — then PR #627 (2026-05-06) reintroduced `protocol.ts` and `CFBundleURLTypes` for the PKCE auth callback (`lightfast://auth/callback`) only. The general URL→renderer-route dispatcher §10 originally described is still absent.
 
 ### Pre-release batch plan: scope + external setup
 
@@ -531,7 +531,7 @@ Verification pass logged at [`thoughts/shared/research/2026-05-06-desktop-prod-r
 
 - **PR #621** (`aef1d3240`, 2026-04-24) — pre-release-batch phases B–F. Closes IN PROGRESS rows in §2 (Sentry source-map upload), §6 (multi-arch matrix), §13 (build-metadata stamping). Source artifacts: `apps/desktop/src/env/{main,renderer}.ts`, `apps/desktop/scripts/upload-sourcemaps.mjs`, `.github/workflows/desktop-{release,ci}.yml`, `apps/desktop/.env.example`, `apps/desktop/package.json` `clean` script, `.changeset/config.json` ignore.
 - **PR #637** (`ab634170e`, 2026-05-06) — unsigned-beta-distribution. Adds a `signingMode: "ad-hoc" | "developer-id"` enum threaded through `apps/desktop/package.json:72`, `apps/desktop/src/shared/build-info-schema.ts:6-7,15`, build-info, Sentry tags, updater. `forge.config.ts:14-49` carries a two-branch osxSign (developer-id when `APPLE_SIGNING_IDENTITY` + `APPLE_TEAM_ID` set, else ad-hoc fallback `identity: "-"`). `desktop-release.yml:32-40` auto-derives `prerelease=true` from any hyphen-suffix in the tag; `desktop-release.yml:120-124` flips `signingMode` based on whether `APPLE_SIGNING_IDENTITY` exists. `apps/desktop/src/main/updater.ts:87-89` disables the auto-updater entirely when `signingMode === "ad-hoc"` (Squirrel.Mac requires the new build to satisfy the running app's Designated Requirement; ad-hoc DRs are content-bound).
-- **Mid-flight** — `2565270fa` (floating settings panel), `b30d99975` (custom URL scheme + PKCE). The custom-URL-scheme work does **not** reintroduce a deep-link handler in main: `grep` for `setAsDefaultProtocolClient`, `onDeepLink`, `open-url` across `apps/desktop/src/` returns zero matches. The deletion of `protocol.ts` and the lack of `CFBundleURLTypes` in `forge.config.ts:81-92` extendInfo both still hold. **§10 deep-link surface is genuinely gone.**
+- **Mid-flight** — `2565270fa` (floating settings panel), `b30d99975` (custom URL scheme + PKCE). The 2026-04-25 deletion of `protocol.ts` was reversed by PR #627 (2026-05-06) for PKCE only: `setAsDefaultProtocolClient`, `open-url`, `second-instance`, `CFBundleURLTypes` all back in tree. **§10 surface is single-purpose (PKCE auth callback only); the general URL→route dispatcher remains absent.**
 
 ### Tracker rows state at 2026-05-06
 
@@ -541,7 +541,7 @@ Verification pass logged at [`thoughts/shared/research/2026-05-06-desktop-prod-r
 | 6 | Multi-arch arm64+x64 | IN PROGRESS | **DONE** (PR #621) |
 | 13 | Non-empty version / buildNumber / sparkleFeedUrl | IN PROGRESS | **DONE** (PR #621 — workflow stamps via `npm pkg set`; placeholders in `package.json` are intentional) |
 | 13 | `signingMode` (new) | n/a | **DONE** (PR #637) |
-| 10 | Deep-link `console.log` / dispatcher | DEFERRED | **N/A** — surface removed; was never reintroduced |
+| 10 | Deep-link `console.log` / dispatcher | DEFERRED | **PARTIAL** — PR #627 (2026-05-06) reintroduced `protocol.ts` + `CFBundleURLTypes` for PKCE auth callback (`lightfast://auth/callback`) only; general URL→route dispatcher still absent |
 
 All other DEFERRED / RELEASE rows from the 2026-04-24 tracker remain unchanged.
 

--- a/vendor/observability/package.json
+++ b/vendor/observability/package.json
@@ -17,6 +17,10 @@
       "types": "./src/sentry-electron-main.ts",
       "default": "./src/sentry-electron-main.ts"
     },
+    "./sentry-electron-renderer": {
+      "types": "./src/sentry-electron-renderer.ts",
+      "default": "./src/sentry-electron-renderer.ts"
+    },
     "./sentry-browser": {
       "types": "./src/sentry-browser.ts",
       "default": "./src/sentry-browser.ts"

--- a/vendor/observability/src/sentry-electron-renderer.ts
+++ b/vendor/observability/src/sentry-electron-renderer.ts
@@ -1,0 +1,5 @@
+export {
+  captureException,
+  captureMessage,
+  init,
+} from "@sentry/electron/renderer";


### PR DESCRIPTION
## Summary

W1 worktree slice of the desktop observability tier 2 plan — closes the dry-run finding that we are over-reliant on Sentry to see anything from a packaged build. Plan: [`thoughts/shared/plans/2026-05-06-desktop-w1-observability-tier-2.md`](https://github.com/lightfastai/lightfast/blob/feat/desktop-observability-tier2/thoughts/shared/plans/2026-05-06-desktop-w1-observability-tier-2.md).

- **Phase 1 — `@sentry/electron` 7.11.0 → 7.13.0 in workspace catalog**; `apps/desktop` switched from a literal pin to `catalog:`. Adds `@vendor/observability/sentry-electron-renderer` re-export wrap (`init` / `captureException` / `captureMessage`) so a renderer-side Sentry SDK can land later via the canonical import path. Renderer SDK init is still deferred (wrap-only scope); the existing IPC bridge to main remains the renderer→Sentry path.
- **Phase 2 — hand-rolled file logger** at `apps/desktop/src/main/logger.ts`. ~100 LOC of `node:fs` (no new runtime dep), per-launch JSON-line files at `app.getPath('logs')/YYYY/MM/DD/desktop-<pid>-<HHMMSSsss>.log`, sync `writeSync` for crash-safe append, dev-only stdout mirror. Coverage: `apps/desktop/src/main/__tests__/logger.test.ts` — 7 tests on path shape, `initLogger()` idempotency, level filtering, JSON format, Error stack serialization. Aligns with Codex's hand-rolled approach (verified via local asar inventory — no logger lib).
- **Phase 3 — route 9 of 11 main-process `console.*` sites through the logger** (`settings-store`, `auth-store` ×5, `auth-flow` ×2, `index.ts` renderer-error handler). Existing `captureException` calls preserved everywhere — file logger replaces only the `console.*` half. `bootstrap.ts` (2 sites) intentionally stays pre-logger with an explanatory comment because bootstrap runs before `./index` is dynamically imported.
- **Phase 4 — corrects parent gap doc §10 drift** in `thoughts/shared/research/2026-04-23-codex-vs-lightfast-desktop-production-gap.md`: the "deep-link surface is genuinely gone" claim became inaccurate when PR #627 reintroduced `protocol.ts` and `CFBundleURLTypes` for the PKCE auth callback. The general URL→route dispatcher §10 originally described is still absent; tracker row updated `N/A` → `PARTIAL`. Note: an identical fix was briefly committed to main as `a0df15a6a` and then reverted (`0db520a7e`) so it could land via this PR alongside the rest of W1.

What's explicitly out of scope: renderer Sentry SDK init, auto-forward from logger to Sentry, log rotation/retention/upload, renderer-process logger, the §10 broader URL→route dispatcher fix, eslint enforcement of the renderer-Sentry import boundary.

## Test plan

- [ ] CI green (typecheck, vitest, biome `pnpm check`)
- [ ] `pnpm why @sentry/electron` resolves to `7.13.0` for both `@vendor/observability` and `@lightfast/desktop`
- [ ] `pnpm --filter @lightfast/desktop test` passes (4 files, 45 tests including the new logger.test.ts)
- [ ] `grep -rn 'console\\.\\(error\\|warn\\|log\\|info\\)' apps/desktop/src/main/` returns 2 hits in `bootstrap.ts` (intentional pre-logger) + 3 hits in `logger.ts` (the dev-stdout mirror sinks defined by the logger module)
- [ ] `pnpm dev:desktop` → trigger a settings write to disk → a launch log file appears under `app.getPath('logs')/YYYY/MM/DD/desktop-<pid>-<HHMMSSsss>.log` and contains valid JSON lines
- [ ] Trigger an auth-store error path (delete `auth.bin` mid-session, sign out, sign in) → confirm the file logger line lands; Sentry event lands when DSN is configured
- [ ] Inspect a single packaged `.dmg` build → `app.getPath('logs')` resolves to `~/Library/Logs/Lightfast/...` and a launch log file lands there
- [ ] Read the two updated paragraphs in the gap doc (lines ~500 and ~534) end-to-end → both read coherently with surrounding context; cross-references to §10 elsewhere still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a structured logging system for the desktop application, improving error tracking and debugging capabilities throughout the app.

* **Chores**
  * Updated error tracking library dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->