### PR TITLE
test: verify public oRPC propagation

### DIFF
--- a/.changeset/orpc-public-api.md
+++ b/.changeset/orpc-public-api.md
@@ -5,8 +5,8 @@
 
 Adopt oRPC for the public SDK and MCP surfaces.
 
-- SDK (`lightfast`): `createLightfast(apiKey, options)` now returns a typed `RouterClient<Contract>` constructed via `@orpc/openapi-client/fetch`. Calls hit the new `/api/v1/*` REST surface on `apps/app`. The `LightfastClient` class is removed — it's now a type alias to `RouterClient<Contract>`. Breaking change for any consumer using `new LightfastClient(...)`.
-- MCP (`@lightfastai/mcp`): The server auto-registers tools from `@repo/api-contract`. First exposed tool: `lightfast_system_health` (GET `/api/v1/system/health`). Adding procedures to the contract auto-registers them as MCP tools — no `core/mcp` changes required.
+- SDK (`lightfast`): `createLightfast(apiKey, options)` now returns a typed `ContractRouterClient<Contract>` constructed via `@orpc/openapi-client/fetch`. Calls hit the new `/api/v1/*` REST surface on `apps/app`. The `LightfastClient` class is removed — it's now a type alias to `ContractRouterClient<Contract>`. Breaking change for any consumer using `new LightfastClient(...)`.
+- MCP (`@lightfastai/mcp`): The server auto-registers tools from `@repo/api-contract`. Current exposed tools are `lightfast_system_health`, `lightfast_signals_create`, and `lightfast_signals_get`. Adding procedures to the contract auto-registers them as MCP tools — no `core/mcp` changes required.
 - Publish hygiene: `@repo/api-contract` is bundled into the published `dist/` via tsup `noExternal`. Moved from `dependencies` to `devDependencies` to keep the published manifest free of private workspace references. `lightfast` (in MCP) moved the same way. `publishConfig.tag` changed from `"latest"` to `"alpha"` so pre-release versions no longer claim the default install slot.
 
-Requires: `LIGHTFAST_API_KEY` (`sk-lf-` org API key) to authenticate. Optional: `LIGHTFAST_API_URL` to point at non-prod environments.
+Requires: `LIGHTFAST_API_KEY` (`lf_` org API key) to authenticate. Optional: `LIGHTFAST_API_URL` to point at non-prod environments.

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -4,14 +4,24 @@ on:
   push:
     branches: [main]
     paths:
+      - 'api/app/src/orpc/**'
+      - 'api/app/src/__tests__/signal-orpc.test.ts'
+      - 'apps/app/src/app/(api)/api/v1/**'
       - 'core/**'
+      - 'packages/api-contract/**'
+      - 'vendor/mcp/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.github/workflows/ci-core.yml'
   pull_request:
     branches: [main]
     paths:
+      - 'api/app/src/orpc/**'
+      - 'api/app/src/__tests__/signal-orpc.test.ts'
+      - 'apps/app/src/app/(api)/api/v1/**'
       - 'core/**'
+      - 'packages/api-contract/**'
+      - 'vendor/mcp/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.github/workflows/ci-core.yml'
@@ -50,17 +60,15 @@ jobs:
       - name: Lint (biome)
         run: pnpm turbo //#check --summarize
 
-      - name: Type check affected core packages
+      - name: Type check public oRPC surface
         env:
           SKIP_ENV_VALIDATION: "true"
-          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: pnpm turbo typecheck --affected --filter=lightfast --filter=@lightfastai/mcp --filter=@lightfastai/cli --continue --summarize
+        run: pnpm turbo typecheck --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize
 
-      - name: Test affected core packages
+      - name: Test public oRPC surface
         env:
           SKIP_ENV_VALIDATION: "true"
-          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: pnpm turbo test --affected --filter=lightfast --filter=@lightfastai/mcp --filter=@lightfastai/cli --continue --summarize
+        run: pnpm turbo test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize
 
       - name: Cache report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: pnpm turbo typecheck --affected --continue --summarize
 
