### PR TITLE
Reset custom auth flows for Clerk 7

### DIFF
--- a/apps/app/src/__tests__/app/(auth)/sign-in/page.test.tsx
+++ b/apps/app/src/__tests__/app/(auth)/sign-in/page.test.tsx
@@ -143,6 +143,29 @@ describe("sign-in — email submit", () => {
       expect(hrefValue).toBe("/sign-in?errorCode=waitlist");
     });
   });
+
+  it("redirects to account_not_found when the submitted email has no account", async () => {
+    signInStub.emailCode.sendCode.mockResolvedValue({
+      error: {
+        code: "form_identifier_not_found",
+        message: "No account found",
+      },
+    });
+    render(<SignInPage />);
+
+    fireEvent.change(screen.getByPlaceholderText(/email address/i), {
+      target: { value: "unknown@example.com" },
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /continue with email/i })
+      );
+    });
+
+    await waitFor(() => {
+      expect(hrefValue).toBe("/sign-in?errorCode=account_not_found");
+    });
+  });
 });
 
 describe("sign-in — OTP verify", () => {
@@ -236,5 +259,16 @@ describe("sign-in — error banner", () => {
     expect(
       screen.getByRole("link", { name: /join the waitlist/i })
     ).toBeInTheDocument();
+  });
+
+  it("renders the waitlist CTA when ?errorCode=account_not_found is present", () => {
+    searchParamsValue = new URLSearchParams("errorCode=account_not_found");
+    render(<SignInPage />);
+    expect(
+      screen.getByText(/couldn't find a lightfast account/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /join the waitlist/i })
+    ).toHaveAttribute("href", "/early-access");
   });
 });

--- a/apps/app/src/__tests__/app/(auth)/sign-up/accept-invitation/page.test.tsx
+++ b/apps/app/src/__tests__/app/(auth)/sign-up/accept-invitation/page.test.tsx
@@ -28,42 +28,39 @@ vi.mock("@repo/ui/components/ui/sonner", () => ({
   },
 }));
 
-interface SignUpStub {
-  create: Mock;
-  emailAddress: string | null;
-  finalize: Mock;
-  missingFields: string[];
-  sso: Mock;
-  status: "missing_requirements" | "complete";
-  ticket: Mock;
-}
-
 interface ClerkStub {
   client: {
     signUp: {
-      authenticateWithRedirect: Mock;
+      create: Mock;
     };
   };
+  loaded: boolean;
+  setActive: Mock;
 }
 
-let signUpStub: SignUpStub;
 let clerkStub: ClerkStub;
 let searchParamsValue: URLSearchParams;
 let isSignedInValue: boolean;
 let isUserLoadedValue: boolean;
 let routerPushMock: Mock;
 
