### PR TITLE
ci: publish prereleases on alpha dist tag

### DIFF
--- a/.changeset/alpha-dist-tag.md
+++ b/.changeset/alpha-dist-tag.md
@@ -1,0 +1,6 @@
+---
+"lightfast": patch
+"@lightfastai/mcp": patch
+---
+
+Publish prerelease packages through the npm alpha dist-tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm changeset publish
+          publish: pnpm changeset publish --tag alpha
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Publish Changesets prereleases with --tag alpha.
- Add a corrective patch changeset so the next SDK/MCP prerelease lands on the npm alpha tag.

## Validation

- git diff --check
- pnpm check

## Context

The trusted-publishing run successfully published 1.0.0-alpha.6, but Changesets placed it on latest because these packages have no normal release. This makes the release command explicit and creates a follow-up alpha prerelease to validate the tag path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to publish packages with alpha tag designation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->