+      - name: Test public oRPC surface
+        env:
+          SKIP_ENV_VALIDATION: "true"
+        run: pnpm turbo test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize
+
       - name: Check boundaries
         run: pnpm turbo boundaries
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -91,10 +91,10 @@ jobs:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo build --filter=lightfast --filter=@lightfastai/mcp --filter=@lightfastai/cli --summarize
 
-      - name: Test lightfast
+      - name: Test public oRPC packages
         env:
           SKIP_ENV_VALIDATION: "true"
-        run: pnpm turbo test --filter=lightfast --summarize
+        run: pnpm turbo test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --summarize
 
       - name: Verify build outputs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Build packages
         env:
           SKIP_ENV_VALIDATION: "true"
-        run: pnpm turbo build --filter lightfast --filter @lightfastai/mcp --filter @lightfastai/cli --summarize
+        run: pnpm turbo build --filter=lightfast --filter=@lightfastai/mcp --filter=@lightfastai/cli --summarize
 
       - name: Run tests
         env:
           SKIP_ENV_VALIDATION: "true"
-        run: pnpm turbo test --filter=lightfast --filter=@lightfastai/mcp --summarize
+        run: pnpm turbo test --filter=@repo/api-contract --filter=lightfast --filter=@lightfastai/mcp --summarize
 
       - name: Cache report
         if: always()

--- a/api/app/src/__tests__/signal-orpc.test.ts
+++ b/api/app/src/__tests__/signal-orpc.test.ts
@@ -156,8 +156,8 @@ describe("orpcRouter.signals", () => {
       },
       errorCode: null,
       errorMessage: null,
-      createdAt: "2026-05-21T00:00:00.000Z",
-      updatedAt: "2026-05-21T00:01:00.000Z",
+      createdAt: new Date("2026-05-21T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-21T00:01:00.000Z"),
     });
 
     const result = await call(
@@ -175,6 +175,8 @@ describe("orpcRouter.signals", () => {
       input: "Run the test plan",
       status: "classified",
       classification: { kind: "review" },
+      createdAt: "2026-05-21T00:00:00.000Z",
+      updatedAt: "2026-05-21T00:01:00.000Z",
     });
   });
 

--- a/api/app/src/orpc/__tests__/contract-coverage.test.ts
+++ b/api/app/src/orpc/__tests__/contract-coverage.test.ts
@@ -1,0 +1,70 @@
+import { isContractProcedure } from "@orpc/contract";
+import { isProcedure } from "@orpc/server";
+import { apiContract } from "@repo/api-contract";
+import { describe, expect, it, vi } from "vitest";
+
+const isOrgBoundMock = vi.fn();
+
+vi.mock("@vendor/unkey/server", () => ({
+  getUnkeyClient: () => ({
+    keys: { verifyKey: vi.fn() },
+  }),
+}));
+
+vi.mock("@db/app/client", () => ({ db: {} }));
+vi.mock("@db/app", () => ({
+  createSignal: vi.fn(),
+  getSignalByPublicId: vi.fn(),
+  isOrgBound: isOrgBoundMock,
+  markSignalFailed: vi.fn(),
+}));
+
+const { orpcRouter } = await import("../router");
+
+function collectContractProcedurePaths(
+  node: unknown,
+  keyPath: string[] = []
+): string[] {
+  if (isContractProcedure(node)) {
+    return [keyPath.join(".")];
+  }
+
+  if (!node || typeof node !== "object") {
+    return [];
+  }
+
+  return Object.entries(node).flatMap(([key, child]) =>
+    collectContractProcedurePaths(child, [...keyPath, key])
+  );
+}
+
+function collectRouterProcedurePaths(
+  node: unknown,
+  keyPath: string[] = []
+): string[] {
+  if (isProcedure(node)) {
+    return [keyPath.join(".")];
+  }
+
+  if (!node || typeof node !== "object") {
+    return [];
+  }
+
+  return Object.entries(node).flatMap(([key, child]) =>
+    collectRouterProcedurePaths(child, [...keyPath, key])
+  );
+}
+
+describe("oRPC contract coverage", () => {
+  it("implements exactly the public contract procedures", () => {
+    const contractPaths = collectContractProcedurePaths(apiContract);
+    const routerPaths = collectRouterProcedurePaths(orpcRouter);
+
+    expect(contractPaths).toEqual([
+      "signals.create",
+      "signals.get",
+      "system.health",
+    ]);
+    expect(routerPaths).toEqual(contractPaths);
+  });
+});

