### PR TITLE
ci: expose npm token to changesets release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Summary

- Pass the existing NPM_TOKEN secret as NPM_TOKEN to changesets/action.
- Keep NODE_AUTH_TOKEN for npm/setup-node compatibility.

## Validation

- git diff --check
- pnpm check

## Context

The oRPC release validation reached the publish step, but changesets/action logged "No NPM_TOKEN found" and fell back to npm trusted publishing. The org secret exists; the workflow only exposed it as NODE_AUTH_TOKEN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal publishing workflow configuration to improve release process reliability.

---

**Note:** This change is an internal infrastructure improvement with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->