### PR TITLE
feat(app): add Terms · Privacy footer to auth layout

### DIFF
--- a/apps/app/src/app/(auth)/layout.tsx
+++ b/apps/app/src/app/(auth)/layout.tsx
@@ -60,7 +60,10 @@ export default function AuthLayout({
           >
             Terms
           </MicrofrontendLink>
-          <span aria-hidden className="size-0.5 rounded-full bg-muted-foreground/60" />
+          <span
+            aria-hidden
+            className="size-0.5 rounded-full bg-muted-foreground/60"
+          />
           <MicrofrontendLink
             className="hover:text-foreground"
             href="/legal/privacy"

--- a/apps/app/src/app/(auth)/layout.tsx
+++ b/apps/app/src/app/(auth)/layout.tsx
@@ -49,8 +49,28 @@ export default function AuthLayout({
       <main className="flex flex-1 items-center justify-center p-4">
         <div className="w-full max-w-xs">{children}</div>
       </main>
-      {/* Bottom spacer to mirror header height for perfect centering */}
-      <div aria-hidden className="h-16 shrink-0 md:h-20" />
+      {/* Footer — mirrors header height for perfect centering */}
+      <footer className="page-gutter flex h-16 shrink-0 items-center justify-center md:h-20">
+        <div className="flex items-center gap-3 text-muted-foreground text-sm">
+          <MicrofrontendLink
+            className="hover:text-foreground"
+            href="/legal/terms"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Terms
+          </MicrofrontendLink>
+          <span aria-hidden className="size-0.5 rounded-full bg-muted-foreground/60" />
+          <MicrofrontendLink
+            className="hover:text-foreground"
+            href="/legal/privacy"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Privacy
+          </MicrofrontendLink>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/apps/app/src/app/(early-access)/_components/early-access-form-server.tsx
+++ b/apps/app/src/app/(early-access)/_components/early-access-form-server.tsx
@@ -1,6 +1,5 @@
 import { Input } from "@repo/ui/components/ui/input";
-import type { Route } from "next";
-import Link from "next/link";
+import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import { joinEarlyAccessAction } from "../_actions/early-access";
 import { CompanySizeIsland } from "./company-size-island";
 import { SourcesIsland } from "./sources-island";
@@ -67,21 +66,25 @@ export function EarlyAccessFormServer({
           <SubmitButton />
         </div>
 
-        <p className="text-muted-foreground text-xs">
+        <p className="text-center text-muted-foreground text-sm">
           By continuing you acknowledge that you understand and agree to our{" "}
-          <Link
-            className="underline transition-colors hover:text-foreground"
-            href={"/legal/terms" as Route}
+          <MicrofrontendLink
+            className="text-foreground underline hover:text-foreground/80"
+            href="/legal/terms"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            Terms and Conditions
-          </Link>{" "}
+            Terms of Service
+          </MicrofrontendLink>{" "}
           and{" "}
-          <Link
-            className="underline transition-colors hover:text-foreground"
-            href={"/legal/privacy" as Route}
+          <MicrofrontendLink
+            className="text-foreground underline hover:text-foreground/80"
+            href="/legal/privacy"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Privacy Policy
-          </Link>
+          </MicrofrontendLink>
           .
         </p>
       </form>


### PR DESCRIPTION
## Summary

- Shared footer with Terms/Privacy links in `apps/app/src/app/(auth)/layout.tsx` so both `/sign-in` and `/sign-up` surface them.
- Aligns the early-access legal copy with the sign-up styling: `text-sm`, centered, `MicrofrontendLink`, wording set to "Terms of Service" to match the actual `/legal/terms` page.

## Test plan

- [ ] Open `/sign-in` and `/sign-up` — footer renders `Terms · Privacy`, dot is a real circle (`size-0.5 rounded-full`), links open `/legal/terms` and `/legal/privacy` in a new tab.
- [ ] Open `/early-access` — legal line matches the sign-up styling and wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth page now includes a footer matching the header height with Terms and Privacy links that open in a new tab.
  * Early access form’s legal link updated to open in a new tab and updated label.

* **Style**
  * Improved styling and spacing of terms/consent text across authentication and early-access flows (visual alignment preserved).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/686)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->