### PR TITLE
Retry PlanetScale deploy while validating

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -152,7 +152,29 @@ jobs:
       - name: deploy-schema-changes
         if: env.HAS_SCHEMA_CHANGES == 'true'
         run: |
-          pscale deploy-request deploy "$PLANETSCALE_DATABASE_NAME" "$DEPLOY_REQUEST_NUMBER" --org "$PLANETSCALE_ORG_NAME" --wait
+          for attempt in {1..18}; do
+            set +e
+            output=$(pscale deploy-request deploy "$PLANETSCALE_DATABASE_NAME" "$DEPLOY_REQUEST_NUMBER" --org "$PLANETSCALE_ORG_NAME" --wait 2>&1)
+            deploy_exit=$?
+            set -e
+
+            if [ "$deploy_exit" -eq 0 ]; then
+              echo "$output"
+              exit 0
+            fi
+
+            if echo "$output" | grep -Eiq "currently validating|try again in a few moments"; then
+              echo "PlanetScale is still validating deploy request ${DEPLOY_REQUEST_NUMBER}; retrying (${attempt}/18)."
+              sleep 20
+              continue
+            fi
+
+            echo "$output" >&2
+            exit "$deploy_exit"
+          done
+
+          echo "Timed out waiting for PlanetScale deploy request ${DEPLOY_REQUEST_NUMBER} to become deployable." >&2
+          exit 1
 
       - name: delete-branch-password
         if: always() && env.PSCALE_PASSWORD_ID != ''


### PR DESCRIPTION
## Summary\n- Retry pscale deploy-request deploy while PlanetScale is still validating a fresh deploy request.\n- Keeps hard failures hard, but handles the transient "currently validating" response that caused run 26708738878 to fail immediately after creating DR #7.\n\n## Verification\n- Parsed .github/workflows/db-migrate.yml as YAML locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database deployment reliability with automatic retry logic to handle transient validation errors, reducing manual intervention during schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->