### PR TITLE
Fix workspace view review feedback

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/views/view-switcher.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/views/view-switcher.tsx
@@ -113,7 +113,7 @@ export function ViewSwitcher({
                 </button>
                 <button
                   aria-label={`Delete ${view.name}`}
-                  className="ml-0.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+                  className="ml-0.5 rounded p-0.5 text-muted-foreground opacity-0 pointer-coarse:opacity-100 transition-opacity hover:text-foreground focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100"
                   onClick={() => setPendingDelete(view)}
                   type="button"
                 >

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/views/view-switcher.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/views/view-switcher.tsx
@@ -113,7 +113,7 @@ export function ViewSwitcher({
                 </button>
                 <button
                   aria-label={`Delete ${view.name}`}
-                  className="ml-0.5 rounded p-0.5 text-muted-foreground opacity-0 pointer-coarse:opacity-100 transition-opacity hover:text-foreground focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100"
+                  className="pointer-events-none pointer-coarse:pointer-events-auto ml-0.5 rounded p-0.5 text-muted-foreground opacity-0 pointer-coarse:opacity-100 transition-opacity hover:text-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
                   onClick={() => setPendingDelete(view)}
                   type="button"
                 >

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-model.ts
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-model.ts
@@ -15,7 +15,7 @@ export type SignalDetailRow =
   AppRouterOutputs["org"]["workspace"]["signals"]["get"];
 
 /**
- * Canonical view-row type for list/board/grouping. It is the projected
+ * Canonical view-row type for list/grouping. It is the projected
  * working-set row plus an optional client-computed `inputPreview` (populated only
  * when adapting a processing row). Classified rows always have
  * `classification.title`, so they leave `inputPreview` undefined.


### PR DESCRIPTION
## Summary
- Make the shared view delete button visible for keyboard focus and coarse-pointer users.
- Update stale signal model JSDoc after removing the board view.

## Test Plan
- `pnpm check`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @lightfast/app test -- src/app/'(app)'/'(pending-not-allowed)'/'[slug]'/'(workspace)'/_components/views/view-switcher.test.tsx src/app/'(app)'/'(pending-not-allowed)'/'[slug]'/'(workspace)'/signals/_components/signals-model.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved view switcher delete-button behavior: buttons are hidden by default and reliably reveal on hover, keyboard focus, touch interaction, and when the surrounding group has focus, improving discoverability and accessibility.

* **Documentation**
  * Minor wording update in internal component documentation for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->