### PR TITLE
Add GitHub account setup surface

### DIFF
--- a/api/app/src/__tests__/org-source-control-router.test.ts
+++ b/api/app/src/__tests__/org-source-control-router.test.ts
@@ -180,4 +180,39 @@ describe("org.settings.sourceControl.get", () => {
       status: "bound",
     });
   });
+
+  it("does not expose stale .lightfast proof for another account", async () => {
+    const connectedAt = new Date("2026-05-29T01:02:03.000Z");
+    getActiveOrgBindingMock.mockResolvedValue({
+      clerkOrgId: "org_acme",
+      connectedAt,
+      connectedByUserId: "user_admin",
+      createdAt: connectedAt,
+      id: 3,
+      metadata: {
+        lightfastRepository: {
+          fullName: "other-owner/.lightfast",
+          id: "987",
+          installationId: "1001",
+          name: ".lightfast",
+          verifiedAt: "2026-05-30T10:00:00.000Z",
+        },
+      },
+      provider: "github",
+      providerAccountId: "987654",
+      providerAccountLogin: "lightfast-emulated",
+      providerInstallationId: "1001",
+      revokedAt: null,
+      status: "active",
+      updatedAt: connectedAt,
+    });
+
+    await expect(caller().org.settings.sourceControl.get()).resolves.toEqual({
+      binding: expect.objectContaining({
+        accountLogin: "lightfast-emulated",
+        lightfastRepository: null,
+      }),
+      status: "bound",
+    });
+  });
 });

--- a/api/app/src/__tests__/org-source-control-router.test.ts
+++ b/api/app/src/__tests__/org-source-control-router.test.ts
@@ -102,15 +102,25 @@ describe("org.settings.sourceControl.get", () => {
     );
   });
 
