### PR TITLE
refactor(dev): move worktree INNGEST_APP_NAME suffixing into env wrapper

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@db/app": "workspace:*",
-    "@lightfastai/dev-core": "catalog:",
     "@repo/app-api-key": "workspace:*",
     "@repo/app-encryption": "workspace:*",
     "@repo/app-validation": "workspace:^",

--- a/api/app/src/inngest/client.ts
+++ b/api/app/src/inngest/client.ts
@@ -1,4 +1,3 @@
-import { resolveWorktreeRuntimeName } from "@lightfastai/dev-core";
 import { EventSchemas, Inngest } from "@vendor/inngest";
 import { createInngestObservabilityMiddleware } from "@vendor/observability/inngest";
 import type { GetEvents } from "inngest";
@@ -6,17 +5,8 @@ import type { GetEvents } from "inngest";
 import { env } from "../env";
 import { appEvents } from "./schemas/app";
 
-// Local development can run multiple git worktrees against one Inngest Dev
-// Server. Suffix the app id with the worktree identity so those registrations
-// do not collapse into the same Inngest app; preview/production keep the stable
-// configured name.
-const appId =
-  env.VERCEL_ENV === "development"
-    ? resolveWorktreeRuntimeName(env.INNGEST_APP_NAME)
-    : env.INNGEST_APP_NAME;
-
 const inngest = new Inngest({
-  id: appId,
+  id: env.INNGEST_APP_NAME,
   eventKey: env.INNGEST_EVENT_KEY,
   schemas: new EventSchemas().fromSchema(appEvents),
   middleware: [createInngestObservabilityMiddleware()],

--- a/api/platform/package.json
+++ b/api/platform/package.json
@@ -33,7 +33,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lightfastai/dev-core": "catalog:",
     "@lightfastai/dev-proxy": "catalog:",
     "@t3-oss/env-nextjs": "^0.12.0",
     "@trpc/server": "catalog:",

--- a/api/platform/src/inngest/client.ts
+++ b/api/platform/src/inngest/client.ts
@@ -1,4 +1,3 @@
-import { resolveWorktreeRuntimeName } from "@lightfastai/dev-core";
 import { EventSchemas, Inngest } from "@vendor/inngest";
 import { createInngestObservabilityMiddleware } from "@vendor/observability/inngest";
 import type { GetEvents } from "inngest";
@@ -6,13 +5,8 @@ import type { GetEvents } from "inngest";
 import { env } from "../env";
 import { platformEvents } from "./schemas/platform";
 
-const appId =
-  env.VERCEL_ENV === "development"
-    ? resolveWorktreeRuntimeName(env.INNGEST_APP_NAME)
-    : env.INNGEST_APP_NAME;
-
 const inngest = new Inngest({
-  id: appId,
+  id: env.INNGEST_APP_NAME,
   eventKey: env.INNGEST_EVENT_KEY,
   schemas: new EventSchemas().fromSchema(platformEvents),
   middleware: [createInngestObservabilityMiddleware()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,9 +245,6 @@ importers:
       '@db/app':
         specifier: workspace:*
         version: link:../../db/app
-      '@lightfastai/dev-core':
-        specifier: 'catalog:'
-        version: 0.4.0
       '@repo/app-api-key':
         specifier: workspace:*
         version: link:../../packages/app-api-key
@@ -306,9 +303,6 @@ importers:
 
   api/platform:
     dependencies:
-      '@lightfastai/dev-core':
-        specifier: 'catalog:'
-        version: 0.4.0
       '@lightfastai/dev-proxy':
         specifier: 'catalog:'
         version: 0.4.0

--- a/scripts/with-dev-services-env.mjs
+++ b/scripts/with-dev-services-env.mjs
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveWorktreeRuntimeName } from "@lightfastai/dev-core";
 import {
   resolveDevPostgresConfig,
   resolveDevRedisConfig,
@@ -62,6 +63,9 @@ function buildEnv() {
     configPath,
     env: resolverEnv,
   });
+  const inngestAppName = process.env.INNGEST_APP_NAME
+    ? resolveWorktreeRuntimeName(process.env.INNGEST_APP_NAME)
+    : undefined;
 
   return {
     ...process.env,
@@ -79,6 +83,7 @@ function buildEnv() {
     UPSTASH_REDIS_REST_TOKEN: redis.token,
     LIGHTFAST_DEV_REDIS_KEY_PREFIX: redis.keyPrefix,
     LIGHTFAST_DEV_SERVICES_ACTIVE: "1",
+    ...(inngestAppName ? { INNGEST_APP_NAME: inngestAppName } : {}),
   };
 }
 
@@ -110,6 +115,7 @@ function printEnv(env) {
     "KV_REST_API_URL",
     "KV_URL",
     "REDIS_URL",
+    "INNGEST_APP_NAME",
     "LIGHTFAST_DEV_REDIS_KEY_PREFIX",
     "LIGHTFAST_DEV_SERVICES_ACTIVE",
   ];


### PR DESCRIPTION
## Summary

- Move `resolveWorktreeRuntimeName(env.INNGEST_APP_NAME)` from per-Inngest-client module-load into `scripts/with-dev-services-env.mjs`. Both `api/app` and `api/platform` Inngest clients are now flat reads of `env.INNGEST_APP_NAME` — the env wrapper rewrites once per `pnpm dev:*` invocation in the parent process before spawning Next dev.
- Side-benefit: `@lightfastai/dev-core` is no longer a dep of `api/{app,platform}` — only the repo-root `package.json` and the env wrapper reference it.
- Net git invocation count goes **down**: previously fired at every Inngest client module-load (each Next dev boot + every server-component import); now once per dev session.

Plan: `thoughts/shared/plans/2026-05-09-inngest-worktree-rewrite-via-dev-services-wrapper.md`

## Test plan

- [x] `pnpm typecheck` — 35/35 tasks
- [x] `pnpm check` — no new errors (3 pre-existing baseline format/import-order errors unchanged)
- [x] `grep -rn 'resolveWorktreeRuntimeName' api/ apps/` → 0 matches
- [x] `grep -rn '@lightfastai/dev-core' api/ apps/` → 0 matches
- [x] Wrapper rewrite probes from secondary worktree on `refactor/inngest-app-name-via-env-wrapper`: `lightfast-app` → `lightfast-app-inngest-app-name-via-env-wrapper`; same shape for `lightfast-platform`
- [x] Primary-checkout pathway returns base name unchanged (no suffix)
- [x] `LIGHTFAST_DEV_SERVICES=0` bypass returns base name unchanged
- [x] `--print` mode emits `INNGEST_APP_NAME` line alongside `LIGHTFAST_DEV_REDIS_KEY_PREFIX`
- [x] Vendor schema `startsWith("lightfast-")` preserved
- [x] **Manual coexistence test**: two `pnpm dev:app` shells in two distinct worktrees on different non-`main` branches, both running new wrapper, registered as **two distinct Inngest app ids** (`lightfast-app-inngest-app-name-via-env-wrapper` and `lightfast-app-temp-validate-inngest-suffix`) on a single Inngest dev server — confirmed via `http://localhost:8288/v0/gql { apps { name url } }`