### PR TITLE
Document SDK and MCP release workflow

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,17 +30,69 @@ Root Changesets is currently in prerelease mode, so do not add CLI to the existi
 
 ## SDK + MCP Workflow
 
-### 1. Make Changes
+### 1. Make oRPC or Package Changes
 
-Work in `core/lightfast/` and/or `core/mcp/`.
+Work in the oRPC contract/API surface and the public packages that consume it:
+
+- `packages/api-contract/`
+- `api/app/src/orpc/`
+- `core/lightfast/`
+- `vendor/mcp/`
+- `core/mcp/`
+
+Before opening a PR, run the SDK/MCP preflight:
 
 ```bash
-pnpm --filter lightfast test
-pnpm --filter @lightfastai/mcp test
-pnpm turbo run build --filter lightfast --filter @lightfastai/mcp
+pnpm --filter lightfast exec pwd
+pnpm verify:orpc
+pnpm check
+git diff --check
 ```
 
-### 2. Create a Changeset
+`pnpm --filter lightfast exec pwd` must resolve to `core/lightfast`. The root package is `@lightfastai/workspace`, so `--filter=lightfast` targets only the public SDK package.
+
+`pnpm verify:orpc` is required whenever oRPC routes change. It verifies the contract, API implementation, SDK, vendor MCP adapter, and published MCP package path.
+
+### 2. Create the Implementation PR
+
+Open a normal PR to `main`.
+
+Expected PR behavior:
+
+- Affected PR CI stays fast and only runs jobs for touched surfaces.
+- `merge-queue-success` passes as the required branch-protection stub.
+- oRPC contract/API changes trigger Core CI and include the public oRPC package test scope.
+
+For oRPC propagation changes, inspect CI logs for:
+
+```text
+Test affected public oRPC surface
+```
+
+The package scope should include:
+
+```text
+@repo/api-contract
+@api/app
+lightfast
+@vendor/mcp
+@lightfastai/mcp
+```
+
+### 3. Merge Through Merge Queue
+
+Add the implementation PR to GitHub merge queue. Do not admin-merge or bypass branch protection.
+
+The `merge_group` run for `.github/workflows/merge-queue.yml` is the real gate. It must pass:
+
+- Full quality checks: lint, typecheck, boundaries, and Knip.
+- Core build/test for `lightfast`, `@lightfastai/mcp`, and CLI.
+- Public oRPC package tests for `@repo/api-contract`, `@api/app`, `lightfast`, and `@lightfastai/mcp`.
+- Desktop package/e2e jobs.
+- CodeQL.
+- `merge-queue-success`.
+
+### 4. Create a Changeset
 
 Do not manually edit package versions or changelogs for SDK/MCP releases.
 
