### PR TITLE
ci: use trusted publishing for lightfast release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,6 @@ jobs:
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Verify published versions match


### PR DESCRIPTION
## Summary

- Remove token auth from the Changesets publish step so npm trusted publishing is used.
- Keep provenance enabled and rely on the existing id-token: write workflow permission.

## Validation

- git diff --check
- pnpm check

## Context

The package-side GitHub automation/trusted publisher is now configured in npm. Passing NPM_TOKEN makes changesets/action prefer token auth, so the workflow needs to omit it to use OIDC.