### PR TITLE
feat: recover isometric empty-state UI

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/people/_components/people-empty-state.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/people/_components/people-empty-state.tsx
@@ -1,4 +1,5 @@
-import { cn } from "@repo/ui/lib/utils";
+import { IsoFigure, peopleScene } from "@repo/ui/components/iso-figure";
+import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import { UsersRound } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -13,33 +14,46 @@ export function PeopleEmptyState({
   size?: "page" | "section";
   title: string;
 }) {
-  // Uniform outer rhythm across every variant: a 4px top gap (`pt-1`), matching
-  // the row spacing — no special vertical padding. The only context-dependent
-  // bit is horizontal: `page` is rendered standalone so it adds `px-3` to align
-  // with the toolbar; `section` sits inside an already-padded scroller, so it
-  // inherits that inset and the box aligns edge-to-edge with the rows.
-  const isPage = size === "page";
+  // Page-wide empty: the upright isometric slab figure alongside the copy. The
+  // figure's foreground silhouette is the single high-contrast element; the
+  // rest stays on bg-background, matching the rest of the workspace chrome.
+  if (size === "page") {
+    return (
+      <div className="flex min-h-0 w-full flex-1 items-center justify-center px-6 pb-12">
+        <div className="flex items-center gap-12 sm:gap-16">
+          <div className="shrink-0">
+            <IsoFigure scene={peopleScene} width={200} />
+          </div>
+          <div className="max-w-md">
+            <p className="font-medium text-foreground text-lg">{title}</p>
+            <p className="mt-2.5 text-base text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+            <div className="mt-7 flex flex-wrap items-center gap-2.5">
+              {action}
+              <MicrofrontendLink
+                className="inline-flex h-6 items-center rounded-lg border border-border/70 bg-muted/30 px-2.5 font-normal text-muted-foreground text-sm hover:bg-muted/60 hover:text-foreground"
+                href="/docs/get-started/overview"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Documentation
+              </MicrofrontendLink>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
+  // Compact inline empty for section scrollers: a 4px top gap (`pt-1`) matching
+  // the row rhythm; it inherits the scroller's horizontal inset so the box
+  // aligns edge-to-edge with the rows.
   return (
-    <div className={cn("pt-1", isPage && "px-3")}>
-      <div
-        className={cn(
-          "flex flex-col items-center justify-center rounded-lg border border-border/70 bg-background px-6 text-center",
-          isPage ? "min-h-96" : "min-h-24"
-        )}
-      >
-        <div
-          className={cn(
-            "flex items-center justify-center rounded-full border border-border/70 bg-muted/20",
-            isPage ? "mb-4 size-10" : "mb-2 size-8"
-          )}
-        >
-          <UsersRound
-            className={cn(
-              "text-muted-foreground",
-              isPage ? "size-4" : "size-3.5"
-            )}
-          />
+    <div className="pt-1">
+      <div className="flex min-h-24 flex-col items-center justify-center rounded-lg border border-border/70 bg-background px-6 text-center">
+        <div className="mb-2 flex size-8 items-center justify-center rounded-full border border-border/70 bg-muted/20">
+          <UsersRound className="size-3.5 text-muted-foreground" />
         </div>
         <p className="font-medium text-sm">{title}</p>
         <p className="mt-1 max-w-sm text-muted-foreground text-sm">

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-client.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@repo/ui/components/ui/button";
 import { useQueryClient } from "@tanstack/react-query";
-import { Plus } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useCallback, useDeferredValue, useMemo } from "react";
 import { useWorkspaceCommands } from "~/components/workspace-command-menu";
@@ -110,7 +109,6 @@ export function SignalsClient() {
       type="button"
       variant="ghost"
     >
-      <Plus aria-hidden="true" className="size-3.5" />
       Add Signal
     </Button>
   );

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-empty-state.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-empty-state.tsx
@@ -1,3 +1,5 @@
+import { IsoFigure, signalsScene } from "@repo/ui/components/iso-figure";
+import { Link as MicrofrontendLink } from "@vercel/microfrontends/next/client";
 import { Signal as SignalIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -12,16 +14,46 @@ export function SignalsEmptyState({
   size?: "page" | "section" | "column";
   title: string;
 }) {
-  const minHeight =
-    size === "page" ? "min-h-96" : size === "section" ? "min-h-32" : "min-h-28";
+  // Page-wide empty: the isometric blueprint figure alongside the copy. The
+  // figure's foreground silhouette is the single high-contrast element; the
+  // rest stays on bg-background, matching the rest of the workspace chrome.
+  if (size === "page") {
+    return (
+      <div className="flex min-h-0 w-full flex-1 items-center justify-center px-6 pb-12">
+        <div className="flex items-center gap-12 sm:gap-16">
+          <div className="shrink-0">
+            <IsoFigure scene={signalsScene} width={200} />
+          </div>
+          <div className="max-w-md">
+            <p className="font-medium text-foreground text-lg">{title}</p>
+            <p className="mt-2.5 text-base text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+            <div className="mt-7 flex flex-wrap items-center gap-2.5">
+              {action}
+              <MicrofrontendLink
+                className="inline-flex h-6 items-center rounded-lg border border-border/70 bg-muted/30 px-2.5 font-normal text-muted-foreground text-sm hover:bg-muted/60 hover:text-foreground"
+                href="/docs/get-started/overview"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Documentation
+              </MicrofrontendLink>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
+  // Compact inline empty for section/column scrollers: a 4px top gap (`pt-1`)
+  // matching the row rhythm; it inherits the scroller's horizontal inset so the
+  // box aligns edge-to-edge with the rows.
   return (
-    <div className="px-3 py-3">
-      <div
-        className={`flex ${minHeight} flex-col items-center justify-center rounded-lg border border-border/70 bg-background px-6 text-center`}
-      >
-        <div className="mb-4 flex size-10 items-center justify-center rounded-full border border-border/70 bg-muted/20">
-          <SignalIcon className="size-4 text-muted-foreground" />
+    <div className="pt-1">
+      <div className="flex min-h-24 flex-col items-center justify-center rounded-lg border border-border/70 bg-background px-6 text-center">
+        <div className="mb-2 flex size-8 items-center justify-center rounded-full border border-border/70 bg-muted/20">
+          <SignalIcon className="size-3.5 text-muted-foreground" />
         </div>
         <p className="font-medium text-sm">{title}</p>
         <p className="mt-1 max-w-sm text-muted-foreground text-sm">

--- a/packages/app-remotion/src/Root.tsx
+++ b/packages/app-remotion/src/Root.tsx
@@ -15,6 +15,7 @@ import { ChangelogV010Events } from "./compositions/changelog-v010-events";
 import { ChangelogV010Featured } from "./compositions/changelog-v010-featured";
 import { ChangelogV010SdkMcp } from "./compositions/changelog-v010-sdk-mcp";
 import { ChangelogV010Sources } from "./compositions/changelog-v010-sources";
+import { PeopleEmpty, SignalsEmpty } from "./compositions/empty-states";
 import { GitHubBanner } from "./compositions/github-banner";
 import { LandingHero } from "./compositions/landing-hero/landing-hero";
 import { Logo } from "./compositions/logo";
@@ -40,6 +41,8 @@ const COMPONENTS: Record<string, React.FC<Record<string, unknown>>> = {
   Logo,
   TwitterBanner,
   GitHubBanner,
+  SignalsEmpty,
+  PeopleEmpty,
 };
 
 export const RemotionRoot = () => (

--- a/packages/app-remotion/src/compositions/empty-states/index.tsx
+++ b/packages/app-remotion/src/compositions/empty-states/index.tsx
@@ -1,0 +1,2 @@
+export { PeopleEmpty } from "./people-empty";
+export { SignalsEmpty } from "./signals-empty";

--- a/packages/app-remotion/src/compositions/empty-states/people-empty.tsx
+++ b/packages/app-remotion/src/compositions/empty-states/people-empty.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import { Btn, EmptyStateLayout } from "./shared/empty-layout";
+import { peopleScene } from "./shared/iso-figure";
+
+export const PeopleEmpty: React.FC = () => (
+  <EmptyStateLayout
+    actions={<Btn>Documentation</Btn>}
+    body="People are discovered automatically as the signal pipeline processes events from email, GitHub, LinkedIn, and the web. They'll appear here as they're found."
+    fig="FIG 0.2"
+    scene={peopleScene}
+    title="No people yet"
+  />
+);

--- a/packages/app-remotion/src/compositions/empty-states/shared/empty-layout.tsx
+++ b/packages/app-remotion/src/compositions/empty-states/shared/empty-layout.tsx
@@ -1,0 +1,107 @@
+import { AbsoluteFill, continueRender, delayRender } from "@vendor/remotion";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { ensureFontsLoaded } from "../../landing-hero/shared/fonts";
+import { IsoFigure, type IsoScene } from "./iso-figure";
+
+const MONO = "ui-monospace, 'SF Mono', Menlo, monospace";
+
+/**
+ * Page-wide empty state: left-aligned isometric figure + copy block.
+ * Everything sits on bg-background; chrome borders use border/50; the only
+ * high-contrast element is the figure's foreground outline.
+ */
+export const EmptyStateLayout: React.FC<{
+  actions: React.ReactNode;
+  body: string;
+  fig: string;
+  scene: IsoScene;
+  title: string;
+}> = ({ actions, body, fig, scene, title }) => {
+  const [handle] = useState(() => delayRender("Loading fonts"));
+  useEffect(() => {
+    void ensureFontsLoaded()
+      .then(() => continueRender(handle))
+      .catch(() => continueRender(handle));
+  }, [handle]);
+
+  return (
+    <AbsoluteFill
+      className="bg-background"
+      style={{ fontFamily: "Geist, ui-sans-serif, sans-serif" }}
+    >
+      <div
+        className="flex h-full w-full items-center"
+        style={{ paddingLeft: 150, gap: 48 }}
+      >
+        <div style={{ flex: "none", width: 264 }}>
+          <IsoFigure scene={scene} width={264} />
+        </div>
+        <div style={{ maxWidth: 380 }}>
+          <div
+            className="text-muted-foreground"
+            style={{
+              fontFamily: MONO,
+              fontSize: 11,
+              letterSpacing: "0.08em",
+              marginBottom: 12,
+            }}
+          >
+            {fig}
+          </div>
+          <div
+            className="text-foreground"
+            style={{ fontSize: 16, fontWeight: 500, marginBottom: 8 }}
+          >
+            {title}
+          </div>
+          <div
+            className="text-muted-foreground"
+            style={{ fontSize: 14, lineHeight: 1.55 }}
+          >
+            {body}
+          </div>
+          <div className="flex" style={{ gap: 10, marginTop: 26 }}>
+            {actions}
+          </div>
+        </div>
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+export const Btn: React.FC<{
+  children: React.ReactNode;
+  kbd?: string;
+  primary?: boolean;
+}> = ({ children, kbd, primary }) => (
+  <div
+    className={`flex items-center border border-border/50 bg-background ${
+      primary ? "text-foreground" : "text-muted-foreground"
+    }`}
+    style={{
+      borderRadius: 8,
+      fontSize: 13,
+      fontWeight: 500,
+      gap: 8,
+      height: 32,
+      padding: "0 12px",
+    }}
+  >
+    <span>{children}</span>
+    {kbd ? (
+      <span
+        className="flex items-center justify-center border border-border/50 bg-background text-muted-foreground"
+        style={{
+          borderRadius: 5,
+          fontFamily: MONO,
+          fontSize: 11,
+          height: 18,
+          minWidth: 18,
+        }}
+      >
+        {kbd}
+      </span>
+    ) : null}
+  </div>
+);

--- a/packages/app-remotion/src/compositions/empty-states/shared/iso-figure.tsx
+++ b/packages/app-remotion/src/compositions/empty-states/shared/iso-figure.tsx
@@ -1,0 +1,10 @@
+// The isometric figure renderer + scenes live in @repo/ui (Remotion-free, pure
+// React + SVG over @repo/ui/lib/iso) so the app's empty states and these
+// Remotion compositions render the exact same figure. Re-exported here to keep
+// the composition imports stable.
+export {
+  IsoFigure,
+  type IsoScene,
+  peopleScene,
+  signalsScene,
+} from "@repo/ui/components/iso-figure";

--- a/packages/app-remotion/src/compositions/empty-states/signals-empty.tsx
+++ b/packages/app-remotion/src/compositions/empty-states/signals-empty.tsx
@@ -1,0 +1,20 @@
+import type React from "react";
+import { Btn, EmptyStateLayout } from "./shared/empty-layout";
+import { signalsScene } from "./shared/iso-figure";
+
+export const SignalsEmpty: React.FC = () => (
+  <EmptyStateLayout
+    actions={
+      <>
+        <Btn kbd="C" primary>
+          Create signal
+        </Btn>
+        <Btn>Documentation</Btn>
+      </>
+    }
+    body="Signals is where every classified event from your API keys and automations lands. As soon as one is processed, it shows up here."
+    fig="FIG 0.1"
+    scene={signalsScene}
+    title="No classified signals yet"
+  />
+);

--- a/packages/app-remotion/src/manifest.ts
+++ b/packages/app-remotion/src/manifest.ts
@@ -81,6 +81,38 @@ export interface CompositionManifest {
 
 export const MANIFEST: CompositionManifest = {
   compositions: {
+    // ── App Empty States (isometric) ───────────────────────────────
+    "signals-empty": {
+      type: "still",
+      component: "SignalsEmpty",
+      width: 1280,
+      height: 760,
+      props: {},
+      outputs: [
+        {
+          format: "png",
+          dest: "packages/app-remotion/out/empty-states",
+          filename: "signals-empty.png",
+          scale: 2,
+        },
+      ],
+    },
+    "people-empty": {
+      type: "still",
+      component: "PeopleEmpty",
+      width: 1280,
+      height: 760,
+      props: {},
+      outputs: [
+        {
+          format: "png",
+          dest: "packages/app-remotion/out/empty-states",
+          filename: "people-empty.png",
+          scale: 2,
+        },
+      ],
+    },
+
     // ── Blog Featured Images ───────────────────────────────────────
     "blog-featured-concentric": {
       type: "still",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,7 @@
     "./components/chat": "./src/components/chat/index.ts",
     "./components/chat/*": "./src/components/chat/*",
     "./components/ssr-code-block": "./src/components/ssr-code-block/index.tsx",
+    "./components/iso-figure": "./src/components/iso-figure.tsx",
     "./components/*": "./src/components/*",
     "./integration-icons": "./src/components/integration-icons.tsx",
     "./framework-icons": "./src/components/framework-icons.tsx",

--- a/packages/ui/src/components/iso-figure.tsx
+++ b/packages/ui/src/components/iso-figure.tsx
@@ -1,12 +1,6 @@
 import { LOGO_CURVE, lissajousPoints } from "@repo/ui/lib/brand";
 import type { Box3D, Face, Vec2 } from "@repo/ui/lib/iso";
-import {
-  createBox,
-  facePath,
-  project,
-  silhouette,
-  subtract,
-} from "@repo/ui/lib/iso";
+import { createBox, facePath, project, silhouette } from "@repo/ui/lib/iso";
 import type React from "react";
 
 // ── Design-language tokens ───────────────────────────────────────────
@@ -341,24 +335,51 @@ export const signalsScene: IsoScene = (() => {
 })();
 
 /**
- * People: an upright slab with a recessed pocket carved into the top-left of
- * the front face, and the Lightfast mark etched (bottom half only) centered on
- * that face. Same isometric projection as signals — just re-proportioned to
- * stand up, so the wide front face dominates.
+ * People: a central hub cube carrying the Lightfast mark on its top face, wired
+ * out to four satellite cubes by dashed construction guides — a symmetric
+ * hub-and-spoke of people discovered around the pipeline. Satellites sit on the
+ * ±x / ±y axes at the hub's mid-height, so the spokes read as a balanced cross.
+ * Each guide runs from the centre of the hub face it exits to the matching
+ * satellite face, so the dashes touch both cubes' outer faces rather than
+ * floating from the centre. The hub is the single high-contrast silhouette;
+ * satellites and guides stay on the quiet border token. The two front spokes
+ * (+x, +y) sit on the visible faces; the two rear spokes emerge from behind the
+ * hub, occluded by its opaque body — a natural depth cue.
  */
 export const peopleScene: IsoScene = (() => {
-  const W = 200; // width  (x)
-  const T = 70; // thickness (y) — thin, so it reads as a standing slab
-  const H = 235; // height (z) — upright
-  const slab: Box3D = { x: 0, y: 0, z: 0, w: W, h: T, d: H };
-  // Rectangular pocket inset into the top-left of the front face; the recess
-  // runs more than half the slab thickness so the cavity walls read clearly.
-  const pd = 40; // recess depth into the slab
-  const pocket: Box3D = { x: 28, y: T - pd, z: 152, w: 68, h: pd, d: 56 };
+  const E = 92; // hub cube edge
+  const hub: Box3D = { x: 74, y: 74, z: 0, w: E, h: E, d: E };
+  const cx = hub.x + E / 2;
+  const cy = hub.y + E / 2;
+  const cz = hub.z + E / 2; // spokes meet the faces at mid-height
+  const e = 38; // satellite cube edge
+  const R = 112; // hub-centre → satellite-centre, along each axis
+  const axes: [number, number][] = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+  const sats: Box3D[] = axes.map(([dx, dy]) => ({
+    x: cx + dx * R - e / 2,
+    y: cy + dy * R - e / 2,
+    z: cz - e / 2,
+    w: e,
+    h: e,
+    d: e,
+  }));
+  const guides: Guide[] = axes.map(([dx, dy]) => ({
+    a: [cx + dx * (E / 2), cy + dy * (E / 2), cz] as [number, number, number],
+    b: [cx + dx * (R - e / 2), cy + dy * (R - e / 2), cz] as [
+      number,
+      number,
+      number,
+    ],
+  }));
   return {
-    boxes: [],
-    shapes: [{ box: slab, faces: subtract(slab, pocket).faces }],
-    logo: { face: "front", cx: W / 2, cz: H / 2, y: T, scale: 64, half: true },
-    outlineBoxes: [slab],
+    boxes: [hub, ...sats],
+    guides,
+    logo: { face: "top", cx, cy, z: hub.z + hub.d, scale: 34 },
+    outlineBoxes: [hub],
   };
 })();

--- a/packages/ui/src/components/iso-figure.tsx
+++ b/packages/ui/src/components/iso-figure.tsx
@@ -1,0 +1,364 @@
+import { LOGO_CURVE, lissajousPoints } from "@repo/ui/lib/brand";
+import type { Box3D, Face, Vec2 } from "@repo/ui/lib/iso";
+import {
+  createBox,
+  facePath,
+  project,
+  silhouette,
+  subtract,
+} from "@repo/ui/lib/iso";
+import type React from "react";
+
+// ── Design-language tokens ───────────────────────────────────────────
+// The whole figure is a quiet blueprint on the border token (opaque bg fill →
+// hidden-line occlusion). The etched Lissajous mark stays on the same border
+// token as the structure — it reads as a mark through its heavier weight and
+// round caps, not through contrast. Construction guides stay dashed.
+//
+// A section can opt into a foreground SILHOUETTE: the outer hexagonal outline
+// of that box only, drawn over the quiet structure. Internal edges stay on the
+// border token, so the boundary pops while the interior detail stays subtle —
+// the Linear blueprint treatment.
+//
+// The etched mark and the structure share the border token AND the same line
+// weight, so the logo reads as part of the same blueprint rather than a fatter
+// overlay.
+const FACE_FILL = "var(--background)";
+const STRUCT = "var(--border)";
+const ACCENT = "var(--border)";
+const OUTLINE = "var(--foreground)";
+const STRUCT_W = 1;
+const ACCENT_W = STRUCT_W;
+const OUTLINE_W = 1.5;
+
+// Render boxes back-to-front so nearer faces occlude farther edges.
+const depthKey = (b: Box3D) => b.x + b.w / 2 + (b.y + b.h / 2);
+const byDepth = (a: Box3D, b: Box3D) => depthKey(a) - depthKey(b) || a.z - b.z;
+
+interface Guide {
+  a: [number, number, number];
+  b: [number, number, number];
+}
+
+// The mark can be etched flat on a horizontal "top" face or on a vertical
+// "front" face. `half` renders only the lower lobes (clipped at the logo's own
+// horizontal midline) so the mark reads as emerging from a baseline.
+type LogoEtch =
+  | {
+      face: "top";
+      cx: number;
+      cy: number;
+      z: number;
+      scale: number;
+      half?: boolean;
+    }
+  | {
+      face: "front";
+      cx: number;
+      cz: number;
+      y: number;
+      scale: number;
+      half?: boolean;
+    };
+
+// Logo-space (px, py ∈ [-1, 1]) → its etch plane in 3D.
+function logoWorld(
+  etch: LogoEtch,
+  px: number,
+  py: number
+): [number, number, number] {
+  if (etch.face === "top") {
+    return [etch.cx + etch.scale * px, etch.cy + etch.scale * py, etch.z];
+  }
+  return [etch.cx + etch.scale * px, etch.y, etch.cz + etch.scale * py];
+}
+
+const LOGO_SAMPLES: Vec2[] = lissajousPoints(
+  LOGO_CURVE.a,
+  LOGO_CURVE.b,
+  LOGO_CURVE.delta,
+  512
+).slice(0, 512);
+
+function loopPath(points: Vec2[]): string {
+  return `${points
+    .map(
+      (v, i) => `${i === 0 ? "M" : "L"}${v[0].toFixed(2)},${v[1].toFixed(2)}`
+    )
+    .join(" ")} Z`;
+}
+
+// Projected polylines for the mark. Full curve → one closed loop. Half curve →
+// the contiguous below-midline (py < 0) runs as open arcs, with each end snapped
+// onto the exact py = 0 crossing so the cut sits cleanly on the baseline.
+function logoSegments(etch: LogoEtch): { closed: boolean; pts: Vec2[] }[] {
+  const proj = (px: number, py: number): Vec2 =>
+    project(...logoWorld(etch, px, py));
+  if (!etch.half) {
+    return [
+      { closed: true, pts: LOGO_SAMPLES.map(([px, py]) => proj(px, py)) },
+    ];
+  }
+  const segs: Vec2[][] = [];
+  let cur: Vec2[] | null = null;
+  for (let i = 0; i < LOGO_SAMPLES.length; i++) {
+    const [px, py] = LOGO_SAMPLES[i] as Vec2;
+    const [ppx, ppy] = LOGO_SAMPLES[
+      i === 0 ? LOGO_SAMPLES.length - 1 : i - 1
+    ] as Vec2;
+    if (py < 0) {
+      if (!cur) {
+        cur = [];
+        if (ppy >= 0 && ppy !== py) {
+          const f = ppy / (ppy - py); // crossing at py = 0
+          cur.push(proj(ppx + (px - ppx) * f, 0));
+        }
+      }
+      cur.push(proj(px, py));
+    } else if (cur) {
+      const f = ppy / (ppy - py);
+      cur.push(proj(ppx + (px - ppx) * f, 0));
+      segs.push(cur);
+      cur = null;
+    }
+  }
+  if (cur) {
+    segs.push(cur);
+  }
+  return segs
+    .filter((pts) => pts.length >= 2)
+    .map((pts) => ({ closed: false, pts }));
+}
+
+function segPath({ closed, pts }: { closed: boolean; pts: Vec2[] }): string {
+  const d = pts
+    .map(
+      (v, i) => `${i === 0 ? "M" : "L"}${v[0].toFixed(2)},${v[1].toFixed(2)}`
+    )
+    .join(" ");
+  return closed ? `${d} Z` : d;
+}
+
+export interface IsoScene {
+  boxes: Box3D[];
+  guides?: Guide[];
+  logo?: LogoEtch;
+  /** Boxes whose outer silhouette is stroked in the foreground accent. */
+  outlineBoxes?: Box3D[];
+  /** Pre-built solids (e.g. a carved slab); `box` gives depth + bounds. */
+  shapes?: { box: Box3D; faces: Face[] }[];
+}
+
+export const IsoFigure: React.FC<{ scene: IsoScene; width: number }> = ({
+  scene,
+  width,
+}) => {
+  const sortedBoxes = [...scene.boxes].sort(byDepth);
+  const shapes = sortedBoxes.map(createBox);
+
+  // Painter's-order draw list: a box's faces sort at its base z; an outline
+  // sorts at the box's top (z + d), so it paints over the faces it wraps yet
+  // is still occluded by any opaque box in front of it (e.g. the floating lid
+  // hides the base silhouette behind it).
+  const draws: { depth: number; level: number; node: React.ReactNode }[] = [];
+  sortedBoxes.forEach((b, si) => {
+    const shape = shapes[si];
+    if (!shape) {
+      return;
+    }
+    draws.push({
+      depth: depthKey(b),
+      level: b.z,
+      node: shape.faces.map((face, fi) => (
+        <path
+          d={facePath(face)}
+          fillRule="evenodd"
+          key={`f-${si}-${fi}`}
+          style={{
+            fill: FACE_FILL,
+            stroke: STRUCT,
+            strokeWidth: STRUCT_W,
+            strokeLinejoin: "miter",
+          }}
+        />
+      )),
+    });
+  });
+  scene.shapes?.forEach((s, si) => {
+    draws.push({
+      depth: depthKey(s.box),
+      level: s.box.z,
+      node: s.faces.map((face, fi) => (
+        <path
+          d={facePath(face)}
+          fillRule="evenodd"
+          key={`s-${si}-${fi}`}
+          style={{
+            fill: FACE_FILL,
+            stroke: STRUCT,
+            strokeWidth: STRUCT_W,
+            strokeLinejoin: "miter",
+          }}
+        />
+      )),
+    });
+  });
+  scene.outlineBoxes?.forEach((b, i) => {
+    draws.push({
+      depth: depthKey(b),
+      level: b.z + b.d,
+      node: (
+        <path
+          d={loopPath(silhouette(b))}
+          key={`o-${i}`}
+          style={{
+            fill: "none",
+            stroke: OUTLINE,
+            strokeWidth: OUTLINE_W,
+            strokeLinejoin: "miter",
+          }}
+        />
+      ),
+    });
+  });
+  scene.guides?.forEach((g, i) => {
+    const a = project(...g.a);
+    const b = project(...g.b);
+    // Depth by the guide's ground corner (x + y), so a guide behind the lid is
+    // occluded by it while front/side guides stay on top.
+    draws.push({
+      depth: g.a[0] + g.a[1],
+      level: g.a[2],
+      node: (
+        <line
+          key={`g-${i}`}
+          style={{
+            stroke: STRUCT,
+            strokeWidth: 1,
+            strokeDasharray: "3 4",
+          }}
+          x1={a[0]}
+          x2={b[0]}
+          y1={a[1]}
+          y2={b[1]}
+        />
+      ),
+    });
+  });
+  draws.sort((p, q) => p.depth - q.depth || p.level - q.level);
+
+  // Bounds across every face + the rendered logo points, so nothing clips.
+  const logoDraw = scene.logo ? logoSegments(scene.logo) : [];
+  const allPts: Vec2[] = [
+    ...shapes.flatMap((s) => s.faces.flatMap((f) => f.contour)),
+    ...(scene.shapes ?? []).flatMap((s) => s.faces.flatMap((f) => f.contour)),
+    ...logoDraw.flatMap((s) => s.pts),
+  ];
+  let minX = Number.POSITIVE_INFINITY,
+    minY = Number.POSITIVE_INFINITY,
+    maxX = Number.NEGATIVE_INFINITY,
+    maxY = Number.NEGATIVE_INFINITY;
+  for (const [px, py] of allPts) {
+    if (px < minX) {
+      minX = px;
+    }
+    if (px > maxX) {
+      maxX = px;
+    }
+    if (py < minY) {
+      minY = py;
+    }
+    if (py > maxY) {
+      maxY = py;
+    }
+  }
+  const PAD = 8;
+  const vx = minX - PAD;
+  const vy = minY - PAD;
+  const vw = maxX - minX + PAD * 2;
+  const vh = maxY - minY + PAD * 2;
+  const height = (width * vh) / vw;
+
+  return (
+    <svg height={height} viewBox={`${vx} ${vy} ${vw} ${vh}`} width={width}>
+      {draws.map((d, i) => (
+        <g key={`d-${i}`}>{d.node}</g>
+      ))}
+
+      {logoDraw.map((s, i) => (
+        <path
+          d={segPath(s)}
+          key={`l-${i}`}
+          style={{
+            fill: "none",
+            stroke: ACCENT,
+            strokeWidth: ACCENT_W,
+            strokeLinecap: "round",
+            strokeLinejoin: "round",
+          }}
+        />
+      ))}
+    </svg>
+  );
+};
+
+// ── Scenes ───────────────────────────────────────────────────────────
+const U = 200;
+
+/** Signals: layered base + floating lid with the Lissajous mark etched on top. */
+export const signalsScene: IsoScene = (() => {
+  // Every slab — the four in the base and the floating lid — shares one
+  // thickness, so they read as the same unit.
+  const slabD = 22;
+  const lidD = slabD;
+  const slabs = 5;
+  const baseTop = slabs * slabD;
+  const gap = 34;
+  const lidZ = baseTop + gap;
+  const boxes: Box3D[] = [];
+  for (let i = 0; i < slabs; i++) {
+    boxes.push({ x: 0, y: 0, z: i * slabD, w: U, h: U, d: slabD });
+  }
+  // Whole base treated as one section: outer silhouette spans all slabs.
+  const base: Box3D = { x: 0, y: 0, z: 0, w: U, h: U, d: baseTop };
+  const lid: Box3D = { x: 0, y: 0, z: lidZ, w: U, h: U, d: lidD };
+  boxes.push(lid);
+  const corners: [number, number][] = [
+    [0, 0],
+    [U, 0],
+    [U, U],
+    [0, U],
+  ];
+  return {
+    boxes,
+    guides: corners.map(([cx, cy]) => ({
+      a: [cx, cy, baseTop],
+      b: [cx, cy, lidZ],
+    })),
+    logo: { face: "top", cx: U / 2, cy: U / 2, z: lidZ + lidD, scale: 48 },
+    outlineBoxes: [base, lid],
+  };
+})();
+
+/**
+ * People: an upright slab with a recessed pocket carved into the top-left of
+ * the front face, and the Lightfast mark etched (bottom half only) centered on
+ * that face. Same isometric projection as signals — just re-proportioned to
+ * stand up, so the wide front face dominates.
+ */
+export const peopleScene: IsoScene = (() => {
+  const W = 200; // width  (x)
+  const T = 70; // thickness (y) — thin, so it reads as a standing slab
+  const H = 235; // height (z) — upright
+  const slab: Box3D = { x: 0, y: 0, z: 0, w: W, h: T, d: H };
+  // Rectangular pocket inset into the top-left of the front face; the recess
+  // runs more than half the slab thickness so the cavity walls read clearly.
+  const pd = 40; // recess depth into the slab
+  const pocket: Box3D = { x: 28, y: T - pd, z: 152, w: 68, h: pd, d: 56 };
+  return {
+    boxes: [],
+    shapes: [{ box: slab, faces: subtract(slab, pocket).faces }],
+    logo: { face: "front", cx: W / 2, cz: H / 2, y: T, scale: 64, half: true },
+    outlineBoxes: [slab],
+  };
+})();

--- a/packages/ui/src/lib/iso/index.ts
+++ b/packages/ui/src/lib/iso/index.ts
@@ -3,5 +3,7 @@ export {
   createBox,
   facePath,
   shapeBounds,
+  silhouette,
+  subtract,
 } from "./shape";
 export type { Bounds, Box3D, Face, FaceType, Polygon, Shape, Vec2 } from "./types";

--- a/packages/ui/src/lib/iso/shape.ts
+++ b/packages/ui/src/lib/iso/shape.ts
@@ -53,7 +53,8 @@ function rightFace(b: Box3D): Face {
 
 // ── Silhouette (hexagonal outline of isometric box) ──────
 
-function silhouette(b: Box3D): Polygon {
+/** The outer hexagonal outline of an isometric box (no internal edges) */
+export function silhouette(b: Box3D): Polygon {
   return ensureCW([
     project(b.x, b.y, b.z + b.d),
     project(b.x + b.w, b.y, b.z + b.d),
@@ -153,8 +154,8 @@ export function createBox(b: Box3D): Shape {
   return { faces: [rightFace(b), frontFace(b), topFace(b)] };
 }
 
-/** A minus B — carves B out of A */
-function _subtract(a: Box3D, b: Box3D): Shape {
+/** A minus B — carves B out of A, revealing the cavity's inner faces */
+export function subtract(a: Box3D, b: Box3D): Shape {
   if (!aabbHit(a, b)) {
     return createBox(a);
   }


### PR DESCRIPTION
## Summary
- restore the Remotion-backed empty-state compositions for people/signals
- restore the shared isometric figure component and scenes
- wire page-level people/signals empty states back to the recovered illustration UI

## Verification
- pnpm exec biome check <recovered empty-state files>
- pnpm --filter @repo/ui typecheck
- pnpm --filter @repo/app-remotion typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @lightfast/app test src/__tests__/app/(app)/(pending-not-allowed)/[slug]/people-client.test.tsx src/__tests__/app/(app)/(pending-not-allowed)/[slug]/signals-client.test.tsx src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/signals/_components/signals-list-view.test.tsx
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blueprint-style isometric illustrations to empty-state screens in People and Signals sections.
  * Enhanced empty-state layouts with improved visual hierarchy and full-page design options.

* **UI Improvements**
  * Simplified the "Add Signal" button by removing its icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->