@@ -59,9 +111,89 @@ Select both packages:
 Describe the SDK and MCP change.
 ```
 
-### 3. Merge the Version Packages PR
+### 5. Merge the Version Packages PR
 
 When the changeset lands on `main`, `.github/workflows/release.yml` creates or updates the Version Packages PR. Review the generated versions and changelogs, then merge that PR to publish.
+
+Before queueing the Version Packages PR, confirm:
+
+- `lightfast` and `@lightfastai/mcp` versions match.
+- `@lightfastai/cli` does not change unless explicitly intended.
+- Changelogs accurately describe the SDK/MCP change.
+- No private workspace package is included in packed manifests.
+- `.changeset/pre.json` is formatted by `pnpm check`.
+
+Release PRs created by `GITHUB_TOKEN` may not trigger required PR checks. If checks do not appear, push a no-op or formatting commit to the release branch, or replace `GITHUB_TOKEN` with an approved release bot token/App that is allowed to trigger workflows.
+
+Merge the Version Packages PR through merge queue. The merge to `main` triggers `.github/workflows/release.yml` again.
+
+### 6. Publish the SDK + MCP Alpha
+
+After the Version Packages PR merges, `Release lightfast` runs on `main`.
+
+The release workflow:
+
+1. Installs with `pnpm install --frozen-lockfile`.
+2. Builds publishable core packages.
+3. Tests the contract, SDK, and MCP package surfaces.
+4. Packs `core/lightfast` and `core/mcp`.
+5. Validates tarball manifests to catch private workspace dependency leaks.
+6. Publishes unpublished alpha packages with `scripts/publish-lightfast-alpha.mjs`.
+7. Verifies `lightfast@alpha` and `@lightfastai/mcp@alpha` resolve to the same version.
+
+SDK/MCP publishing uses npm trusted publishing through GitHub Actions OIDC. Configure npm trusted publisher automation for both packages before publishing:
+
+- Package: `lightfast`
+- Package: `@lightfastai/mcp`
+- Repository: `lightfastai/lightfast`
+- Workflow file: `.github/workflows/release.yml`
+
+The alpha publish script intentionally uses `pnpm publish --tag alpha --access public --no-git-checks`. Changesets still creates Version Packages PRs and GitHub releases, but direct pnpm publish avoids Changesets CLI's prerelease-mode restriction on custom `--tag`.
+
+### 7. Verify npm and Smoke-Test Published Packages
+
+Verify npm tags:
+
+```bash
+npm view lightfast@alpha version
+npm view @lightfastai/mcp@alpha version
+npm view lightfast dist-tags
+npm view @lightfastai/mcp dist-tags
+```
+
+Smoke-test the SDK from a clean temporary project:
+
+```bash
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+npm init -y
+npm install lightfast@alpha
+node -e "import('lightfast').then(m => console.log(typeof m.createLightfast, m.VERSION))"
+```
+
+Expected output:
+
+```text
+function <alpha-version>
+```
+
+Smoke-test the MCP binary without an API key:
+
+```bash
+npm exec --yes --package @lightfastai/mcp@alpha -- lightfast-mcp
+```
+
+Expected output with non-zero exit:
+
+```text
+LIGHTFAST_API_KEY environment variable is required
+```
+
+If a bound `lf_` key is available, run the optional live API smoke:
+
+```bash
+LIGHTFAST_E2E_API_KEY=lf_... LIGHTFAST_E2E_APP_URL=https://app.lightfast.localhost pnpm --filter @lightfast/e2e sdk
+```
 
 ## CLI First Release Workflow
 
@@ -154,6 +286,44 @@ tar -xzOf "$SCRATCH"/lightfastai-cli-*.tgz package/package.json | jq '{name, ver
 
 ## Troubleshooting
 
+### oRPC contract coverage fails
+
+`api/app/src/orpc/__tests__/contract-coverage.test.ts` fails when the public contract exposes a procedure that the API router does not implement. Add the API router implementation, or remove/rename the contract route if it was not intended to ship.
+
+### SDK/MCP tarball manifest validation fails
+
+The release workflow packs `core/lightfast` and `core/mcp` before publishing. A failure usually means a private workspace dependency, unresolved `workspace:` range, or unexpected runtime dependency leaked into a public package. Move private internals to dev dependencies, bundle them, or expose only approved public runtime dependencies.
+
+### SDK/MCP npm publish fails
+
+If the log says `No NPM_TOKEN found, but OIDC is available`, the workflow is using npm trusted publishing. A registry `404` during publish means npm does not consider the workflow authorized for that package or the publish command path is not using the same toolchain as the trusted-publishing path.
+
+Use the current publish script path:
+
+```bash
+node scripts/publish-lightfast-alpha.mjs
+```
+
+Do not use `pnpm changeset publish --tag alpha` while Changesets is in prerelease mode. Changesets rejects custom tags in pre mode, so the workflow publishes with the focused pnpm shim instead.
+
+### SDK/MCP alpha tags drift
+
+Check live npm tags:
+
+```bash
+npm view lightfast dist-tags
+npm view @lightfastai/mcp dist-tags
+```
+
+The release workflow fails if `lightfast@alpha` and `@lightfastai/mcp@alpha` resolve to different versions. Repair tags explicitly only after confirming the intended version:
+
+```bash
+npm dist-tag add lightfast@<version> alpha
+npm dist-tag add @lightfastai/mcp@<version> alpha
+```
+
+An earlier failed alpha setup may leave `latest` pointing at an alpha version. Do not rely on `latest` for SDK/MCP prereleases; verify the `alpha` tag directly until a stable release intentionally repoints `latest`.
+
 ### CLI tarball contains `@repo/*` dependencies
 
 Move private workspace packages from `dependencies` to `devDependencies` and bundle them through `tsup` `noExternal`.
@@ -166,26 +336,11 @@ Use `pnpm pack`, not `npm pack`, for local validation. `pnpm pack` understands w
 
 Do not retry with the same version. Bump `core/cli/package.json`, update `core/cli/CHANGELOG.md`, rerun validation, and publish the new version after approval.
 
-### SDK/MCP alpha tags drift
-
-Check live npm tags:
-
-```bash
-npm view lightfast dist-tags
-npm view @lightfastai/mcp dist-tags
-```
-
-Repair tags explicitly only after confirming the intended version:
-
-```bash
-npm dist-tag add lightfast@<version> alpha
-npm dist-tag add @lightfastai/mcp@<version> alpha
-```
-
 ## Command Reference
 
 ```bash
 # SDK/MCP
+pnpm verify:orpc
 pnpm changeset
 pnpm changeset pre enter alpha
 pnpm changeset pre exit


### PR DESCRIPTION
## Summary
- Document the validated oRPC SDK/MCP PR -> merge queue -> Version Packages PR -> alpha publish workflow.
- Add required `pnpm verify:orpc` preflight and post-publish npm smoke commands.
- Capture troubleshooting notes from the real validation run: contract drift, tarball manifest leaks, trusted publishing, alpha tag drift, and generated release PR checks.

## Validation
- `pnpm check`
- `git diff --check`
- `git diff --cached --check`