### PR TITLE
Fix app dev origins for worktree auth

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -7,34 +7,19 @@ import withVercelToolbar from "@vercel/toolbar/plugins/next";
 import merge from "lodash.merge";
 import type { NextConfig } from "next";
 import { env } from "./src/env";
+import {
+  localAllowedDevOrigins,
+  localServerActionHosts,
+} from "./src/local-dev-origins";
 
-function localHostFromUrl(value: string): string | null {
-  try {
-    const url = new URL(value);
-    const isLocalhost =
-      url.hostname === "localhost" || url.hostname.endsWith(".localhost");
-    return isLocalhost ? url.host : null;
-  } catch {
-    return null;
-  }
-}
-
-function localServerActionHosts(): string[] {
-  return Array.from(
-    new Set(
-      [
-        env.NEXT_PUBLIC_APP_URL,
-        env.NEXT_PUBLIC_WWW_URL,
-        env.NEXT_PUBLIC_PLATFORM_URL,
-      ].flatMap((value) => {
-        const host = localHostFromUrl(value);
-        return host ? [host] : [];
-      })
-    )
-  );
-}
+const localDevUrls = [
+  env.NEXT_PUBLIC_APP_URL,
+  env.NEXT_PUBLIC_WWW_URL,
+  env.NEXT_PUBLIC_PLATFORM_URL,
+];
 
 const appConfig: NextConfig = merge({}, baseConfig, {
+  allowedDevOrigins: localAllowedDevOrigins(localDevUrls),
   typedRoutes: true,
   images: {
     remotePatterns: [
@@ -84,7 +69,7 @@ const appConfig: NextConfig = merge({}, baseConfig, {
         if (vercelEnv === "preview") {
           return ["lightfast.ai", "*.lightfast.ai", "*.vercel.app"];
         }
-        return localServerActionHosts();
+        return localServerActionHosts(localDevUrls);
       })(),
     },
   },

--- a/apps/app/src/__tests__/local-dev-origins.test.ts
+++ b/apps/app/src/__tests__/local-dev-origins.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  localAllowedDevOrigins,
+  localServerActionHosts,
+} from "../local-dev-origins";
+
+describe("local dev origins", () => {
+  it("derives direct service and aggregate hosts for a worktree app URL", () => {
+    expect(
+      localAllowedDevOrigins([
+        "https://debug-auth-local-infra.app.lightfast.localhost",
+        "https://debug-auth-local-infra.www.lightfast.localhost",
+        "https://debug-auth-local-infra.platform.lightfast.localhost",
+      ])
+    ).toEqual([
+      "debug-auth-local-infra.app.lightfast.localhost",
+      "debug-auth-local-infra.lightfast.localhost",
+      "debug-auth-local-infra.www.lightfast.localhost",
+      "debug-auth-local-infra.platform.lightfast.localhost",
+    ]);
+  });
+
+  it("keeps server action hosts scoped to exact injected service hosts", () => {
+    expect(
+      localServerActionHosts([
+        "https://debug-auth-local-infra.app.lightfast.localhost",
+        "https://debug-auth-local-infra.www.lightfast.localhost",
+        "https://debug-auth-local-infra.platform.lightfast.localhost",
+      ])
+    ).toEqual([
+      "debug-auth-local-infra.app.lightfast.localhost",
+      "debug-auth-local-infra.www.lightfast.localhost",
+      "debug-auth-local-infra.platform.lightfast.localhost",
+    ]);
+  });
+});

--- a/apps/app/src/local-dev-origins.ts
+++ b/apps/app/src/local-dev-origins.ts
@@ -1,0 +1,54 @@
+function localHostFromUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    const isLocalhost =
+      url.hostname === "localhost" || url.hostname.endsWith(".localhost");
+    return isLocalhost ? url.host : null;
+  } catch {
+    return null;
+  }
+}
+
+function aggregateHostFromAppHost(host: string): string | null {
+  if (host === "app.lightfast.localhost") {
+    return "lightfast.localhost";
+  }
+
+  const suffix = ".app.lightfast.localhost";
+  if (!host.endsWith(suffix)) {
+    return null;
+  }
+
+  return `${host.slice(0, -suffix.length)}.lightfast.localhost`;
+}
+
+export function localServerActionHosts(values: readonly string[]): string[] {
+  return Array.from(
+    new Set(
+      values.flatMap((value) => {
+        const host = localHostFromUrl(value);
+        return host ? [host] : [];
+      })
+    )
+  );
+}
+
+export function localAllowedDevOrigins(values: readonly string[]): string[] {
+  const hosts = new Set<string>();
+
+  for (const value of values) {
+    const host = localHostFromUrl(value);
+    if (!host) {
+      continue;
+    }
+
+    hosts.add(host);
+
+    const aggregateHost = aggregateHostFromAppHost(host);
+    if (aggregateHost) {
+      hosts.add(aggregateHost);
+    }
+  }
+
+  return Array.from(hosts);
+}


### PR DESCRIPTION
## Summary
- add local dev origin derivation for worktree Portless hosts
- wire Next allowedDevOrigins while keeping Server Action origins scoped to exact local service hosts
- cover worktree host derivation with a focused Vitest test

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/local-dev-origins.test.ts
- pnpm --filter @lightfast/app typecheck
- git diff --check HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for local development environment configuration handling.

* **Refactor**
  * Reorganized local development origin configuration logic into a dedicated utility module for improved code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightfastai/lightfast/pull/728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->