### PR TITLE
refactor(api/app): drop orgApiKeys.rotate end-to-end

### DIFF
--- a/api/app/src/router/org/org-api-keys.ts
+++ b/api/app/src/router/org/org-api-keys.ts
@@ -5,7 +5,6 @@ import {
   createOrgApiKeySchema,
   deleteOrgApiKeySchema,
   revokeOrgApiKeySchema,
-  rotateOrgApiKeySchema,
 } from "@repo/app-validation/schemas";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
@@ -23,7 +22,6 @@ import { orgScopedProcedure } from "../../trpc";
  * - Keys are hashed using SHA-256 before storage (never store plaintext)
  * - Full key is only returned once on creation (never again)
  * - Keys can be revoked (soft delete) or permanently deleted
- * - Key rotation atomically revokes old key and creates new one
  */
 export const orgApiKeysRouter = {
   /**
@@ -193,91 +191,5 @@ export const orgApiKeysRouter = {
       });
 
       return { success: true };
-    }),
-
-  /**
-   * Rotate an API key (revoke old, create new with same name)
-   * Returns the new full key ONLY on rotation (never again)
-   */
-  rotate: orgScopedProcedure
-    .input(rotateOrgApiKeySchema)
-    .mutation(async ({ ctx, input }) => {
-      const [existingKey] = await db
-        .select({
-          id: orgApiKeys.id,
-          name: orgApiKeys.name,
-          isActive: orgApiKeys.isActive,
-        })
-        .from(orgApiKeys)
-        .where(
-          and(
-            eq(orgApiKeys.publicId, input.keyId),
-            eq(orgApiKeys.clerkOrgId, ctx.auth.orgId)
-          )
-        )
-        .limit(1);
-
-      if (!existingKey) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "API key not found",
-        });
-      }
-
-      const { key, prefix, suffix } = generateOrgApiKey();
-      const keyHash = hashApiKey(key);
-
-      // Batch: revoke old, create new (atomic — neon-http doesn't support transactions)
-      const [, insertResult] = await db.batch([
-        // Revoke old key
-        db
-          .update(orgApiKeys)
-          .set({ isActive: false, updatedAt: new Date().toISOString() })
-          .where(eq(orgApiKeys.id, existingKey.id)),
-        // Create new key
-        db
-          .insert(orgApiKeys)
-          .values({
-            clerkOrgId: ctx.auth.orgId,
-            createdByUserId: ctx.auth.userId,
-            name: existingKey.name,
-            keyHash,
-            keyPrefix: prefix,
-            keySuffix: suffix,
-            expiresAt: input.expiresAt?.toISOString(),
-          })
-          .returning({
-            id: orgApiKeys.id,
-            publicId: orgApiKeys.publicId,
-          }),
-      ] as const);
-
-      const [newKey] = insertResult;
-
-      if (!newKey) {
-        log.error("[org-api-keys] rotate failed", {
-          clerkOrgId: ctx.auth.orgId,
-          oldKeyId: input.keyId,
-        });
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to rotate API key",
-        });
-      }
-
-      log.info("[org-api-keys] rotated", {
-        clerkOrgId: ctx.auth.orgId,
-        oldKeyId: input.keyId,
-        newKeyId: newKey.publicId,
-      });
-
-      return {
-        id: newKey.publicId,
-        key, // Full key - only returned once!
-        name: existingKey.name,
-        keyPreview: `${prefix}...${suffix}`,
-        expiresAt: input.expiresAt?.toISOString() ?? null,
-        createdAt: new Date().toISOString(),
-      };
     }),
 } satisfies TRPCRouterRecord;

--- a/apps/app/src/app/(app)/(org)/[slug]/(workspace)/(manage)/settings/api-keys/_components/org-api-key-list.tsx
+++ b/apps/app/src/app/(app)/(org)/[slug]/(workspace)/(manage)/settings/api-keys/_components/org-api-key-list.tsx
@@ -43,7 +43,6 @@ import {
   Loader2,
   MoreHorizontal,
   Plus,
-  RefreshCw,
   ShieldOff,
   Trash2,
 } from "lucide-react";
@@ -67,7 +66,7 @@ export function OrgApiKeyList() {
 
   // Alert dialog state
   const [alertAction, setAlertAction] = useState<{
-    type: "revoke" | "rotate" | "delete";
+    type: "revoke" | "delete";
     keyId: string;
     keyName: string;
   } | null>(null);
@@ -98,18 +97,6 @@ export function OrgApiKeyList() {
     })
   );
 
