### PR TITLE
Publish alpha packages with pnpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.changeset/**'
       - '.github/workflows/release.yml'
+      - 'scripts/publish-lightfast-alpha.mjs'
     branches: [main]
   workflow_dispatch:
 

--- a/scripts/publish-lightfast-alpha.mjs
+++ b/scripts/publish-lightfast-alpha.mjs
@@ -97,11 +97,15 @@ for (const pkg of packageJsons) {
   }
 
   if (dryRun) {
-    console.log(`[dry-run] npm publish --tag alpha --access public (${pkg.dir})`);
+    console.log(
+      `[dry-run] pnpm publish --tag alpha --access public --no-git-checks (${pkg.dir})`,
+    );
   } else {
-    run("npm", ["publish", "--tag", "alpha", "--access", "public"], {
-      cwd: pkg.dir,
-    });
+    run(
+      "pnpm",
+      ["publish", "--tag", "alpha", "--access", "public", "--no-git-checks"],
+      { cwd: pkg.dir },
+    );
   }
 
   if (!hasTag(tag)) {


### PR DESCRIPTION
## Summary
- Switch the alpha publish shim from `npm publish` to `pnpm publish`, matching the Changesets CLI path that works with trusted publishing.
- Include `scripts/publish-lightfast-alpha.mjs` in the release workflow path trigger so publish-shim fixes trigger release validation.

## Validation
- `DRY_RUN=1 node scripts/publish-lightfast-alpha.mjs`
- `pnpm check`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflow configuration to support additional deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->