### PR TITLE
Fix db-migrate deploy request reuse

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -92,10 +92,16 @@ jobs:
 
           if [ "$show_exit" -eq 0 ]; then
             deploy_request_number=$(echo "$existing" | jq -r '.number')
-            echo "DEPLOY_REQUEST_NUMBER=$deploy_request_number" >> "$GITHUB_ENV"
-            echo "HAS_SCHEMA_CHANGES=true" >> "$GITHUB_ENV"
-            echo "Using existing deploy request $deploy_request_number."
-            exit 0
+            deploy_request_state=$(echo "$existing" | jq -r '.state // ""')
+
+            if [ "$deploy_request_state" != "closed" ]; then
+              echo "DEPLOY_REQUEST_NUMBER=$deploy_request_number" >> "$GITHUB_ENV"
+              echo "HAS_SCHEMA_CHANGES=true" >> "$GITHUB_ENV"
+              echo "Using existing deploy request $deploy_request_number."
+              exit 0
+            fi
+
+            echo "Ignoring closed deploy request $deploy_request_number."
           fi
 
           set +e


### PR DESCRIPTION
## Summary\n- Ignore closed PlanetScale deploy requests when db-migrate probes by branch name.\n- Allows the workflow to create a fresh staging -> main deploy request instead of reusing closed deploy request #2.\n\n## Verification\n- Parsed .github/workflows/db-migrate.yml as YAML locally.\n- Confirmed current latest staging deploy request is #2 with state=closed, matching the failure mode from run 26708648653.\n\nThis is the second fix needed to make the end-to-end db-migrate workflow complete after #736.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database migration deployment workflow to properly handle closed deploy requests by ignoring them and creating fresh requests for new deployments, improving overall deployment reliability and preventing stale request reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->