-  const rotateMutation = useMutation(
-    trpc.orgApiKeys.rotate.mutationOptions({
-      meta: { errorTitle: "Failed to rotate API key" },
-      onSuccess: (data) => {
-        setCreatedKey(data.key);
-        setIsCreateOpen(true);
-        toast.success("API key rotated — copy your new key");
-      },
-      onSettled: () => void invalidateList(),
-    })
-  );
-
   const deleteMutation = useMutation(
     trpc.orgApiKeys.delete.mutationOptions({
       meta: { errorTitle: "Failed to delete API key" },
@@ -134,9 +121,6 @@ export function OrgApiKeyList() {
     switch (alertAction.type) {
       case "revoke":
         revokeMutation.mutate({ keyId: alertAction.keyId });
-        break;
-      case "rotate":
-        rotateMutation.mutate({ keyId: alertAction.keyId });
         break;
       case "delete":
         deleteMutation.mutate({ keyId: alertAction.keyId });
@@ -272,9 +256,7 @@ export function OrgApiKeyList() {
               (revokeMutation.isPending &&
                 revokeMutation.variables?.keyId === key.id) ||
               (deleteMutation.isPending &&
-                deleteMutation.variables?.keyId === key.id) ||
-              (rotateMutation.isPending &&
-                rotateMutation.variables?.keyId === key.id);
+                deleteMutation.variables?.keyId === key.id);
 
             return (
               <div
@@ -337,18 +319,6 @@ export function OrgApiKeyList() {
                         <DropdownMenuItem
                           onClick={() =>
                             setAlertAction({
-                              type: "rotate",
-                              keyId: key.id,
-                              keyName: key.name,
-                            })
-                          }
-                        >
-                          <RefreshCw className="mr-2 h-4 w-4" />
-                          Rotate
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() =>
-                            setAlertAction({
                               type: "revoke",
                               keyId: key.id,
                               keyName: key.name,
@@ -395,14 +365,11 @@ export function OrgApiKeyList() {
           <AlertDialogHeader>
             <AlertDialogTitle>
               {alertAction?.type === "revoke" && "Revoke API Key?"}
-              {alertAction?.type === "rotate" && "Rotate API Key?"}
               {alertAction?.type === "delete" && "Delete API Key?"}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {alertAction?.type === "revoke" &&
                 `"${alertAction.keyName}" will be deactivated immediately. Any requests using this key will fail.`}
-              {alertAction?.type === "rotate" &&
-                `"${alertAction.keyName}" will be revoked and replaced with a new key. Update your integrations with the new key.`}
               {alertAction?.type === "delete" &&
                 `"${alertAction.keyName}" will be permanently deleted. This action cannot be undone.`}
             </AlertDialogDescription>
@@ -418,7 +385,6 @@ export function OrgApiKeyList() {
               onClick={handleConfirmAlert}
             >
               {alertAction?.type === "revoke" && "Revoke"}
-              {alertAction?.type === "rotate" && "Rotate"}
               {alertAction?.type === "delete" && "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/www/src/content/changelog/2026-03-26-lightfast-engineering-intelligence-shipped.mdx
+++ b/apps/www/src/content/changelog/2026-03-26-lightfast-engineering-intelligence-shipped.mdx
@@ -120,7 +120,6 @@ npm install lightfast
 
 API keys in Lightfast are org-scoped and managed from the dashboard. Keys are hashed at rest and shown only once on creation.
 
-- Create, rotate, and revoke keys from the settings page
-- Rotate atomically — the old key is revoked and a new one is issued in a single operation
+- Create and revoke keys from the settings page
 - All keys are scoped to the organization that created them
 

--- a/packages/app-validation/src/schemas/org-api-key.ts
+++ b/packages/app-validation/src/schemas/org-api-key.ts
@@ -29,16 +29,7 @@ export const deleteOrgApiKeySchema = z.object({
   keyId: z.string().min(1), // publicId
 });
 
-/**
- * Schema for rotating an API key (revoke old, create new)
- */
-export const rotateOrgApiKeySchema = z.object({
-  keyId: z.string().min(1), // publicId
-  expiresAt: z.coerce.date().optional(),
-});
-
 // Type exports
 export type CreateOrgApiKey = z.infer<typeof createOrgApiKeySchema>;
 export type RevokeOrgApiKey = z.infer<typeof revokeOrgApiKeySchema>;
 export type DeleteOrgApiKey = z.infer<typeof deleteOrgApiKeySchema>;
-export type RotateOrgApiKey = z.infer<typeof rotateOrgApiKeySchema>;


### PR DESCRIPTION
## Summary

- Removes the `orgApiKeys.rotate` tRPC procedure, its `rotateOrgApiKeySchema` + `RotateOrgApiKey` type, and the sole UI consumer (Rotate menu item + alert dialog branches in settings/api-keys).
- Updates the 2026-03-26 changelog: bullet now reads "Create and revoke keys from the settings page", and the now-orphaned "Rotate atomically…" bullet is removed.
- Net diff: 4 files, +3 / -135. No DB migration — `rotate` was pure orchestration over existing columns. Users replace the affordance with revoke-then-create.

Plan: [`thoughts/shared/plans/2026-05-09-drop-org-api-key-rotate.md`](thoughts/shared/plans/2026-05-09-drop-org-api-key-rotate.md)

## Test plan

- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @repo/app-validation typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm typecheck` (35/35 packages)
- [x] `pnpm check` (ultracite, 770 files)
- [x] `rg "orgApiKeys\.rotate|rotateOrgApiKey|RotateOrgApiKey" api apps packages` → 0 hits
- [x] `…/settings/api-keys` `…` menu on active key shows only Revoke + Delete; revoked key shows only Delete
- [x] 2026-03-26 changelog page renders with the updated bullets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * API key rotation has been removed from API key management across all interfaces and documentation. Users can still create, revoke, and delete API keys as before. Applications and integrations previously using the rotation feature will need to implement an alternative approach for their key lifecycle management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->