### PR TITLE
fix(desktop): build Sparkle feed URLs deterministically

### DIFF
--- a/apps/desktop/scripts/generate-update-feed.mjs
+++ b/apps/desktop/scripts/generate-update-feed.mjs
@@ -35,6 +35,15 @@ const assetsJson = gh([
 ]);
 const { assets } = JSON.parse(assetsJson);
 
+// Don't use `match.url` from `gh release view`: the Finalize job runs this
+// step while the release is still a draft, and GitHub reports draft asset
+// URLs under a temporary `untagged-<hash>/` path that 404s after the
+// `Publish release (undraft)` step rebinds the release to its tag. Build
+// the URL deterministically from the tag instead. Slashes inside the tag
+// (e.g. `@lightfast/desktop@0.1.0`) are preserved literally — GitHub only
+// percent-encodes per path segment.
+const encodedTag = TAG.split("/").map(encodeURIComponent).join("/");
+
 const outDir = mkdtempSync(join(tmpdir(), "lightfast-update-feed-"));
 const outputs = [];
 for (const arch of ARCHES) {
@@ -45,8 +54,9 @@ for (const arch of ARCHES) {
     console.error(`No darwin-${arch} zip asset found on release ${TAG}`);
     process.exit(1);
   }
+  const downloadUrl = `https://github.com/${REPO}/releases/download/${encodedTag}/${encodeURIComponent(match.name)}`;
   const feed = {
-    url: match.url,
+    url: downloadUrl,
     name: VERSION,
     notes: NOTES,
     pub_date: new Date().toISOString(),
@@ -54,7 +64,7 @@ for (const arch of ARCHES) {
   const file = join(outDir, `latest-mac-${arch}.json`);
   writeFileSync(file, JSON.stringify(feed, null, 2), "utf8");
   outputs.push(file);
-  console.log(`wrote ${file} -> ${match.url}`);
+  console.log(`wrote ${file} -> ${downloadUrl}`);
 }
 
 gh(["release", "upload", TAG, "--repo", REPO, "--clobber", ...outputs], {


### PR DESCRIPTION
## Summary

- The Finalize job runs \`generate-update-feed.mjs\` *before* the \`Publish (undraft)\` step, so \`gh release view\` returns draft-state URLs under \`/releases/download/untagged-<hash>/\` that 404 after the release is rebound to its tag.
- Result: \`latest-mac-{arm64,x64}.json\` shipped with broken \`url\` fields, blocking Sparkle auto-update to any future release.
- Build the URL deterministically from \`REPO\` + \`TAG\` + asset name instead. Per-segment percent-encoding preserves the slash inside \`@lightfast/desktop@0.1.0\`.

## Detected

After cutting \`@lightfast/desktop@0.1.0\` (the first signed release where the auto-updater actually runs — rc.* installs short-circuit on \`signingMode=ad-hoc\`):

\`\`\`
$ curl -fsSL .../latest-mac-arm64.json
{"url":".../releases/download/untagged-13a31337e2a5768ad71c/Lightfast-darwin-arm64-0.1.0.zip", ...}

$ curl -sI .../releases/download/untagged-13a31337e2a5768ad71c/Lightfast-darwin-arm64-0.1.0.zip
HTTP/2 404
\`\`\`

Constructed URL (post-fix) verified against the live release:
\`https://github.com/lightfastai/lightfast/releases/download/%40lightfast/desktop%400.1.0/Lightfast-darwin-arm64-0.1.0.zip\` → 302 → 200, 124.7 MB.

## Follow-up

- The \`@lightfast/desktop@0.1.0\` release itself still carries broken feeds. They'll be replaced on the next tag (any new release re-uploads \`latest-mac-*.json\` via this script), or can be patched in place by running the fixed script locally with \`RELEASE_TAG=@lightfast/desktop@0.1.0\` env and \`gh release upload --clobber\`.
- No 0.1.0 install is hurt while 0.1.0 is the only public release (the feed advertises 0.1.0; installs already match). The hazard window opens the moment 0.1.1 ships — fix must land first.

## Test plan

- [ ] Cut a throwaway prerelease tag (\`@lightfast/desktop@0.1.0-rc.8\` or similar) after merge; verify the resulting \`latest-mac-arm64.json\` advertises a 200-returning URL.
- [ ] (Optional but recommended) Manually patch \`@lightfast/desktop@0.1.0\` feeds via the fixed script + \`gh release upload --clobber\` so existing 0.1.0 installs can auto-update once 0.1.1 ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of application update feed generation with more deterministic URL construction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->