### PR TITLE
chore: clarify GitHub Actions workflows

### DIFF
--- a/.agents/skills/github-actions-docs/SKILL.md
+++ b/.agents/skills/github-actions-docs/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: github-actions-docs
+description: Use when users ask how to write, explain, customize, migrate, secure, or troubleshoot GitHub Actions workflows, workflow syntax, triggers, matrices, runners, reusable workflows, artifacts, caching, secrets, OIDC, deployments, custom actions, or Actions Runner Controller, especially when they need official GitHub documentation, exact links, or docs-grounded YAML guidance.
+---
+
+GitHub Actions questions are easy to answer from stale memory. Use this skill to ground answers in official GitHub documentation and return the closest authoritative page instead of generic CI/CD advice.
+
+## When to Use
+
+Use this skill when the request is about:
+
+- GitHub Actions concepts, terminology, or product boundaries
+- Workflow YAML, triggers, jobs, matrices, concurrency, variables, contexts, or expressions
+- GitHub-hosted runners, larger runners, self-hosted runners, or Actions Runner Controller
+- Artifacts, caches, reusable workflows, workflow templates, or custom actions
+- Secrets, `GITHUB_TOKEN`, OpenID Connect, artifact attestations, or secure workflow patterns
+- Environments, deployment protection rules, deployment history, or deployment examples
+- Migrating from Jenkins, CircleCI, GitLab CI/CD, Travis CI, Azure Pipelines, or other CI systems
+- Troubleshooting workflow behavior when the user needs documentation, syntax guidance, or official references
+
+Do not use this skill for:
+
+- A specific failing PR check, missing workflow log, or CI failure triage. Use `gh-fix-ci`.
+- General GitHub pull request, branch, or repository operations. Use `github`.
+- CodeQL-specific configuration or code scanning guidance. Use `codeql`.
+- Dependabot configuration, grouping, or dependency update strategy. Use `dependabot`.
+
+## Workflow
+
+### 1. Classify the request
+
+Decide which bucket the question belongs to before searching:
+
+- Getting started or tutorials
+- Workflow authoring and syntax
+- Runners and execution environment
+- Security and supply chain
+- Deployments and environments
+- Custom actions and publishing
+- Monitoring, logs, and troubleshooting
+- Migration
+
+If you need a quick starting point, load `references/topic-map.md` and jump to the closest section.
+
+### 2. Search official GitHub docs first
+
+- Treat `docs.github.com` as the source of truth.
+- Prefer pages under <https://docs.github.com/en/actions>.
+- Search with the user's exact terms plus a focused Actions phrase such as `workflow syntax`, `OIDC`, `reusable workflows`, or `self-hosted runners`.
+- When multiple pages are plausible, compare 2-3 candidate pages and pick the one that most directly answers the user's question.
+
+### 3. Open the best page before answering
+
+- Read the most relevant page, and the exact section when practical.
+- Use the topic map only to narrow the search space or surface likely starting pages.
+- If a page appears renamed, moved, or incomplete, say that explicitly and return the nearest authoritative pages instead of guessing.
+
+### 4. Answer with docs-grounded guidance
+
+- Start with a direct answer in plain language.
+- Include exact GitHub docs links, not just the docs homepage.
+- Only provide YAML or step-by-step examples when the user asks for them or when the docs page makes an example necessary.
+- Make any inference explicit. Good phrasing:
+  - `According to GitHub docs, ...`
+  - `Inference: this likely means ...`
+
+## Answer Shape
+
+Use a compact structure unless the user asks for depth:
+
+1. Direct answer
+2. Relevant docs
+3. Example YAML or steps, only if needed
+4. Explicit inference callout, only if you had to connect multiple docs pages
+
+Keep citations close to the claim they support.
+
+## Search and Routing Tips
+
+- For concept questions, prefer overview or concept pages before deep reference pages.
+- For syntax questions, prefer workflow syntax, events, contexts, variables, or expressions reference pages.
+- For security questions, prefer `Secure use`, `Secrets`, `GITHUB_TOKEN`, `OpenID Connect`, and artifact attestation docs.
+- For deployment questions, prefer environments and deployment protection docs before cloud-specific examples.
+- For migration questions, prefer the migration hub page first, then a platform-specific migration guide.
+- If the user asks for a beginner walkthrough, start with a tutorial or quickstart instead of a raw reference page.
+
+## Common Mistakes
+
+- Answering from memory without verifying the current docs
+- Linking the GitHub Actions docs landing page when a narrower page exists
+- Mixing up reusable workflows and composite actions
+- Suggesting long-lived cloud credentials when OIDC is the better documented path
+- Treating repo-specific CI debugging as a documentation question when it should be handed to `gh-fix-ci`
+- Letting adjacent domains absorb the request when `codeql` or `dependabot` is the sharper fit
+
+## Bundled Reference
+
+Read `references/topic-map.md` only as a compact index of likely doc entry points. It is intentionally incomplete and should never replace the live GitHub docs as the final authority.

