### PR TITLE
fix: harden Next diagnostics surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,6 @@ pnpm db:studio        # starts Drizzle Studio through Portless
 cd apps/app && pnpm with-env next typegen
 cd apps/app && pnpm with-env next build --debug
 cd apps/app && pnpm with-env next build --debug-prerender
-cd apps/app && pnpm with-env next build --debug-build-paths "app/**/page.tsx"
 cd apps/app && pnpm with-env next experimental-analyze --output
 cd apps/app && pnpm with-env next dev --experimental-cpu-prof
 cd apps/app && NEXT_TURBOPACK_TRACING=1 pnpm with-env next dev

--- a/api/app/src/__tests__/org-binding-helpers.test.ts
+++ b/api/app/src/__tests__/org-binding-helpers.test.ts
@@ -1,9 +1,8 @@
 import type { Database, OrgSourceControlBinding } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// `@db/app`'s barrel re-exports `db` from `./client`, which eagerly builds a
-// database client and validates DB env at import. Stub the client module so the
-// real binding *helpers* (which only type-import `Database`) load env-free.
+// Stub the shared client so the real binding helpers load env-free while the
+// tests keep using fake DB objects.
 vi.mock("@db/app/client", () => ({ db: {} }));
 
 const {

--- a/api/app/src/__tests__/trpc-gates.test.ts
+++ b/api/app/src/__tests__/trpc-gates.test.ts
@@ -5,9 +5,9 @@ import { isDiagnosticCause } from "../diagnostics";
 
 // ----- module mocks (must precede the dynamic imports below) -----------------
 
-// `@db/app`'s barrel re-exports the eager database client; stub it so
-// the binding *helpers* used by `task.*` load without DB env. Handlers read the
-// fake `db` injected via tRPC context, never this stub.
+// Stub the shared db export so the binding helpers used by `task.*` stay
+// isolated from runtime DB env. Handlers read the fake `db` injected via tRPC
+// context, never this stub.
 vi.mock("@db/app/client", () => ({ db: {} }));
 
 const getOrganizationMock = vi.fn();

--- a/apps/app/src/app/(early-access)/early-access/page.tsx
+++ b/apps/app/src/app/(early-access)/early-access/page.tsx
@@ -28,6 +28,8 @@ export const metadata: Metadata = createMetadata({
   },
 });
 