-function makeSignUpStub(): SignUpStub {
+function makeClerkStub(): ClerkStub {
   return {
-    status: "missing_requirements",
-    emailAddress: null,
-    missingFields: [],
-    create: vi.fn().mockResolvedValue({ error: null }),
-    ticket: vi.fn().mockResolvedValue({ error: null }),
-    finalize: vi.fn(
+    client: {
+      signUp: {
+        create: vi.fn().mockResolvedValue({
+          createdSessionId: "sess_123",
+          missingFields: [],
+          status: "complete",
+        }),
+      },
+    },
+    loaded: true,
+    setActive: vi.fn(
       async (opts?: {
         navigate?: (a: {
           decorateUrl: (u: string) => string;
+          session?: { currentTask?: unknown } | null;
         }) => undefined | Promise<unknown>;
       }) => {
         if (opts?.navigate) {
@@ -71,22 +68,10 @@ function makeSignUpStub(): SignUpStub {
         }
       }
     ),
-    sso: vi.fn().mockResolvedValue({ error: null }),
-  };
-}
-
-function makeClerkStub(): ClerkStub {
-  return {
-    client: {
-      signUp: {
-        authenticateWithRedirect: vi.fn().mockResolvedValue(undefined),
-      },
-    },
   };
 }
 
 vi.mock("@vendor/clerk/client", () => ({
-  useSignUp: () => ({ signUp: signUpStub }),
   useClerk: () => clerkStub,
   useUser: () => ({
     isLoaded: isUserLoadedValue,
@@ -131,7 +116,6 @@ Object.defineProperty(window, "location", {
 });
 
 beforeEach(() => {
-  signUpStub = makeSignUpStub();
   clerkStub = makeClerkStub();
   searchParamsValue = new URLSearchParams();
   isSignedInValue = false;
@@ -154,8 +138,7 @@ describe("accept-invitation — no ticket guard", () => {
     expect(
       screen.getByRole("heading", { name: /no invitation found/i })
     ).toBeInTheDocument();
-    expect(signUpStub.ticket).not.toHaveBeenCalled();
-    expect(signUpStub.create).not.toHaveBeenCalled();
+    expect(clerkStub.client.signUp.create).not.toHaveBeenCalled();
   });
 });
 
@@ -164,15 +147,15 @@ describe("accept-invitation — Accept Invitation button", () => {
     searchParamsValue = new URLSearchParams("__clerk_ticket=tok_abc123");
   });
 
-  it("calls signUp.create({strategy:'ticket',...}) and finalizes on complete", async () => {
+  it("uses Clerk's ticket strategy and activates the created session", async () => {
     let createCallCount = 0;
-    signUpStub.create.mockImplementation(async () => {
+    clerkStub.client.signUp.create.mockImplementation(async () => {
       createCallCount += 1;
-      // Only the strategy:'ticket' shape transitions to complete (Bug A
-      // family) — the test mirrors runtime: any other shape would leave
-      // status missing_requirements.
-      signUpStub.status = "complete";
-      return { error: null };
+      return {
+        createdSessionId: "sess_invite",
+        missingFields: [],
+        status: "complete",
+      };
     });
 
     render(<AcceptInvitationPage />);
@@ -184,20 +167,59 @@ describe("accept-invitation — Accept Invitation button", () => {
     });
 
     expect(createCallCount).toBe(1);
-    expect(signUpStub.create).toHaveBeenCalledWith({
+    expect(clerkStub.client.signUp.create).toHaveBeenCalledWith({
       strategy: "ticket",
       ticket: "tok_abc123",
       legalAccepted: true,
     });
     await waitFor(() => {
-      expect(signUpStub.finalize).toHaveBeenCalledTimes(1);
+      expect(clerkStub.setActive).toHaveBeenCalledTimes(1);
+    });
+    expect(clerkStub.setActive).toHaveBeenCalledWith({
+      session: "sess_invite",
+      navigate: expect.any(Function),
     });
     expect(hrefValue).toBe("/");
   });
 
+  it("surfaces a blocked Clerk task instead of leaving the form submitting", async () => {
+    clerkStub.setActive.mockImplementationOnce(
+      async (opts?: {
+        navigate?: (a: {
+          decorateUrl: (u: string) => string;
+          session?: { currentTask?: unknown } | null;
+        }) => undefined | Promise<unknown>;
+      }) => {
+        await opts?.navigate?.({
+          decorateUrl: (u) => u,
+          session: { currentTask: { key: "reset-password" } },
+        });
+      }
+    );
+
+    render(<AcceptInvitationPage />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /accept invitation/i })
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/additional authentication setup is required/i)
+      ).toBeInTheDocument();
+    });
+    expect(hrefValue).toBe("");
+    expect(
+      screen.getByRole("button", { name: /accept invitation/i })
+    ).toBeEnabled();
+  });
+
   it("redirects to accept-invitation?errorCode=waitlist on waitlist rejection", async () => {
-    signUpStub.create.mockResolvedValue({
-      error: { code: "sign_up_restricted_waitlist", message: "waitlist" },
+    clerkStub.client.signUp.create.mockRejectedValue({
+      code: "sign_up_restricted_waitlist",
+      message: "waitlist",
     });
 
     render(<AcceptInvitationPage />);
@@ -216,8 +238,9 @@ describe("accept-invitation — Accept Invitation button", () => {
   });
 
   it("renders inline pageError on ticket_expired", async () => {
-    signUpStub.create.mockResolvedValue({
-      error: { code: "ticket_expired", message: "ticket expired" },
+    clerkStub.client.signUp.create.mockRejectedValue({
+      code: "ticket_expired",
+      message: "ticket expired",
     });
 
     render(<AcceptInvitationPage />);
@@ -233,61 +256,22 @@ describe("accept-invitation — Accept Invitation button", () => {
         screen.getByText(/this invitation link has expired/i)
       ).toBeInTheDocument();
     });
-    expect(signUpStub.finalize).not.toHaveBeenCalled();
+    expect(clerkStub.setActive).not.toHaveBeenCalled();
   });
 });
 
-describe("accept-invitation — OAuth path (Bug D workaround)", () => {
+describe("accept-invitation — OAuth path", () => {
   beforeEach(() => {
     searchParamsValue = new URLSearchParams("__clerk_ticket=tok_abc123");
   });
 
-  it("calls signUp.create({ticket,legalAccepted}) then legacy authenticateWithRedirect", async () => {
+  it("does not offer OAuth because invitation acceptance is ticket-only", () => {
     render(<AcceptInvitationPage />);
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: /continue with github/i })
-      );
-    });
-
-    expect(signUpStub.create).toHaveBeenCalledWith({
-      ticket: "tok_abc123",
-      legalAccepted: true,
-    });
     expect(
-      clerkStub.client.signUp.authenticateWithRedirect
-    ).toHaveBeenCalledWith({
-      strategy: "oauth_github",
-      redirectUrl: "/sso-callback?__clerk_ticket=tok_abc123",
-      redirectUrlComplete: "/",
-      continueSignUp: true,
-      legalAccepted: true,
-    });
-    expect(signUpStub.sso).not.toHaveBeenCalled();
-  });
-
-  it("redirects to accept-invitation?errorCode=waitlist when create rejects with waitlist", async () => {
-    signUpStub.create.mockResolvedValue({
-      error: { code: "sign_up_restricted_waitlist", message: "waitlist" },
-    });
-
-    render(<AcceptInvitationPage />);
-
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: /continue with github/i })
-      );
-    });
-
-    await waitFor(() => {
-      expect(hrefValue).toBe(
-        "/sign-up/accept-invitation?__clerk_ticket=tok_abc123&errorCode=waitlist"
-      );
-    });
-    expect(
-      clerkStub.client.signUp.authenticateWithRedirect
-    ).not.toHaveBeenCalled();
+      screen.queryByRole("button", { name: /continue with github/i })
+    ).not.toBeInTheDocument();
+    expect(clerkStub.client.signUp.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/app/src/app/(auth)/_components/error-banner.tsx
+++ b/apps/app/src/app/(auth)/_components/error-banner.tsx
@@ -37,7 +37,7 @@ export function ErrorBanner({ message, errorCode, backUrl }: ErrorBannerProps) {
           <p className="text-foreground text-sm">{displayMessage}</p>
         </div>
         <Button asChild className="w-full" size="lg">
-          <a href="/sign-up">Sign Up</a>
+          <Link href="/early-access">Join the Waitlist</Link>
         </Button>
         <Button asChild className="w-full" size="lg" variant="outline">
           <a href={backUrl}>Try again</a>

--- a/apps/app/src/app/(auth)/_hooks/auth-errors.ts
+++ b/apps/app/src/app/(auth)/_hooks/auth-errors.ts
@@ -10,10 +10,6 @@ export type MappedAuthError =
 
 const SUCCESS_REDIRECT = "/";
 
-// Future API types say ClerkError, but clerk-js currently returns an
-// unwrapped ClerkAPIError-shaped object at runtime (not a ClerkAPIResponseError
-// instance). Native guards like isUserLockedError gate on constructor.kind and
-// would silently return false against the unwrapped shape. This handles both.
 function asClerkAPIError(err: unknown): ClerkAPIError | null {
   if (!err) {
     return null;
@@ -34,6 +30,10 @@ export function mapOtpClerkError(err: unknown): MappedAuthError {
   switch (e.code) {
     case "sign_up_restricted_waitlist":
       return { kind: "code", errorCode: "waitlist" };
+    case "form_identifier_not_found":
+    case "identifier_not_found":
+    case "user_not_found":
+      return { kind: "code", errorCode: "account_not_found" };
     case "verification_already_verified":
       return { kind: "success" };
     case "session_exists":
@@ -73,6 +73,13 @@ export function mapOAuthClerkError(err: unknown): MappedAuthError {
 
   if (e.code === "sign_up_restricted_waitlist") {
     return { kind: "code", errorCode: "waitlist" };
+  }
+  if (
+    e.code === "form_identifier_not_found" ||
+    e.code === "identifier_not_found" ||
+    e.code === "user_not_found"
+  ) {
+    return { kind: "code", errorCode: "account_not_found" };
   }
   if (e.code === "session_exists") {
     return { kind: "redirect", target: SUCCESS_REDIRECT };

--- a/apps/app/src/app/(auth)/_hooks/auth-navigate.test.ts
+++ b/apps/app/src/app/(auth)/_hooks/auth-navigate.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { makeFinalizeNavigate } from "./auth-navigate";
+
+let hrefValue = "";
+
+Object.defineProperty(window, "location", {
+  configurable: true,
+  value: {
+    get href() {
+      return hrefValue;
+    },
+    set href(v: string) {
+      hrefValue = v;
+    },
+  },
+});
+
+beforeEach(() => {
+  hrefValue = "";
+});
+
+describe("makeFinalizeNavigate", () => {
+  it("navigates choose-organization sessions to the post-auth relay", () => {
+    const onBlockedTask = vi.fn();
+    const navigate = makeFinalizeNavigate("/account/welcome", {
+      onBlockedTask,
+    });
+
+    navigate({
+      decorateUrl: (url) => `/decorated${url}`,
+      session: { currentTask: { key: "choose-organization" } },
+    });
+
+    expect(hrefValue).toBe("/decorated/account/welcome");
+    expect(onBlockedTask).not.toHaveBeenCalled();
+  });
+
+  it("waits on unsupported Clerk session tasks", () => {
+    let blockedTask: string | null = null;
+    const navigate = makeFinalizeNavigate("/account/welcome", {
+      onBlockedTask: (taskKey) => {
+        blockedTask = taskKey;
+      },
+    });
+
+    navigate({
+      decorateUrl: (url) => `/decorated${url}`,
+      session: { currentTask: { key: "reset-password" } },
+    });
+
+    expect(hrefValue).toBe("");
+    expect(blockedTask).toBe("reset-password");
+  });
+});

--- a/apps/app/src/app/(auth)/_hooks/auth-navigate.ts
+++ b/apps/app/src/app/(auth)/_hooks/auth-navigate.ts
@@ -3,12 +3,27 @@ interface FinalizeNavigateParams {
   session?: { currentTask?: unknown } | null;
 }
 
-// Clerk's signIn/signUp/setActive `navigate` callback. If the new session has
-// a currentTask (force-MFA, accept-org-invite, etc.), let Clerk handle the
-// task navigation by returning early. Otherwise route to `target`.
-export function makeFinalizeNavigate(target: string) {
+interface FinalizeNavigateOptions {
+  onBlockedTask?: (taskKey: string) => void;
+}
+
+function currentTaskKey(task: unknown): string | null {
+  return typeof task === "object" &&
+    task !== null &&
+    "key" in task &&
+    typeof task.key === "string"
+    ? task.key
+    : null;
+}
+
+export function makeFinalizeNavigate(
+  target: string,
+  options?: FinalizeNavigateOptions
+) {
   return (params: FinalizeNavigateParams) => {
-    if (params.session?.currentTask) {
+    const taskKey = currentTaskKey(params.session?.currentTask);
+    if (taskKey && taskKey !== "choose-organization") {
+      options?.onBlockedTask?.(taskKey);
       return;
     }
     window.location.href = params.decorateUrl(target);

--- a/apps/app/src/app/(auth)/_lib/search-params.ts
+++ b/apps/app/src/app/(auth)/_lib/search-params.ts
@@ -10,7 +10,7 @@ export const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
   waitlist:
     "Sign-ups are currently unavailable. Join the waitlist to be notified when access becomes available.",
   account_not_found:
-    "No Lightfast account is linked to this GitHub account. Sign up to create one.",
+    "We couldn't find a Lightfast account for that email. Join the waitlist to request access.",
 };
 
 // Shared error-only schema for sign-in and sign-up.

--- a/apps/app/src/app/(auth)/sign-up/accept-invitation/page.tsx
+++ b/apps/app/src/app/(auth)/sign-up/accept-invitation/page.tsx
@@ -2,21 +2,13 @@
 
 import { Icons } from "@repo/ui/components/icons";
 import { Button } from "@repo/ui/components/ui/button";
-import { toast } from "@repo/ui/components/ui/sonner";
-import { useClerk, useSignUp, useUser } from "@vendor/clerk/client";
-import type { OAuthStrategy } from "@vendor/clerk/types";
+import { useClerk, useUser } from "@vendor/clerk/client";
 import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import type { Route } from "next";
 import { useRouter, useSearchParams } from "next/navigation";
 import * as React from "react";
-import { env } from "~/env";
 import { ErrorBanner } from "../../_components/error-banner";
-import { SeparatorWithText } from "../../_components/separator-with-text";
-import {
-  authErrorMessage,
-  mapOAuthClerkError,
-  mapOtpClerkError,
-} from "../../_hooks/auth-errors";
+import { authErrorMessage, mapOtpClerkError } from "../../_hooks/auth-errors";
 import { makeFinalizeNavigate } from "../../_hooks/auth-navigate";
 import { authBreadcrumb, authSpan } from "../../_hooks/auth-telemetry";
 import { type AuthErrorCode, authErrorCodes } from "../../_lib/search-params";
@@ -59,7 +51,6 @@ export default function AcceptInvitationPage() {
 
 function AcceptInvitationView() {
   const { isSignedIn, isLoaded: isUserLoaded } = useUser();
-  const { signUp } = useSignUp();
   const clerk = useClerk();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -69,7 +60,6 @@ function AcceptInvitationView() {
   const hasError = !!(errorParam ?? errorCode);
 
   const [submitting, setSubmitting] = React.useState(false);
-  const [oauthLoading, setOauthLoading] = React.useState(false);
   const [pageError, setPageError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -77,49 +67,6 @@ function AcceptInvitationView() {
       router.push(SUCCESS_REDIRECT);
     }
   }, [isUserLoaded, isSignedIn, router]);
-
-  React.useEffect(() => {
-    const reset = () => setOauthLoading(false);
-    // bfcache restore on this page leaves window.Clerk.loaded === false and
-    // window.Clerk.client === undefined; the React closures hold a dead
-    // signUp/clerk and OAuth/email clicks silently no-op. This combination is
-    // unique to /sign-up/accept-invitation because the OAuth handler below
-    // drops to legacy clerk.client.signUp.authenticateWithRedirect() — that
-    // codepath leaves Clerk's singleton in an unrecoverable state after
-    // bfcache restore. /sign-in and /sign-up (no ticket) use signUp.sso() /
-    // signIn.sso() and hydrate cleanly after restore.
-    //
-    // The legacy escape hatch exists because clerk-js@6.10.1's signUp.sso()
-    // POSTs to the sign_ups collection URL after signUp.create({strategy:
-    // 'ticket'}) instead of the resource URL → 405. Filed upstream as
-    // clerk/javascript#8551.
-    //
-    // The bfcache state-corruption itself (Clerk.loaded === false after Back
-    // from IdP on this page) appears to be a latent bug newly exposed by
-    // clerk/javascript#7775 (which intentionally re-enabled bfcache
-    // eligibility by removing SafeLock's beforeunload listener). Verified
-    // empirically in this app at clerk-js@6.10.1, but could not isolate to
-    // a minimal Next.js + @clerk/nextjs repro — the missing ingredient
-    // appears to be clerkMiddleware / MFE-proxy / HTTPS-cookie related.
-    // Not currently filed upstream.
-    //
-    // Reload on bfcache restore to force fresh Clerk init. Drop this once
-    // either #8551 is closed (eliminating the legacy path entirely) or a
-    // minimal repro reveals the bfcache trigger.
-    const onPageShow = (e: PageTransitionEvent) => {
-      if (e.persisted) {
-        window.location.reload();
-        return;
-      }
-      reset();
-    };
-    window.addEventListener("pagehide", reset);
-    window.addEventListener("pageshow", onPageShow);
-    return () => {
-      window.removeEventListener("pagehide", reset);
-      window.removeEventListener("pageshow", onPageShow);
-    };
-  }, []);
 
   const ticketErrorPath = React.useCallback(
     (params: { errorCode?: string; error?: string }) => {
@@ -139,7 +86,7 @@ function AcceptInvitationView() {
   );
 
   const handleAccept = React.useCallback(async () => {
-    if (!ticket || submitting) {
+    if (!ticket || submitting || !clerk.loaded) {
       return;
     }
     setSubmitting(true);
@@ -147,148 +94,65 @@ function AcceptInvitationView() {
     authBreadcrumb("Invitation accept initiated", "info", { mode: "sign-up" });
 
     try {
-      // strategy:"ticket" is required when passing `ticket` — per
-      // SignUpFutureCreateParams. Verified empirically (2026-05-14): without
-      // it, signUp.create returns no error but leaves emailAddress null and
-      // status stuck at "missing_requirements". signUp.ticket({ticket,…})
-      // has the same problem.
-      const { error: ticketError } = await authSpan(
+      const signUpAttempt = await authSpan(
         "auth.ticket.consume",
         { mode: "sign-up" },
         () =>
-          signUp.create({
+          clerk.client.signUp.create({
             strategy: "ticket",
             ticket,
             legalAccepted: true,
           })
       );
-
-      if (ticketError) {
-        authBreadcrumb("Invitation accept rejected", "warning", {
-          mode: "sign-up",
-          code: ticketError.code,
-        });
-        const mapped = mapOtpClerkError(ticketError);
-        if (mapped.kind === "redirect") {
-          window.location.replace(mapped.target);
-          return;
-        }
-        if (mapped.kind === "code") {
-          window.location.replace(
-            ticketErrorPath({ errorCode: mapped.errorCode })
-          );
-          return;
-        }
-        if (mapped.kind === "inline") {
-          setPageError(mapped.message);
-          setSubmitting(false);
-          return;
-        }
-      }
-
-      if (signUp.status === "complete") {
+      if (signUpAttempt.status === "complete") {
         authBreadcrumb("Invitation accepted", "info", { mode: "sign-up" });
-        await signUp.finalize({
-          navigate: makeFinalizeNavigate(SUCCESS_REDIRECT),
+        let navigationBlocked = false;
+        const navigateAfterSession = makeFinalizeNavigate(SUCCESS_REDIRECT, {
+          onBlockedTask: () => {
+            navigationBlocked = true;
+          },
         });
+        await clerk.setActive({
+          session: signUpAttempt.createdSessionId,
+          navigate: navigateAfterSession,
+        });
+        if (navigationBlocked) {
+          setPageError(
+            "Additional authentication setup is required before continuing."
+          );
+          setSubmitting(false);
+        }
         return;
       }
 
       authBreadcrumb("Invitation accept incomplete", "error", {
         mode: "sign-up",
-        status: signUp.status,
-        missingFields: signUp.missingFields,
+        status: signUpAttempt.status,
+        missingFields: signUpAttempt.missingFields,
       });
       setPageError("Couldn't accept invitation. Please try again.");
       setSubmitting(false);
-    } catch {
-      setPageError("An unexpected error occurred. Please try again.");
-      setSubmitting(false);
-    }
-  }, [ticket, submitting, signUp, ticketErrorPath]);
-
-  const handleOAuth = React.useCallback(
-    async (strategy: OAuthStrategy) => {
-      if (!ticket || oauthLoading) {
+    } catch (err) {
+      const mapped = mapOtpClerkError(err);
+      if (mapped.kind === "redirect") {
+        window.location.replace(mapped.target);
         return;
       }
-      setOauthLoading(true);
-      setPageError(null);
-      authBreadcrumb("OAuth sign-in initiated", "info", {
-        strategy,
-        mode: "sign-up",
-      });
-
-      try {
-        const { error: createError } = await authSpan(
-          "auth.ticket.create",
-          { mode: "sign-up", strategy },
-          () => signUp.create({ ticket, legalAccepted: true })
+      if (mapped.kind === "code") {
+        window.location.replace(
+          ticketErrorPath({ errorCode: mapped.errorCode })
         );
-        if (createError) {
-          const mapped = mapOAuthClerkError(createError);
-          if (mapped.kind === "code" && mapped.errorCode === "waitlist") {
-            window.location.replace(ticketErrorPath({ errorCode: "waitlist" }));
-            return;
-          }
-          if (mapped.kind === "redirect") {
-            window.location.href = mapped.target;
-            return;
-          }
-          if (mapped.kind === "inline") {
-            setPageError(mapped.message);
-            setOauthLoading(false);
-            return;
-          }
-        }
-
-        // Future API gap on clerk-js@6.10.1: there's no clean OAuth-with-ticket
-        // primitive. Verified empirically (2026-05-14):
-        //   - signUp.create({strategy:'ticket',ticket,legalAccepted}) auto-
-        //     completes the signUp via the ticket verification, so signUp.sso()
-        //     becomes a no-op on an already-finalized resource (user created,
-        //     no external account, no session).
-        //   - signUp.ticket({ticket,legalAccepted}) binds the resource but
-        //     leaves emailAddress null (missing_requirements stays).
-        //     signUp.sso() then 405s — sends POST /v1/client/sign_ups?_method=
-        //     PATCH instead of PATCH /v1/client/sign_ups/{id}.
-        //   - signUp.sso({strategy,…}) alone (no prior call) fails the same way.
-        // The legacy authenticateWithRedirect({continueSignUp:true,legalAccepted})
-        // sends the correct PATCH against the ticket-bound resource above.
-        await authSpan(
-          "auth.oauth.initiate",
-          { mode: "sign-up", strategy },
-          () =>
-            clerk.client.signUp.authenticateWithRedirect({
-              strategy,
-              redirectUrl: `/sso-callback?__clerk_ticket=${encodeURIComponent(ticket)}`,
-              redirectUrlComplete: SUCCESS_REDIRECT,
-              continueSignUp: true,
-              legalAccepted: true,
-            })
-        );
-        // On success, Clerk navigates to the IdP — control doesn't return.
-      } catch (err) {
-        const mapped = mapOAuthClerkError(err);
-        if (mapped.kind === "code" && mapped.errorCode === "waitlist") {
-          window.location.replace(ticketErrorPath({ errorCode: "waitlist" }));
-          return;
-        }
-        if (mapped.kind === "redirect") {
-          window.location.href = mapped.target;
-          return;
-        }
-        if (mapped.kind === "inline") {
-          toast.error(mapped.message);
-          setOauthLoading(false);
-          return;
-        }
-        toast.error("An unexpected error occurred");
-        setOauthLoading(false);
+        return;
       }
-    },
-    [ticket, oauthLoading, signUp, clerk, ticketErrorPath]
-  );
+      if (mapped.kind === "inline") {
+        setPageError(mapped.message);
+        setSubmitting(false);
+        return;
+      }
+      setPageError("Authentication failed");
+      setSubmitting(false);
+    }
+  }, [clerk, ticket, submitting, ticketErrorPath]);
 
   if (!ticket) {
     return (
@@ -335,40 +199,7 @@ function AcceptInvitationView() {
           <>
             <Button
               className="w-full"
-              disabled={oauthLoading || submitting}
-              onClick={() => handleOAuth("oauth_github")}
-              size="lg"
-              variant="outline"
-            >
-              {oauthLoading ? (
-                <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Icons.gitHub className="mr-2 h-4 w-4" />
-              )}
-              Continue with GitHub
-            </Button>
-            {env.NEXT_PUBLIC_VERCEL_ENV === "development" ? (
-              <Button
-                className="w-full"
-                disabled={oauthLoading || submitting}
-                onClick={() => handleOAuth("oauth_custom_test_idp")}
-                size="lg"
-                variant="outline"
-              >
-                {oauthLoading ? (
-                  <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Icons.gitHub className="mr-2 h-4 w-4" />
-                )}
-                Continue with Test IdP
-              </Button>
-            ) : null}
-
-            <SeparatorWithText text="Or" />
-
-            <Button
-              className="w-full"
-              disabled={submitting || oauthLoading}
+              disabled={submitting || !clerk.loaded}
               onClick={handleAccept}
               size="lg"
             >

--- a/apps/app/src/app/(auth)/sso-callback/page.tsx
+++ b/apps/app/src/app/(auth)/sso-callback/page.tsx
@@ -8,15 +8,8 @@ import { makeFinalizeNavigate } from "../_hooks/auth-navigate";
 
 const SUCCESS_REDIRECT = "/";
 
-// Unified OAuth callback. Mirrors Clerk's Future-API reference:
+// Unified OAuth callback for custom sign-in and sign-up flows:
 // https://clerk.com/docs/guides/development/custom-flows/authentication/oauth-connections
-//
-// The effect re-runs as signIn/signUp resources hydrate from the IdP callback
-// URL; hasRun gates the state machine to one pass.
-//
-// __clerk_ticket preservation: /sign-up/accept-invitation appends the ticket
-// to its callback URL. On error we route back to accept-invitation so the
-// ticket UI re-mounts with a banner instead of dropping into /sign-in.
 function SSOCallback() {
   const clerk = useClerk();
   const { signIn } = useSignIn();
@@ -71,8 +64,6 @@ function SSOCallback() {
       signUp.finalize({ navigate: navigateAfterSession });
 
     const run = async () => {
-      // Resource-level rejections (waitlist, etc.) land on the verification
-      // objects rather than throwing — inspect before walking happy branches.
       const inboundErr =
         signIn.firstFactorVerification?.error ??
         signUp.verifications?.externalAccount?.error;
@@ -86,8 +77,6 @@ function SSOCallback() {
         return;
       }
 
-      // Sign-up's external account matched an existing user — transfer it
-      // back into a sign-in.
       if (signUp.isTransferable) {
         try {
           await signIn.create({ transfer: true });
@@ -95,8 +84,6 @@ function SSOCallback() {
           handleMappedError(err);
           return;
         }
-        // signIn.create() can flip status to "complete", but the static type
-        // doesn't widen after the await. Cast per Clerk's reference.
         const signInStatus = signIn.status as typeof signIn.status | "complete";
         if (signInStatus === "complete") {
           await finalizeSignIn();
@@ -116,8 +103,6 @@ function SSOCallback() {
         return;
       }
 
-      // Sign-in's external account isn't tied to a user — transfer it into
-      // a sign-up.
       if (signIn.isTransferable) {
         try {
           await signUp.create({ transfer: true, legalAccepted: true });
@@ -146,8 +131,6 @@ function SSOCallback() {
         return;
       }
 
-      // External account already active on this client — switch the session
-      // instead of finalizing a sign-in/up.
       const existingSessionId =
         signIn.existingSession?.sessionId ?? signUp.existingSession?.sessionId;
       if (existingSessionId) {
@@ -168,8 +151,6 @@ function SSOCallback() {
     <div className="flex items-center justify-center gap-2 text-muted-foreground text-sm">
       <Icons.spinner className="h-4 w-4 animate-spin" />
       <span>Signing in...</span>
-      {/* Required when a sign-in transfers to a sign-up — Clerk renders the
-          bot-protection captcha here. */}
       <div id="clerk-captcha" />
     </div>
   );

--- a/docs/superpowers/plans/2026-05-20-auth-ui-reset.md
+++ b/docs/superpowers/plans/2026-05-20-auth-ui-reset.md
@@ -1,0 +1,69 @@
+# Auth UI Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reset the custom auth UI to Clerk's current custom-flow APIs and upgrade Clerk patch versions.
+
+**Architecture:** Keep the same auth routes and visual components, but replace stale page-level Clerk workarounds with direct Core 3 hook calls and a small shared helper layer for navigation and error routing. Boundary A only: no middleware, API, tRPC, desktop, org, or waitlist server-action changes.
+
+**Tech Stack:** Next.js App Router, React 19, Clerk Core 3 hooks through `@vendor/clerk`, Vitest, Testing Library, pnpm catalogs.
+
+---
+
+### Task 1: Red Tests
+
+**Files:**
+- Modify: `apps/app/src/app/(auth)/sign-in/page.test.tsx`
+- Modify: `apps/app/src/app/(auth)/sign-up/accept-invitation/page.test.tsx`
+
+- [ ] Add a sign-in test asserting `form_identifier_not_found` redirects to `/sign-in?errorCode=account_not_found` and renders the waitlist CTA.
+- [ ] Change invitation acceptance tests to expect Clerk ticket-strategy sign-up creation and session activation.
+- [ ] Remove invitation OAuth workaround assertions against `clerk.client.signUp.authenticateWithRedirect`.
+- [ ] Run `pnpm --filter @lightfast/app test -- src/app/\\(auth\\)/sign-in/page.test.tsx src/app/\\(auth\\)/sign-up/accept-invitation/page.test.tsx` and confirm the new expectations fail against the old implementation.
+
+### Task 2: Shared Auth Helpers
+
+**Files:**
+- Modify: `apps/app/src/app/(auth)/_hooks/auth-errors.ts`
+- Modify: `apps/app/src/app/(auth)/_hooks/auth-navigate.ts`
+- Modify: `apps/app/src/app/(auth)/_lib/search-params.ts`
+
+- [ ] Map account-not-found Clerk errors to `account_not_found`.
+- [ ] Remove comments that describe stale Clerk runtime bugs as current facts.
+- [ ] Keep `decorateUrl()` in every finalize/setActive navigation path.
+- [ ] Run the focused helper/page tests and keep them green.
+
+### Task 3: Page Reset
+
+**Files:**
+- Modify: `apps/app/src/app/(auth)/sign-in/page.tsx`
+- Modify: `apps/app/src/app/(auth)/sign-up/page.tsx`
+- Modify: `apps/app/src/app/(auth)/sign-up/accept-invitation/page.tsx`
+- Modify: `apps/app/src/app/(auth)/sso-callback/page.tsx`
+- Modify: `apps/app/src/app/(auth)/sign-up/continue/page.tsx`
+
+- [ ] Rebuild sign-in around `signIn.emailCode` and `signIn.sso`.
+- [ ] Rebuild sign-up around `signUp.create`, `signUp.verifications`, and `signUp.sso`.
+- [ ] Rebuild invitation acceptance around Clerk's ticket sign-up strategy.
+- [ ] Keep captcha mounts on sign-up, invitation, OAuth callback, and continuation pages.
+- [ ] Keep visual components and copy consistent with the approved diagrams.
+- [ ] Run all `(auth)` page tests until green.
+
+### Task 4: Clerk Upgrade
+
+**Files:**
+- Modify: `pnpm-workspace.yaml`
+- Modify: `pnpm-lock.yaml`
+
+- [ ] Update Clerk catalog pins to `@clerk/nextjs@7.3.7`, `@clerk/backend@3.4.11`, and `@clerk/shared@4.12.2`.
+- [ ] Run `pnpm install --lockfile-only` to regenerate the lockfile.
+- [ ] Run focused auth tests again after the lockfile update.
+
+### Task 5: Verification
+
+**Files:**
+- No planned source edits.
+
+- [ ] Run `pnpm --filter @lightfast/app test -- src/app/\\(auth\\)`.
+- [ ] Run `pnpm --filter @lightfast/app typecheck`.
+- [ ] Start or reuse the app dev server and verify `/sign-in`, `/sign-up`, and `/sign-up/accept-invitation` in the in-app browser.

--- a/docs/superpowers/specs/2026-05-20-auth-ui-reset-design.md
+++ b/docs/superpowers/specs/2026-05-20-auth-ui-reset-design.md
@@ -1,0 +1,54 @@
+# Auth UI Reset Design
+
+## Goal
+
+Reimplement the custom auth UI under `apps/app/src/app/(auth)` using Clerk's current Core 3 custom-flow APIs, remove stale invitation and OAuth workarounds, and upgrade Clerk patch versions. This reset does not change ClerkProvider, middleware, protected app routes, API auth, tRPC auth, desktop auth handoff, or the `/early-access` waitlist action.
+
+## Architecture
+
+The auth surface remains a small set of client pages backed by Clerk hooks:
+
+- `/sign-in`: email-code sign-in and OAuth sign-in.
+- `/sign-up`: email-code sign-up and OAuth sign-up, gated by legal acceptance and Clerk captcha.
+- `/sign-up/accept-invitation`: application invitation acceptance through Clerk's ticket strategy.
+- `/sso-callback`: one OAuth callback state walker for sign-in, sign-up, transfer, existing-session, and error branches.
+- `/sign-up/continue`: finalizes sign-up after OAuth transfer when only `legal_accepted` is missing.
+
+Shared helpers stay local to `(auth)`:
+
+- `auth-errors.ts`: normalizes Clerk API errors into URL codes, inline messages, success, or redirects.
+- `auth-navigate.ts`: centralizes `finalize()` and `setActive()` navigation, always using `decorateUrl()`.
+- `search-params.ts`: owns public error-code query params and display copy.
+
+## Flow Decisions
+
+Email sign-in calls `signIn.emailCode.sendCode({ emailAddress })`. If Clerk reports that no user can sign in with that identifier, the page redirects to `/sign-in?errorCode=account_not_found`, whose banner sends the user to `/early-access`.
+
+Email sign-up calls `signUp.create({ emailAddress, legalAccepted: true })`, sends an email code, verifies the code, then finalizes. Waitlist-restricted Clerk errors route to `/sign-up?errorCode=waitlist`.
+
+OAuth sign-in/sign-up call `signIn.sso()` or `signUp.sso()` with `/sso-callback` and `/account/welcome`. The callback handles transferable resources instead of each page doing callback-specific work.
+
+Invitation acceptance requires `__clerk_ticket`. Missing tickets render a no-invitation state. Accepting the invitation consumes the ticket with `clerk.client.signUp.create({ strategy: "ticket", ticket, legalAccepted: true })`, activates the returned session, routes waitlist errors back to the same invitation URL, and renders ticket-expired errors inline. OAuth-with-ticket is removed because the current official application-invitation custom-flow docs only document ticket acceptance, not OAuth ticket binding.
+
+Session-task pages are not added in this boundary because they require ClerkProvider task URLs and middleware allowances outside `(auth)`. The finalize helper does route Clerk's `choose-organization` task to `/account/welcome`, because that route is already pending-session-allowed and owns Lightfast's organization onboarding. A follow-up should add dedicated task routes for Clerk's `TaskResetPassword` and `TaskSetupMFA` components if those dashboard features are enabled.
+
+## Testing
+
+Update the current Vitest/Testing Library auth page tests first. The key red tests are:
+
+- sign-in unknown-account errors show the waitlist CTA.
+- invitation acceptance uses Clerk's ticket strategy and never uses the legacy `authenticateWithRedirect()` OAuth workaround.
+- callback transfer and existing-session branches still finalize to `/account/welcome`.
+- captcha containers remain mounted for sign-up, invitation, callback, and continuation flows.
+
+Run focused auth tests first, then the app typecheck/build path after the Clerk upgrade.
+
+## Clerk Upgrade
+
+Upgrade catalog pins to the latest npm versions verified on 2026-05-20:
+
+- `@clerk/nextjs`: `7.3.7`
+- `@clerk/backend`: `3.4.11`
+- `@clerk/shared`: `4.12.2`
+
+Regenerate `pnpm-lock.yaml` through pnpm instead of manual lockfile edits.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ settings:
 catalogs:
   default:
     '@clerk/backend':
-      specifier: 3.4.7
-      version: 3.4.7
+      specifier: 3.4.11
+      version: 3.4.11
     '@clerk/nextjs':
-      specifier: 7.3.3
-      version: 7.3.3
+      specifier: 7.3.7
+      version: 7.3.7
     '@clerk/shared':
-      specifier: 4.10.2
-      version: 4.10.2
+      specifier: 4.12.2
+      version: 4.12.2
     '@hookform/resolvers':
       specifier: ^5.2.2
       version: 5.2.2
@@ -351,7 +351,7 @@ importers:
         version: link:../../api/app
       '@clerk/nextjs':
         specifier: 'catalog:'
-        version: 7.3.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 7.3.7(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@db/app':
         specifier: workspace:*
         version: link:../../db/app
@@ -1572,13 +1572,13 @@ importers:
     dependencies:
       '@clerk/backend':
         specifier: 'catalog:'
-        version: 3.4.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.4.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@clerk/nextjs':
         specifier: 'catalog:'
-        version: 7.3.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 7.3.7(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@clerk/shared':
         specifier: 'catalog:'
-        version: 4.10.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 4.12.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
@@ -2375,27 +2375,27 @@ packages:
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
-  '@clerk/backend@3.4.7':
-    resolution: {integrity: sha512-zAELfaYtrlxlxxB6PT3EHPsHck6IPuyTQSKm7hWQqXp9GoFOM6wKOflFZgI0Q2M1C5SgrkDcrMNchkWXRwbsQw==}
+  '@clerk/backend@3.4.11':
+    resolution: {integrity: sha512-WT+4FrcMMofxe+irQYUkawoRWaHHXT9/wiRYhRbSb30cOPjN95ViydqPhAyp8ZWAHInHg4mILynQQRJH14SKZQ==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/nextjs@7.3.3':
-    resolution: {integrity: sha512-MvDczhXM5v9H/a6qd7O52Ydj6CNtgSSPBrpC6HzlfB+nkP8GrsRl/sH+jFrGmRnLsT7Q7A9TESXkrbuHoeGAeQ==}
+  '@clerk/nextjs@7.3.7':
+    resolution: {integrity: sha512-CLG63zKPHditk52Z/+c6BJ47V1Q68ACjeps0xHDRW3X/Yv/FZdM+IUKu9Egb5PJ/TkRFxsI1nU5SOY2B8o/WxA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
       react: ^19.2.5
       react-dom: ^19.2.5
 
-  '@clerk/react@6.6.2':
-    resolution: {integrity: sha512-eLev3C21yh2vqyvEBfXpc1QHa4q+wxbtRdTtBG0fCI+tMQUim8TIS300AJAciM6ox8tgInTWwIeIxr5jiYsvtw==}
+  '@clerk/react@6.6.6':
+    resolution: {integrity: sha512-MVHLDZeGobSbGSZgAdb4G1BbB8ZU5XAmBBdIVLXiPOLEst2TYM5bP137WRA76y9GlmVmKYdKzph/TUi87P/JOA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^19.2.5
       react-dom: ^19.2.5
 
-  '@clerk/shared@4.10.2':
-    resolution: {integrity: sha512-2RXGaCV94U2wYWaMQZA/AhVkqjcSx8f+oVjh6wgr4yXDmZ24BQRjPJ+K4L6IHiB/agoaXtKWJ0GI8InRZjo9/g==}
+  '@clerk/shared@4.12.2':
+    resolution: {integrity: sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^19.2.5
@@ -14089,34 +14089,34 @@ snapshots:
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
-  '@clerk/backend@3.4.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@clerk/backend@3.4.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@clerk/shared': 4.10.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/shared': 4.12.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@clerk/nextjs@7.3.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@clerk/nextjs@7.3.7(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@clerk/backend': 3.4.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@clerk/react': 6.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@clerk/shared': 4.10.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/backend': 3.4.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/react': 6.6.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/shared': 4.12.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next: 16.2.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       server-only: 0.0.1
       tslib: 2.8.1
 
-  '@clerk/react@6.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@clerk/react@6.6.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@clerk/shared': 4.10.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/shared': 4.12.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
 
-  '@clerk/shared@4.10.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@clerk/shared@4.12.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/query-core': 5.100.9
       dequal: 2.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,9 @@ packages:
 catalog:
   '@ai-sdk/gateway': 1.0.7
   '@ai-sdk/react': 2.0.15
-  '@clerk/backend': 3.4.7
-  '@clerk/nextjs': 7.3.3
-  '@clerk/shared': 4.10.2
+  '@clerk/backend': 3.4.11
+  '@clerk/nextjs': 7.3.7
+  '@clerk/shared': 4.12.2
   '@hookform/resolvers': ^5.2.2
   '@lightfastai/dev-cli': ^0.4.2
   '@lightfastai/dev-core': ^0.4.2

--- a/scripts/dev-emulate.mjs
+++ b/scripts/dev-emulate.mjs
@@ -20,7 +20,7 @@ const repoRoot = path.resolve(
   "..",
 );
 const EMULATOR_PORT = 4000;
-const NGROK_LOCAL_API = "http://127.0.0.1:4040/api/tunnels";
+const NGROK_LOCAL_API_PORTS = Array.from({ length: 11 }, (_, i) => 4040 + i);
 const ENV_FILE = path.join(repoRoot, "apps/app/.vercel/.env.development.local");
 const SEED_FILE = path.join(repoRoot, "scripts/dev-emulate.seed.yaml");
 // ngrok reserved static domain under the *.local.lghtfst.com wildcard.
@@ -126,7 +126,7 @@ async function ensureNgrokForStaticDomain(port) {
   log(`starting ngrok for port ${port} → ${expectedUrl}…`);
   const child = spawn(
     "ngrok",
-    ["http", `--domain=${NGROK_STATIC_DOMAIN}`, String(port)],
+    ["http", `--url=${NGROK_STATIC_DOMAIN}`, String(port)],
     {
       cwd: repoRoot,
       stdio: ["ignore", "ignore", "inherit"],
@@ -143,14 +143,22 @@ async function ensureNgrokForStaticDomain(port) {
 }
 
 async function fetchNgrokTunnels() {
-  try {
-    const res = await fetch(NGROK_LOCAL_API);
-    if (!res.ok) return null;
-    const data = await res.json();
-    return Array.isArray(data?.tunnels) ? data.tunnels : null;
-  } catch {
-    return null;
+  const allTunnels = [];
+  for (const port of NGROK_LOCAL_API_PORTS) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/tunnels`);
+      if (!res.ok) {
+        continue;
+      }
+      const data = await res.json();
+      if (Array.isArray(data?.tunnels)) {
+        allTunnels.push(...data.tunnels);
+      }
+    } catch {
+      // ngrok picks the next available API port when 4040 is occupied.
+    }
   }
+  return allTunnels.length ? allTunnels : null;
 }
 
 async function fetchNgrokUrlForPort(port) {


### PR DESCRIPTION
## Summary
- Upgrade Clerk catalog pins and reset the custom auth error/navigation handling around current Clerk flows.
- Remove the invitation OAuth workaround; invitation acceptance is ticket-only and activates the created session.
- Restore `pnpm dev:emulate` and make ngrok tunnel discovery work when another ngrok API is already bound to `4040`.

## Validation
- `pnpm --filter @lightfast/app test -- 'src/app/(auth)'`
- `pnpm --filter @lightfast/app typecheck`
- `npx ultracite@latest check .gitignore package.json scripts/dev-emulate.mjs 'apps/app/src/app/(auth)' pnpm-workspace.yaml docs/superpowers/specs/2026-05-20-auth-ui-reset-design.md docs/superpowers/plans/2026-05-20-auth-ui-reset.md`
- Agent-browser flows: email sign-in, unknown-account sign-in, waitlist sign-up, invitation ticket acceptance, Test IdP OAuth sign-in and waitlist gates.

## Notes
- `.superpowers/` local artifacts are intentionally not included.
- The worktree uses a local ignored `apps/app/.vercel` symlink for development env only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated "account not found" error message and call-to-action to direct users to join the early access waitlist instead of sign-up.

* **Tests**
  * Added new error handling test cases and refactored authentication flow tests.

* **Chores**
  * Updated third-party authentication service dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->