--- a/api/app/src/orpc/router/signals.ts
+++ b/api/app/src/orpc/router/signals.ts
@@ -72,8 +72,8 @@ export const signalsRouter = {
       input: signal.input,
       status: signal.status,
       classification: signal.classification,
-      createdAt: signal.createdAt,
-      updatedAt: signal.updatedAt,
+      createdAt: signal.createdAt.toISOString(),
+      updatedAt: signal.updatedAt.toISOString(),
     };
   }),
 };

--- a/core/lightfast/src/__tests__/client.test.ts
+++ b/core/lightfast/src/__tests__/client.test.ts
@@ -70,4 +70,76 @@ describe("createLightfast", () => {
 
     expect(capturedUrl).toBe("https://example.test/api/v1/system/health");
   });
+
+  it("posts signal creation requests to the contract route", async () => {
+    let lastRequest: { body: unknown; method: string; url: string } | undefined;
+    const fetchMock = vi.fn(async (input: Request) => {
+      lastRequest = {
+        body: await input.json(),
+        method: input.method,
+        url: input.url,
+      };
+      return new Response(
+        JSON.stringify({
+          id: "signal_123e4567-e89b-12d3-a456-426614174000",
+          status: "queued",
+        }),
+        { status: 202, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const lf = createLightfast("lf_test", {
+      baseUrl: "https://example.test",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await lf.signals.create({ input: "Classify this" });
+
+    expect(result).toEqual({
+      id: "signal_123e4567-e89b-12d3-a456-426614174000",
+      status: "queued",
+    });
+    expect(lastRequest).toEqual({
+      body: { input: "Classify this" },
+      method: "POST",
+      url: "https://example.test/api/v1/signals",
+    });
+  });
+
+  it("interpolates signal ids into contract paths", async () => {
+    let lastRequest: { method: string; url: string } | undefined;
+    const fetchMock = vi.fn(async (input: Request) => {
+      lastRequest = {
+        method: input.method,
+        url: input.url,
+      };
+      return new Response(
+        JSON.stringify({
+          classification: null,
+          createdAt: "2026-05-21T00:00:00.000Z",
+          id: "signal_123e4567-e89b-12d3-a456-426614174000",
+          input: "Classify this",
+          status: "queued",
+          updatedAt: "2026-05-21T00:01:00.000Z",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const lf = createLightfast("lf_test", {
+      baseUrl: "https://example.test/api/v1",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await lf.signals.get({
+      id: "signal_123e4567-e89b-12d3-a456-426614174000",
+    });
+
+    expect(result).toMatchObject({
+      id: "signal_123e4567-e89b-12d3-a456-426614174000",
+      status: "queued",
+    });
+    expect(lastRequest).toEqual({
+      method: "GET",
+      url: "https://example.test/api/v1/signals/signal_123e4567-e89b-12d3-a456-426614174000",
+    });
+  });
 });

--- a/core/mcp/src/__tests__/registration.test.ts
+++ b/core/mcp/src/__tests__/registration.test.ts
@@ -1,32 +1,164 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { apiContract } from "@repo/api-contract";
 import { McpServer, registerContractTools } from "@vendor/mcp";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
+const queuedSignal = {
+  id: signalId,
+  status: "queued",
+};
+const systemHealth = {
+  status: "ok",
+  timestamp: "2026-05-21T00:00:00.000Z",
+  version: "test",
+};
+
+function createLightfastClientStub() {
+  return {
+    signals: {
+      create: vi.fn(async () => queuedSignal),
+      get: vi.fn(async () => ({
+        ...queuedSignal,
+        classification: null,
+        createdAt: "2026-05-21T00:00:00.000Z",
+        input: "Run the verification plan",
+        updatedAt: "2026-05-21T00:01:00.000Z",
+      })),
+    },
+    system: {
+      health: vi.fn(async () => systemHealth),
+    },
+  };
+}
+
+async function connectRegisteredServer(
+  contract: Record<string, unknown> = apiContract,
+  lightfastClient = createLightfastClientStub()
+) {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  registerContractTools(server, contract, lightfastClient, {
+    prefix: "lightfast",
+  });
+
+  const mcpClient = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  await Promise.all([
+    server.connect(serverTransport),
+    mcpClient.connect(clientTransport),
+  ]);
+
+  return { lightfastClient, mcpClient, server };
+}
+
+async function closeRegisteredServer(
+  context: Awaited<ReturnType<typeof connectRegisteredServer>>
+) {
+  await context.mcpClient.close();
+  await context.server.close();
+}
 
 describe("MCP tool registration", () => {
-  it("registers lightfast_system_health from the contract", () => {
-    const server = new McpServer({ name: "test", version: "0.0.0" });
+  it("exposes every public contract procedure as an MCP tool", async () => {
+    const context = await connectRegisteredServer();
 
-    const client = {
-      signals: {
-        create: async () => ({
-          id: "signal_123e4567-e89b-12d3-a456-426614174000",
-          status: "queued",
-        }),
-        get: async () => ({
-          id: "signal_123e4567-e89b-12d3-a456-426614174000",
-          status: "queued",
-        }),
-      },
-      system: {
-        health: async () => ({ status: "ok", timestamp: "x", version: "x" }),
-      },
-    };
+    try {
+      const { tools } = await context.mcpClient.listTools();
 
-    expect(() =>
-      registerContractTools(server, apiContract, client, {
-        prefix: "lightfast",
-      })
-    ).not.toThrow();
+      expect(tools.map((tool) => tool.name)).toEqual([
+        "lightfast_signals_create",
+        "lightfast_signals_get",
+        "lightfast_system_health",
+      ]);
+      expect(
+        tools.find((tool) => tool.name === "lightfast_signals_create")
+      ).toMatchObject({
+        description:
+          "Creates an org-scoped signal from raw text and queues asynchronous classification.",
+        inputSchema: {
+          properties: {
+            input: expect.objectContaining({ type: "string" }),
+          },
+          required: ["input"],
+          type: "object",
+        },
+        outputSchema: {
+          properties: {
+            id: expect.objectContaining({ type: "string" }),
+            status: expect.objectContaining({ const: "queued" }),
+          },
+          required: ["id", "status"],
+          type: "object",
+        },
+      });
+    } finally {
+      await closeRegisteredServer(context);
+    }
+  });
+
+  it("calls the Lightfast SDK client and returns structured MCP content", async () => {
+    const context = await connectRegisteredServer();
+
+    try {
+      const result = (await context.mcpClient.callTool({
+        arguments: { input: "  Run the verification plan  " },
+        name: "lightfast_signals_create",
+      })) as {
+        content?: unknown;
+        structuredContent?: unknown;
+      };
+
+      expect(context.lightfastClient.signals.create).toHaveBeenCalledWith({
+        input: "Run the verification plan",
+      });
+      expect(result.structuredContent).toEqual(queuedSignal);
+      expect(result.content).toEqual([
+        { type: "text", text: JSON.stringify(queuedSignal, null, 2) },
+      ]);
+    } finally {
+      await closeRegisteredServer(context);
+    }
+  });
+
+  it("calls zero-input contract procedures without synthetic arguments", async () => {
+    const context = await connectRegisteredServer();
+
+    try {
+      const result = (await context.mcpClient.callTool({
+        name: "lightfast_system_health",
+      })) as {
+        structuredContent?: unknown;
+      };
+
+      expect(context.lightfastClient.system.health).toHaveBeenCalledWith();
+      expect(result.structuredContent).toEqual(systemHealth);
+    } finally {
+      await closeRegisteredServer(context);
+    }
+  });
+
+  it("returns MCP error content when the SDK client rejects", async () => {
+    const lightfastClient = createLightfastClientStub();
+    lightfastClient.signals.get.mockRejectedValueOnce(new Error("api down"));
+    const context = await connectRegisteredServer(apiContract, lightfastClient);
+
+    try {
+      const result = (await context.mcpClient.callTool({
+        arguments: { id: signalId },
+        name: "lightfast_signals_get",
+      })) as {
+        content?: unknown;
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "api down" }]);
+    } finally {
+      await closeRegisteredServer(context);
+    }
   });
 
   it("does not throw on an empty contract", () => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lightfast",
+  "name": "@lightfastai/workspace",
   "license": "MIT",
   "private": true,
   "engines": {
@@ -27,6 +27,7 @@
     "postinstall": "pnpm lint:ws",
     "test": "SKIP_ENV_VALIDATION=true turbo run test",
     "typecheck": "SKIP_ENV_VALIDATION=true turbo run typecheck",
+    "verify:orpc": "SKIP_ENV_VALIDATION=true turbo run typecheck test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize",
     "ui": "pnpm --filter @repo/ui ui",
     "vercel:link": "pnpm dlx vercel@latest link --repo",
     "changeset": "changeset",

--- a/vendor/mcp/src/index.ts
+++ b/vendor/mcp/src/index.ts
@@ -20,6 +20,19 @@ export interface RegisterContractToolsOptions {
   separator?: string;
 }
 
+function toStructuredContent(result: unknown): Record<string, unknown> {
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return result as Record<string, unknown>;
+  }
+
+  return { result };
+}
+
+function stringifyResult(result: unknown): string {
+  const json = JSON.stringify(result, null, 2);
+  return json ?? String(result);
+}
+
 /**
  * Walk an oRPC contract router and register each procedure as an MCP tool.
  *
@@ -74,8 +87,15 @@ export function registerContractTools(
           // Without inputSchema: args = [extra]
           const input = def.inputSchema ? args[0] : undefined;
           const result = input === undefined ? await fn() : await fn(input);
+          const structuredContent = toStructuredContent(result);
           return {
-            structuredContent: result as Record<string, unknown>,
+            content: [
+              {
+                type: "text" as const,
+                text: stringifyResult(result),
+              },
+            ],
+            structuredContent,
           };
         } catch (error) {
           return {


### PR DESCRIPTION
## Summary\n- add contract coverage tests so public oRPC contract procedures must be implemented by the API router\n- verify SDK and MCP tool propagation from the shared contract\n- update CI, merge queue, and release workflows to test the public oRPC surface with the unambiguous `--filter=lightfast` package target\n\n## Validation\n- `pnpm --filter lightfast exec pwd` -> `core/lightfast`\n- `pnpm verify:orpc`\n- `pnpm check`\n- `git diff --check`\n- throwaway PR #711 proved contract-only drift fails GitHub CI in `contract-coverage.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signals API now consistently returns createdAt/updatedAt as ISO-formatted strings.
  * MCP tool calls now always include both structured data and a readable text representation for results.

* **Tests**
  * Added contract coverage tests and expanded client/integration and tool-registration test suites.

* **Chores**
  * CI workflows updated to broaden testing of the public API surface.
  * Repository package metadata and a verification script were updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->