+export const dynamic = "force-dynamic";
+
 export default async function EarlyAccessPage({
   searchParams,
 }: {

--- a/apps/www/src/app/(app)/(content)/api/search/route.test.ts
+++ b/apps/www/src/app/(app)/(content)/api/search/route.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = {
+  MXBAI_API_KEY: process.env.MXBAI_API_KEY,
+  MXBAI_STORE_ID: process.env.MXBAI_STORE_ID,
+  SKIP_ENV_VALIDATION: process.env.SKIP_ENV_VALIDATION,
+};
+
+describe("search route", () => {
+  afterEach(() => {
+    restoreEnv("MXBAI_API_KEY", ORIGINAL_ENV.MXBAI_API_KEY);
+    restoreEnv("MXBAI_STORE_ID", ORIGINAL_ENV.MXBAI_STORE_ID);
+    restoreEnv("SKIP_ENV_VALIDATION", ORIGINAL_ENV.SKIP_ENV_VALIDATION);
+    vi.resetModules();
+  });
+
+  it("does not create the Mixedbread client during module evaluation", async () => {
+    delete process.env.MXBAI_API_KEY;
+    delete process.env.MXBAI_STORE_ID;
+    process.env.SKIP_ENV_VALIDATION = "true";
+    vi.resetModules();
+
+    await expect(import("./route")).resolves.toHaveProperty("GET");
+  });
+
+  it("returns an empty result without Mixedbread credentials for blank queries", async () => {
+    delete process.env.MXBAI_API_KEY;
+    delete process.env.MXBAI_STORE_ID;
+    process.env.SKIP_ENV_VALIDATION = "true";
+    vi.resetModules();
+
+    const { GET } = await import("./route");
+    const response = await GET(
+      new NextRequest("https://www.lightfast.localhost/api/search?query=")
+    );
+
+    await expect(response.json()).resolves.toEqual([]);
+  });
+});
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/apps/www/src/app/(app)/(content)/api/search/route.ts
+++ b/apps/www/src/app/(app)/(content)/api/search/route.ts
@@ -7,7 +7,12 @@ import { env } from "~/env";
 
 export const runtime = "edge";
 
-const mxbaiClient = new Mixedbread({ apiKey: env.MXBAI_API_KEY });
+let mxbaiClient: Mixedbread | undefined;
+
+function getMxbaiClient() {
+  mxbaiClient ??= new Mixedbread({ apiKey: env.MXBAI_API_KEY });
+  return mxbaiClient;
+}
 
 // --- Types ---
 
@@ -159,7 +164,7 @@ export async function GET(request: NextRequest) {
       return Response.json([]);
     }
 
-    const response = await mxbaiClient.stores.search({
+    const response = await getMxbaiClient().stores.search({
       query,
       store_identifiers: [env.MXBAI_STORE_ID],
       top_k: 10,

--- a/apps/www/src/app/(app)/(internal)/pitch-deck/layout.tsx
+++ b/apps/www/src/app/(app)/(internal)/pitch-deck/layout.tsx
@@ -9,6 +9,8 @@ import { PitchDeckMobileNav } from "./_components/pitch-deck-mobile-nav";
 import { PitchDeckNavbar } from "./_components/pitch-deck-navbar";
 import { PrefaceToggle } from "./_components/preface-toggle";
 
+export const dynamic = "force-dynamic";
+
 export default async function PitchDeckLayout({
   children,
 }: {

--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -1,9 +1,15 @@
+import { fileURLToPath } from "node:url";
 import sharedConfig from "@repo/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   sharedConfig,
   defineConfig({
+    resolve: {
+      alias: {
+        "~": fileURLToPath(new URL("./src", import.meta.url)),
+      },
+    },
     test: {
       globals: true,
       environment: "node",

--- a/db/app/src/__tests__/client.test.ts
+++ b/db/app/src/__tests__/client.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = {
+  DATABASE_HOST: process.env.DATABASE_HOST,
+  DATABASE_PASSWORD: process.env.DATABASE_PASSWORD,
+  DATABASE_USERNAME: process.env.DATABASE_USERNAME,
+  SKIP_ENV_VALIDATION: process.env.SKIP_ENV_VALIDATION,
+};
+
+describe("database client", () => {
+  afterEach(() => {
+    restoreEnv("DATABASE_HOST", ORIGINAL_ENV.DATABASE_HOST);
+    restoreEnv("DATABASE_PASSWORD", ORIGINAL_ENV.DATABASE_PASSWORD);
+    restoreEnv("DATABASE_USERNAME", ORIGINAL_ENV.DATABASE_USERNAME);
+    restoreEnv("SKIP_ENV_VALIDATION", ORIGINAL_ENV.SKIP_ENV_VALIDATION);
+    vi.resetModules();
+  });
+
+  it("preserves database env values when validation is skipped", async () => {
+    process.env.DATABASE_HOST = "example.planetscale.com";
+    process.env.DATABASE_PASSWORD = "password";
+    process.env.DATABASE_USERNAME = "username";
+    process.env.SKIP_ENV_VALIDATION = "true";
+    vi.resetModules();
+
+    const { env } = await import("../env");
+
+    expect(env.DATABASE_HOST).toBe("example.planetscale.com");
+    expect(env.DATABASE_PASSWORD).toBe("password");
+    expect(env.DATABASE_USERNAME).toBe("username");
+  });
+
+  it("does not create the PlanetScale client during module evaluation", async () => {
+    delete process.env.DATABASE_HOST;
+    delete process.env.DATABASE_PASSWORD;
+    delete process.env.DATABASE_USERNAME;
+    process.env.SKIP_ENV_VALIDATION = "true";
+    vi.resetModules();
+
+    await expect(import("../client")).resolves.toHaveProperty("db");
+  });
+
+  it("still requires database env when the client is used", async () => {
+    delete process.env.DATABASE_HOST;
+    delete process.env.DATABASE_PASSWORD;
+    delete process.env.DATABASE_USERNAME;
+    process.env.SKIP_ENV_VALIDATION = "true";
+    vi.resetModules();
+
+    const { createClient } = await import("../client");
+
+    expect(() => createClient()).toThrow(
+      "DATABASE_HOST is required to create the PlanetScale client."
+    );
+  });
+});
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/db/app/src/client.ts
+++ b/db/app/src/client.ts
@@ -9,13 +9,26 @@ export function createClient() {
   return createDatabase({ host, password, username }, schema);
 }
 
-export const db = createClient();
-
 /**
  * The Drizzle database client type. Repository helpers accept this so they
  * stay testable and transport-agnostic — callers pass `ctx.db`.
  */
-export type Database = typeof db;
+export type Database = ReturnType<typeof createClient>;
+
+let client: Database | undefined;
+
+export function getClient(): Database {
+  client ??= createClient();
+  return client;
+}
+
+export const db = new Proxy({} as Database, {
+  get(_target, prop) {
+    const database = getClient();
+    const value = Reflect.get(database as object, prop, database);
+    return typeof value === "function" ? value.bind(database) : value;
+  },
+});
 
 function requireEnv(name: string, value: string | undefined): string {
   if (!value) {

--- a/db/app/src/env.ts
+++ b/db/app/src/env.ts
@@ -6,7 +6,11 @@ export const env = createEnv({
   clientPrefix: "" as const,
   client: {},
   server: {},
-  runtimeEnv: {},
+  runtimeEnv: {
+    DATABASE_HOST: process.env.DATABASE_HOST,
+    DATABASE_USERNAME: process.env.DATABASE_USERNAME,
+    DATABASE_PASSWORD: process.env.DATABASE_PASSWORD,
+  },
   skipValidation:
     !!process.env.SKIP_ENV_VALIDATION ||
     process.env.npm_lifecycle_event === "lint",

--- a/db/app/src/index.ts
+++ b/db/app/src/index.ts
@@ -1,7 +1,7 @@
 // Schema exports
 
 // Client
-export { type Database, db } from "./client";
+export { type Database, db, getClient } from "./client";
 
 // Re-exported schema definitions
 export {


### PR DESCRIPTION
## Summary
- make the shared DB client lazy while preserving DB env values under skipped validation
- make the www search Mixedbread client lazy and add focused regression coverage
- mark request-bound Next routes dynamic for diagnostic/build correctness
- remove the unreliable debug-build-paths diagnostic command from AGENTS.md

## Verification
- pnpm --filter @db/app test src/__tests__/client.test.ts
- pnpm --filter @lightfast/www test "src/app/(app)/(content)/api/search/route.test.ts"
- pnpm --filter @api/app test src/__tests__/trpc-gates.test.ts src/__tests__/org-binding-helpers.test.ts
- pnpm --filter @db/app typecheck
- pnpm --filter @lightfast/www typecheck
- pnpm --filter @lightfast/app typecheck
- next typegen / build --debug / experimental-analyze --output across app, www, platform
- next build --debug-prerender passed for app and platform; www still hits Next worker heap OOM after compile/typecheck/static-generation start
