### PR TITLE
refactor: align authenticated not found shells

### DIFF
--- a/.agents/skills/lightfast-desktop-signin/lib/write-auth-bin.mjs
+++ b/.agents/skills/lightfast-desktop-signin/lib/write-auth-bin.mjs
@@ -21,10 +21,15 @@ import { app, safeStorage } from "electron";
 
 function parseArgs() {
   const out = { product: null };
-  const argv = process.argv.slice(2);
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--product") {
-      out.product = argv[++i];
+  let isProductValue = false;
+  for (const arg of process.argv.slice(2)) {
+    if (isProductValue) {
+      out.product = arg;
+      isProductValue = false;
+      continue;
+    }
+    if (arg === "--product") {
+      isProductValue = true;
     }
   }
   return out;

--- a/apps/app/src/app/(app)/(pending-allowed)/layout.test.tsx
+++ b/apps/app/src/app/(app)/(pending-allowed)/layout.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import UserLayout from "./layout";
+
+function containsComponentNamed(node: unknown, componentName: string): boolean {
+  if (!React.isValidElement(node)) {
+    return false;
+  }
+
+  const type = node.type;
+  if (typeof type === "function" && type.name === componentName) {
+    return true;
+  }
+
+  const props = node.props as { children?: React.ReactNode };
+  return React.Children.toArray(props.children).some((child) =>
+    containsComponentNamed(child, componentName)
+  );
+}
+
+describe("user layout", () => {
+  it("uses the shared authenticated topbar", () => {
+    const element = UserLayout({ children: <div>Account page</div> });
+
+    expect(containsComponentNamed(element, "AuthenticatedTopbar")).toBe(true);
+  });
+});

--- a/apps/app/src/app/(app)/(pending-allowed)/layout.tsx
+++ b/apps/app/src/app/(app)/(pending-allowed)/layout.tsx
@@ -1,7 +1,6 @@
-import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import { Suspense } from "react";
+import { AuthenticatedTopbar } from "~/components/authenticated-topbar";
 import { TeamSwitcher, TeamSwitcherSkeleton } from "~/components/team-switcher";
-import { UserMenu, UserMenuSkeleton } from "~/components/user-menu";
 
 export default function UserLayout({
   children,
@@ -10,32 +9,13 @@ export default function UserLayout({
 }) {
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      <header className="flex h-14 shrink-0 items-center gap-3 px-4">
-        <Suspense fallback={<TeamSwitcherSkeleton />}>
-          <TeamSwitcher />
-        </Suspense>
-        <div className="ml-auto flex items-center gap-3">
-          <MicrofrontendLink
-            className="text-muted-foreground text-sm hover:text-foreground"
-            href="/docs/get-started/overview"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Docs
-          </MicrofrontendLink>
-          <MicrofrontendLink
-            className="text-muted-foreground text-sm hover:text-foreground"
-            href="/docs/api-reference"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            API Reference
-          </MicrofrontendLink>
-          <Suspense fallback={<UserMenuSkeleton />}>
-            <UserMenu />
+      <AuthenticatedTopbar
+        left={
+          <Suspense fallback={<TeamSwitcherSkeleton />}>
+            <TeamSwitcher />
           </Suspense>
-        </div>
-      </header>
+        }
+      />
       <div className="relative flex flex-1 flex-col overflow-y-auto bg-background">
         {children}
       </div>

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@repo/app-trpc/server", () => ({
+  HydrateClient: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@vendor/observability/error/next", () => ({
+  parseError: (error: unknown) => error,
+}));
+
+vi.mock("@vendor/observability/log/next", () => ({
+  log: {
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/components/app-sidebar", () => {
+  function AppSidebar() {
+    return <aside data-testid="app-sidebar" />;
+  }
+
+  return { AppSidebar };
+});
+
+vi.mock("~/lib/org-access-clerk", () => ({
+  requireOrgAccess: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+const { requireOrgAccess } = await import("~/lib/org-access-clerk");
+const { default: OrgLayout } = await import("./layout");
+
+function containsComponentNamed(node: unknown, componentName: string): boolean {
+  if (!React.isValidElement(node)) {
+    return false;
+  }
+
+  const type = node.type;
+  if (typeof type === "function" && type.name === componentName) {
+    return true;
+  }
+
+  const props = node.props as { children?: React.ReactNode };
+  return React.Children.toArray(props.children).some((child) =>
+    containsComponentNamed(child, componentName)
+  );
+}
+
+describe("org layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the authenticated header shell when org access is denied", async () => {
+    (requireOrgAccess as Mock).mockRejectedValue(new Error("denied"));
+
+    const element = await OrgLayout({
+      children: <div>Workspace</div>,
+      params: Promise.resolve({ slug: "missing-team" }),
+    });
+
+    expect(containsComponentNamed(element, "AuthenticatedTopbar")).toBe(true);
+    expect(containsComponentNamed(element, "AppSidebar")).toBe(false);
+  });
+
+  it("returns the org sidebar shell when org access is allowed", async () => {
+    (requireOrgAccess as Mock).mockResolvedValue({
+      org: {
+        id: "org_123",
+        imageUrl: "",
+        name: "Acme",
+        slug: "acme",
+      },
+      role: "org:member",
+    });
+
+    const element = await OrgLayout({
+      children: <div>Workspace</div>,
+      params: Promise.resolve({ slug: "acme" }),
+    });
+
+    expect(containsComponentNamed(element, "AuthenticatedTopbar")).toBe(true);
+    expect(containsComponentNamed(element, "AppSidebar")).toBe(true);
+  });
+});

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.tsx
@@ -6,13 +6,13 @@ import {
 } from "@repo/ui/components/ui/sidebar";
 import { parseError } from "@vendor/observability/error/next";
 import { log } from "@vendor/observability/log/next";
-import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import { Loader2 } from "lucide-react";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { AppSidebar } from "~/components/app-sidebar";
+import { AuthenticatedTopbar } from "~/components/authenticated-topbar";
 import { OrgPageErrorBoundary } from "~/components/errors/org-page-error-boundary";
-import { UserMenu, UserMenuSkeleton } from "~/components/user-menu";
+import { TeamSwitcher, TeamSwitcherSkeleton } from "~/components/team-switcher";
 import { requireOrgAccess } from "~/lib/org-access-clerk";
 
 interface OrgLayoutProps {
@@ -36,8 +36,24 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     log.debug("[org-layout] access denied", { slug, error: parseError(error) });
     hasAccess = false;
   }
+
   if (!hasAccess) {
-    notFound();
+    return (
+      <HydrateClient>
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <AuthenticatedTopbar
+            left={
+              <Suspense fallback={<TeamSwitcherSkeleton />}>
+                <TeamSwitcher />
+              </Suspense>
+            }
+          />
+          <div className="relative flex flex-1 flex-col overflow-y-auto bg-background">
+            <OrgAccessNotFound />
+          </div>
+        </div>
+      </HydrateClient>
+    );
   }
 
   return (
@@ -46,30 +62,9 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
         <SidebarProvider className="!h-full !min-h-0 overflow-hidden bg-background">
           <AppSidebar />
           <SidebarInset className="min-h-0 overflow-hidden">
-            <header className="flex h-14 shrink-0 items-center gap-3 px-4">
-              <SidebarTrigger className="lg:hidden" />
-              <div className="ml-auto flex items-center gap-3">
-                <MicrofrontendLink
-                  className="text-muted-foreground text-sm hover:text-foreground"
-                  href="/docs/get-started/overview"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Docs
-                </MicrofrontendLink>
-                <MicrofrontendLink
-                  className="text-muted-foreground text-sm hover:text-foreground"
-                  href="/docs/api-reference"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  API Reference
-                </MicrofrontendLink>
-                <Suspense fallback={<UserMenuSkeleton />}>
-                  <UserMenu />
-                </Suspense>
-              </div>
-            </header>
+            <AuthenticatedTopbar
+              left={<SidebarTrigger className="lg:hidden" />}
+            />
             <div className="min-h-0 flex-1 overflow-y-auto">
               <Suspense fallback={<PageLoadingSkeleton />}>{children}</Suspense>
             </div>
@@ -78,6 +73,11 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
       </OrgPageErrorBoundary>
     </HydrateClient>
   );
+}
+
+function OrgAccessNotFound(): React.ReactNode {
+  notFound();
+  return null;
 }
 
 function PageLoadingSkeleton() {

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/not-found.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/not-found.tsx
@@ -1,20 +1,9 @@
 import { Button } from "@repo/ui/components/ui/button";
 import { currentUser } from "@vendor/clerk/server";
 import Link from "next/link";
-import { SignOutButton } from "./sign-out-button";
+import { SignOutButton } from "../sign-out-button";
 
-/**
- * Organization Not Found page
- *
- * Shown when:
- * - User tries to access an organization that doesn't exist
- * - User doesn't have access to the organization (not a member)
- * - Organization slug is invalid
- * - User's org membership was removed while they were viewing the org
- *
- * Triggered by notFound() in [slug]/layout.tsx when requireOrgAccess fails
- */
-export default async function AuthenticatedRouteNotFound() {
+export default async function OrganizationNotFound() {
   const user = await currentUser();
 
   const emailAddress =
@@ -35,7 +24,7 @@ export default async function AuthenticatedRouteNotFound() {
 
         <h1 className="mb-5 font-bold text-7xl text-foreground">404</h1>
         <p className="mx-auto mb-6 max-w-sm text-muted-foreground text-sm">
-          Sorry, we couldn't find the page you're looking for.
+          This team doesn't exist, or you don't have access to it.
         </p>
 
         {emailAddress && (

--- a/apps/app/src/app/(app)/(pending-not-allowed)/not-found.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/not-found.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@vendor/clerk/server", () => ({
+  currentUser: vi.fn().mockResolvedValue({
+    emailAddresses: [],
+    primaryEmailAddress: { emailAddress: "user@example.com" },
+    username: null,
+  }),
+}));
+
+const { default: PendingNotAllowedNotFound } = await import("./not-found");
+const { default: OrganizationNotFound } = await import("./[slug]/not-found");
+
+function containsComponentNamed(node: unknown, componentName: string): boolean {
+  if (!React.isValidElement(node)) {
+    return false;
+  }
+
+  const type = node.type;
+  if (typeof type === "function" && type.name === componentName) {
+    return true;
+  }
+
+  const props = node.props as { children?: React.ReactNode };
+  return React.Children.toArray(props.children).some((child) =>
+    containsComponentNamed(child, componentName)
+  );
+}
+
+describe("pending-not-allowed not-found pages", () => {
+  it("inlines the authenticated route not-found body", async () => {
+    const element = await PendingNotAllowedNotFound();
+
+    expect(containsComponentNamed(element, "AuthenticatedNotFound")).toBe(
+      false
+    );
+  });
+
+  it("inlines the organization not-found body", async () => {
+    const element = await OrganizationNotFound();
+
+    expect(containsComponentNamed(element, "AuthenticatedNotFound")).toBe(
+      false
+    );
+  });
+});

--- a/apps/app/src/app/(app)/(pending-not-allowed)/sign-out-button.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/sign-out-button.tsx
@@ -3,11 +3,6 @@
 import { Button } from "@repo/ui/components/ui/button";
 import { useClerk } from "@vendor/clerk/client";
 
-/**
- * Sign out button for not-found page
- *
- * Signs the user out and redirects to the sign-in page
- */
 export function SignOutButton() {
   const { signOut } = useClerk();
 

--- a/apps/app/src/app/(app)/not-found.tsx
+++ b/apps/app/src/app/(app)/not-found.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@repo/ui/components/ui/button";
+import Link from "next/link";
+
+export default function AppNotFound() {
+  return (
+    <div className="flex min-h-full w-full items-center justify-center bg-background px-6 py-16">
+      <div className="w-full max-w-xl rounded-sm border border-border border-dashed p-10 text-center sm:p-16">
+        <div className="mb-8 flex justify-center">
+          <div className="relative h-20 w-20">
+            <div className="h-20 w-20 rounded-full border-2 border-border" />
+            <div className="absolute top-1/2 left-1/2 h-10 w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground" />
+          </div>
+        </div>
+
+        <h1 className="mb-5 font-bold text-7xl text-foreground">404</h1>
+        <p className="mx-auto mb-8 max-w-sm text-muted-foreground text-sm">
+          Sorry, we couldn't find the page you're looking for.
+        </p>
+
+        <Button asChild className="rounded-full" size="lg" variant="outline">
+          <Link href="/account/welcome">Return Home</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/authenticated-topbar.tsx
+++ b/apps/app/src/components/authenticated-topbar.tsx
@@ -1,0 +1,36 @@
+import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
+import { Suspense } from "react";
+import { UserMenu, UserMenuSkeleton } from "~/components/user-menu";
+
+interface AuthenticatedTopbarProps {
+  left?: React.ReactNode;
+}
+
+export function AuthenticatedTopbar({ left }: AuthenticatedTopbarProps) {
+  return (
+    <header className="flex h-14 shrink-0 items-center gap-3 px-4">
+      {left}
+      <div className="ml-auto flex items-center gap-3">
+        <MicrofrontendLink
+          className="text-muted-foreground text-sm hover:text-foreground"
+          href="/docs/get-started/overview"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Docs
+        </MicrofrontendLink>
+        <MicrofrontendLink
+          className="text-muted-foreground text-sm hover:text-foreground"
+          href="/docs/api-reference"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          API Reference
+        </MicrofrontendLink>
+        <Suspense fallback={<UserMenuSkeleton />}>
+          <UserMenu />
+        </Suspense>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract shared authenticated topbar chrome for account and org layouts.
- Keep invalid/no-access org routes inside authenticated header chrome before rendering the route-level not-found.
- Add authenticated and org-specific not-found boundaries with route-local sign-out UI.

## Verification
- pnpm --filter @lightfast/app test -- src/app/(app)/(pending-not-allowed)/[slug]/layout.test.tsx src/app/(app)/(pending-allowed)/layout.test.tsx src/app/(app)/(pending-not-allowed)/not-found.test.tsx
- pnpm --filter @lightfast/app typecheck
- pnpm typecheck
- npx ultracite@latest check <changed app files>
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Return Home" navigation button on error pages for easier navigation back to the app
  * Integrated team switcher into the application header

* **UI/UX Improvements**
  * Redesigned not-found pages with improved styling, responsive layout, and updated typography

* **Tests**
  * Added comprehensive unit tests for layout and authentication components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->