### PR TITLE
chore: drop stale legacy config ignores

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -107,8 +107,6 @@ reviews:
     - "!.claude/**"
     - "!.agents/**"
     - "!.codex/**"
-    - "!.devcontainer/**"
-    - "!.dual/**"
     - "!.entire/**"
     - "!.mcp/**"
     - "!.mcp.json"
@@ -117,7 +115,6 @@ reviews:
     - "!.env.mcp.example"
     - "!.github/ISSUE_TEMPLATE/**"
     - "!.vscode/**"
-    - "!sub/**"
     - "!skills-lock.json"
 
   # ── Path-specific review instructions ──


### PR DESCRIPTION
## Summary
- Remove stale CodeRabbit ignore entries for `.devcontainer`, `.dual`, and `sub` after dropping those paths from the repo.

## Verification
- `rg -n --hidden -g '!node_modules' -g '!.git' -e 'sub/\\.github|\\.gitmodules|\\.devcontainer|\\.dual|devcontainer|\"!sub/\\*\\*\"|!sub/'`
- `git diff --check`
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->