--- a/.agents/skills/github-actions-docs/references/topic-map.md
+++ b/.agents/skills/github-actions-docs/references/topic-map.md
@@ -1,0 +1,90 @@
+# GitHub Actions Topic Map
+
+This reference is a compact routing aid derived from the source catalog. It is intentionally selective and deduplicated. Use it to find the right documentation neighborhood quickly, then verify against the live docs on `docs.github.com`.
+
+## Getting Started
+
+- [Understanding GitHub Actions](https://docs.github.com/en/actions/get-started/understand-github-actions)
+- [Quickstart for GitHub Actions](https://docs.github.com/en/actions/get-started/quickstart)
+- [Continuous integration](https://docs.github.com/en/actions/get-started/continuous-integration)
+- [Continuous deployment](https://docs.github.com/en/actions/get-started/continuous-deployment)
+- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+
+## Workflow Authoring
+
+- [Workflows](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflows)
+- [Variables](https://docs.github.com/en/actions/concepts/workflows-and-actions/variables)
+- [Contexts](https://docs.github.com/en/actions/concepts/workflows-and-actions/contexts)
+- [Expressions](https://docs.github.com/en/actions/concepts/workflows-and-actions/expressions)
+- [Using jobs in a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-jobs)
+- [Running variations of jobs in a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations)
+- [Passing information between jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs)
+- [Reuse workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
+- [Reusing workflow configurations](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations)
+
+## Runners and Execution
+
+- [GitHub-hosted runners](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners)
+- [Using GitHub-hosted runners](https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/use-github-hosted-runners)
+- [Choosing the runner for a job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job)
+- [Running jobs in a container](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container)
+- [Self-hosted runners](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners)
+- [Larger runners](https://docs.github.com/en/actions/concepts/runners/larger-runners)
+- [Actions Runner Controller](https://docs.github.com/en/actions/concepts/runners/actions-runner-controller)
+- [Get started with Actions Runner Controller](https://docs.github.com/en/actions/tutorials/use-actions-runner-controller/get-started)
+
+## Security and Supply Chain
+
+- [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Secrets](https://docs.github.com/en/actions/concepts/security/secrets)
+- [GITHUB_TOKEN](https://docs.github.com/en/actions/concepts/security/github_token)
+- [OpenID Connect](https://docs.github.com/en/actions/concepts/security/openid-connect)
+- [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc)
+- [Artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations)
+- [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations)
+- [Using OpenID Connect with reusable workflows](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-with-reusable-workflows)
+- [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws)
+
+## Deployments and Environments
+
+- [Deployment environments](https://docs.github.com/en/actions/concepts/workflows-and-actions/deployment-environments)
+- [Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
+- [Deploying with GitHub Actions](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments)
+- [Managing environments for deployment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
+- [Reviewing deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments)
+- [Viewing deployment history](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/view-deployment-history)
+- [Deploying to Amazon Elastic Container Service](https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/amazon-elastic-container-service)
+- [Deploying Node.js to Azure App Service](https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/nodejs-to-azure-app-service)
+
+## Custom Actions and Publishing
+
+- [About custom actions](https://docs.github.com/en/actions/concepts/workflows-and-actions/custom-actions)
+- [Metadata syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax)
+- [Managing custom actions](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/manage-custom-actions)
+- [Creating a JavaScript action](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action)
+- [Creating a composite action](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action)
+- [Creating a third party CLI action](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/create-a-cli-action)
+- [Publishing actions in GitHub Marketplace](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/publish-in-github-marketplace)
+- [Releasing and maintaining actions](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/release-and-maintain-actions)
+
+## Monitoring, Logs, and Troubleshooting
+
+- [Using the visualization graph](https://docs.github.com/en/actions/how-tos/monitor-workflows/use-the-visualization-graph)
+- [Viewing workflow run history](https://docs.github.com/en/actions/how-tos/monitor-workflows/view-workflow-run-history)
+- [Using workflow run logs](https://docs.github.com/en/actions/how-tos/monitor-workflows/use-workflow-run-logs)
+- [Viewing job condition expression logs](https://docs.github.com/en/actions/how-tos/monitor-workflows/view-job-condition-logs)
+- [Enabling debug logging](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging)
+- [Troubleshooting workflows](https://docs.github.com/en/actions/how-tos/troubleshoot-workflows)
+- [Viewing GitHub Actions metrics](https://docs.github.com/en/actions/how-tos/administer/view-metrics)
+
+## Migration and Tutorials
+
+- [Migrating to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions)
+- [Automating migration with GitHub Actions Importer](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/automated-migrations/use-github-actions-importer)
+- [Migrating from Jenkins to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/manual-migrations/migrate-from-jenkins)
+- [Migrating from CircleCI to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/manual-migrations/migrate-from-circleci)
+- [Migrating from GitLab CI/CD to GitHub Actions](https://docs.github.com/en/actions/tutorials/migrate-to-github-actions/manual-migrations/migrate-from-gitlab-cicd)
+- [Building and testing Node.js](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs)
+- [Use GITHUB_TOKEN for authentication in workflows](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)
+- [Store and share data with workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data)

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,5 +1,8 @@
-name: Core CI
+name: core-public-api-ci
+run-name: core-public-api-ci / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
+# Runs on PRs touching the public oRPC/API/SDK/MCP surface that need the
+# focused core public API lint/typecheck/test suite.
 on:
   push:
     branches: [main]
@@ -31,48 +34,51 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  core-ci:
-    name: core-ci
+  core-public-api-lint-typecheck-test:
+    name: core-public-api-lint-typecheck-test
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - name: Checkout code
+      - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint (biome)
+      - name: lint-biome
         run: pnpm turbo //#check --summarize
 
-      - name: Type check public oRPC surface
+      - name: typecheck-public-orpc-surface
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo typecheck --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize
 
-      - name: Test public oRPC surface
+      - name: test-public-orpc-surface
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — Core CI / core-ci'
-          artifact-name: turbo-cache-core-ci
+          title: 'Turbo cache report - core-public-api-ci / core-public-api-lint-typecheck-test'
+          artifact-name: turbo-cache-core-public-api-ci-lint-typecheck-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
-name: CI
+name: repo-ci
+run-name: repo-ci / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
+# Runs on PRs touching app, package, core, or workspace files that need the
+# affected lint/typecheck/test/boundary suite.
 on:
   push:
     branches: [main]
@@ -27,71 +30,74 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  quality:
-    name: Quality
+  repo-lint-typecheck-test-boundaries:
+    name: repo-lint-typecheck-test-boundaries
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - name: Checkout code
+      - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint (biome)
+      - name: lint-biome
         run: pnpm turbo //#check --summarize
 
-      - name: Type check affected packages
+      - name: typecheck-affected-packages
         env:
           SKIP_ENV_VALIDATION: "true"
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: pnpm turbo typecheck --affected --continue --summarize
 
-      - name: Test public oRPC surface
+      - name: test-public-orpc-surface
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --filter=@vendor/mcp --continue --summarize
 
-      - name: Check boundaries
+      - name: check-boundaries
         run: pnpm turbo boundaries
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — CI / Quality'
-          artifact-name: turbo-cache-ci-quality
+          title: 'Turbo cache report - repo-ci / repo-lint-typecheck-test-boundaries'
+          artifact-name: turbo-cache-repo-ci-lint-typecheck-test-boundaries
 
-  # Summary job (required status check)
-  ci-success:
-    name: CI Success
+  # Summary job
+  repo-ci-success:
+    name: repo-ci-success
     if: always()
-    needs: [quality]
+    needs: [repo-lint-typecheck-test-boundaries]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Evaluate results
+      - name: evaluate-results
         run: |
-          quality="${{ needs.quality.result }}"
+          repo_checks="${{ needs['repo-lint-typecheck-test-boundaries'].result }}"
 
-          echo "quality.result = $quality"
+          echo "repo-lint-typecheck-test-boundaries.result = $repo_checks"
 
-          if [[ "$quality" != "success" ]]; then
+          if [[ "$repo_checks" != "success" ]]; then
             echo "CI quality checks failed."
             exit 1
           fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,5 @@
-name: "CodeQL"
+name: codeql-security
+run-name: codeql-security / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
 on:
   push:
@@ -8,8 +9,8 @@ on:
     - cron: "30 3 * * 1"
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
+  codeql-analyze:
+    name: codeql-analyze-${{ matrix.language }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -28,17 +29,17 @@ jobs:
             build-mode: none
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Initialize CodeQL
+      - name: initialize-codeql
         uses: github/codeql-action/init@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Perform CodeQL Analysis
+      - name: analyze-codeql
         uses: github/codeql-action/analyze@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/db-check.yml
+++ b/.github/workflows/db-check.yml
@@ -1,34 +1,44 @@
-name: DB Schema Drift
+name: db-schema-drift
+run-name: db-schema-drift / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
+# Runs only when DB app schema or migration sources change, then checks that
+# generated migrations are committed.
 on:
   pull_request:
     paths: ["db/app/**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  drift:
-    name: DB Schema Drift
+  db-schema-drift:
+    name: db-schema-drift
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Checkout code
+      - name: checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "pnpm"
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Regenerate migrations
+      - name: regenerate-migrations
         run: pnpm --filter @db/app db:generate
 
-      - name: Assert no uncommitted migration drift
+      - name: assert-no-uncommitted-migration-drift
         run: |
           # git diff is blind to untracked files; intent-to-add makes new
           # generated migrations and snapshots visible to the diff.

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,4 +1,5 @@
-name: Database Migration
+name: db-migrate
+run-name: db-migrate / ${{ github.actor }} / ${{ github.run_number }}
 
 on:
   workflow_dispatch:
@@ -12,9 +13,12 @@ concurrency:
   group: db-migration
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
-  migrate:
-    name: Run PlanetScale MySQL Migrations
+  db-migrate-planetscale:
+    name: db-migrate-planetscale
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'migrate'
     timeout-minutes: 20
@@ -26,32 +30,32 @@ jobs:
       PSCALE_BRANCH_NAME: staging
 
     steps:
-      - name: Checkout code
+      - name: checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "pnpm"
 
-      - name: Setup pscale
+      - name: setup-pscale
         uses: planetscale/setup-pscale-action@v1
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Assert staging branch exists
+      - name: assert-staging-branch-exists
         run: |
           if ! pscale branch show "$PLANETSCALE_DATABASE_NAME" "$PSCALE_BRANCH_NAME" --org "$PLANETSCALE_ORG_NAME" >/dev/null; then
             echo "staging branch missing - run the one-time bootstrap documented in db/CLAUDE.md" >&2
             exit 1
           fi
 
-      - name: Create branch password
+      - name: create-branch-password
         run: |
           response=$(pscale password create "$PLANETSCALE_DATABASE_NAME" "$PSCALE_BRANCH_NAME" "github-actions-${GITHUB_RUN_ID}" -f json --org "$PLANETSCALE_ORG_NAME")
           password_id=$(echo "$response" | jq -r '.id')
@@ -66,7 +70,7 @@ jobs:
           echo "DATABASE_PASSWORD=$password" >> "$GITHUB_ENV"
           echo "DATABASE_NAME=$PLANETSCALE_DATABASE_NAME" >> "$GITHUB_ENV"
 
-      - name: Show pending migrations
+      - name: show-pending-migrations
         working-directory: db/app
         run: |
           echo "Pending migration files:"
@@ -75,11 +79,11 @@ jobs:
           echo "Migration journal:"
           cat src/migrations/meta/_journal.json
 
-      - name: Run migrations on branch
+      - name: run-migrations-on-branch
         working-directory: db/app
         run: pnpm db:migrate
 
-      - name: Open deploy request
+      - name: open-deploy-request
         run: |
           set +e
           existing=$(pscale deploy-request show "$PLANETSCALE_DATABASE_NAME" "$PSCALE_BRANCH_NAME" --org "$PLANETSCALE_ORG_NAME" -f json 2>/dev/null)
@@ -115,7 +119,7 @@ jobs:
           echo "HAS_SCHEMA_CHANGES=true" >> "$GITHUB_ENV"
           echo "Opened deploy request $deploy_request_number."
 
-      - name: Check schema lint
+      - name: check-schema-lint
         if: env.HAS_SCHEMA_CHANGES == 'true'
         run: |
           deploy_request=$(pscale deploy-request show "$PLANETSCALE_DATABASE_NAME" "$DEPLOY_REQUEST_NUMBER" --org "$PLANETSCALE_ORG_NAME" -f json)
@@ -139,17 +143,17 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy schema changes
+      - name: deploy-schema-changes
         if: env.HAS_SCHEMA_CHANGES == 'true'
         run: |
           pscale deploy-request deploy "$PLANETSCALE_DATABASE_NAME" "$DEPLOY_REQUEST_NUMBER" --org "$PLANETSCALE_ORG_NAME" --wait
 
-      - name: Delete branch password
+      - name: delete-branch-password
         if: always() && env.PSCALE_PASSWORD_ID != ''
         run: |
           pscale password delete "$PLANETSCALE_DATABASE_NAME" "$PSCALE_BRANCH_NAME" "$PSCALE_PASSWORD_ID" --force --org "$PLANETSCALE_ORG_NAME"
 
-      - name: Summary
+      - name: summarize-migration
         run: |
           if [ "$HAS_SCHEMA_CHANGES" = "true" ]; then
             echo "Database migrations deployed through PlanetScale deploy request ${DEPLOY_REQUEST_NUMBER}."
@@ -157,12 +161,13 @@ jobs:
             echo "Database migrations applied to staging; no schema deploy was needed."
           fi
 
-  no-confirmation:
-    name: Migration Not Confirmed
+  db-migrate-confirmation-required:
+    name: db-migrate-confirmation-required
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.inputs.confirm != 'migrate'
     steps:
-      - name: Show error
+      - name: show-confirmation-error
         run: |
           echo "Migration was not confirmed."
           echo "You must type 'migrate' in the confirmation input."

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -1,5 +1,8 @@
-name: Desktop CI
+name: desktop-ci
+run-name: desktop-ci / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
+# Runs on PRs touching the desktop app or shared renderer/runtime dependencies
+# that can affect Electron typecheck, tests, packaging, or e2e.
 on:
   pull_request:
     paths:
@@ -29,51 +32,57 @@ permissions:
   contents: read
 
 jobs:
-  package:
-    name: Typecheck + package (unsigned, ${{ matrix.os }})
+  desktop-typecheck-test-package-e2e:
+    name: ${{ matrix.check_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        include:
+          - os: macos-14
+            check_name: desktop-typecheck-test-package-e2e-macos-14
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - name: setup-pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - name: setup-node-22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install Linux maker prerequisites
+      - name: install-linux-maker-prerequisites
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update && sudo apt-get install -y rpm fakeroot
           # Fail fast if the runner image (x64 or arm) is missing any tool
           which dpkg-deb fakeroot rpm rpmbuild
 
-      - run: pnpm install --frozen-lockfile
+      - name: install-dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
+      - name: typecheck-desktop
         run: pnpm turbo typecheck --filter=@lightfast/desktop --summarize
 
-      - name: Test
+      - name: test-desktop
         run: pnpm --filter @lightfast/desktop test
 
-      - name: Package (unsigned)
+      - name: package-desktop-unsigned
         # electron-forge defaults to host platform: macOS leg packages darwin
         # via MakerZIP/MakerDMG, Linux leg packages linux via MakerDeb/MakerRpm.
         # Each maker's platform filter (forge.config.ts:143-152) does the routing.
         run: pnpm turbo package --filter=@lightfast/desktop --summarize
 
-      - name: Upload packaged app
+      - name: upload-packaged-app
         # Lets reviewers grab the packaged tree to verify native bindings ship
         # under app.asar.unpacked/ (e.g. better_sqlite3.node on both legs).
         # if-no-files-found=error catches a silent forge regression where out/
@@ -85,14 +94,14 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-      - name: E2E (Playwright Electron)
+      - name: e2e-playwright-electron
         # macOS-only: Linux Electron e2e needs Xvfb/system deps that W5 didn't
         # plan for (the matrix's Linux leg landed in a separate W3 worktree).
         # Adding Linux e2e is a separate effort; keep W5's promise to macos-14.
         if: runner.os == 'macOS'
         run: pnpm --filter @lightfast/desktop exec playwright test --config=playwright.config.ts
 
-      - name: Upload Playwright report on failure
+      - name: upload-playwright-report-on-failure
         if: failure() && runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
@@ -100,9 +109,9 @@ jobs:
           path: apps/desktop/playwright-report/
           retention-days: 7
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — Desktop CI / ${{ matrix.os }}'
-          artifact-name: turbo-cache-desktop-ci-${{ matrix.os }}
+          title: 'Turbo cache report - desktop-ci / ${{ matrix.check_name }}'
+          artifact-name: turbo-cache-${{ matrix.check_name }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,4 +1,5 @@
-name: Release desktop
+name: desktop-release
+run-name: desktop-release / ${{ github.ref_name }}
 
 on:
   push:
@@ -10,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare:
-    name: Prepare draft release
+  desktop-release-prepare:
+    name: desktop-release-prepare
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
@@ -20,12 +21,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Resolve version
+      - name: resolve-version
         id: ver
         run: |
           tag="${{ github.ref_name }}"
@@ -39,7 +40,7 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create draft release if missing
+      - name: create-draft-release-if-missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -71,9 +72,9 @@ jobs:
               "${notes_arg[@]}"
           fi
 
-  build_macos:
-    name: Build macOS ${{ matrix.arch }}
-    needs: prepare
+  desktop-release-macos:
+    name: desktop-release-macos-${{ matrix.arch }}
+    needs: desktop-release-prepare
     runs-on: macos-14
     timeout-minutes: 60
     strategy:
@@ -95,25 +96,25 @@ jobs:
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Stamp version, feed URL, signing mode, prerelease env
+      - name: stamp-version-feed-url-signing-mode-prerelease-env
         working-directory: apps/desktop
         run: |
-          npm version "${{ needs.prepare.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm version "${{ needs['desktop-release-prepare'].outputs.version }}" --no-git-tag-version --allow-same-version
           npm pkg set buildFlavor=prod
           npm pkg set buildNumber="$GITHUB_RUN_NUMBER"
           npm pkg set sparkleFeedUrl='https://github.com/${{ github.repository }}/releases/latest/download/latest-mac-${arch}.json'
@@ -126,9 +127,9 @@ jobs:
           # publisher's createRelease fallback path. The prepare job already
           # set --prerelease at draft creation (the load-bearing path); this
           # is belt-and-suspenders.
-          echo "LIGHTFAST_DESKTOP_RELEASE_PRERELEASE=${{ needs.prepare.outputs.prerelease }}" >> "$GITHUB_ENV"
+          echo "LIGHTFAST_DESKTOP_RELEASE_PRERELEASE=${{ needs['desktop-release-prepare'].outputs.prerelease }}" >> "$GITHUB_ENV"
 
-      - name: Import Apple signing certificate
+      - name: import-apple-signing-certificate
         if: env.APPLE_SIGNING_IDENTITY != ''
         env:
           APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
@@ -144,7 +145,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
           rm /tmp/cert.p12
 
-      - name: Write notarize API key
+      - name: write-notarize-api-key
         if: env.APPLE_SIGNING_IDENTITY != ''
         env:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
@@ -155,24 +156,24 @@ jobs:
           printf '%s' "$APPLE_API_KEY_CONTENT" > "$key_file"
           echo "APPLE_API_KEY=$key_file" >> "$GITHUB_ENV"
 
-      - name: Publish (forge)
+      - name: publish-forge
         working-directory: apps/desktop
         run: pnpm exec electron-forge publish --arch=${{ matrix.arch }} --platform=darwin
 
-      - name: Upload source maps to Sentry
+      - name: upload-source-maps-to-sentry
         working-directory: apps/desktop
         run: pnpm sourcemaps:upload
 
-      - name: Attest build provenance
+      - name: attest-build-provenance
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
             apps/desktop/out/make/**/*.zip
             apps/desktop/out/make/**/*.dmg
 
-  build_linux:
-    name: Build Linux ${{ matrix.arch }}
-    needs: prepare
+  desktop-release-linux:
+    name: desktop-release-linux-${{ matrix.arch }}
+    needs: desktop-release-prepare
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -194,31 +195,31 @@ jobs:
       # renderer/main JS source is identical across platforms, so a second
       # upload would be duplicated work, not added coverage.
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install Linux maker prerequisites
+      - name: install-linux-maker-prerequisites
         run: |
           sudo apt-get update && sudo apt-get install -y rpm fakeroot
           # Fail fast if the runner image (x64 or arm) is missing any tool
           which dpkg-deb fakeroot rpm rpmbuild
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Stamp version, buildFlavor, buildNumber, signingMode, prerelease env
+      - name: stamp-version-build-flavor-build-number-signing-mode-prerelease-env
         working-directory: apps/desktop
         run: |
-          npm version "${{ needs.prepare.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm version "${{ needs['desktop-release-prepare'].outputs.version }}" --no-git-tag-version --allow-same-version
           npm pkg set buildFlavor=prod
           npm pkg set buildNumber="$GITHUB_RUN_NUMBER"
           # `signingMode=ad-hoc` keeps build-info shape platform-uniform.
@@ -227,65 +228,65 @@ jobs:
           # the safe-default guard (same pattern as the mac path). Delete this
           # line if/when Linux Sparkle introduces a Linux-specific signing scheme.
           npm pkg set signingMode=ad-hoc
-          echo "LIGHTFAST_DESKTOP_RELEASE_PRERELEASE=${{ needs.prepare.outputs.prerelease }}" >> "$GITHUB_ENV"
+          echo "LIGHTFAST_DESKTOP_RELEASE_PRERELEASE=${{ needs['desktop-release-prepare'].outputs.prerelease }}" >> "$GITHUB_ENV"
 
-      - name: Publish (forge)
+      - name: publish-forge
         working-directory: apps/desktop
         run: pnpm exec electron-forge publish --arch=${{ matrix.arch }} --platform=linux
 
-      - name: Attest build provenance
+      - name: attest-build-provenance
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
             apps/desktop/out/make/**/*.deb
             apps/desktop/out/make/**/*.rpm
 
-  finalize:
-    name: Finalize release
-    needs: [prepare, build_macos, build_linux]
+  desktop-release-finalize:
+    name: desktop-release-finalize
+    needs: [desktop-release-prepare, desktop-release-macos, desktop-release-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Squirrel.Mac update feed
+      - name: generate-squirrel-mac-update-feed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
-          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_TAG: ${{ needs['desktop-release-prepare'].outputs.tag }}
+          RELEASE_VERSION: ${{ needs['desktop-release-prepare'].outputs.version }}
         run: node apps/desktop/scripts/generate-update-feed.mjs
 
-      - name: Generate third-party notices
+      - name: generate-third-party-notices
         run: pnpm --filter @lightfast/desktop notices:generate
 
-      - name: Attach third-party notices to release
+      - name: attach-third-party-notices-to-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ needs.prepare.outputs.tag }}" \
+          gh release upload "${{ needs['desktop-release-prepare'].outputs.tag }}" \
             apps/desktop/THIRD_PARTY_NOTICES.txt \
             --repo "${{ github.repository }}" \
             --clobber
 
-      - name: Publish release (undraft)
+      - name: publish-release-undraft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit "${{ needs.prepare.outputs.tag }}" \
+          gh release edit "${{ needs['desktop-release-prepare'].outputs.tag }}" \
             --repo "${{ github.repository }}" \
             --draft=false

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,4 +1,5 @@
-name: Merge Queue
+name: merge-queue
+run-name: merge-queue / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
 # Dual-trigger pattern: the `merge-queue-success` status check is required by
 # the ruleset for both PR commits AND merge_group commits. So this workflow
@@ -20,8 +21,8 @@ permissions:
   security-events: write
 
 jobs:
-  quality:
-    name: Quality (full)
+  merge-queue-lint-typecheck-boundaries-knip:
+    name: merge-queue-lint-typecheck-boundaries-knip
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -29,43 +30,47 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - name: setup-pnpm
+        uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - name: setup-node-22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile
+      - name: install-dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Lint (biome)
+      - name: lint-biome
         run: pnpm turbo //#check --summarize
 
-      - name: Typecheck (full, no --affected)
+      - name: typecheck-full
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo typecheck --continue --summarize
 
-      - name: Boundaries
+      - name: check-boundaries
         run: pnpm turbo boundaries
 
-      - name: Knip dead-code
+      - name: check-dead-code-knip
         continue-on-error: true # pre-existing dead code on main; remove flag once cleanup sprint completes
         run: pnpm turbo //#knip --summarize
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — Merge Queue / Quality'
-          artifact-name: turbo-cache-merge-queue-quality
+          title: 'Turbo cache report - merge-queue / merge-queue-lint-typecheck-boundaries-knip'
+          artifact-name: turbo-cache-merge-queue-lint-typecheck-boundaries-knip
 
-  core-build:
-    name: Core build + test (full)
+  merge-queue-core-build-test:
+    name: merge-queue-core-build-test
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -73,85 +78,97 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - name: setup-pnpm
+        uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - name: setup-node-22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile
+      - name: install-dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Build core packages
+      - name: build-core-packages
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo build --filter=lightfast --filter=@lightfastai/mcp --filter=@lightfastai/cli --summarize
 
-      - name: Test public oRPC packages
+      - name: test-public-orpc-packages
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo test --filter=@repo/api-contract --filter=@api/app --filter=lightfast --filter=@lightfastai/mcp --summarize
 
-      - name: Verify build outputs
+      - name: verify-build-outputs
         run: |
           ls -la core/lightfast/dist/
           ls -la core/mcp/dist/
           ls -la core/cli/dist/
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — Merge Queue / Core build + test'
-          artifact-name: turbo-cache-merge-queue-core-build
+          title: 'Turbo cache report - merge-queue / merge-queue-core-build-test'
+          artifact-name: turbo-cache-merge-queue-core-build-test
 
-  desktop-package:
-    name: Desktop package + e2e (${{ matrix.os }})
+  merge-queue-desktop-typecheck-package-e2e:
+    name: ${{ matrix.check_name }}
     if: github.event_name == 'merge_group'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04]
+        include:
+          - os: macos-14
+            check_name: merge-queue-desktop-typecheck-package-e2e-macos-14
+          - os: ubuntu-22.04
+            check_name: merge-queue-desktop-typecheck-package-ubuntu-22.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - name: setup-pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - name: setup-node-22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Install Linux maker prerequisites
+      - name: install-linux-maker-prerequisites
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update && sudo apt-get install -y rpm fakeroot
           which dpkg-deb fakeroot rpm rpmbuild
 
-      - run: pnpm install --frozen-lockfile
+      - name: install-dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
+      - name: typecheck-desktop
         run: pnpm turbo typecheck --filter=@lightfast/desktop --summarize
 
-      - name: Package (unsigned)
+      - name: package-desktop-unsigned
         run: pnpm turbo package --filter=@lightfast/desktop --summarize
 
-      - name: E2E (Playwright Electron)
+      - name: e2e-playwright-electron
         if: runner.os == 'macOS'
         run: pnpm --filter @lightfast/desktop exec playwright test --config=playwright.config.ts
 
-      - name: Upload Playwright report on failure
+      - name: upload-playwright-report-on-failure
         if: failure() && runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
@@ -159,15 +176,15 @@ jobs:
           path: apps/desktop/playwright-report/
           retention-days: 7
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — Merge Queue / Desktop ${{ matrix.os }}'
-          artifact-name: turbo-cache-merge-queue-desktop-${{ matrix.os }}
+          title: 'Turbo cache report - merge-queue / ${{ matrix.check_name }}'
+          artifact-name: turbo-cache-${{ matrix.check_name }}
 
-  codeql:
-    name: CodeQL (${{ matrix.language }})
+  merge-queue-codeql:
+    name: merge-queue-codeql-${{ matrix.language }}
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -185,36 +202,43 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: github/codeql-action/init@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
+      - name: initialize-codeql
+        uses: github/codeql-action/init@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/analyze@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
+      - name: analyze-codeql
+        uses: github/codeql-action/analyze@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           category: "/language:${{ matrix.language }}"
 
   merge-queue-success:
     name: merge-queue-success
     if: always()
-    needs: [quality, core-build, desktop-package, codeql]
+    needs:
+      - merge-queue-lint-typecheck-boundaries-knip
+      - merge-queue-core-build-test
+      - merge-queue-desktop-typecheck-package-e2e
+      - merge-queue-codeql
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Evaluate gate
+      - name: evaluate-gate
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "PR event — gating stub. Real battery runs on merge_group."
             exit 0
           fi
-          quality="${{ needs.quality.result }}"
-          core_build="${{ needs.core-build.result }}"
-          desktop_package="${{ needs.desktop-package.result }}"
-          codeql="${{ needs.codeql.result }}"
-          echo "quality=$quality core-build=$core_build desktop-package=$desktop_package codeql=$codeql"
+          quality="${{ needs['merge-queue-lint-typecheck-boundaries-knip'].result }}"
+          core_build="${{ needs['merge-queue-core-build-test'].result }}"
+          desktop_package="${{ needs['merge-queue-desktop-typecheck-package-e2e'].result }}"
+          codeql="${{ needs['merge-queue-codeql'].result }}"
+          echo "merge-queue-lint-typecheck-boundaries-knip=$quality merge-queue-core-build-test=$core_build merge-queue-desktop-typecheck-package-e2e=$desktop_package merge-queue-codeql=$codeql"
           if [[ "$quality" != "success" || \
                 "$core_build" != "success" || \
                 "$desktop_package" != "success" || \

--- a/.github/workflows/publish-sdk-mcp.yml
+++ b/.github/workflows/publish-sdk-mcp.yml
@@ -1,4 +1,5 @@
-name: Publish SDK + MCP
+name: sdk-mcp-publish
+run-name: sdk-mcp-publish / ${{ github.event_name }} / ${{ github.ref_name }}
 
 on:
   push:
@@ -11,8 +12,8 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  publish:
-    name: Publish SDK + MCP
+  sdk-mcp-publish:
+    name: sdk-mcp-publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -23,30 +24,30 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Configure git user
+      - name: configure-git-user
         run: |
           git config --global user.name 'lightfast-release-bot'
           git config --global user.email 'releases@lightfast.ai'
 
-      - name: Checkout Repo
+      - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
+      - name: setup-pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: install-dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Reject CLI changesets
+      - name: reject-cli-changesets
         run: |
           CLI_CHANGESETS="$(grep -R -n '"@lightfastai/cli"' .changeset/*.md 2>/dev/null || true)"
           if [ -n "$CLI_CHANGESETS" ]; then
@@ -55,24 +56,24 @@ jobs:
             exit 1
           fi
 
-      - name: Build SDK + MCP packages
+      - name: build-sdk-mcp-packages
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo build --filter=lightfast --filter=@lightfastai/mcp --summarize
 
-      - name: Run tests
+      - name: test-sdk-mcp-packages
         env:
           SKIP_ENV_VALIDATION: "true"
         run: pnpm turbo test --filter=@repo/api-contract --filter=lightfast --filter=@lightfastai/mcp --summarize
 
-      - name: Cache report
+      - name: turbo-cache-report
         if: always()
         uses: ./.github/actions/turbo-summary
         with:
-          title: 'Turbo cache report — Publish SDK + MCP'
-          artifact-name: turbo-cache-publish-sdk-mcp
+          title: 'Turbo cache report - sdk-mcp-publish / sdk-mcp-publish'
+          artifact-name: turbo-cache-sdk-mcp-publish
 
-      - name: Validate package tarballs
+      - name: validate-package-tarballs
         run: |
           echo "Packing tarballs to validate manifests..."
           SCRATCH=$(mktemp -d)
@@ -86,7 +87,7 @@ jobs:
             || (echo "❌ @lightfastai/mcp has unexpected runtime deps"; tar -xzOf "$SCRATCH"/lightfastai-mcp-*.tgz package/package.json | jq '.dependencies'; exit 1)
           echo "✅ Tarball manifests valid"
 
-      - name: Create SDK/MCP Version PR or Publish to npm
+      - name: create-sdk-mcp-version-pr-or-publish-npm
         id: changesets
         uses: changesets/action@v1
         with:
@@ -97,7 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Verify SDK/MCP latest versions match
+      - name: verify-sdk-mcp-latest-versions-match
         if: steps.changesets.outputs.published == 'true'
         run: |
           echo "Verifying SDK/MCP packages published successfully to latest tag..."
@@ -123,7 +124,7 @@ jobs:
 
           echo "✅ Both packages at $LIGHTFAST_VERSION on latest tag"
 
-      - name: Send a Slack notification if a publish happens
+      - name: notify-slack-on-publish
         if: steps.changesets.outputs.published == 'true'
         # TODO: First users are through Slack/Discord channels. Notify via Pylon + Lightfast
         # integration to post release notes to each team's custom channel.

--- a/.github/workflows/verify-changeset.yml
+++ b/.github/workflows/verify-changeset.yml
@@ -2,8 +2,10 @@
 # - patch: Bug fixes, performance improvements  
 # - minor: New features, non-breaking changes
 # - major: Breaking changes, API changes
-name: Verify Changesets
+name: changeset-verify
+run-name: changeset-verify / ${{ github.event_name }} / ${{ github.head_ref || github.ref_name }}
 
+# Runs only on PRs that touch changeset files for publishable core packages.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -12,28 +14,37 @@ on:
     paths:
       - '.changeset/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  verify-changesets:
+  changeset-verify:
+    name: changeset-verify
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
+      - name: setup-node-22
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Get changed changeset files
+      - name: get-changed-changeset-files
         id: changeset-files
         run: |
           echo "changed-files=$(git diff --diff-filter=dr --name-only $BASE_SHA -- '.changeset/*.md' | tr '\n' ' ')" >> $GITHUB_OUTPUT
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
-      - name: Verify changeset format
+      - name: verify-changeset-format
         if: steps.changeset-files.outputs.changed-files != ''
         run: |
           echo "Checking changeset files: ${{ steps.changeset-files.outputs.changed-files }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -121,7 +121,7 @@ Expected PR behavior:
 
 - Affected PR CI stays fast and only runs jobs for touched surfaces.
 - `merge-queue-success` passes as the required branch-protection stub.
-- oRPC contract/API changes trigger Core CI and include the public oRPC package test scope.
+- oRPC contract/API changes trigger `core-public-api-ci` and include the public oRPC package test scope.
 
 For oRPC propagation changes, inspect CI logs for:
 
@@ -189,7 +189,7 @@ Merge the Version Packages PR through merge queue. The merge to `main` triggers 
 
 ### 6. Publish SDK + MCP
 
-After the Version Packages PR merges, `Publish SDK + MCP` runs on `main`.
+After the Version Packages PR merges, `sdk-mcp-publish` runs on `main`.
 
 The workflow:
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -91,6 +91,12 @@
       "skillPath": "skills/finishing-a-development-branch/SKILL.md",
       "computedHash": "932d23af11a3eb2b758f5b1d9aec7b6d28ddd26658328414f87f34dff7179d19"
     },
+    "github-actions-docs": {
+      "source": "xixu-me/skills",
+      "sourceType": "github",
+      "skillPath": "skills/github-actions-docs/SKILL.md",
+      "computedHash": "e9ac24e79715ef3060bd4ae376052f8d863b830604e69cb513b39764bf47ee53"
+    },
     "mysql": {
       "source": "planetscale/database-skills",
       "sourceType": "github",


### PR DESCRIPTION
## Summary
- Rename workflow, job, run, and step labels to readable kebab-case check names.
- Add the `github-actions-docs` skill and align release docs with the new workflow names.
- Tighten low-risk workflow hygiene with read-only token permissions, stale-run cancellation for small PR checks, and missing guard-job timeouts.

## Test Plan
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check -- .github/workflows RELEASE.md skills-lock.json .agents/skills/github-actions-docs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
- `gh api repos/lightfastai/lightfast/rulesets/15254385 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized and standardized GitHub Actions workflow naming and structure across CI, build, and release pipelines for improved clarity
  * Added explicit read-only permissions to workflows for enhanced security
  * Updated job identifiers and step labels to follow consistent kebab-case conventions
  * Enhanced workflow run displays with event context and branch information for better visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->