### PR TITLE
fix(ui): guard empty iso scenes

### DIFF
--- a/packages/ui/src/components/iso-figure.tsx
+++ b/packages/ui/src/components/iso-figure.tsx
@@ -246,8 +246,15 @@ export const IsoFigure: React.FC<{ scene: IsoScene; width: number }> = ({
   const allPts: Vec2[] = [
     ...shapes.flatMap((s) => s.faces.flatMap((f) => f.contour)),
     ...(scene.shapes ?? []).flatMap((s) => s.faces.flatMap((f) => f.contour)),
+    ...(scene.guides ?? []).flatMap((g) => [project(...g.a), project(...g.b)]),
     ...logoDraw.flatMap((s) => s.pts),
   ];
+  const PAD = 8;
+  if (allPts.length === 0) {
+    return (
+      <svg aria-hidden="true" height={width} viewBox="0 0 1 1" width={width} />
+    );
+  }
   let minX = Number.POSITIVE_INFINITY,
     minY = Number.POSITIVE_INFINITY,
     maxX = Number.NEGATIVE_INFINITY,
@@ -266,7 +273,6 @@ export const IsoFigure: React.FC<{ scene: IsoScene; width: number }> = ({
       maxY = py;
     }
   }
-  const PAD = 8;
   const vx = minX - PAD;
   const vy = minY - PAD;
   const vw = maxX - minX + PAD * 2;


### PR DESCRIPTION
## Summary
- guard `IsoFigure` against empty scenes so SVG bounds never become Infinity/NaN
- include guide endpoints in bounds so guide-only scenes still get a valid viewBox

## Verification
- pnpm exec biome check packages/ui/src/components/iso-figure.tsx
- pnpm --filter @repo/ui typecheck
- pnpm --filter @repo/app-remotion typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewport display of isometric figures to properly account for guide elements, preventing them from being cut off when guides extend beyond the figure.
  * Improved robustness when rendering figures with no content points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->