### PR TITLE
Fix PlanetScale migration timestamp precision

### DIFF
--- a/db/app/src/migrations/0005_long_screwball.sql
+++ b/db/app/src/migrations/0005_long_screwball.sql
@@ -1,8 +1,8 @@
 ALTER TABLE `lightfast_automation_runs` MODIFY COLUMN `created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);--> statement-breakpoint
-ALTER TABLE `lightfast_automation_runs` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP;--> statement-breakpoint
+ALTER TABLE `lightfast_automation_runs` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3);--> statement-breakpoint
 ALTER TABLE `lightfast_automations` MODIFY COLUMN `created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);--> statement-breakpoint
-ALTER TABLE `lightfast_automations` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP;--> statement-breakpoint
+ALTER TABLE `lightfast_automations` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3);--> statement-breakpoint
 ALTER TABLE `lightfast_people` MODIFY COLUMN `created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);--> statement-breakpoint
-ALTER TABLE `lightfast_people` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP;--> statement-breakpoint
+ALTER TABLE `lightfast_people` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3);--> statement-breakpoint
 ALTER TABLE `lightfast_signals` MODIFY COLUMN `created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);--> statement-breakpoint
-ALTER TABLE `lightfast_signals` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP;
+ALTER TABLE `lightfast_signals` MODIFY COLUMN `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3);

--- a/db/app/src/migrations/0006_gifted_darwin.sql
+++ b/db/app/src/migrations/0006_gifted_darwin.sql
@@ -5,7 +5,7 @@ CREATE TABLE `lightfast_source_control_repositories` (
 	`full_name` varchar(256) NOT NULL,
 	`watched_path_globs` json NOT NULL,
 	`created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP,
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 	CONSTRAINT `lightfast_source_control_repositories_id` PRIMARY KEY(`id`),
 	CONSTRAINT `source_control_repositories_binding_repository_uq` UNIQUE(`org_source_control_binding_id`,`provider_repository_id`)
 );
@@ -18,7 +18,7 @@ CREATE TABLE `lightfast_source_control_webhook_deliveries` (
 	`provider_repository_id` varchar(128) NOT NULL,
 	`status` varchar(64) NOT NULL,
 	`created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP,
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 	CONSTRAINT `lightfast_source_control_webhook_deliveries_id` PRIMARY KEY(`id`),
 	CONSTRAINT `source_control_webhook_deliveries_delivery_id_uq` UNIQUE(`delivery_id`)
 );


### PR DESCRIPTION
## Summary\n- Make historical timestamp(3) ON UPDATE clauses use CURRENT_TIMESTAMP(3) so PlanetScale/MySQL accepts pending migrations from staging.\n\n## Verification\n- pnpm --filter @db/app typecheck\n- pnpm --filter @db/app test\n- Smoke-tested on throwaway PlanetScale branch cloned from staging: baseline through 0004, migrated through 0008, verified lightfast_signal_views and signals.visibility_scope.\n\nThis unblocks the db-migrate workflow after #736.