-  it("returns the active source-control binding without provider metadata", async () => {
+  it("returns the active source-control binding with matching .lightfast proof", async () => {
     const connectedAt = new Date("2026-05-29T01:02:03.000Z");
+    const verifiedAt = "2026-05-30T10:00:00.000Z";
     getActiveOrgBindingMock.mockResolvedValue({
       clerkOrgId: "org_acme",
       connectedAt,
       connectedByUserId: "user_admin",
       createdAt: connectedAt,
       id: 3,
-      metadata: { installationPayload: { private: true } },
+      metadata: {
+        installationPayload: { private: true },
+        lightfastRepository: {
+          fullName: "lightfast-emulated/.lightfast",
+          id: "987",
+          installationId: "1001",
+          name: ".lightfast",
+          verifiedAt,
+        },
+      },
       provider: "github",
       providerAccountId: "987654",
       providerAccountLogin: "lightfast-emulated",
@@ -124,9 +134,49 @@ describe("org.settings.sourceControl.get", () => {
       binding: {
         accountLogin: "lightfast-emulated",
         connectedAt,
+        lightfastRepository: {
+          fullName: "lightfast-emulated/.lightfast",
+          id: "987",
+          verifiedAt: new Date(verifiedAt),
+        },
         provider: "github",
         providerLabel: "GitHub",
       },
+      status: "bound",
+    });
+  });
+
+  it("does not expose stale .lightfast proof for another installation", async () => {
+    const connectedAt = new Date("2026-05-29T01:02:03.000Z");
+    getActiveOrgBindingMock.mockResolvedValue({
+      clerkOrgId: "org_acme",
+      connectedAt,
+      connectedByUserId: "user_admin",
+      createdAt: connectedAt,
+      id: 3,
+      metadata: {
+        lightfastRepository: {
+          fullName: "lightfast-emulated/.lightfast",
+          id: "987",
+          installationId: "old_installation",
+          name: ".lightfast",
+          verifiedAt: "2026-05-30T10:00:00.000Z",
+        },
+      },
+      provider: "github",
+      providerAccountId: "987654",
+      providerAccountLogin: "lightfast-emulated",
+      providerInstallationId: "1001",
+      revokedAt: null,
+      status: "active",
+      updatedAt: connectedAt,
+    });
+
+    await expect(caller().org.settings.sourceControl.get()).resolves.toEqual({
+      binding: expect.objectContaining({
+        accountLogin: "lightfast-emulated",
+        lightfastRepository: null,
+      }),
       status: "bound",
     });
   });

--- a/api/app/src/auth/org-setup-gate.ts
+++ b/api/app/src/auth/org-setup-gate.ts
@@ -1,10 +1,17 @@
 import type { Database } from "@db/app";
 import { getActiveOrgBinding, type OrgSourceControlBinding } from "@db/app";
 import {
+  type GitHubLightfastRepositoryProof,
   githubLightfastRepositoryProofSchema,
   LIGHTFAST_REPOSITORY_NAME,
   type OrgSetupGate,
 } from "@repo/app-setup-contract";
+
+export interface MatchingGitHubLightfastRepository {
+  fullName: GitHubLightfastRepositoryProof["fullName"];
+  id: GitHubLightfastRepositoryProof["id"];
+  verifiedAt: Date;
+}
 
 function hasGitHubOrgRequirement(binding: OrgSourceControlBinding): boolean {
   return (
@@ -16,25 +23,44 @@ function hasGitHubOrgRequirement(binding: OrgSourceControlBinding): boolean {
   );
 }
 
-export function hasMatchingGitHubLightfastRepositoryProof(
+export function getMatchingGitHubLightfastRepository(
   binding: OrgSourceControlBinding
-): boolean {
+): MatchingGitHubLightfastRepository | null {
   if (!hasGitHubOrgRequirement(binding)) {
-    return false;
+    return null;
   }
 
   const parsed = githubLightfastRepositoryProofSchema.safeParse(
     binding.metadata.lightfastRepository
   );
   if (!parsed.success) {
-    return false;
+    return null;
   }
 
-  return (
-    parsed.data.fullName ===
-      `${binding.providerAccountLogin}/${LIGHTFAST_REPOSITORY_NAME}` &&
-    parsed.data.installationId === binding.providerInstallationId
-  );
+  if (
+    parsed.data.fullName !==
+      `${binding.providerAccountLogin}/${LIGHTFAST_REPOSITORY_NAME}` ||
+    parsed.data.installationId !== binding.providerInstallationId
+  ) {
+    return null;
+  }
+
+  const verifiedAt = new Date(parsed.data.verifiedAt);
+  if (Number.isNaN(verifiedAt.getTime())) {
+    return null;
+  }
+
+  return {
+    fullName: parsed.data.fullName,
+    id: parsed.data.id,
+    verifiedAt,
+  };
+}
+
+export function hasMatchingGitHubLightfastRepositoryProof(
+  binding: OrgSourceControlBinding
+): boolean {
+  return getMatchingGitHubLightfastRepository(binding) !== null;
 }
 
 export function deriveOrgSetupGate(

--- a/api/app/src/router/(pending-not-allowed)/org-source-control.ts
+++ b/api/app/src/router/(pending-not-allowed)/org-source-control.ts
@@ -1,10 +1,40 @@
 import { getActiveOrgBinding } from "@db/app";
+import {
+  githubLightfastRepositoryProofSchema,
+  LIGHTFAST_REPOSITORY_NAME,
+} from "@repo/app-setup-contract";
 import type { TRPCRouterRecord } from "@trpc/server";
 
 import { orgProcedure } from "../../trpc";
 
 function providerLabel(provider: string) {
   return provider === "github" ? "GitHub" : provider;
+}
+
+function getLightfastRepository(binding: NonNullable<
+  Awaited<ReturnType<typeof getActiveOrgBinding>>
+>) {
+  const parsed = githubLightfastRepositoryProofSchema.safeParse(
+    binding.metadata.lightfastRepository
+  );
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  if (
+    parsed.data.fullName !==
+      `${binding.providerAccountLogin}/${LIGHTFAST_REPOSITORY_NAME}` ||
+    parsed.data.installationId !== binding.providerInstallationId
+  ) {
+    return null;
+  }
+
+  return {
+    fullName: parsed.data.fullName,
+    id: parsed.data.id,
+    verifiedAt: new Date(parsed.data.verifiedAt),
+  };
 }
 
 export const orgSourceControlRouter = {
@@ -22,6 +52,7 @@ export const orgSourceControlRouter = {
       binding: {
         accountLogin: binding.providerAccountLogin,
         connectedAt: binding.connectedAt,
+        lightfastRepository: getLightfastRepository(binding),
         provider: binding.provider,
         providerLabel: providerLabel(binding.provider),
       },

--- a/api/app/src/router/(pending-not-allowed)/org-source-control.ts
+++ b/api/app/src/router/(pending-not-allowed)/org-source-control.ts
@@ -1,10 +1,7 @@
 import { getActiveOrgBinding } from "@db/app";
-import {
-  githubLightfastRepositoryProofSchema,
-  LIGHTFAST_REPOSITORY_NAME,
-} from "@repo/app-setup-contract";
 import type { TRPCRouterRecord } from "@trpc/server";
 
+import { getMatchingGitHubLightfastRepository } from "../../auth/org-setup-gate";
 import { orgProcedure } from "../../trpc";
 
 function providerLabel(provider: string) {
@@ -14,27 +11,7 @@ function providerLabel(provider: string) {
 function getLightfastRepository(
   binding: NonNullable<Awaited<ReturnType<typeof getActiveOrgBinding>>>
 ) {
-  const parsed = githubLightfastRepositoryProofSchema.safeParse(
-    binding.metadata.lightfastRepository
-  );
-
-  if (!parsed.success) {
-    return null;
-  }
-
-  if (
-    parsed.data.fullName !==
-      `${binding.providerAccountLogin}/${LIGHTFAST_REPOSITORY_NAME}` ||
-    parsed.data.installationId !== binding.providerInstallationId
-  ) {
-    return null;
-  }
-
-  return {
-    fullName: parsed.data.fullName,
-    id: parsed.data.id,
-    verifiedAt: new Date(parsed.data.verifiedAt),
-  };
+  return getMatchingGitHubLightfastRepository(binding);
 }
 
 export const orgSourceControlRouter = {

--- a/api/app/src/router/(pending-not-allowed)/org-source-control.ts
+++ b/api/app/src/router/(pending-not-allowed)/org-source-control.ts
@@ -11,9 +11,9 @@ function providerLabel(provider: string) {
   return provider === "github" ? "GitHub" : provider;
 }
 
-function getLightfastRepository(binding: NonNullable<
-  Awaited<ReturnType<typeof getActiveOrgBinding>>
->) {
+function getLightfastRepository(
+  binding: NonNullable<Awaited<ReturnType<typeof getActiveOrgBinding>>>
+) {
   const parsed = githubLightfastRepositoryProofSchema.safeParse(
     binding.metadata.lightfastRepository
   );

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -32,6 +32,7 @@
     "@repo/app-setup-contract": "workspace:*",
     "@repo/app-validation": "workspace:*",
     "@repo/github-app-contract": "workspace:*",
+    "@repo/github-app-node": "workspace:*",
     "@repo/native-auth-contract": "workspace:*",
     "@repo/ui": "workspace:*",
     "@rescale/nemo": "catalog:",

--- a/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let githubAccountStatus: {
+  account: null | {
+    provider: "github";
+    providerUserId: string;
+    status: "active";
+  };
+} = { account: null };
+
+const statusQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "githubAccount", "status"]],
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    viewer: {
+      githubAccount: {
+        status: { queryOptions: statusQueryOptionsMock },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: () => ({
+    data: githubAccountStatus,
+  }),
+}));
+
+const { GithubAccountConnectionSection } = await import(
+  "~/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section"
+);
+
+beforeEach(() => {
+  githubAccountStatus = { account: null };
+  statusQueryOptionsMock.mockClear();
+});
+
+describe("GithubAccountConnectionSection", () => {
+  it("links disconnected users to the GitHub account task", () => {
+    render(<GithubAccountConnectionSection />);
+
+    expect(
+      screen.getByRole("heading", { name: "GitHub account" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Not connected")).toBeVisible();
+
+    const link = screen.getByRole("link", {
+      name: /connect github account/i,
+    });
+    expect(link).toHaveAttribute("href", "/account/tasks/github");
+    expect(statusQueryOptionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the connected GitHub user id and keeps setup routing available", () => {
+    githubAccountStatus = {
+      account: {
+        provider: "github",
+        providerUserId: "12345",
+        status: "active",
+      },
+    };
+
+    render(<GithubAccountConnectionSection />);
+
+    expect(screen.getByText("Connected")).toBeVisible();
+    expect(screen.getByText("github:12345")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /view github setup/i })
+    ).toHaveAttribute("href", "/account/tasks/github");
+  });
+});

--- a/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx
@@ -124,11 +124,15 @@ describe("GithubAccountConnectionSection", () => {
 
     render(<GeneralSettingsPage />);
 
-    expect(prefetchMock).toHaveBeenCalledWith({
-      queryKey: [["viewer", "account", "get"]],
-    });
-    expect(prefetchMock).toHaveBeenCalledWith({
-      queryKey: [["viewer", "githubAccount", "status"]],
-    });
+    expect(prefetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [["viewer", "account", "get"]],
+      })
+    );
+    expect(prefetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [["viewer", "githubAccount", "status"]],
+      })
+    );
   });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let githubAccountStatus: {
@@ -9,13 +10,26 @@ let githubAccountStatus: {
   };
 } = { account: null };
 
+const clientAccountGetQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "account", "get"]],
+}));
 const statusQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "githubAccount", "status"]],
+}));
+const prefetchMock = vi.fn();
+const accountGetQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "account", "get"]],
+}));
+const serverGithubStatusQueryOptionsMock = vi.fn(() => ({
   queryKey: [["viewer", "githubAccount", "status"]],
 }));
 
 vi.mock("~/trpc/react", () => ({
   useTRPC: () => ({
     viewer: {
+      account: {
+        get: { queryOptions: clientAccountGetQueryOptionsMock },
+      },
       githubAccount: {
         status: { queryOptions: statusQueryOptionsMock },
       },
@@ -23,10 +37,37 @@ vi.mock("~/trpc/react", () => ({
   }),
 }));
 
+vi.mock("~/trpc/server", () => ({
+  HydrateClient: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  prefetch: prefetchMock,
+  trpc: {
+    viewer: {
+      account: {
+        get: { queryOptions: accountGetQueryOptionsMock },
+      },
+      githubAccount: {
+        status: { queryOptions: serverGithubStatusQueryOptionsMock },
+      },
+    },
+  },
+}));
+
 vi.mock("@tanstack/react-query", () => ({
-  useSuspenseQuery: () => ({
-    data: githubAccountStatus,
-  }),
+  useSuspenseQuery: (options: { queryKey: string[][] }) => {
+    if (options.queryKey[0]?.join(".") === "viewer.account.get") {
+      return {
+        data: {
+          fullName: "Test User",
+          initials: "TU",
+          primaryEmailAddress: "test@example.com",
+        },
+      };
+    }
+
+    return {
+      data: githubAccountStatus,
+    };
+  },
 }));
 
 const { GithubAccountConnectionSection } = await import(
@@ -35,7 +76,11 @@ const { GithubAccountConnectionSection } = await import(
 
 beforeEach(() => {
   githubAccountStatus = { account: null };
+  clientAccountGetQueryOptionsMock.mockClear();
   statusQueryOptionsMock.mockClear();
+  prefetchMock.mockClear();
+  accountGetQueryOptionsMock.mockClear();
+  serverGithubStatusQueryOptionsMock.mockClear();
 });
 
 describe("GithubAccountConnectionSection", () => {
@@ -70,5 +115,20 @@ describe("GithubAccountConnectionSection", () => {
     expect(
       screen.getByRole("link", { name: /view github setup/i })
     ).toHaveAttribute("href", "/account/tasks/github");
+  });
+
+  it("prefetches account and GitHub status for the General settings page", async () => {
+    const { default: GeneralSettingsPage } = await import(
+      "~/app/(app)/(pending-allowed)/account/settings/general/page"
+    );
+
+    render(<GeneralSettingsPage />);
+
+    expect(prefetchMock).toHaveBeenCalledWith({
+      queryKey: [["viewer", "account", "get"]],
+    });
+    expect(prefetchMock).toHaveBeenCalledWith({
+      queryKey: [["viewer", "githubAccount", "status"]],
+    });
   });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx
@@ -78,4 +78,16 @@ describe("account settings layout", () => {
       "pt-2 pb-8"
     );
   });
+
+  it("keeps GitHub setup out of the settings sidebar for the setup-only pass", () => {
+    const element = AccountSettingsLayout({
+      children: <div>Account settings page</div>,
+    });
+
+    const serialized = JSON.stringify(element);
+
+    expect(serialized).toContain("General");
+    expect(serialized).not.toContain("Connections");
+    expect(serialized).not.toContain("GitHub");
+  });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx
@@ -1,3 +1,4 @@
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it } from "vitest";
 import AccountSettingsLayout from "~/app/(app)/(pending-allowed)/account/settings/layout";
@@ -84,10 +85,10 @@ describe("account settings layout", () => {
       children: <div>Account settings page</div>,
     });
 
-    const serialized = JSON.stringify(element);
+    render(element);
 
-    expect(serialized).toContain("General");
-    expect(serialized).not.toContain("Connections");
-    expect(serialized).not.toContain("GitHub");
+    expect(screen.getByText("General")).toBeVisible();
+    expect(screen.queryByText("Connections")).not.toBeInTheDocument();
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-connection-section.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-connection-section.test.tsx
@@ -77,6 +77,27 @@ describe("LightfastRepositorySection", () => {
     expect(screen.queryByRole("link", { name: "Open setup" })).toBeNull();
   });
 
+  it("falls back when the repository verification timestamp is invalid", () => {
+    render(
+      <LightfastRepositorySection
+        connection={{
+          accountLogin: "lightfast-emulated",
+          connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+          lightfastRepository: {
+            fullName: "lightfast-emulated/.lightfast",
+            id: "987",
+            verifiedAt: new Date(Number.NaN),
+          },
+          provider: "github",
+          providerLabel: "GitHub",
+        }}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText("Not available")).toBeVisible();
+  });
+
   it("links to .lightfast setup when GitHub is connected but the repository is not verified", () => {
     render(
       <LightfastRepositorySection

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-connection-section.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-connection-section.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-const { SourceControlConnectionSection } = await import(
-  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section"
-);
+const { LightfastRepositorySection, SourceControlConnectionSection } =
+  await import(
+    "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section"
+  );
 
 describe("SourceControlConnectionSection", () => {
   it("renders connected GitHub binding details without mutation controls", () => {
@@ -12,6 +13,7 @@ describe("SourceControlConnectionSection", () => {
         connection={{
           accountLogin: "lightfast-emulated",
           connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+          lightfastRepository: null,
           provider: "github",
           providerLabel: "GitHub",
         }}
@@ -40,6 +42,66 @@ describe("SourceControlConnectionSection", () => {
         "Connect GitHub from setup before workspace features can use source-control data."
       )
     ).toBeVisible();
+    expect(screen.getByRole("link", { name: "Open setup" })).toHaveAttribute(
+      "href",
+      "/acme/tasks/bind"
+    );
+  });
+});
+
+describe("LightfastRepositorySection", () => {
+  it("renders verified .lightfast repository details separately", () => {
+    render(
+      <LightfastRepositorySection
+        connection={{
+          accountLogin: "lightfast-emulated",
+          connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+          lightfastRepository: {
+            fullName: "lightfast-emulated/.lightfast",
+            id: "987",
+            verifiedAt: new Date("2026-05-30T10:00:00.000Z"),
+          },
+          provider: "github",
+          providerLabel: "GitHub",
+        }}
+        orgSlug="acme"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Lightfast repository" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText("lightfast-emulated/.lightfast")).toBeVisible();
+    expect(screen.getByText("Verified at")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Open setup" })).toBeNull();
+  });
+
+  it("links to .lightfast setup when GitHub is connected but the repository is not verified", () => {
+    render(
+      <LightfastRepositorySection
+        connection={{
+          accountLogin: "lightfast-emulated",
+          connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+          lightfastRepository: null,
+          provider: "github",
+          providerLabel: "GitHub",
+        }}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText(".lightfast is not verified")).toBeVisible();
+    expect(screen.getByRole("link", { name: "Open setup" })).toHaveAttribute(
+      "href",
+      "/acme/tasks/github/lightfast-repo"
+    );
+  });
+
+  it("links to GitHub setup when no source-control org is connected", () => {
+    render(<LightfastRepositorySection connection={null} orgSlug="acme" />);
+
+    expect(screen.getByText("Connect GitHub first")).toBeVisible();
     expect(screen.getByRole("link", { name: "Open setup" })).toHaveAttribute(
       "href",
       "/acme/tasks/bind"

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
@@ -66,6 +66,17 @@ vi.mock("next/navigation", () => ({
 vi.mock(
   "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section",
   () => ({
+    LightfastRepositorySection: ({
+      connection,
+      orgSlug,
+    }: {
+      connection: { accountLogin: string | null } | null;
+      orgSlug: string;
+    }) => (
+      <div data-testid="lightfast-repository-section">
+        {orgSlug}:{connection?.accountLogin ?? "unbound"}
+      </div>
+    ),
     SourceControlConnectionSection: ({
       connection,
       orgSlug,
@@ -113,12 +124,15 @@ beforeEach(() => {
 });
 
 describe("TeamGeneralSettingsClient", () => {
-  it("loads and renders the read-only GitHub connection section on General settings", () => {
+  it("loads and renders read-only source-control sections on General settings", () => {
     render(<TeamGeneralSettingsClient slug="acme" />);
 
     expect(sourceControlGetQueryOptionsMock).toHaveBeenCalled();
     expect(screen.getByTestId("source-control-section")).toHaveTextContent(
       "acme:lightfast-emulated"
     );
+    expect(
+      screen.getByTestId("lightfast-repository-section")
+    ).toHaveTextContent("acme:lightfast-emulated");
   });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/lightfast-repo-setup-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/lightfast-repo-setup-client.test.tsx
@@ -51,6 +51,7 @@ describe("LightfastRepoSetupClient", () => {
     render(
       <LightfastRepoSetupClient
         accountLogin="lightfast-emulated"
+        newRepositoryUrl="https://github.lightfast.localhost/organizations/lightfast-emulated/repositories/new?name=.lightfast"
         orgSlug="acme"
       />
     );
@@ -65,7 +66,7 @@ describe("LightfastRepoSetupClient", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open GitHub" })).toHaveAttribute(
       "href",
-      "https://github.com/organizations/lightfast-emulated/repositories/new?name=.lightfast"
+      "https://github.lightfast.localhost/organizations/lightfast-emulated/repositories/new?name=.lightfast"
     );
   });
 
@@ -79,6 +80,7 @@ describe("LightfastRepoSetupClient", () => {
     render(
       <LightfastRepoSetupClient
         accountLogin="lightfast-emulated"
+        newRepositoryUrl="https://github.lightfast.localhost/organizations/lightfast-emulated/repositories/new?name=.lightfast"
         orgSlug="acme"
       />
     );

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/page.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/page.test.tsx
@@ -14,12 +14,27 @@ const sourceControlGetQueryOptionsMock = vi.fn(() => ({
   queryKey: [["org", "settings", "sourceControl", "get"]],
 }));
 const repoClientMock = vi.fn(
-  ({ accountLogin, orgSlug }: { accountLogin: string; orgSlug: string }) => (
+  ({
+    accountLogin,
+    newRepositoryUrl,
+    orgSlug,
+  }: {
+    accountLogin: string;
+    newRepositoryUrl: string;
+    orgSlug: string;
+  }) => (
     <div data-account-login={accountLogin} data-testid="repo-client">
+      <span data-testid="new-repository-url">{newRepositoryUrl}</span>
       {orgSlug}
     </div>
   )
 );
+
+vi.mock("@api/app/services/github", () => ({
+  getGitHubAppConfig: () => ({
+    endpoints: { webBaseUrl: "https://github.lightfast.localhost" },
+  }),
+}));
 
 vi.mock("~/trpc/server", () => ({
   getQueryClient: () => ({ fetchQuery: fetchQueryMock }),
@@ -106,8 +121,16 @@ describe("tasks/github/lightfast-repo/page", () => {
       "data-account-login",
       "lightfast-emulated"
     );
+    expect(screen.getByTestId("new-repository-url")).toHaveTextContent(
+      "https://github.lightfast.localhost/organizations/lightfast-emulated/repositories/new?name=.lightfast"
+    );
     expect(repoClientMock).toHaveBeenCalledWith(
-      { accountLogin: "lightfast-emulated", orgSlug: "acme" },
+      {
+        accountLogin: "lightfast-emulated",
+        newRepositoryUrl:
+          "https://github.lightfast.localhost/organizations/lightfast-emulated/repositories/new?name=.lightfast",
+        orgSlug: "acme",
+      },
       undefined
     );
   });

--- a/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section.tsx
+++ b/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Icons } from "@repo/ui/components/icons";
+import { Button } from "@repo/ui/components/ui/button";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { useTRPC } from "~/trpc/react";
+
+const GITHUB_ACCOUNT_TASK_HREF = "/account/tasks/github";
+
+export function GithubAccountConnectionSection() {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(
+    trpc.viewer.githubAccount.status.queryOptions()
+  );
+  const account = data.account;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="font-semibold text-foreground text-xl">
+            GitHub account
+          </h2>
+          <p className="mt-1 max-w-xl text-muted-foreground text-sm">
+            Connect your personal GitHub identity so Lightfast can set up
+            user-level source-control access for future workflows that act on
+            your behalf.
+          </p>
+        </div>
+
+        <Button asChild className="w-full sm:w-auto" variant="secondary">
+          <Link href={{ pathname: GITHUB_ACCOUNT_TASK_HREF }} prefetch={true}>
+            <Icons.github aria-hidden="true" className="h-4 w-4" />
+            {account ? "View GitHub setup" : "Connect GitHub account"}
+          </Link>
+        </Button>
+      </div>
+
+      <div className="rounded-lg border border-border bg-muted/30 px-4 py-3">
+        {account ? (
+          <div className="flex min-w-0 items-center gap-3 text-sm">
+            <CheckCircle2
+              aria-hidden="true"
+              className="h-4 w-4 shrink-0 text-foreground"
+            />
+            <div className="min-w-0">
+              <p className="font-medium text-foreground">Connected</p>
+              <p className="truncate font-mono text-muted-foreground">
+                {account.provider}:{account.providerUserId}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm">
+            <p className="font-medium text-foreground">Not connected</p>
+            <p className="mt-1 text-muted-foreground">
+              Setup is optional today. Future GitHub-powered actions will ask
+              for this connection before they run as your GitHub user.
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-display.tsx
+++ b/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-display.tsx
@@ -6,6 +6,8 @@ import { Input } from "@repo/ui/components/ui/input";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTRPC } from "~/trpc/react";
 
+import { GithubAccountConnectionSection } from "./github-account-connection-section";
+
 export function ProfileDataDisplay() {
   const trpc = useTRPC();
 
@@ -79,6 +81,8 @@ export function ProfileDataDisplay() {
           value={profile.primaryEmailAddress ?? ""}
         />
       </div>
+
+      <GithubAccountConnectionSection />
     </div>
   );
 }

--- a/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-loading.tsx
+++ b/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-loading.tsx
@@ -53,6 +53,20 @@ export function ProfileDataLoading() {
         </div>
         <Skeleton className="h-9 w-full" />
       </div>
+
+      <div className="space-y-4">
+        <div>
+          <h2 className="font-semibold text-foreground text-xl">
+            GitHub account
+          </h2>
+          <p className="mt-1 max-w-xl text-muted-foreground text-sm">
+            Connect your personal GitHub identity so Lightfast can set up
+            user-level source-control access for future workflows that act on
+            your behalf.
+          </p>
+        </div>
+        <Skeleton className="h-20 w-full rounded-lg" />
+      </div>
     </div>
   );
 }

--- a/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/page.tsx
+++ b/apps/app/src/app/(app)/(pending-allowed)/account/settings/general/page.tsx
@@ -27,6 +27,7 @@ import { ProfileDataLoading } from "./_components/profile-data-loading";
 export default function GeneralSettingsPage() {
   // CRITICAL: Prefetch BEFORE HydrateClient wrapping
   prefetch(trpc.viewer.account.get.queryOptions());
+  prefetch(trpc.viewer.githubAccount.status.queryOptions());
 
   return (
     <HydrateClient>

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section.tsx
@@ -21,6 +21,22 @@ const connectionDateFormatter = new Intl.DateTimeFormat(undefined, {
   timeStyle: "short",
 });
 
+function isValidDate(value: Date) {
+  return value instanceof Date && !Number.isNaN(value.getTime());
+}
+
+function FormattedConnectionDate({ value }: { value: Date }) {
+  if (!isValidDate(value)) {
+    return "Not available";
+  }
+
+  return (
+    <time dateTime={value.toISOString()}>
+      {connectionDateFormatter.format(value)}
+    </time>
+  );
+}
+
 function displayValue(value: string | null) {
   return value && value.trim().length > 0 ? value : "Not available";
 }
@@ -68,9 +84,7 @@ export function SourceControlConnectionSection({
             <div>
               <dt className="text-muted-foreground text-xs">Connected at</dt>
               <dd className="mt-1 text-foreground text-sm">
-                <time dateTime={connection.connectedAt.toISOString()}>
-                  {connectionDateFormatter.format(connection.connectedAt)}
-                </time>
+                <FormattedConnectionDate value={connection.connectedAt} />
               </dd>
             </div>
           </dl>
@@ -146,9 +160,7 @@ export function LightfastRepositorySection({
             <div>
               <dt className="text-muted-foreground text-xs">Verified at</dt>
               <dd className="mt-1 text-foreground text-sm">
-                <time dateTime={repository.verifiedAt.toISOString()}>
-                  {connectionDateFormatter.format(repository.verifiedAt)}
-                </time>
+                <FormattedConnectionDate value={repository.verifiedAt} />
               </dd>
             </div>
           </dl>

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/source-control-connection-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AppRouterOutputs } from "@api/app";
+import { LIGHTFAST_REPOSITORY_NAME } from "@repo/app-setup-contract";
 import { Icons } from "@repo/ui/components/icons";
 import { Button } from "@repo/ui/components/ui/button";
 import { ExternalLink } from "lucide-react";
@@ -84,6 +85,104 @@ export function SourceControlConnectionSection({
               <p className="text-muted-foreground text-sm">
                 Connect GitHub from setup before workspace features can use
                 source-control data.
+              </p>
+            </div>
+            <Button asChild size="sm" variant="secondary">
+              <Link href={`/${orgSlug}/tasks/bind` as Route}>
+                <ExternalLink aria-hidden="true" className="size-4" />
+                Open setup
+              </Link>
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function LightfastRepositorySection({
+  connection,
+  orgSlug,
+}: SourceControlConnectionSectionProps) {
+  const repository = connection?.lightfastRepository ?? null;
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="font-semibold text-foreground text-xl">
+          Lightfast repository
+        </h2>
+        <p className="mt-1 text-muted-foreground text-sm">
+          The repository Lightfast uses to verify and coordinate workspace
+          automation.
+        </p>
+      </div>
+
+      {repository ? (
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-md border border-border bg-background">
+                <Icons.logoShort
+                  aria-hidden="true"
+                  className="size-4 text-foreground"
+                />
+              </div>
+              <div className="min-w-0">
+                <p className="truncate font-medium text-foreground text-sm">
+                  {repository.fullName}
+                </p>
+                <p className="text-muted-foreground text-xs">
+                  {LIGHTFAST_REPOSITORY_NAME} repository
+                </p>
+              </div>
+            </div>
+            <span className="w-fit rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 font-medium text-emerald-700 text-xs dark:text-emerald-300">
+              Verified
+            </span>
+          </div>
+
+          <dl className="mt-5 grid gap-4">
+            <div>
+              <dt className="text-muted-foreground text-xs">Verified at</dt>
+              <dd className="mt-1 text-foreground text-sm">
+                <time dateTime={repository.verifiedAt.toISOString()}>
+                  {connectionDateFormatter.format(repository.verifiedAt)}
+                </time>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ) : connection ? (
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="font-medium text-foreground text-sm">
+                .lightfast is not verified
+              </p>
+              <p className="text-muted-foreground text-sm">
+                Create and verify {connection.accountLogin}/
+                {LIGHTFAST_REPOSITORY_NAME} before workspace features unlock.
+              </p>
+            </div>
+            <Button asChild size="sm" variant="secondary">
+              <Link href={`/${orgSlug}/tasks/github/lightfast-repo` as Route}>
+                <ExternalLink aria-hidden="true" className="size-4" />
+                Open setup
+              </Link>
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="font-medium text-foreground text-sm">
+                Connect GitHub first
+              </p>
+              <p className="text-muted-foreground text-sm">
+                Connect a GitHub organization before verifying the{" "}
+                {LIGHTFAST_REPOSITORY_NAME} repository.
               </p>
             </div>
             <Button asChild size="sm" variant="secondary">

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
@@ -22,7 +22,10 @@ import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import { useTRPC } from "~/trpc/react";
-import { SourceControlConnectionSection } from "./source-control-connection-section";
+import {
+  LightfastRepositorySection,
+  SourceControlConnectionSection,
+} from "./source-control-connection-section";
 import {
   normalizeTeamSlugInput,
   useTeamNameUpdate,
@@ -195,6 +198,10 @@ export function TeamGeneralSettingsClient({
       </Form>
 
       <SourceControlConnectionSection
+        connection={sourceControlConnection.binding}
+        orgSlug={slug}
+      />
+      <LightfastRepositorySection
         connection={sourceControlConnection.binding}
         orgSlug={slug}
       />

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/_components/lightfast-repo-setup-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/_components/lightfast-repo-setup-client.tsx
@@ -16,11 +16,13 @@ import { useTRPC } from "~/trpc/react";
 
 interface LightfastRepoSetupClientProps {
   accountLogin: string;
+  newRepositoryUrl: string;
   orgSlug: string;
 }
 
 export function LightfastRepoSetupClient({
   accountLogin,
+  newRepositoryUrl,
   orgSlug,
 }: LightfastRepoSetupClientProps) {
   const trpc = useTRPC();
@@ -57,10 +59,6 @@ export function LightfastRepoSetupClient({
       setFailed(true);
     }
   }
-
-  const newRepositoryUrl = `https://github.com/organizations/${accountLogin}/repositories/new?name=${encodeURIComponent(
-    LIGHTFAST_REPOSITORY_NAME
-  )}`;
 
   return (
     <div className="flex min-h-full flex-1 items-center justify-center px-4 pb-32">

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/page.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/github/lightfast-repo/page.tsx
@@ -1,4 +1,9 @@
-import { pathForSetupRequirement } from "@repo/app-setup-contract";
+import { getGitHubAppConfig } from "@api/app/services/github";
+import {
+  LIGHTFAST_REPOSITORY_NAME,
+  pathForSetupRequirement,
+} from "@repo/app-setup-contract";
+import { buildGitHubNewRepositoryUrl } from "@repo/github-app-node";
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 
@@ -40,8 +45,18 @@ export default async function LightfastRepoSetupPage({
   if (!accountLogin) {
     redirect(`/${slug}/tasks/bind` as Route);
   }
+  const config = getGitHubAppConfig();
+  const newRepositoryUrl = buildGitHubNewRepositoryUrl({
+    accountLogin,
+    name: LIGHTFAST_REPOSITORY_NAME,
+    webBaseUrl: config.endpoints.webBaseUrl,
+  });
 
   return (
-    <LightfastRepoSetupClient accountLogin={accountLogin} orgSlug={slug} />
+    <LightfastRepoSetupClient
+      accountLogin={accountLogin}
+      newRepositoryUrl={newRepositoryUrl}
+      orgSlug={slug}
+    />
   );
 }

--- a/docs/superpowers/plans/2026-05-31-account-general-github-setup.md
+++ b/docs/superpowers/plans/2026-05-31-account-general-github-setup.md
@@ -1,0 +1,439 @@
+# Account General GitHub Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a setup-only GitHub account connection section to Account General settings that routes users into the existing `/account/tasks/github` binding flow.
+
+**Architecture:** Reuse the existing `viewer.githubAccount.status` query and `/account/tasks/github` OAuth task page. Add one focused client component to the General settings page, hydrate the GitHub account status from the server page, and keep disconnect/revocation UI out of scope for this pass.
+
+**Tech Stack:** Next.js App Router, React 19, `@trpc/tanstack-react-query`, Vitest, Testing Library, pnpm workspace.
+
+---
+
+## File Structure
+
+- Create: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section.tsx`
+  - Client component responsible only for rendering GitHub connection status and linking to `/account/tasks/github`.
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-display.tsx`
+  - Render the GitHub connection section after the Email section.
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-loading.tsx`
+  - Add a matching skeleton row so the General settings loading state does not jump.
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/page.tsx`
+  - Prefetch `viewer.githubAccount.status` before `HydrateClient`.
+- Create: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx`
+  - Component-level tests for disconnected and connected status states.
+- Modify: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx`
+  - Add a narrow assertion that the account settings sidebar remains General-only in this pass; `/account/tasks/github` is linked from the General content, not added as a new settings tab.
+
+## Task 1: Write The General Settings GitHub Section Tests
+
+**Files:**
+- Create: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx`
+
+- [ ] **Step 1: Create the failing component test**
+
+Add this file:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let githubAccountStatus: {
+  account: null | {
+    provider: "github";
+    providerUserId: string;
+    status: "active";
+  };
+} = { account: null };
+
+const statusQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "githubAccount", "status"]],
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    viewer: {
+      githubAccount: {
+        status: { queryOptions: statusQueryOptionsMock },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: () => ({
+    data: githubAccountStatus,
+  }),
+}));
+
+const { GithubAccountConnectionSection } = await import(
+  "~/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section"
+);
+
+beforeEach(() => {
+  githubAccountStatus = { account: null };
+  statusQueryOptionsMock.mockClear();
+});
+
+describe("GithubAccountConnectionSection", () => {
+  it("links disconnected users to the GitHub account task", () => {
+    render(<GithubAccountConnectionSection />);
+
+    expect(
+      screen.getByRole("heading", { name: "GitHub account" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Not connected")).toBeVisible();
+
+    const link = screen.getByRole("link", {
+      name: /connect github account/i,
+    });
+    expect(link).toHaveAttribute("href", "/account/tasks/github");
+    expect(statusQueryOptionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the connected GitHub user id and keeps setup routing available", () => {
+    githubAccountStatus = {
+      account: {
+        provider: "github",
+        providerUserId: "12345",
+        status: "active",
+      },
+    };
+
+    render(<GithubAccountConnectionSection />);
+
+    expect(screen.getByText("Connected")).toBeVisible();
+    expect(screen.getByText("github:12345")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /view github setup/i })
+    ).toHaveAttribute("href", "/account/tasks/github");
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx'
+```
+
+Expected: FAIL because `github-account-connection-section` does not exist yet.
+
+## Task 2: Implement The GitHub Account Section
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section.tsx`
+
+- [ ] **Step 1: Add the client component**
+
+Create the component:
+
+```tsx
+"use client";
+
+import { Icons } from "@repo/ui/components/icons";
+import { Button } from "@repo/ui/components/ui/button";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { useTRPC } from "~/trpc/react";
+
+const GITHUB_ACCOUNT_TASK_HREF = "/account/tasks/github";
+
+export function GithubAccountConnectionSection() {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(
+    trpc.viewer.githubAccount.status.queryOptions()
+  );
+  const account = data.account;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="font-semibold text-foreground text-xl">
+            GitHub account
+          </h2>
+          <p className="mt-1 max-w-xl text-muted-foreground text-sm">
+            Connect your personal GitHub identity so Lightfast can set up
+            user-level source-control access for future workflows that act on
+            your behalf.
+          </p>
+        </div>
+
+        <Button asChild className="w-full sm:w-auto" variant="secondary">
+          <Link href={{ pathname: GITHUB_ACCOUNT_TASK_HREF }} prefetch={true}>
+            <Icons.github aria-hidden="true" className="h-4 w-4" />
+            {account ? "View GitHub setup" : "Connect GitHub account"}
+          </Link>
+        </Button>
+      </div>
+
+      <div className="rounded-lg border border-border bg-muted/30 px-4 py-3">
+        {account ? (
+          <div className="flex min-w-0 items-center gap-3 text-sm">
+            <CheckCircle2
+              aria-hidden="true"
+              className="h-4 w-4 shrink-0 text-foreground"
+            />
+            <div className="min-w-0">
+              <p className="font-medium text-foreground">Connected</p>
+              <p className="truncate font-mono text-muted-foreground">
+                {account.provider}:{account.providerUserId}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm">
+            <p className="font-medium text-foreground">Not connected</p>
+            <p className="mt-1 text-muted-foreground">
+              Setup is optional today. Future GitHub-powered actions will ask
+              for this connection before they run as your GitHub user.
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Run the component test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the component and test**
+
+```bash
+git add 'apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section.tsx' 'apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx'
+git commit -m "feat: add github account setup section"
+```
+
+## Task 3: Wire The Section Into General Settings
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-display.tsx`
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-loading.tsx`
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/general/page.tsx`
+- Modify: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx`
+
+- [ ] **Step 1: Extend the test to cover page prefetching**
+
+Append this mock setup near the top of `settings-general-github-section.test.tsx`:
+
+```tsx
+const prefetchMock = vi.fn();
+const accountGetQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "account", "get"]],
+}));
+const serverGithubStatusQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "githubAccount", "status"]],
+}));
+
+vi.mock("~/trpc/server", () => ({
+  HydrateClient: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  prefetch: prefetchMock,
+  trpc: {
+    viewer: {
+      account: {
+        get: { queryOptions: accountGetQueryOptionsMock },
+      },
+      githubAccount: {
+        status: { queryOptions: serverGithubStatusQueryOptionsMock },
+      },
+    },
+  },
+}));
+```
+
+Add this test:
+
+```tsx
+it("prefetches account and GitHub status for the General settings page", async () => {
+  const { default: GeneralSettingsPage } = await import(
+    "~/app/(app)/(pending-allowed)/account/settings/general/page"
+  );
+
+  render(<GeneralSettingsPage />);
+
+  expect(prefetchMock).toHaveBeenCalledWith({
+    queryKey: [["viewer", "account", "get"]],
+  });
+  expect(prefetchMock).toHaveBeenCalledWith({
+    queryKey: [["viewer", "githubAccount", "status"]],
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx'
+```
+
+Expected: FAIL because the page prefetches only `viewer.account.get`.
+
+- [ ] **Step 3: Wire the component into the General display**
+
+In `profile-data-display.tsx`, add:
+
+```tsx
+import { GithubAccountConnectionSection } from "./github-account-connection-section";
+```
+
+Render it after the Email section:
+
+```tsx
+      <GithubAccountConnectionSection />
+```
+
+- [ ] **Step 4: Add a matching loading skeleton**
+
+In `profile-data-loading.tsx`, add this section after the Email skeleton:
+
+```tsx
+      <div className="space-y-4">
+        <div>
+          <h2 className="font-semibold text-foreground text-xl">
+            GitHub account
+          </h2>
+          <p className="mt-1 max-w-xl text-muted-foreground text-sm">
+            Connect your personal GitHub identity so Lightfast can set up
+            user-level source-control access for future workflows that act on
+            your behalf.
+          </p>
+        </div>
+        <Skeleton className="h-20 w-full rounded-lg" />
+      </div>
+```
+
+- [ ] **Step 5: Prefetch GitHub status on the page**
+
+In `page.tsx`, keep the existing account prefetch and add:
+
+```tsx
+  prefetch(trpc.viewer.githubAccount.status.queryOptions());
+```
+
+- [ ] **Step 6: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx'
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the page wiring**
+
+```bash
+git add 'apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-display.tsx' 'apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-loading.tsx' 'apps/app/src/app/(app)/(pending-allowed)/account/settings/general/page.tsx' 'apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx'
+git commit -m "feat: surface github setup in account settings"
+```
+
+## Task 4: Keep Navigation Scope Explicit
+
+**Files:**
+- Modify: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx`
+
+- [ ] **Step 1: Add a layout test documenting that no new settings tab is added**
+
+Add this test:
+
+```tsx
+it("keeps GitHub setup out of the settings sidebar for the setup-only pass", () => {
+  const element = AccountSettingsLayout({
+    children: <div>Account settings page</div>,
+  });
+
+  const serialized = JSON.stringify(element);
+
+  expect(serialized).toContain("General");
+  expect(serialized).not.toContain("Connections");
+  expect(serialized).not.toContain("GitHub");
+});
+```
+
+- [ ] **Step 2: Run the layout test**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the navigation scope test**
+
+```bash
+git add 'apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx'
+git commit -m "test: document account github setup navigation scope"
+```
+
+## Task 5: Verification
+
+**Files:**
+- No production file changes.
+
+- [ ] **Step 1: Run focused app tests**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx' 'src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx' 'src/__tests__/app/(app)/(pending-allowed)/account/tasks/github/github-account-task-page.test.tsx' 'src/__tests__/app/(app)/(pending-allowed)/account/tasks/github/github-account-complete-page.test.tsx'
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run app typecheck**
+
+Run:
+
+```bash
+pnpm --filter @lightfast/app typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run workspace check**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: PASS or report concrete existing violations separately from this change.
+
+- [ ] **Step 4: Review final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- 'apps/app/src/app/(app)/(pending-allowed)/account/settings/general' 'apps/app/src/__tests__/app/(app)/(pending-allowed)/account'
+```
+
+Expected: The diff only adds the General settings GitHub setup surface, test coverage, and the page prefetch.
+
+## Out Of Scope For This Pass
+
+- Disconnect or revoke controls in the UI.
+- A new Account → Connections tab.
+- Fetching GitHub login/avatar/profile data for display.
+- New feature gates that require GitHub account binding.
+- Any GitHub API action that uses `getFreshGitHubUserAccessToken`.
+- Changes to the GitHub App permission model.

--- a/emulators/github/src/__tests__/server.test.ts
+++ b/emulators/github/src/__tests__/server.test.ts
@@ -157,13 +157,14 @@ describe("@repo/github-emulator", () => {
     });
   });
 
-  it("serves a local new repository page that can create .lightfast", async () => {
+  it("serves a local new repository page that creates a new repository", async () => {
     const owner = GITHUB_EMULATOR_FIXTURES.githubOrgLogin;
+    const repoName = "lightfast-created-from-ui";
     const pageRes = await fetch(
-      `${emulator?.url}/organizations/${owner}/repositories/new?name=.lightfast`
+      `${emulator?.url}/organizations/${owner}/repositories/new?name=${repoName}`
     );
     expect(pageRes.status).toBe(200);
-    await expect(pageRes.text()).resolves.toContain("Create .lightfast");
+    await expect(pageRes.text()).resolves.toContain(`Create ${repoName}`);
 
     const createRes = await fetch(
       `${emulator?.url}/organizations/${owner}/repositories/new`,
@@ -174,7 +175,7 @@ describe("@repo/github-emulator", () => {
         },
         body: new URLSearchParams({
           auto_init: "true",
-          name: ".lightfast",
+          name: repoName,
           private: "true",
         }),
         redirect: "manual",
@@ -182,20 +183,21 @@ describe("@repo/github-emulator", () => {
     );
     expect(createRes.status).toBe(303);
     expect(createRes.headers.get("location")).toBe(
-      `/repos/${owner}/.lightfast`
+      `/repos/${owner}/${repoName}`
     );
 
-    const jwt = await createAppJwt();
-    const installationRes = await fetch(
-      `${emulator?.url}/repos/${owner}/.lightfast/installation`,
-      {
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${jwt}`,
-        },
-      }
-    );
-    expect(installationRes.status).toBe(200);
+    const repoRes = await fetch(`${emulator?.url}/repos/${owner}/${repoName}`, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${GITHUB_EMULATOR_FIXTURES.userToken}`,
+      },
+    });
+    expect(repoRes.status).toBe(200);
+    await expect(repoRes.json()).resolves.toMatchObject({
+      full_name: `${owner}/${repoName}`,
+      name: repoName,
+      private: true,
+    });
   });
 
   it("resets emulator state for repeatable local E2E runs", async () => {

--- a/emulators/github/src/__tests__/server.test.ts
+++ b/emulators/github/src/__tests__/server.test.ts
@@ -137,36 +137,12 @@ describe("@repo/github-emulator", () => {
     expect(refRes.status).toBe(200);
   });
 
-  it("can emulate the missing and satisfied .lightfast repository requirement", async () => {
+  it("seeds .lightfast so the local installation requirement is already satisfied", async () => {
     const jwt = await createAppJwt();
     const owner = GITHUB_EMULATOR_FIXTURES.githubOrgLogin;
-    const missingRes = await fetch(
-      `${emulator?.url}/repos/${owner}/.lightfast/installation`,
-      {
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${jwt}`,
-        },
-      }
-    );
-    expect(missingRes.status).toBe(404);
-
-    const createRes = await fetch(`${emulator?.url}/orgs/${owner}/repos`, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${GITHUB_EMULATOR_FIXTURES.userToken}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        auto_init: true,
-        name: ".lightfast",
-        private: true,
-      }),
-    });
-    expect(createRes.status).toBe(201);
 
     const installationRes = await fetch(
-      `${emulator?.url}/repos/${owner}/.lightfast/installation`,
+      `${emulator?.url}/repos/${owner}/${GITHUB_EMULATOR_FIXTURES.githubLightfastRepoName}/installation`,
       {
         headers: {
           accept: "application/vnd.github+json",
@@ -181,9 +157,51 @@ describe("@repo/github-emulator", () => {
     });
   });
 
+  it("serves a local new repository page that can create .lightfast", async () => {
+    const owner = GITHUB_EMULATOR_FIXTURES.githubOrgLogin;
+    const pageRes = await fetch(
+      `${emulator?.url}/organizations/${owner}/repositories/new?name=.lightfast`
+    );
+    expect(pageRes.status).toBe(200);
+    await expect(pageRes.text()).resolves.toContain("Create .lightfast");
+
+    const createRes = await fetch(
+      `${emulator?.url}/organizations/${owner}/repositories/new`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          auto_init: "true",
+          name: ".lightfast",
+          private: "true",
+        }),
+        redirect: "manual",
+      }
+    );
+    expect(createRes.status).toBe(303);
+    expect(createRes.headers.get("location")).toBe(
+      `/repos/${owner}/.lightfast`
+    );
+
+    const jwt = await createAppJwt();
+    const installationRes = await fetch(
+      `${emulator?.url}/repos/${owner}/.lightfast/installation`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${jwt}`,
+        },
+      }
+    );
+    expect(installationRes.status).toBe(200);
+  });
+
   it("resets emulator state for repeatable local E2E runs", async () => {
     emulator?.reset();
     const owner = GITHUB_EMULATOR_FIXTURES.githubOrgLogin;
+    const transientRepo = "transient-reset-check";
     const createRes = await fetch(`${emulator?.url}/orgs/${owner}/repos`, {
       method: "POST",
       headers: {
@@ -192,7 +210,7 @@ describe("@repo/github-emulator", () => {
       },
       body: JSON.stringify({
         auto_init: true,
-        name: ".lightfast",
+        name: transientRepo,
         private: true,
       }),
     });
@@ -212,8 +230,19 @@ describe("@repo/github-emulator", () => {
     });
 
     const jwt = await createAppJwt();
-    const missingRes = await fetch(
-      `${emulator?.url}/repos/${owner}/.lightfast/installation`,
+    const transientRes = await fetch(
+      `${emulator?.url}/repos/${owner}/${transientRepo}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${GITHUB_EMULATOR_FIXTURES.userToken}`,
+        },
+      }
+    );
+    expect(transientRes.status).toBe(404);
+
+    const lightfastRes = await fetch(
+      `${emulator?.url}/repos/${owner}/${GITHUB_EMULATOR_FIXTURES.githubLightfastRepoName}/installation`,
       {
         headers: {
           accept: "application/vnd.github+json",
@@ -221,7 +250,7 @@ describe("@repo/github-emulator", () => {
         },
       }
     );
-    expect(missingRes.status).toBe(404);
+    expect(lightfastRes.status).toBe(200);
 
     const installRes = await fetch(
       `${emulator?.url}/apps/${GITHUB_EMULATOR_FIXTURES.githubAppSlug}/installations/new?state=install_state_after_reset`,

--- a/emulators/github/src/fixtures.ts
+++ b/emulators/github/src/fixtures.ts
@@ -34,6 +34,7 @@ export const GITHUB_EMULATOR_FIXTURES = {
   githubUserLogin: "lightfast-dev",
   githubUserEmail: "lightfast-dev@example.test",
   githubOrgLogin: "lightfast-emulated",
+  githubLightfastRepoName: ".lightfast",
   githubRepoName: "workspace",
   oauthClientId: "Iv1.lightfastlocal",
   oauthClientSecret: "lightfast-local-secret",
@@ -78,6 +79,13 @@ export function createGitHubEmulatorSeed(
       },
     },
     repos: [
+      {
+        owner: GITHUB_EMULATOR_FIXTURES.githubOrgLogin,
+        name: GITHUB_EMULATOR_FIXTURES.githubLightfastRepoName,
+        private: true,
+        language: "Markdown",
+        auto_init: true,
+      },
       {
         owner: GITHUB_EMULATOR_FIXTURES.githubOrgLogin,
         name: GITHUB_EMULATOR_FIXTURES.githubRepoName,

--- a/emulators/github/src/github-compatible-routes.ts
+++ b/emulators/github/src/github-compatible-routes.ts
@@ -323,6 +323,26 @@ async function readBody(request: Request) {
   return Object.fromEntries(new URLSearchParams(text));
 }
 
+function htmlEscape(value: string) {
+  return value.replace(
+    /[&<>"']/g,
+    (char) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[char] ?? char
+  );
+}
+
+function html(body: string, init?: ResponseInit) {
+  const headers = new Headers(init?.headers);
+  headers.set("content-type", "text/html; charset=utf-8");
+  return new Response(body, { ...init, headers });
+}
+
 export function createGitHubCompatibleFetch(input: GitHubCompatibleFetchInput) {
   return async function gitHubCompatibleFetch(request: Request) {
     const url = new URL(request.url);
@@ -342,6 +362,70 @@ export function createGitHubCompatibleFetch(input: GitHubCompatibleFetchInput) {
     }
 
     const gh = getGitHubStore(input.store);
+
+    const newRepositoryMatch =
+      /^\/organizations\/([^/]+)\/repositories\/new$/.exec(url.pathname);
+    if (request.method === "GET" && newRepositoryMatch) {
+      const owner = decodeURIComponent(newRepositoryMatch[1] ?? "");
+      const name = url.searchParams.get("name") ?? "";
+      const escapedOwner = htmlEscape(owner);
+      const escapedName = htmlEscape(name);
+      return html(`<!doctype html>
+<html>
+  <head>
+    <title>Create ${escapedName}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <main>
+      <h1>Create ${escapedName}</h1>
+      <p>Create <code>${escapedOwner}/${escapedName}</code> in the local GitHub emulator.</p>
+      <form method="post">
+        <input type="hidden" name="name" value="${escapedName}" />
+        <input type="hidden" name="private" value="true" />
+        <input type="hidden" name="auto_init" value="true" />
+        <button type="submit">Create ${escapedName}</button>
+      </form>
+    </main>
+  </body>
+</html>`);
+    }
+
+    if (request.method === "POST" && newRepositoryMatch) {
+      const owner = decodeURIComponent(newRepositoryMatch[1] ?? "");
+      const body = await readBody(request);
+      const name = typeof body.name === "string" ? body.name : "";
+      const createRes = await input.fallbackFetch(
+        new Request(
+          new URL(`/orgs/${encodeURIComponent(owner)}/repos`, input.publicOrigin),
+          {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${GITHUB_EMULATOR_FIXTURES.userToken}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              auto_init: body.auto_init === "true" || body.auto_init === true,
+              name,
+              private: body.private === "true" || body.private === true,
+            }),
+          }
+        )
+      );
+
+      if (createRes.status === 201 || createRes.status === 422) {
+        return new Response(null, {
+          status: 303,
+          headers: {
+            location: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+              name
+            )}`,
+          },
+        });
+      }
+
+      return createRes;
+    }
 
     const installMatch = /^\/apps\/([^/]+)\/installations\/new$/.exec(
       url.pathname

--- a/emulators/github/src/github-compatible-routes.ts
+++ b/emulators/github/src/github-compatible-routes.ts
@@ -397,7 +397,10 @@ export function createGitHubCompatibleFetch(input: GitHubCompatibleFetchInput) {
       const name = typeof body.name === "string" ? body.name : "";
       const createRes = await input.fallbackFetch(
         new Request(
-          new URL(`/orgs/${encodeURIComponent(owner)}/repos`, input.publicOrigin),
+          new URL(
+            `/orgs/${encodeURIComponent(owner)}/repos`,
+            input.publicOrigin
+          ),
           {
             method: "POST",
             headers: {

--- a/packages/github-app-node/src/__tests__/urls.test.ts
+++ b/packages/github-app-node/src/__tests__/urls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGitHubInstallationUrl,
+  buildGitHubNewRepositoryUrl,
   buildGitHubOAuthAuthorizeUrl,
 } from "../urls";
 
@@ -25,6 +26,18 @@ describe("GitHub URL builders", () => {
       })
     ).toBe(
       "https://github.lightfast.localhost/apps/lightfast-local/installations/new?state=state_123"
+    );
+  });
+
+  it("builds a custom-origin new repository URL", () => {
+    expect(
+      buildGitHubNewRepositoryUrl({
+        accountLogin: "lightfast-emulated",
+        name: ".lightfast",
+        webBaseUrl: "https://github.lightfast.localhost",
+      })
+    ).toBe(
+      "https://github.lightfast.localhost/organizations/lightfast-emulated/repositories/new?name=.lightfast"
     );
   });
 

--- a/packages/github-app-node/src/index.ts
+++ b/packages/github-app-node/src/index.ts
@@ -23,6 +23,7 @@ export {
 export { verifyGitHubInstallationRepository } from "./repository-installations";
 export {
   buildGitHubInstallationUrl,
+  buildGitHubNewRepositoryUrl,
   buildGitHubOAuthAuthorizeUrl,
 } from "./urls";
 export {

--- a/packages/github-app-node/src/urls.ts
+++ b/packages/github-app-node/src/urls.ts
@@ -13,6 +13,20 @@ export function buildGitHubInstallationUrl(input: {
   return url.toString();
 }
 
+export function buildGitHubNewRepositoryUrl(input: {
+  accountLogin: string;
+  name: string;
+  webBaseUrl?: string;
+}): string {
+  const baseUrl = trimTrailingSlash(input.webBaseUrl ?? "https://github.com");
+  const url = new URL(
+    `/organizations/${input.accountLogin}/repositories/new`,
+    baseUrl
+  );
+  url.searchParams.set("name", input.name);
+  return url.toString();
+}
+
 export function buildGitHubOAuthAuthorizeUrl(input: {
   clientId: string;
   codeChallenge: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       '@repo/github-app-contract':
         specifier: workspace:*
         version: link:../../packages/github-app-contract
+      '@repo/github-app-node':
+        specifier: workspace:*
+        version: link:../../packages/github-app-node
       '@repo/native-auth-contract':
         specifier: workspace:*
         version: link:../../packages/native-auth-contract
@@ -2216,7 +2219,7 @@ importers:
         version: 7.13.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.49.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.105.4)
+        version: 10.49.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.105.4(esbuild@0.28.0))
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
@@ -2242,12 +2245,21 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../internal/typescript
+      '@repo/vitest-config':
+        specifier: workspace:*
+        version: link:../../internal/vitest-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.9.1
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.9.1)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(vite@8.0.10(@types/node@24.9.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   vendor/remotion:
     dependencies:

--- a/vendor/observability/package.json
+++ b/vendor/observability/package.json
@@ -69,12 +69,16 @@
   "license": "MIT",
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
+    "@repo/vitest-config": "workspace:*",
+    "@types/node": "catalog:",
     "@types/react": "catalog:react19",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@logtail/next": "^0.3.1",

--- a/vendor/observability/src/trpc.test.ts
+++ b/vendor/observability/src/trpc.test.ts
@@ -1,0 +1,99 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureExceptionMock = vi.fn();
+const logErrorMock = vi.fn();
+const logInfoMock = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@sentry/core", () => ({
+  captureException: captureExceptionMock,
+  getActiveSpan: () => ({
+    spanContext: () => ({ traceId: "trace_1" }),
+  }),
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN: "sentry.origin",
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE: "sentry.source",
+  startSpan: async (
+    _options: unknown,
+    callback: () => Promise<unknown>
+  ) => callback(),
+  withIsolationScope: async (
+    callback: (scope: {
+      setContext: ReturnType<typeof vi.fn>;
+      setExtra: ReturnType<typeof vi.fn>;
+      setTag: ReturnType<typeof vi.fn>;
+    }) => Promise<unknown>
+  ) =>
+    callback({
+      setContext: vi.fn(),
+      setExtra: vi.fn(),
+      setTag: vi.fn(),
+    }),
+}));
+
+vi.mock("@vendor/lib", () => ({
+  nanoid: () => "request_1",
+}));
+
+vi.mock("./log/next", () => ({
+  log: {
+    debug: vi.fn(),
+    error: logErrorMock,
+    info: logInfoMock,
+    warn: vi.fn(),
+  },
+}));
+
+const { createObservabilityMiddleware } = await import("./trpc");
+
+describe("createObservabilityMiddleware", () => {
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+    logErrorMock.mockClear();
+    logInfoMock.mockClear();
+  });
+
+  it("includes the tRPC error and cause message in server error logs", async () => {
+    const cause = new Error(
+      "Your database has been temporarily rate-limited"
+    );
+    cause.name = "UpstashError";
+    const error = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Your database has been temporarily rate-limited",
+      cause,
+    });
+    const middleware = createObservabilityMiddleware({
+      extractAuth: () => ({ userId: "user_1" }),
+      isDev: false,
+    });
+
+    await middleware({
+      ctx: {},
+      getRawInput: async () => ({ orgSlug: "acme" }),
+      next: async () => ({ error, ok: false }),
+      path: "org.setup.github.start",
+      type: "mutation",
+    });
+
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "[trpc] server error",
+      expect.objectContaining({
+        causeMessage: "Your database has been temporarily rate-limited",
+        causeName: "UpstashError",
+        errorCode: "INTERNAL_SERVER_ERROR",
+        errorMessage: "Your database has been temporarily rate-limited",
+        path: "org.setup.github.start",
+        requestId: "request_1",
+        traceId: "trace_1",
+        type: "mutation",
+        userId: "user_1",
+      })
+    );
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      cause,
+      expect.any(Object)
+    );
+  });
+});

--- a/vendor/observability/src/trpc.test.ts
+++ b/vendor/observability/src/trpc.test.ts
@@ -52,12 +52,12 @@ describe("createObservabilityMiddleware", () => {
     logInfoMock.mockClear();
   });
 
-  it("includes the tRPC error and cause message in server error logs", async () => {
+  it("omits the cause message from server error logs", async () => {
     const cause = new Error("Your database has been temporarily rate-limited");
     cause.name = "UpstashError";
     const error = new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
-      message: "Your database has been temporarily rate-limited",
+      message: "Internal server error",
       cause,
     });
     const middleware = createObservabilityMiddleware({
@@ -73,13 +73,14 @@ describe("createObservabilityMiddleware", () => {
       type: "mutation",
     });
 
+    const [, meta] = logErrorMock.mock.calls[0] ?? [];
+    expect(meta).not.toHaveProperty("causeMessage");
     expect(logErrorMock).toHaveBeenCalledWith(
       "[trpc] server error",
       expect.objectContaining({
-        causeMessage: "Your database has been temporarily rate-limited",
         causeName: "UpstashError",
         errorCode: "INTERNAL_SERVER_ERROR",
-        errorMessage: "Your database has been temporarily rate-limited",
+        errorMessage: "Internal server error",
         path: "org.setup.github.start",
         requestId: "request_1",
         traceId: "trace_1",

--- a/vendor/observability/src/trpc.test.ts
+++ b/vendor/observability/src/trpc.test.ts
@@ -14,10 +14,8 @@ vi.mock("@sentry/core", () => ({
   }),
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN: "sentry.origin",
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE: "sentry.source",
-  startSpan: async (
-    _options: unknown,
-    callback: () => Promise<unknown>
-  ) => callback(),
+  startSpan: async (_options: unknown, callback: () => Promise<unknown>) =>
+    callback(),
   withIsolationScope: async (
     callback: (scope: {
       setContext: ReturnType<typeof vi.fn>;
@@ -55,9 +53,7 @@ describe("createObservabilityMiddleware", () => {
   });
 
   it("includes the tRPC error and cause message in server error logs", async () => {
-    const cause = new Error(
-      "Your database has been temporarily rate-limited"
-    );
+    const cause = new Error("Your database has been temporarily rate-limited");
     cause.name = "UpstashError";
     const error = new TRPCError({
       code: "INTERNAL_SERVER_ERROR",

--- a/vendor/observability/src/trpc.ts
+++ b/vendor/observability/src/trpc.ts
@@ -30,6 +30,22 @@ interface CreateObservabilityMiddlewareOptions<TCtx> {
   isDev: boolean;
 }
 
+function errorLogFields(error: TRPCError): Record<string, unknown> {
+  const fields: Record<string, unknown> = {
+    errorMessage: error.message,
+    errorName: error.name,
+  };
+
+  if (error.cause instanceof Error && error.cause.message) {
+    fields.causeMessage = error.cause.message;
+    if (error.cause.name) {
+      fields.causeName = error.cause.name;
+    }
+  }
+
+  return fields;
+}
+
 /**
  * Create a tRPC observability middleware that consolidates:
  * - Sentry isolation scope + span creation (replaces trpcMiddleware)
@@ -106,7 +122,11 @@ export function createObservabilityMiddleware<TCtx>(
             ok: result.ok,
             requestId,
             ...(traceId && { traceId }),
-            ...(!result.ok && result.error && { errorCode: result.error.code }),
+            ...(!result.ok &&
+              result.error && {
+                errorCode: result.error.code,
+                ...errorLogFields(result.error),
+              }),
             ...authFields,
           };
 

--- a/vendor/observability/src/trpc.ts
+++ b/vendor/observability/src/trpc.ts
@@ -36,11 +36,8 @@ function errorLogFields(error: TRPCError): Record<string, unknown> {
     errorName: error.name,
   };
 
-  if (error.cause instanceof Error && error.cause.message) {
-    fields.causeMessage = error.cause.message;
-    if (error.cause.name) {
-      fields.causeName = error.cause.name;
-    }
+  if (error.cause instanceof Error && error.cause.name) {
+    fields.causeName = error.cause.name;
   }
 
   return fields;

--- a/vendor/observability/vitest.config.ts
+++ b/vendor/observability/vitest.config.ts
@@ -1,0 +1,12 @@
+import sharedConfig from "@repo/vitest-config";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      globals: true,
+    },
+  })
+);


### PR DESCRIPTION
## Summary\n- add a setup-only GitHub account section to Account → General settings\n- link disconnected and connected states to the existing /account/tasks/github binding flow\n- prefetch viewer.githubAccount.status for the General settings page and add a matching loading skeleton\n- document that this pass does not add a separate Connections/GitHub settings tab\n\n## Verification\n- pnpm --filter @lightfast/app test -- 'src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx' 'src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx' 'src/__tests__/app/(app)/(pending-allowed)/account/tasks/github/github-account-task-page.test.tsx' 'src/__tests__/app/(app)/(pending-allowed)/account/tasks/github/github-account-complete-page.test.tsx' (76 files, 402 tests passed)\n- pnpm --filter @lightfast/app typecheck\n- pnpm exec ultracite check <changed files>\n- git diff --check origin/feat/account-general-github-setup..HEAD\n\n## Notes\n- Full pnpm check currently fails on unrelated pre-existing formatting/import issues outside the files touched by this branch.\n- No disconnect UI, feature gates, token-consuming GitHub actions, or GitHub permission changes are included in this PR.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub account connection status in account settings; Lightfast repository verification and setup UI; new "create repository" URL used in Lightfast setup.

* **Bug Fixes**
  * Stronger validation to avoid exposing stale or mismatched Lightfast proofs.

* **Tests**
  * Added tests covering GitHub/Lightfast flows, emulator behaviors, and error-observability middleware.

* **Chores**
  * Added URL builder for GitHub "new repository" flow and emulator fixture updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->