### PR TITLE
docs: connector/source-control/emulator/skills design plans

### DIFF
--- a/docs/superpowers/plans/2026-06-01-account-settings-source-control.md
+++ b/docs/superpowers/plans/2026-06-01-account-settings-source-control.md
@@ -1,0 +1,857 @@
+# Account Settings: Source Control route + connector-style General — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the personal GitHub connection out of account General into a new `Source Control & Git` route, and upgrade General to the workspace `SettingsGroup`/`SettingRow` connector-style pattern.
+
+**Architecture:** Mirror the already-shipped workspace settings (`[slug]/(workspace)/(manage)/settings`). Promote the row primitives to a shared `apps/app/src/components/settings-section.tsx`, add an account-level `source-control` route with a `GithubAccountCard` modeled on the workspace `OrganizationCard`, and restyle the General page. No server/tRPC changes.
+
+**Tech Stack:** Next.js App Router (RSC + client islands), tRPC (`viewer.githubAccount.status`, `viewer.account.get`), `@tanstack/react-query` `useSuspenseQuery`, `@repo/ui` (shadcn), Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-account-settings-source-control-design.md`
+
+**Branch:** work in-place on `feat/connectors-linear-mcp` (no worktree). Commit only the files named in each task via explicit pathspec — a concurrent writer may stage unrelated in-flight work.
+
+**Run tests with:** `cd apps/app && pnpm with-env vitest run <path>` (or `pnpm --filter @lightfast/app test` for the full suite). Typecheck: `pnpm --filter @lightfast/app typecheck`.
+
+---
+
+## File structure
+
+| Action | Path | Responsibility |
+| --- | --- | --- |
+| Create | `apps/app/src/components/settings-section.tsx` | Shared `SettingsGroup` + `SettingRow` primitives |
+| Modify | `…/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx` | Import primitives from shared path |
+| Delete | `…/[slug]/(workspace)/(manage)/settings/_components/settings-section.tsx` | Superseded by shared file |
+| Create | `…/account/settings/source-control/page.tsx` | RSC: prefetch GitHub status + hydrate |
+| Create | `…/account/settings/source-control/_components/account-source-control-client.tsx` | Client island: header + connected/empty branch |
+| Create | `…/account/settings/source-control/_components/github-account-card.tsx` | Connector card (mirrors `OrganizationCard`) |
+| Modify | `…/account/settings/general/_components/profile-data-display.tsx` | Profile group rows; drop GitHub section |
+| Modify | `…/account/settings/general/_components/profile-data-loading.tsx` | Skeleton matching new layout |
+| Modify | `…/account/settings/general/page.tsx` | Drop `githubAccount.status` prefetch |
+| Delete | `…/account/settings/general/_components/github-account-connection-section.tsx` | Moved to source-control route |
+| Modify | `…/account/settings/layout.tsx` | Add sidebar item + `max-w-4xl` content |
+| Create | `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx` | Tests for new route + card |
+| Create | `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx` | Tests for upgraded General |
+| Delete | `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx` | Replaced by the two above |
+| Modify | `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx` | Assert new sidebar item |
+
+`…` = `apps/app/src/app/(app)/(pending-allowed)` or `apps/app/src/app/(app)/(pending-not-allowed)` as shown.
+
+---
+
+## Task 1: Promote shared `settings-section.tsx` primitives
+
+**Files:**
+- Create: `apps/app/src/components/settings-section.tsx`
+- Modify: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx`
+- Delete: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/settings-section.tsx`
+
+- [ ] **Step 1: Confirm the only importer**
+
+Run: `cd /Users/jeevanpillay/Code/@lightfastai/lightfast && grep -rn "settings-section" apps/app/src --include="*.tsx" --include="*.ts"`
+Expected: the only import is in `team-general-settings-client.tsx` (`./settings-section`). If others appear, add them to Step 3.
+
+- [ ] **Step 2: Create the shared file**
+
+Create `apps/app/src/components/settings-section.tsx` (verbatim move):
+
+```tsx
+import type { ReactNode } from "react";
+
+export function SettingsGroup({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  return (
+    <section>
+      <h3 className="font-semibold text-base text-foreground">{title}</h3>
+      <div className="mt-2 divide-y divide-border/55">{children}</div>
+    </section>
+  );
+}
+
+export function SettingRow({
+  children,
+  description,
+  label,
+}: {
+  children: ReactNode;
+  description?: string;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-6 py-4">
+      <div className="min-w-0">
+        <p className="text-foreground text-sm">{label}</p>
+        {description ? (
+          <p className="mt-1 text-muted-foreground text-xs leading-relaxed">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-2">{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Repoint the workspace import**
+
+In `…/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx`, change:
+
+```tsx
+import { SettingRow, SettingsGroup } from "./settings-section";
+```
+to:
+```tsx
+import { SettingRow, SettingsGroup } from "~/components/settings-section";
+```
+
+- [ ] **Step 4: Delete the old colocated file**
+
+Run: `cd /Users/jeevanpillay/Code/@lightfastai/lightfast && git rm "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/settings-section.tsx"`
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS (no unresolved `./settings-section`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "apps/app/src/components/settings-section.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/settings-section.tsx"
+git commit -m "refactor(settings): promote SettingsGroup/SettingRow to shared component" -- \
+  "apps/app/src/components/settings-section.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/settings-section.tsx"
+```
+
+(Append the Co-Authored-By trailer required by the harness when committing.)
+
+---
+
+## Task 2: Account-level GitHub connector route
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-allowed)/account/settings/source-control/_components/github-account-card.tsx`
+- Create: `apps/app/src/app/(app)/(pending-allowed)/account/settings/source-control/_components/account-source-control-client.tsx`
+- Create: `apps/app/src/app/(app)/(pending-allowed)/account/settings/source-control/page.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let githubAccountStatus: {
+  account: null | {
+    accessTokenExpiresAt: Date;
+    connectedAt: Date;
+    provider: "github";
+    providerUserId: string;
+    refreshTokenExpiresAt: Date;
+    status: "active";
+  };
+} = { account: null };
+
+const statusQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "githubAccount", "status"]],
+}));
+const prefetchMock = vi.fn();
+const serverStatusQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "githubAccount", "status"]],
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    viewer: {
+      githubAccount: { status: { queryOptions: statusQueryOptionsMock } },
+    },
+  }),
+}));
+
+vi.mock("~/trpc/server", () => ({
+  HydrateClient: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  prefetch: prefetchMock,
+  trpc: {
+    viewer: {
+      githubAccount: { status: { queryOptions: serverStatusQueryOptionsMock } },
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: () => ({ data: githubAccountStatus }),
+}));
+
+const { AccountSourceControlClient } = await import(
+  "~/app/(app)/(pending-allowed)/account/settings/source-control/_components/account-source-control-client"
+);
+
+beforeEach(() => {
+  githubAccountStatus = { account: null };
+  statusQueryOptionsMock.mockClear();
+  prefetchMock.mockClear();
+  serverStatusQueryOptionsMock.mockClear();
+});
+
+describe("AccountSourceControlClient", () => {
+  it("offers a connect CTA when no account is linked", () => {
+    render(<AccountSourceControlClient />);
+
+    expect(
+      screen.getByRole("heading", { name: /source control & git/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /connect github account/i })
+    ).toHaveAttribute("href", "/account/tasks/github");
+  });
+
+  it("renders the connector card with the GitHub user id when linked", () => {
+    githubAccountStatus = {
+      account: {
+        accessTokenExpiresAt: new Date("2026-07-01T00:00:00Z"),
+        connectedAt: new Date("2026-06-01T00:00:00Z"),
+        provider: "github",
+        providerUserId: "12345",
+        refreshTokenExpiresAt: new Date("2026-12-01T00:00:00Z"),
+        status: "active",
+      },
+    };
+
+    render(<AccountSourceControlClient />);
+
+    // The card shows the linked identity + the "Connected" status pill trigger.
+    // "View GitHub setup" lives inside a closed Radix dropdown, so it is not in
+    // the DOM until opened — assert only on the visible card content here.
+    expect(screen.getByText("github:12345")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /connected/i })
+    ).toBeVisible();
+    expect(screen.queryByText(/connect github account/i)).not.toBeInTheDocument();
+  });
+
+  it("prefetches the GitHub account status for the page", async () => {
+    const { default: SourceControlPage } = await import(
+      "~/app/(app)/(pending-allowed)/account/settings/source-control/page"
+    );
+
+    render(SourceControlPage());
+
+    expect(prefetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [["viewer", "githubAccount", "status"]],
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx"`
+Expected: FAIL — cannot resolve `account-source-control-client` / `page`.
+
+- [ ] **Step 3: Create the connector card**
+
+Create `…/account/settings/source-control/_components/github-account-card.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { Icons } from "@repo/ui/components/icons";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@repo/ui/components/ui/tooltip";
+import { ChevronDown, Settings, Unplug } from "lucide-react";
+import Link from "next/link";
+
+type GithubUserAccount = NonNullable<
+  AppRouterOutputs["viewer"]["githubAccount"]["status"]["account"]
+>;
+
+const GITHUB_ACCOUNT_TASK_HREF = "/account/tasks/github";
+const DISCONNECT_TOOLTIP = "Connection is managed from the GitHub setup task.";
+
+const shortDateFormatter = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+});
+
+function formatConnectedAt(value: Date): string | null {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return null;
+  }
+  return `Connected on ${shortDateFormatter.format(value)}`;
+}
+
+export function GithubAccountCard({
+  account,
+}: {
+  account: GithubUserAccount;
+}) {
+  const subtitle = formatConnectedAt(account.connectedAt);
+
+  return (
+    <section className="flex items-center justify-between gap-4 rounded-[8px] border border-border bg-background p-4">
+      <div className="flex min-w-0 items-center gap-2.5">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-[8px] border border-input bg-background">
+          <Icons.github aria-hidden="true" className="size-4 text-foreground" />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-foreground text-sm">
+            {account.provider}:{account.providerUserId}
+          </p>
+          {subtitle ? (
+            <p className="text-muted-foreground text-xs">{subtitle}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className="h-7 rounded-[9px]"
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <span
+              aria-hidden="true"
+              className="size-1.5 rounded-full bg-emerald-500"
+            />
+            Connected
+            <ChevronDown aria-hidden="true" className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuItem asChild>
+            <Link
+              href={{ pathname: GITHUB_ACCOUNT_TASK_HREF }}
+              prefetch={true}
+            >
+              <Settings aria-hidden="true" className="size-4" />
+              View GitHub setup
+            </Link>
+          </DropdownMenuItem>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <DropdownMenuItem disabled variant="destructive">
+                  <Unplug aria-hidden="true" className="size-4" />
+                  Disconnect
+                </DropdownMenuItem>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>{DISCONNECT_TOOLTIP}</TooltipContent>
+          </Tooltip>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Create the client island**
+
+Create `…/account/settings/source-control/_components/account-source-control-client.tsx`:
+
+```tsx
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { useTRPC } from "~/trpc/react";
+import { GithubAccountCard } from "./github-account-card";
+
+const GITHUB_ACCOUNT_TASK_HREF = "/account/tasks/github";
+
+export function AccountSourceControlClient() {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(
+    trpc.viewer.githubAccount.status.queryOptions()
+  );
+  const account = data.account;
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <h2 className="font-medium font-pp text-2xl text-foreground">
+          Source Control &amp; Git
+        </h2>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Connect your personal GitHub identity so Lightfast can set up
+          user-level source-control access for future workflows that act on your
+          behalf.
+        </p>
+      </div>
+
+      {account ? (
+        <GithubAccountCard account={account} />
+      ) : (
+        <div className="rounded-[8px] border border-border bg-background p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="font-medium text-foreground text-sm">
+                No GitHub account connected
+              </p>
+              <p className="text-muted-foreground text-sm">
+                Setup is optional today. Future GitHub-powered actions will ask
+                for this connection before they run as your GitHub user.
+              </p>
+            </div>
+            <Button
+              asChild
+              className="h-7 rounded-[9px]"
+              size="sm"
+              variant="secondary"
+            >
+              <Link
+                href={{ pathname: GITHUB_ACCOUNT_TASK_HREF }}
+                prefetch={true}
+              >
+                <ExternalLink aria-hidden="true" className="size-4" />
+                Connect GitHub account
+              </Link>
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Create the page**
+
+Create `…/account/settings/source-control/page.tsx`:
+
+```tsx
+import { HydrateClient, prefetch, trpc } from "~/trpc/server";
+
+export const dynamic = "force-dynamic";
+
+import { AccountSourceControlClient } from "./_components/account-source-control-client";
+
+export default function AccountSourceControlPage() {
+  prefetch(trpc.viewer.githubAccount.status.queryOptions());
+
+  return (
+    <HydrateClient>
+      <AccountSourceControlClient />
+    </HydrateClient>
+  );
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-allowed)/account/settings/source-control" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx"
+git commit -m "feat(account-settings): add Source Control & Git route with GitHub connector card" -- \
+  "apps/app/src/app/(app)/(pending-allowed)/account/settings/source-control" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-source-control.test.tsx"
+```
+
+---
+
+## Task 3: Upgrade General page + remove inline GitHub
+
+**Files:**
+- Modify: `…/account/settings/general/_components/profile-data-display.tsx`
+- Modify: `…/account/settings/general/_components/profile-data-loading.tsx`
+- Modify: `…/account/settings/general/page.tsx`
+- Delete: `…/account/settings/general/_components/github-account-connection-section.tsx`
+- Create: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx`
+- Delete: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientAccountGetQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "account", "get"]],
+}));
+const prefetchMock = vi.fn();
+const accountGetQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["viewer", "account", "get"]],
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    viewer: {
+      account: { get: { queryOptions: clientAccountGetQueryOptionsMock } },
+    },
+  }),
+}));
+
+vi.mock("~/trpc/server", () => ({
+  HydrateClient: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  prefetch: prefetchMock,
+  trpc: {
+    viewer: {
+      account: { get: { queryOptions: accountGetQueryOptionsMock } },
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: () => ({
+    data: {
+      fullName: "Test User",
+      initials: "TU",
+      primaryEmailAddress: "test@example.com",
+    },
+  }),
+}));
+
+const { ProfileDataDisplay } = await import(
+  "~/app/(app)/(pending-allowed)/account/settings/general/_components/profile-data-display"
+);
+
+beforeEach(() => {
+  clientAccountGetQueryOptionsMock.mockClear();
+  prefetchMock.mockClear();
+  accountGetQueryOptionsMock.mockClear();
+});
+
+describe("account General settings", () => {
+  it("renders profile rows without the GitHub section", () => {
+    render(<ProfileDataDisplay />);
+
+    expect(
+      screen.getByRole("heading", { name: "General" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Display name")).toBeVisible();
+    expect(screen.getByText("Email")).toBeVisible();
+    expect(screen.getByDisplayValue("Test User")).toBeVisible();
+    expect(screen.getByDisplayValue("test@example.com")).toBeVisible();
+    expect(screen.queryByText(/github/i)).not.toBeInTheDocument();
+  });
+
+  it("prefetches only the account profile for the General page", async () => {
+    const { default: GeneralSettingsPage } = await import(
+      "~/app/(app)/(pending-allowed)/account/settings/general/page"
+    );
+
+    render(<GeneralSettingsPage />);
+
+    expect(prefetchMock).toHaveBeenCalledTimes(1);
+    expect(prefetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [["viewer", "account", "get"]],
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx"`
+Expected: FAIL — current `ProfileDataDisplay` renders a GitHub section (the `queryByText(/github/i)` assertion fails) and current page prefetches twice.
+
+- [ ] **Step 3: Rewrite `profile-data-display.tsx`**
+
+Replace the whole file with:
+
+```tsx
+"use client";
+
+import { Avatar, AvatarFallback } from "@repo/ui/components/ui/avatar";
+import { Input } from "@repo/ui/components/ui/input";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { SettingRow, SettingsGroup } from "~/components/settings-section";
+import { useTRPC } from "~/trpc/react";
+
+export function ProfileDataDisplay() {
+  const trpc = useTRPC();
+
+  const { data: profile } = useSuspenseQuery({
+    ...trpc.viewer.account.get.queryOptions(),
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <h2 className="font-medium font-pp text-foreground text-xl">General</h2>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Manage your personal account settings.
+        </p>
+      </div>
+
+      <SettingsGroup title="Profile">
+        <SettingRow label="Avatar">
+          <Avatar className="size-7">
+            <AvatarFallback className="bg-foreground text-background text-xs">
+              {profile.initials}
+            </AvatarFallback>
+          </Avatar>
+        </SettingRow>
+
+        <SettingRow
+          description="Please enter your full name, or a display name you are comfortable with."
+          label="Display name"
+        >
+          <Input
+            className="w-64 bg-muted/50"
+            disabled
+            readOnly
+            size="lf"
+            type="text"
+            value={profile.fullName ?? ""}
+            variant="lf"
+          />
+        </SettingRow>
+
+        <SettingRow description="Your primary email address." label="Email">
+          <Input
+            className="w-64 bg-muted/50"
+            disabled
+            readOnly
+            size="lf"
+            type="email"
+            value={profile.primaryEmailAddress ?? ""}
+            variant="lf"
+          />
+        </SettingRow>
+      </SettingsGroup>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Rewrite `profile-data-loading.tsx` to match the new layout**
+
+Replace the whole file with:
+
+```tsx
+import { Skeleton } from "@repo/ui/components/ui/skeleton";
+import { SettingRow, SettingsGroup } from "~/components/settings-section";
+
+export function ProfileDataLoading() {
+  return (
+    <div className="space-y-10">
+      <div>
+        <h2 className="font-medium font-pp text-foreground text-xl">General</h2>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Manage your personal account settings.
+        </p>
+      </div>
+
+      <SettingsGroup title="Profile">
+        <SettingRow label="Avatar">
+          <Skeleton className="size-7 rounded-full" />
+        </SettingRow>
+        <SettingRow
+          description="Please enter your full name, or a display name you are comfortable with."
+          label="Display name"
+        >
+          <Skeleton className="h-7 w-64" />
+        </SettingRow>
+        <SettingRow description="Your primary email address." label="Email">
+          <Skeleton className="h-7 w-64" />
+        </SettingRow>
+      </SettingsGroup>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Drop the GitHub prefetch in `general/page.tsx`**
+
+Replace the whole file with:
+
+```tsx
+import { Suspense } from "react";
+import { HydrateClient, prefetch, trpc } from "~/trpc/server";
+
+export const dynamic = "force-dynamic";
+
+import { ProfileDataDisplay } from "./_components/profile-data-display";
+import { ProfileDataLoading } from "./_components/profile-data-loading";
+
+export default function GeneralSettingsPage() {
+  // CRITICAL: Prefetch BEFORE HydrateClient wrapping
+  prefetch(trpc.viewer.account.get.queryOptions());
+
+  return (
+    <HydrateClient>
+      <Suspense fallback={<ProfileDataLoading />}>
+        <ProfileDataDisplay />
+      </Suspense>
+    </HydrateClient>
+  );
+}
+```
+
+- [ ] **Step 6: Delete the moved component and its old test**
+
+Run:
+```bash
+cd /Users/jeevanpillay/Code/@lightfastai/lightfast
+git rm "apps/app/src/app/(app)/(pending-allowed)/account/settings/general/_components/github-account-connection-section.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx"
+```
+
+- [ ] **Step 7: Run the General test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-allowed)/account/settings/general" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx"
+git commit -m "feat(account-settings): connector-style General page, GitHub moved to Source Control" -- \
+  "apps/app/src/app/(app)/(pending-allowed)/account/settings/general" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general.test.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-general-github-section.test.tsx"
+```
+
+---
+
+## Task 4: Account settings sidebar + content width
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-allowed)/account/settings/layout.tsx`
+- Modify: `apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx`
+
+- [ ] **Step 1: Update the layout test**
+
+In `settings-layout.test.tsx`, replace the third `it(...)` block ("keeps GitHub setup out of the settings sidebar for the setup-only pass") with:
+
+```tsx
+  it("lists General and Source Control & Git in the settings sidebar", () => {
+    const element = AccountSettingsLayout({
+      children: <div>Account settings page</div>,
+    });
+
+    render(element);
+
+    expect(screen.getByText("General")).toBeVisible();
+    expect(screen.getByText("Source Control & Git")).toBeVisible();
+    expect(screen.queryByText("Connections")).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx"`
+Expected: FAIL — `getByText("Source Control & Git")` not found.
+
+- [ ] **Step 3: Add the sidebar item and content max-width**
+
+In `…/account/settings/layout.tsx`:
+
+Change the sidebar items:
+```tsx
+          <SettingsSidebar
+            basePath="/account/settings"
+            items={[{ name: "General", path: "general" }]}
+          />
+```
+to:
+```tsx
+          <SettingsSidebar
+            basePath="/account/settings"
+            items={[
+              { name: "General", path: "general" },
+              { name: "Source Control & Git", path: "source-control" },
+            ]}
+          />
+```
+
+Change the content wrapper:
+```tsx
+          <div className="min-w-0 flex-1">{children}</div>
+```
+to:
+```tsx
+          <div className="min-w-0 max-w-4xl flex-1">{children}</div>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx"`
+Expected: PASS (the `pl-3` / `pt-2 pb-8` header assertions still hold; the new sidebar assertion passes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-allowed)/account/settings/layout.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx"
+git commit -m "feat(account-settings): add Source Control & Git sidebar item" -- \
+  "apps/app/src/app/(app)/(pending-allowed)/account/settings/layout.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-allowed)/account/settings-layout.test.tsx"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Typecheck the app**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS.
+
+- [ ] **Step 2: Run the account settings test suite**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-allowed)/account"`
+Expected: PASS — `settings-layout`, `settings-general`, `settings-source-control`, plus the untouched `tasks/github/*` tests.
+
+- [ ] **Step 3: Lint the touched files**
+
+Run: `pnpm check`
+Expected: PASS (or only pre-existing warnings unrelated to these files).
+
+- [ ] **Step 4: Manual smoke (optional, dev server running)**
+
+Visit `https://app.lightfast.localhost/account/settings/general` → Profile group (Avatar / Display name / Email), no GitHub block.
+Visit `https://app.lightfast.localhost/account/settings/source-control` → connector card when linked ("github:<id>", "Connected" dropdown with enabled "View GitHub setup", disabled "Disconnect"); empty-state "Connect GitHub account" when not linked. Sidebar shows both items; clicking navigates.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** separate route (Task 2 + 4), connector card with disabled disconnect (Task 2), General upgrade + GitHub removal (Task 3), shared primitives (Task 1), tests for all (Tasks 2–4). All spec sections mapped.
+- **Type consistency:** `GithubUserAccount` derived from `AppRouterOutputs["viewer"]["githubAccount"]["status"]["account"]`; card consumes `account.provider`, `account.providerUserId`, `account.connectedAt` — all present on that type. `SettingsGroup`/`SettingRow` signatures identical across shared file and both consumers.
+- **No placeholders:** every step ships complete code or an exact command.
+- **Behavior parity:** the only enabled action remains routing to `/account/tasks/github`; disconnect stays disabled with a tooltip, matching the workspace card.

--- a/docs/superpowers/plans/2026-06-01-automations-markdown-inline-edit.md
+++ b/docs/superpowers/plans/2026-06-01-automations-markdown-inline-edit.md
@@ -1,0 +1,1022 @@
+# Automations Markdown + Inline Auto-Save Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render automation instructions as markdown and convert the detail-page name + instructions editors from popover/Edit-button UI to inline click-to-edit controls that auto-save on blur / ⌘↵.
+
+**Architecture:** Pure `apps/app` UI change — no DB/schema/tRPC/runtime change (`prompt` is already a plain string and the agent consumes it as raw text). A headless `useInlineEdit` hook owns the view↔edit state machine and commit/cancel keyboard+blur logic; a shared `automationUpdateMutationOptions` factory owns the optimistic-cache mutation wiring. The instructions view renders with the existing `Markdown` component.
+
+**Tech Stack:** Next.js (App Router) client components, React 19, `@tanstack/react-query` (tRPC mutationOptions), `@vendor/clerk` `useAuth`, `@repo/ui` (`Markdown`, `Textarea`), Vitest + React Testing Library (happy-dom).
+
+---
+
+## Spec
+
+Design doc: `docs/superpowers/specs/2026-06-01-automations-markdown-inline-edit-design.md`
+
+## File Structure
+
+- **Create** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/use-inline-edit.ts` — headless hook: `{ editing, draft, begin, fieldProps }` + commit/cancel logic.
+- **Modify** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-cache.ts` — add `applyAutomationPatch` (pure) + `automationUpdateMutationOptions` (factory).
+- **Rewrite** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor.tsx` — inline single-line editor.
+- **Rewrite** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor.tsx` — inline markdown editor.
+- **Modify** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx` — add "Markdown supported" hint.
+- **Create tests:**
+  - `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/use-inline-edit.test.ts`
+  - `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-cache-patch.test.ts`
+  - `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-name-editor.test.tsx`
+  - `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-prompt-editor.test.tsx`
+
+## Conventions (read once)
+
+- **Run a single test file** (from `apps/app`):
+  ```bash
+  cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "<relative path>"
+  ```
+  Paths contain `(` `)` `[` `]` — always quote them.
+- Test imports of the component/hook under test use the `~` alias (mapped to `apps/app/src` in `apps/app/vitest.config.ts`). For components that need mocked modules, follow the existing repo pattern: declare `vi.mock(...)` then `await import("~/app/...")` inside the test body (see `signal-create-dialog.test.tsx`).
+- Test environment is `happy-dom`; `globals: true` (so `describe/it/expect/vi` are global, but importing them explicitly is also fine and matches existing tests).
+
+---
+
+## Task 1: `useInlineEdit` headless hook
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/use-inline-edit.ts`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/use-inline-edit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/use-inline-edit.test.ts`:
+
+```ts
+import { act, renderHook } from "@testing-library/react";
+import type { ChangeEvent, KeyboardEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useInlineEdit } from "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/use-inline-edit";
+
+function changeEvent(value: string) {
+  return { target: { value } } as unknown as ChangeEvent<HTMLInputElement>;
+}
+
+function keyEvent(over: Partial<{
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+}>) {
+  return {
+    key: "",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    ...over,
+  } as unknown as KeyboardEvent<HTMLInputElement>;
+}
+
+describe("useInlineEdit", () => {
+  it("begins editing and seeds the draft from value", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    expect(result.current.editing).toBe(false);
+    act(() => result.current.begin());
+    expect(result.current.editing).toBe(true);
+    expect(result.current.draft).toBe("Hello");
+  });
+
+  it("commits the trimmed draft on blur and exits editing", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("  World  ")));
+    act(() => result.current.fieldProps.onBlur());
+
+    expect(onCommit).toHaveBeenCalledWith("World");
+    expect(result.current.editing).toBe(false);
+  });
+
+  it("does not commit when the trimmed draft is unchanged", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("  Hello  ")));
+    act(() => result.current.fieldProps.onBlur());
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("does not commit when the draft is empty", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("   ")));
+    act(() => result.current.fieldProps.onBlur());
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("commits on Enter when single-line", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("Renamed")));
+    act(() => result.current.fieldProps.onKeyDown(keyEvent({ key: "Enter" })));
+
+    expect(onCommit).toHaveBeenCalledWith("Renamed");
+  });
+
+  it("commits only on Cmd/Ctrl+Enter when multiline", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", multiline: true, onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("New body")));
+    act(() => result.current.fieldProps.onKeyDown(keyEvent({ key: "Enter" })));
+    expect(onCommit).not.toHaveBeenCalled();
+
+    act(() =>
+      result.current.fieldProps.onKeyDown(keyEvent({ key: "Enter", metaKey: true }))
+    );
+    expect(onCommit).toHaveBeenCalledWith("New body");
+  });
+
+  it("cancels on Escape without committing and resets the draft", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("Discard me")));
+    act(() => result.current.fieldProps.onKeyDown(keyEvent({ key: "Escape" })));
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(result.current.editing).toBe(false);
+    expect(result.current.draft).toBe("Hello");
+  });
+
+  it("suppresses the trailing blur after Escape (no double-handle)", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() =>
+      useInlineEdit({ value: "Hello", onCommit })
+    );
+
+    act(() => result.current.begin());
+    act(() => result.current.fieldProps.onChange(changeEvent("Changed")));
+    act(() => result.current.fieldProps.onKeyDown(keyEvent({ key: "Escape" })));
+    act(() => result.current.fieldProps.onBlur());
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/use-inline-edit.test.ts"
+```
+Expected: FAIL — cannot resolve `use-inline-edit` (module does not exist yet).
+
+- [ ] **Step 3: Write the hook**
+
+Create `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/use-inline-edit.ts`:
+
+```ts
+import type { ChangeEvent, KeyboardEvent } from "react";
+import { useRef, useState } from "react";
+
+type EditableElement = HTMLInputElement | HTMLTextAreaElement;
+
+interface UseInlineEditOptions {
+  /** Current persisted value — source of truth for revert and change detection. */
+  value: string;
+  /** When true, the commit chord is Cmd/Ctrl+Enter and plain Enter inserts a newline. */
+  multiline?: boolean;
+  /** Called with the trimmed draft when a real change is committed. */
+  onCommit: (next: string) => void;
+}
+
+export interface InlineEditFieldProps {
+  value: string;
+  onChange: (event: ChangeEvent<EditableElement>) => void;
+  onBlur: () => void;
+  onKeyDown: (event: KeyboardEvent<EditableElement>) => void;
+  autoFocus: boolean;
+}
+
+export interface UseInlineEditResult {
+  editing: boolean;
+  draft: string;
+  begin: () => void;
+  fieldProps: InlineEditFieldProps;
+}
+
+export function useInlineEdit({
+  value,
+  multiline = false,
+  onCommit,
+}: UseInlineEditOptions): UseInlineEditResult {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  // Set before any programmatic exit so the trailing blur (e.g. on unmount or
+  // after Escape) does not commit a second time.
+  const suppressBlur = useRef(false);
+
+  function begin() {
+    setDraft(value);
+    suppressBlur.current = false;
+    setEditing(true);
+  }
+
+  function commit() {
+    suppressBlur.current = true;
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed.length === 0 || trimmed === value) {
+      setDraft(value);
+      return;
+    }
+    onCommit(trimmed);
+  }
+
+  function cancel() {
+    suppressBlur.current = true;
+    setDraft(value);
+    setEditing(false);
+  }
+
+  function handleBlur() {
+    if (suppressBlur.current) {
+      suppressBlur.current = false;
+      return;
+    }
+    commit();
+  }
+
+  function handleKeyDown(event: KeyboardEvent<EditableElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancel();
+      return;
+    }
+    const isCommitChord = multiline
+      ? event.key === "Enter" && (event.metaKey || event.ctrlKey)
+      : event.key === "Enter" && !event.shiftKey;
+    if (isCommitChord) {
+      event.preventDefault();
+      commit();
+    }
+  }
+
+  return {
+    editing,
+    draft,
+    begin,
+    fieldProps: {
+      value: draft,
+      onChange: (event) => setDraft(event.target.value),
+      onBlur: handleBlur,
+      onKeyDown: handleKeyDown,
+      autoFocus: true,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/use-inline-edit.test.ts"
+```
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/use-inline-edit.ts" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/use-inline-edit.test.ts"
+git commit -m "feat(automations): add useInlineEdit hook for inline auto-save"
+```
+
+---
+
+## Task 2: Shared optimistic update factory
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-cache.ts`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-cache-patch.test.ts`
+
+- [ ] **Step 1: Write the failing test** (covers the only branching logic — the pure patch helper)
+
+Create `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-cache-patch.test.ts`:
+
+```ts
+import type { Automation } from "@db/app/schema";
+import { describe, expect, it } from "vitest";
+import { applyAutomationPatch } from "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-cache";
+
+function make(over: Partial<Automation>): Automation {
+  return { name: "Old name", prompt: "Old prompt", ...over } as unknown as Automation;
+}
+
+describe("applyAutomationPatch", () => {
+  it("patches only the name", () => {
+    const result = applyAutomationPatch(make({}), { name: "New name" });
+    expect(result.name).toBe("New name");
+    expect(result.prompt).toBe("Old prompt");
+  });
+
+  it("patches only the prompt", () => {
+    const result = applyAutomationPatch(make({}), { prompt: "New prompt" });
+    expect(result.prompt).toBe("New prompt");
+    expect(result.name).toBe("Old name");
+  });
+
+  it("leaves fields untouched when the patch has neither key", () => {
+    const result = applyAutomationPatch(make({}), {});
+    expect(result.name).toBe("Old name");
+    expect(result.prompt).toBe("Old prompt");
+  });
+
+  it("ignores undefined values (does not blank a field)", () => {
+    const result = applyAutomationPatch(make({}), { name: undefined });
+    expect(result.name).toBe("Old name");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-cache-patch.test.ts"
+```
+Expected: FAIL — `applyAutomationPatch` is not exported.
+
+- [ ] **Step 3: Add the helper + factory**
+
+In `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-cache.ts`, append after the existing `setRuns` function (the existing imports at the top — `Automation`, `AutomationRun`, `QueryClient`, `useTRPC`/`TRPCClient` — already cover everything used below):
+
+```ts
+export function applyAutomationPatch(
+  prev: Automation,
+  patch: { name?: string; prompt?: string }
+): Automation {
+  return {
+    ...prev,
+    ...(patch.name !== undefined ? { name: patch.name } : {}),
+    ...(patch.prompt !== undefined ? { prompt: patch.prompt } : {}),
+  };
+}
+
+/**
+ * Shared optimistic-update wiring for `automations.update`. Snapshots the get +
+ * list caches, applies the patch optimistically, rolls back on error, and
+ * replaces both caches with the server result on success.
+ */
+export function automationUpdateMutationOptions(
+  qc: QueryClient,
+  trpc: TRPCClient,
+  id: string,
+  opts: { errorTitle: string }
+) {
+  const getKey = trpc.org.workspace.automations.get.queryOptions({ id }).queryKey;
+  const listKey = trpc.org.workspace.automations.list.queryOptions().queryKey;
+
+  return trpc.org.workspace.automations.update.mutationOptions({
+    meta: { errorTitle: opts.errorTitle },
+    onMutate: async (patch) => {
+      await Promise.all([
+        qc.cancelQueries({ queryKey: getKey }),
+        qc.cancelQueries({ queryKey: listKey }),
+      ]);
+      const prevGet = qc.getQueryData(getKey);
+      const prevList = qc.getQueryData(listKey);
+      setOne(qc, trpc, id, (a) => applyAutomationPatch(a as Automation, patch));
+      upsertInList(qc, trpc, id, (a) => applyAutomationPatch(a as Automation, patch));
+      return { prevGet, prevList };
+    },
+    onError: (_error, _patch, ctx) => {
+      if (ctx?.prevGet) {
+        qc.setQueryData(getKey, ctx.prevGet);
+      }
+      if (ctx?.prevList) {
+        qc.setQueryData(listKey, ctx.prevList);
+      }
+    },
+    onSuccess: (updated) => {
+      setOne(qc, trpc, id, () => updated);
+      upsertInList(qc, trpc, id, () => updated);
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-cache-patch.test.ts"
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-cache.ts" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-cache-patch.test.ts"
+git commit -m "feat(automations): add shared optimistic update mutation factory"
+```
+
+---
+
+## Task 3: Inline name editor
+
+**Files:**
+- Rewrite: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-name-editor.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-name-editor.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useAuthMock = vi.fn();
+const mutateMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      workspace: {
+        automations: {
+          get: { queryOptions: () => ({ queryKey: ["get"] }) },
+          list: { queryOptions: () => ({ queryKey: ["list"] }) },
+          update: { mutationOptions: (options: unknown) => options },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ mutate: mutateMock, isPending: false }),
+  useQueryClient: () => ({}),
+}));
+
+vi.mock("@vendor/clerk", () => ({
+  useAuth: useAuthMock,
+}));
+
+const automation = { publicId: "automation_1", name: "Daily review" } as never;
+
+async function renderEditor() {
+  const { AutomationNameEditor } = await import(
+    "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor"
+  );
+  render(<AutomationNameEditor automation={automation} />);
+}
+
+describe("AutomationNameEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({ isLoaded: true, has: () => true });
+  });
+
+  it("renders the name and no editor for a non-admin", async () => {
+    useAuthMock.mockReturnValue({ isLoaded: true, has: () => false });
+    await renderEditor();
+    expect(screen.getByText("Daily review")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("commits a renamed value on blur", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Weekly review" } });
+    fireEvent.blur(input);
+    expect(mutateMock).toHaveBeenCalledWith({
+      id: "automation_1",
+      name: "Weekly review",
+    });
+  });
+
+  it("commits on Enter", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mutateMock).toHaveBeenCalledWith({ id: "automation_1", name: "Renamed" });
+  });
+
+  it("reverts on Escape without committing", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Discarded" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Daily review")).toBeTruthy();
+  });
+
+  it("does not commit an unchanged value", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const input = screen.getByRole("textbox");
+    fireEvent.blur(input);
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-name-editor.test.tsx"
+```
+Expected: FAIL — current `AutomationNameEditor` uses a Popover (no `textbox` appears on click; `mutate` payload shape differs).
+
+- [ ] **Step 3: Rewrite the component**
+
+Replace the entire contents of `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { AUTOMATION_NAME_MAX_LENGTH } from "@repo/app-validation/schemas";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@vendor/clerk";
+import { useTRPC } from "~/trpc/react";
+import { automationUpdateMutationOptions } from "../../_components/automations-cache";
+import { useInlineEdit } from "./use-inline-edit";
+
+type Automation = AppRouterOutputs["org"]["workspace"]["automations"]["get"];
+
+export function AutomationNameEditor({
+  automation,
+}: {
+  automation: Automation;
+}) {
+  const { has, isLoaded } = useAuth();
+  const canManage = isLoaded && !!has?.({ role: "org:admin" });
+
+  const qc = useQueryClient();
+  const trpc = useTRPC();
+  const id = automation.publicId;
+
+  const update = useMutation(
+    automationUpdateMutationOptions(qc, trpc, id, {
+      errorTitle: "Failed to rename automation",
+    })
+  );
+
+  const { editing, begin, fieldProps } = useInlineEdit({
+    value: automation.name,
+    onCommit: (next) => update.mutate({ id, name: next }),
+  });
+
+  if (!canManage) {
+    return (
+      <h1 className="font-medium font-pp text-2xl text-foreground">
+        {automation.name}
+      </h1>
+    );
+  }
+
+  if (editing) {
+    return (
+      <input
+        {...fieldProps}
+        className="-mx-1 w-full bg-transparent px-1 font-medium font-pp text-2xl text-foreground outline-none"
+        maxLength={AUTOMATION_NAME_MAX_LENGTH}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="-mx-1 cursor-text rounded px-1 transition-colors hover:bg-accent/50"
+      onClick={begin}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          begin();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <h1 className="font-medium font-pp text-2xl text-foreground">
+        {automation.name}
+      </h1>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-name-editor.test.tsx"
+```
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-name-editor.test.tsx"
+git commit -m "feat(automations): inline click-to-edit name with auto-save"
+```
+
+---
+
+## Task 4: Inline markdown instructions editor
+
+**Files:**
+- Rewrite: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-prompt-editor.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-prompt-editor.test.tsx`. The `Markdown` component is mocked to a plain element so the test does not pull in react-markdown/shiki and so we can assert the view renders the prompt text:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useAuthMock = vi.fn();
+const mutateMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      workspace: {
+        automations: {
+          get: { queryOptions: () => ({ queryKey: ["get"] }) },
+          list: { queryOptions: () => ({ queryKey: ["list"] }) },
+          update: { mutationOptions: (options: unknown) => options },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ mutate: mutateMock, isPending: false }),
+  useQueryClient: () => ({}),
+}));
+
+vi.mock("@vendor/clerk", () => ({
+  useAuth: useAuthMock,
+}));
+
+vi.mock("@repo/ui/components/markdown", () => ({
+  Markdown: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+const automation = {
+  publicId: "automation_1",
+  prompt: "## Review\n- summarize diffs",
+} as never;
+
+async function renderEditor() {
+  const { AutomationPromptEditor } = await import(
+    "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor"
+  );
+  render(<AutomationPromptEditor automation={automation} />);
+}
+
+describe("AutomationPromptEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({ isLoaded: true, has: () => true });
+  });
+
+  it("renders the prompt as markdown", async () => {
+    await renderEditor();
+    expect(screen.getByTestId("markdown").textContent).toContain("Review");
+  });
+
+  it("renders read-only markdown for a non-admin (no editor)", async () => {
+    useAuthMock.mockReturnValue({ isLoaded: true, has: () => false });
+    await renderEditor();
+    expect(screen.getByTestId("markdown")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("commits on Cmd+Enter", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "New instructions" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    expect(mutateMock).toHaveBeenCalledWith({
+      id: "automation_1",
+      prompt: "New instructions",
+    });
+  });
+
+  it("commits on blur", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Blurred body" } });
+    fireEvent.blur(textarea);
+    expect(mutateMock).toHaveBeenCalledWith({
+      id: "automation_1",
+      prompt: "Blurred body",
+    });
+  });
+
+  it("does not commit on plain Enter (newline) ", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Line one" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("reverts on Escape", async () => {
+    await renderEditor();
+    fireEvent.click(screen.getByRole("button"));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Discarded" } });
+    fireEvent.keyDown(textarea, { key: "Escape" });
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("markdown")).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-prompt-editor.test.tsx"
+```
+Expected: FAIL — current editor renders a plain `<p>` (no `markdown` testid) and uses an Edit button + Save button (mutate shape/flow differs).
+
+- [ ] **Step 3: Rewrite the component**
+
+Replace the entire contents of `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { AUTOMATION_PROMPT_MAX_LENGTH } from "@repo/app-validation/schemas";
+import { Markdown } from "@repo/ui/components/markdown";
+import { Textarea } from "@repo/ui/components/ui/textarea";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@vendor/clerk";
+import { useTRPC } from "~/trpc/react";
+import { automationUpdateMutationOptions } from "../../_components/automations-cache";
+import { useInlineEdit } from "./use-inline-edit";
+
+type Automation = AppRouterOutputs["org"]["workspace"]["automations"]["get"];
+
+export function AutomationPromptEditor({
+  automation,
+}: {
+  automation: Automation;
+}) {
+  const { has, isLoaded } = useAuth();
+  const canManage = isLoaded && !!has?.({ role: "org:admin" });
+
+  const qc = useQueryClient();
+  const trpc = useTRPC();
+  const id = automation.publicId;
+
+  const update = useMutation(
+    automationUpdateMutationOptions(qc, trpc, id, {
+      errorTitle: "Failed to update instructions",
+    })
+  );
+
+  const { editing, draft, begin, fieldProps } = useInlineEdit({
+    value: automation.prompt,
+    multiline: true,
+    onCommit: (next) => update.mutate({ id, prompt: next }),
+  });
+
+  const rendered = (
+    <Markdown className="text-muted-foreground">{automation.prompt}</Markdown>
+  );
+
+  if (!canManage) {
+    return rendered;
+  }
+
+  if (editing) {
+    const length = draft.trim().length;
+    const isTooLong = length > AUTOMATION_PROMPT_MAX_LENGTH;
+    return (
+      <div className="space-y-1.5">
+        <Textarea
+          {...fieldProps}
+          maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
+          variant="lf"
+        />
+        <div className="flex items-center justify-between">
+          <p className="text-muted-foreground text-xs">
+            Markdown supported · ⌘↵ to save · Esc to cancel
+          </p>
+          <p
+            className={`font-mono text-xs ${
+              isTooLong ? "text-destructive" : "text-muted-foreground"
+            }`}
+          >
+            {length} / {AUTOMATION_PROMPT_MAX_LENGTH}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="-mx-2 cursor-text rounded-[9px] px-2 py-1 transition-colors hover:bg-accent/50"
+      onClick={(event) => {
+        // Let links inside the rendered markdown navigate instead of editing.
+        if ((event.target as HTMLElement).closest("a")) {
+          return;
+        }
+        begin();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          begin();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      {rendered}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-prompt-editor.test.tsx"
+```
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automation-prompt-editor.test.tsx"
+git commit -m "feat(automations): render instructions as markdown with inline auto-save"
+```
+
+---
+
+## Task 5: "Markdown supported" hint on the /new create form
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx`
+
+No automated test: the create form has no existing test, the change is a single static hint string inside a heavily-wired react-hook-form, and a dedicated render harness would be high-cost/low-value. Covered by typecheck + the manual verification in Task 6.
+
+- [ ] **Step 1: Add the hint under the Instructions label**
+
+In `automation-create-form.tsx`, locate the Instructions `FormField` (the `name="prompt"` render). Find this `FormControl` closing block followed by `<FormMessage />`:
+
+```tsx
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+```
+
+Insert a hint paragraph between the `</FormControl>` and `<FormMessage />` of the **prompt** FormField only:
+
+```tsx
+                  </FormControl>
+                  <p className="text-muted-foreground text-xs">
+                    Markdown supported.
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+```
+
+> Note: this exact `</FormControl>\n<FormMessage />` sequence appears in more than one FormField. Apply the edit inside the `name="prompt"` field (the one whose `FormControl` wraps the `<Textarea ... maxLength={AUTOMATION_PROMPT_MAX_LENGTH} ...>` with the char-count `<span>`), not the name field.
+
+- [ ] **Step 2: Typecheck the app**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm typecheck
+```
+Expected: PASS (no type errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx"
+git commit -m "feat(automations): note markdown support on the create form"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full app test suite**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm exec vitest run
+```
+Expected: PASS — all new tests pass and the existing `automations-page` / `automations-client` suites are unaffected.
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+```bash
+cd apps/app && SKIP_ENV_VALIDATION=true pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 3: Lint/format**
+
+Run (from repo root):
+```bash
+pnpm check
+```
+Expected: PASS (no new violations). If it auto-fixes formatting, restage and amend the relevant commit.
+
+- [ ] **Step 4: Manual smoke test**
+
+Start dev (`pnpm dev`) and open an automation detail page as an org admin (see the authenticated E2E approach in memory if needed):
+- Click the **name** → inline input appears with matching heading typography → type → blur or Enter saves → heading updates; Escape reverts.
+- Click the **instructions** → textarea with raw markdown appears → edit → ⌘↵ or blur saves → block re-renders as markdown (headings/lists/`code`); Escape reverts; counter + "Markdown supported" hint show while editing.
+- Visit **/new** → the Instructions field shows the "Markdown supported." hint.
+- As a **non-admin**, confirm the name and rendered markdown are read-only (no edit affordance).
+
+- [ ] **Step 5: Final commit (only if `pnpm check` made changes)**
+
+```bash
+git add -A
+git commit -m "chore(automations): formatting from pnpm check"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Markdown rendering of instructions → Task 4 (`Markdown`). ✓
+- Click-to-edit, blur/⌘↵ commit, Esc revert → Task 1 (hook) + Tasks 3/4 (wiring). ✓
+- Name inline (replaces popover) → Task 3. ✓
+- Instructions inline (replaces Edit button) → Task 4. ✓
+- Shared optimistic mutation factory → Task 2. ✓
+- /new "Markdown supported" hint, no preview → Task 5. ✓
+- Schedule editor unchanged → not touched. ✓
+- No DB/schema/tRPC/runtime change → none in plan. ✓
+- Testing per existing vitest+RTL pattern → Tasks 1–4. ✓
+
+**Type consistency:** `useInlineEdit` returns `{ editing, draft, begin, fieldProps }` — consumed exactly so in Tasks 3/4. `automationUpdateMutationOptions(qc, trpc, id, { errorTitle })` signature matches both call sites. `applyAutomationPatch(prev, { name?, prompt? })` matches its test and factory usage. Mutation payloads `{ id, name }` / `{ id, prompt }` match the test assertions.
+
+**Placeholder scan:** none — every code/test step contains complete content.
+
+**Accepted tradeoffs (noted, not gaps):**
+- Clicking a link inside rendered instructions navigates rather than entering edit (anchor guard in Task 4); all other clicks edit. Acceptable for prompt text.
+- The previous explicit "name too long" message is dropped; `maxLength` makes over-length entry impossible, and empty/unchanged drafts silently revert.

--- a/docs/superpowers/plans/2026-06-01-automations-schedule-model-backend.md
+++ b/docs/superpowers/plans/2026-06-01-automations-schedule-model-backend.md
@@ -1,0 +1,657 @@
+# Automations Schedule-Model Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the automations schedule model from `hourly | daily` to `manual | hourly | daily | weekdays | weekly`, and make `nextRunAt` nullable so manual automations carry no next run.
+
+**Architecture:** Three coupled layers change. (1) `@repo/app-validation` widens the Zod discriminated union and the display formatter. (2) `@db/app` schema widens the column `$type`s and drops `nextRunAt`'s `NOT NULL`; `calculateNextRunAt` returns `Date | null` and gains `manual`/`weekdays`/`weekly` branches; the write/claim/list helpers tolerate null. (3) The tRPC router and Inngest scheduler need **no** code change — they pass the union through and the `lte(nextRunAt, now)` claim filter already excludes NULL. This plan is backend-only and fully testable offline; it does NOT touch the UI, which keeps offering only hourly/daily until the follow-up UI plan.
+
+**Tech Stack:** TypeScript, Zod, Drizzle ORM (PlanetScale MySQL), Vitest. No new dependencies.
+
+**Scope boundary:** This is one of two plans. The visual-language seed + the automations UI surfaces (create form, list, detail editors) are covered by `2026-06-01-automations-visual-language-ui.md` and depend on this plan landing first.
+
+**Schedule model reference:**
+
+| Kind | `scheduleConfig` | `nextRunAt` | Display |
+|---|---|---|---|
+| `manual` | `{}` | `null` | "Manual" |
+| `hourly` | `{ intervalHours: 1–24 }` | every N hours | "Hourly" / "Every N hours" |
+| `daily` | `{ time: "HH:mm" }` | daily at time | "Daily at 9:00 AM" |
+| `weekdays` | `{ time: "HH:mm" }` | next Mon–Fri at time | "Weekdays at 9:00 AM" |
+| `weekly` | `{ dayOfWeek: 0–6, time: "HH:mm" }` | next that-weekday at time | "Weekly on Monday at 9:00 AM" |
+
+`dayOfWeek` uses the JS `Date.getDay()` convention: `0 = Sunday … 6 = Saturday`.
+
+---
+
+## Task 1: Widen the validation discriminated union
+
+**Files:**
+- Modify: `packages/app-validation/src/schemas/automations.ts:41-58`
+- Test: `packages/app-validation/src/__tests__/automations.test.ts:45-108`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these `it(...)` blocks inside the existing `describe("normalizeAutomationSchedule", ...)` block in `packages/app-validation/src/__tests__/automations.test.ts` (after the existing case at line 68, before the "rejects hourly intervals" case):
+
+```ts
+  it("normalizes manual schedules with an empty config", () => {
+    expect(
+      normalizeAutomationSchedule({
+        kind: "manual",
+        config: {},
+      })
+    ).toEqual({
+      kind: "manual",
+      config: {},
+    });
+  });
+
+  it("rejects manual schedules carrying extra config keys", () => {
+    expect(() =>
+      normalizeAutomationSchedule({
+        kind: "manual",
+        config: { time: "09:00" },
+      })
+    ).toThrow();
+  });
+
+  it("normalizes weekdays schedules into a UTC HH:mm time", () => {
+    expect(
+      normalizeAutomationSchedule({
+        kind: "weekdays",
+        config: { time: "08:15" },
+      })
+    ).toEqual({
+      kind: "weekdays",
+      config: { time: "08:15" },
+    });
+  });
+
+  it("normalizes weekly schedules with a dayOfWeek and time", () => {
+    expect(
+      normalizeAutomationSchedule({
+        kind: "weekly",
+        config: { dayOfWeek: 1, time: "09:00" },
+      })
+    ).toEqual({
+      kind: "weekly",
+      config: { dayOfWeek: 1, time: "09:00" },
+    });
+  });
+
+  it("rejects weekly schedules with a dayOfWeek outside 0..6", () => {
+    expect(() =>
+      normalizeAutomationSchedule({
+        kind: "weekly",
+        config: { dayOfWeek: 7, time: "09:00" },
+      })
+    ).toThrow();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @repo/app-validation test automations`
+Expected: FAIL — the new kinds are rejected by the current two-member union (`Invalid discriminator value` / parse throws where we expect success).
+
+- [ ] **Step 3: Widen the union**
+
+Replace lines 41-58 of `packages/app-validation/src/schemas/automations.ts` (the `hourlyScheduleSchema` / `dailyScheduleSchema` / `automationScheduleSchema` block) with:
+
+```ts
+const timeSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:mm format");
+
+const manualScheduleSchema = z.object({
+  kind: z.literal("manual"),
+  config: z.object({}).strict(),
+});
+
+const hourlyScheduleSchema = z.object({
+  kind: z.literal("hourly"),
+  config: z.object({
+    intervalHours: z.number().int().min(1).max(24),
+  }),
+});
+
+const dailyScheduleSchema = z.object({
+  kind: z.literal("daily"),
+  config: z.object({
+    time: timeSchema,
+  }),
+});
+
+const weekdaysScheduleSchema = z.object({
+  kind: z.literal("weekdays"),
+  config: z.object({
+    time: timeSchema,
+  }),
+});
+
+const weeklyScheduleSchema = z.object({
+  kind: z.literal("weekly"),
+  config: z.object({
+    dayOfWeek: z.number().int().min(0).max(6),
+    time: timeSchema,
+  }),
+});
+
+export const automationScheduleSchema = z.discriminatedUnion("kind", [
+  manualScheduleSchema,
+  hourlyScheduleSchema,
+  dailyScheduleSchema,
+  weekdaysScheduleSchema,
+  weeklyScheduleSchema,
+]);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @repo/app-validation test automations`
+Expected: PASS — all five new cases plus the existing hourly/daily/mismatch cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app-validation/src/schemas/automations.ts packages/app-validation/src/__tests__/automations.test.ts
+git commit -m "feat(app-validation): add manual/weekdays/weekly automation schedule kinds"
+```
+
+---
+
+## Task 2: Extend the schedule formatter
+
+**Files:**
+- Modify: `packages/app-validation/src/schemas/automations.ts:128-158`
+- Test: `packages/app-validation/src/__tests__/automations.test.ts:155-205`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these `it(...)` blocks inside the existing `describe("formatAutomationSchedule", ...)` block (after the daily case at line 204):
+
+```ts
+  it("labels manual schedules as 'Manual'", () => {
+    expect(
+      formatAutomationSchedule({
+        status: "active",
+        scheduleKind: "manual",
+        scheduleConfig: {},
+      })
+    ).toBe("Manual");
+  });
+
+  it("formats weekdays schedules with the 12h clock time", () => {
+    expect(
+      formatAutomationSchedule({
+        status: "active",
+        scheduleKind: "weekdays",
+        scheduleConfig: { time: "08:15" },
+      })
+    ).toBe("Weekdays at 8:15 AM");
+  });
+
+  it("formats weekly schedules with the weekday name and time", () => {
+    expect(
+      formatAutomationSchedule({
+        status: "active",
+        scheduleKind: "weekly",
+        scheduleConfig: { dayOfWeek: 1, time: "09:00" },
+      })
+    ).toBe("Weekly on Monday at 9:00 AM");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @repo/app-validation test automations`
+Expected: FAIL — `formatAutomationSchedule` falls through to the daily branch and TypeScript also rejects `scheduleKind: "manual"` against the current `"hourly" | "daily"` summary type.
+
+- [ ] **Step 3: Widen the summary type, add the weekday helper, and extend the formatter**
+
+In `packages/app-validation/src/schemas/automations.ts`, add the weekday label table and helper immediately above `formatClockTime` (currently line 119):
+
+```ts
+const WEEKDAY_LABELS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+export function formatWeekday(dayOfWeek: number): string {
+  return WEEKDAY_LABELS[dayOfWeek] ?? "Sunday";
+}
+```
+
+Replace the `AutomationScheduleSummary` interface (lines 128-132) with:
+
+```ts
+export interface AutomationScheduleSummary {
+  scheduleConfig:
+    | Record<string, never>
+    | { intervalHours: number }
+    | { time: string }
+    | { dayOfWeek: number; time: string };
+  scheduleKind: "manual" | "hourly" | "daily" | "weekdays" | "weekly";
+  status: "active" | "paused" | "deleted";
+}
+```
+
+Replace the body of `formatAutomationSchedule` (lines 134-158) with:
+
+```ts
+export function formatAutomationSchedule(
+  automation: AutomationScheduleSummary
+): string {
+  if (automation.status === "deleted") {
+    return "Deleted";
+  }
+
+  if (automation.status === "paused") {
+    return "Paused";
+  }
+
+  const config = automation.scheduleConfig;
+
+  switch (automation.scheduleKind) {
+    case "manual":
+      return "Manual";
+    case "hourly": {
+      const interval =
+        "intervalHours" in config ? config.intervalHours : 1;
+      return interval === 1 ? "Hourly" : `Every ${interval} hours`;
+    }
+    case "daily": {
+      const time = "time" in config ? config.time : "09:00";
+      return `Daily at ${formatClockTime(time)}`;
+    }
+    case "weekdays": {
+      const time = "time" in config ? config.time : "09:00";
+      return `Weekdays at ${formatClockTime(time)}`;
+    }
+    case "weekly": {
+      const time = "time" in config ? config.time : "09:00";
+      const dayOfWeek = "dayOfWeek" in config ? config.dayOfWeek : 1;
+      return `Weekly on ${formatWeekday(dayOfWeek)} at ${formatClockTime(time)}`;
+    }
+    default:
+      return "Manual";
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @repo/app-validation test automations`
+Expected: PASS — all formatter cases including the three new ones.
+
+- [ ] **Step 5: Typecheck the package**
+
+Run: `pnpm --filter @repo/app-validation typecheck`
+Expected: PASS — no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app-validation/src/schemas/automations.ts packages/app-validation/src/__tests__/automations.test.ts
+git commit -m "feat(app-validation): format manual/weekdays/weekly schedules"
+```
+
+---
+
+## Task 3: Widen the DB column `$type`s
+
+**Files:**
+- Modify: `db/app/src/schema/tables/automations.ts:30-34`
+
+- [ ] **Step 1: Widen the type unions**
+
+In `db/app/src/schema/tables/automations.ts`, replace lines 31-34:
+
+```ts
+export type AutomationScheduleKind = "hourly" | "daily";
+export type AutomationScheduleConfig =
+  | { intervalHours: number }
+  | { time: string };
+```
+
+with:
+
+```ts
+export type AutomationScheduleKind =
+  | "manual"
+  | "hourly"
+  | "daily"
+  | "weekdays"
+  | "weekly";
+export type AutomationScheduleConfig =
+  | Record<string, never>
+  | { intervalHours: number }
+  | { time: string }
+  | { dayOfWeek: number; time: string };
+```
+
+No column changes here — `scheduleKind` is `varchar(32)` (CODE_LENGTH = 32, fits all kinds) and `scheduleConfig` is `json`. These are `$type` annotations only; they do not produce a migration.
+
+- [ ] **Step 2: Typecheck the package**
+
+Run: `pnpm --filter @db/app typecheck`
+Expected: PASS — widening the unions is backward compatible (existing values still assignable).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/app/src/schema/tables/automations.ts
+git commit -m "feat(db): widen automation schedule kind and config types"
+```
+
+---
+
+## Task 4: Make `nextRunAt` nullable and generate the migration
+
+**Files:**
+- Modify: `db/app/src/schema/tables/automations.ts:89`
+- Create: a generated migration SQL file under the drizzle `out` dir (name auto-assigned — do NOT hand-write it)
+
+- [ ] **Step 1: Drop `.notNull()` from the column**
+
+In `db/app/src/schema/tables/automations.ts`, replace line 89:
+
+```ts
+    nextRunAt: datetime("next_run_at", { mode: "date", fsp: 3 }).notNull(),
+```
+
+with:
+
+```ts
+    nextRunAt: datetime("next_run_at", { mode: "date", fsp: 3 }),
+```
+
+Leave the two indexes that reference `nextRunAt` (`orgStatusNextRunIdx` at lines 108-113, `dueIdx` at lines 114-118) unchanged — MySQL indexes permit NULL key values.
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `pnpm --filter @db/app db:generate`
+Expected: A new migration file is written under the drizzle output directory. Do NOT edit it by hand (per `db/CLAUDE.md`).
+
+- [ ] **Step 3: Verify the generated SQL**
+
+Run: `git status --porcelain db/app` then open the new migration file.
+Expected: it contains a single `ALTER TABLE \`lightfast_automations\` MODIFY COLUMN \`next_run_at\` datetime(3);` (i.e. the column loses `NOT NULL`). It must NOT drop/recreate the indexes or touch any other column. If it shows unrelated changes, stop and reconcile the schema — do not commit spurious diffs.
+
+- [ ] **Step 4: Typecheck (insert/update types now accept null)**
+
+Run: `pnpm --filter @db/app typecheck`
+Expected: PASS — `nextRunAt` becomes `Date | null` in `$inferSelect` and optional-nullable in `$inferInsert`. (Compile errors in `utils/automations.ts` are expected NOT here yet because the current code always passes a `Date`; the `Date | null` return type is introduced in Task 5.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/app/src/schema/tables/automations.ts db/app/src/migrations
+git commit -m "feat(db): make automations.next_run_at nullable for manual schedules"
+```
+
+> Note: applying this migration to environments is a deploy concern, not part of local verification. Per `db/CLAUDE.md`, CI runs `pnpm db:migrate` against the persistent `staging` branch and opens a `staging → main` deploy request; never run `db:migrate` against `main`. For a local PlanetScale branch smoke test, load the `lightfast-local-infra` skill and follow its `db up` runbook (memory: `pnpm db:push` is unreliable on worktree branches — apply the generated SQL directly if push fails). The unit tests below do not require a live DB.
+
+---
+
+## Task 5: `calculateNextRunAt` returns `Date | null` with manual/weekdays/weekly branches
+
+**Files:**
+- Modify: `db/app/src/utils/automations.ts:102-139` (and add a `getLocalWeekday` helper near line 100)
+- Test: `db/app/src/__tests__/automations.test.ts:11-74`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `db/app/src/__tests__/automations.test.ts`, first update the FIVE existing assertions in `describe("calculateNextRunAt", ...)` so they compile against the new `Date | null` return type. Change every `expect(next.toISOString())` to `expect(next?.toISOString())` (lines 22, 34, 46, 59, 72).
+
+Then add these cases at the end of the `describe("calculateNextRunAt", ...)` block (after line 73):
+
+```ts
+  it("returns null for manual schedules", () => {
+    expect(
+      calculateNextRunAt({
+        after: new Date("2026-05-27T10:15:00.000Z"),
+        schedule: { kind: "manual", config: {} },
+      })
+    ).toBeNull();
+  });
+
+  it("skips weekend days for weekdays schedules", () => {
+    // 2026-05-30 is a Saturday (UTC); next weekday run is Monday 2026-06-01.
+    const next = calculateNextRunAt({
+      after: new Date("2026-05-30T10:00:00.000Z"),
+      schedule: { kind: "weekdays", config: { time: "09:00" } },
+    });
+
+    expect(next?.toISOString()).toBe("2026-06-01T09:00:00.000Z");
+  });
+
+  it("returns today for a weekdays schedule when the weekday time is still ahead", () => {
+    // 2026-05-27 is a Wednesday (UTC); 09:00 is still ahead of 08:15.
+    const next = calculateNextRunAt({
+      after: new Date("2026-05-27T08:15:00.000Z"),
+      schedule: { kind: "weekdays", config: { time: "09:00" } },
+    });
+
+    expect(next?.toISOString()).toBe("2026-05-27T09:00:00.000Z");
+  });
+
+  it("returns the next matching weekday for weekly schedules", () => {
+    // 2026-05-27 is a Wednesday (UTC, getUTCDay() === 3); next Monday (1) is 2026-06-01.
+    const next = calculateNextRunAt({
+      after: new Date("2026-05-27T08:15:00.000Z"),
+      schedule: { kind: "weekly", config: { dayOfWeek: 1, time: "09:00" } },
+    });
+
+    expect(next?.toISOString()).toBe("2026-06-01T09:00:00.000Z");
+  });
+
+  it("returns today for a weekly schedule when today matches and the time is ahead", () => {
+    // 2026-05-27 is a Wednesday (getUTCDay() === 3); time 09:00 is ahead of 08:15.
+    const next = calculateNextRunAt({
+      after: new Date("2026-05-27T08:15:00.000Z"),
+      schedule: { kind: "weekly", config: { dayOfWeek: 3, time: "09:00" } },
+    });
+
+    expect(next?.toISOString()).toBe("2026-05-27T09:00:00.000Z");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @db/app test automations`
+Expected: FAIL — `manual`/`weekdays`/`weekly` are not handled (manual falls into the time-split path and throws / weekday cases return the wrong date), and the new return type is required for `toBeNull()`.
+
+- [ ] **Step 3: Add the weekday helper**
+
+In `db/app/src/utils/automations.ts`, add this helper immediately after `addLocalDays` (after line 100):
+
+```ts
+function getLocalWeekday(parts: LocalDate): number {
+  return new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day)
+  ).getUTCDay();
+}
+```
+
+- [ ] **Step 4: Rewrite `calculateNextRunAt`**
+
+Replace the entire `calculateNextRunAt` function (lines 102-139) with:
+
+```ts
+export function calculateNextRunAt(input: {
+  after: Date;
+  from?: Date;
+  schedule: NormalizedSchedule;
+  timezone?: string;
+}): Date | null {
+  const { schedule } = input;
+
+  if (schedule.kind === "manual") {
+    return null;
+  }
+
+  if (schedule.kind === "hourly") {
+    const intervalMs = schedule.config.intervalHours * 60 * 60 * 1000;
+    let next = new Date((input.from ?? input.after).getTime() + intervalMs);
+    while (next <= input.after) {
+      next = new Date(next.getTime() + intervalMs);
+    }
+    return next;
+  }
+
+  // daily | weekdays | weekly all resolve a local HH:mm time in the timezone,
+  // then advance day-by-day until the slot is both in the future and lands on
+  // an acceptable weekday.
+  const [hours = 0, minutes = 0] = schedule.config.time.split(":").map(Number);
+  const timezone = input.timezone ?? "UTC";
+  const afterParts = getZonedParts(input.after, timezone);
+  let dateParts: LocalDate = {
+    day: afterParts.day,
+    month: afterParts.month,
+    year: afterParts.year,
+  };
+
+  const isAcceptableDay = (parts: LocalDate): boolean => {
+    if (schedule.kind === "weekdays") {
+      const weekday = getLocalWeekday(parts);
+      return weekday >= 1 && weekday <= 5;
+    }
+    if (schedule.kind === "weekly") {
+      return getLocalWeekday(parts) === schedule.config.dayOfWeek;
+    }
+    return true;
+  };
+
+  let next = zonedTimeToUtc(
+    { ...dateParts, hour: hours, minute: minutes },
+    timezone
+  );
+  while (next <= input.after || !isAcceptableDay(dateParts)) {
+    dateParts = addLocalDays(dateParts, 1);
+    next = zonedTimeToUtc(
+      { ...dateParts, hour: hours, minute: minutes },
+      timezone
+    );
+  }
+  return next;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @db/app test automations`
+Expected: PASS — the five existing hourly/daily cases plus all five new cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/app/src/utils/automations.ts db/app/src/__tests__/automations.test.ts
+git commit -m "feat(db): calculateNextRunAt handles manual/weekdays/weekly and null"
+```
+
+---
+
+## Task 6: Tolerate null `nextRunAt` in writes, claim, and list ordering
+
+**Files:**
+- Modify: `db/app/src/utils/automations.ts:206-220` (list ordering), `:400-462` (claim guard)
+
+`createAutomation` (line 170) and `updateAutomation` (line 259) need NO change: they assign `calculateNextRunAt(...)`'s `Date | null` result straight into a now-nullable column, which the widened insert/update types accept. The two changes below make the claim loop type-safe and keep manual (null) automations from floating to the top of the list.
+
+- [ ] **Step 1: Push null `nextRunAt` rows to the end of the list**
+
+In `listAutomations`, replace the `.orderBy(...)` call (line 219):
+
+```ts
+    .orderBy(asc(automations.nextRunAt), asc(automations.id));
+```
+
+with:
+
+```ts
+    .orderBy(
+      sql`${automations.nextRunAt} is null`,
+      asc(automations.nextRunAt),
+      asc(automations.id)
+    );
+```
+
+(`sql` is already imported at line 7.) This sorts non-null next-run rows first (the boolean `is null` yields 0 before 1), then by soonest run, with manual automations last.
+
+- [ ] **Step 2: Guard the claim loop against null**
+
+In `claimDueAutomationRuns`, add a defensive guard as the first statement inside the `for (const automation of due)` loop (immediately after line 415 `for (const automation of due) {`), before `const dueAt = automation.nextRunAt;`:
+
+```ts
+    if (automation.nextRunAt === null) {
+      continue;
+    }
+```
+
+The `where(... lte(automations.nextRunAt, now))` filter at line 409 already excludes NULL rows, so this branch is never taken at runtime — it narrows `automation.nextRunAt` from `Date | null` to `Date` for the rest of the loop body (`dueAt`, the idempotency key's `.toISOString()`, and the optimistic `eq(automations.nextRunAt, automation.nextRunAt)` guard all now typecheck).
+
+- [ ] **Step 3: Typecheck the package**
+
+Run: `pnpm --filter @db/app typecheck`
+Expected: PASS — no `'next​RunAt' is possibly 'null'` errors remain.
+
+- [ ] **Step 4: Run the full db test suite**
+
+Run: `pnpm --filter @db/app test`
+Expected: PASS — `automations.test.ts` plus any other suites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/app/src/utils/automations.ts
+git commit -m "feat(db): tolerate null next_run_at in claim and list ordering"
+```
+
+---
+
+## Task 7: Verify the router and scheduler need no change
+
+**Files:**
+- Inspect only: `api/app/src/router/(pending-not-allowed)/automations.ts`, `api/app/src/inngest/workflow/automation-scheduler.ts`
+- Run: existing `api/app` test suites
+
+The `create`/`update` procedures pass `input.schedule` (the widened union) straight into the DB helpers; `runNow` is schedule-independent; the scheduler's `claimDueAutomationRuns` filter already excludes manual (null) rows. No source edits expected — this task proves it.
+
+- [ ] **Step 1: Typecheck the api package**
+
+Run: `pnpm --filter @api/app typecheck`
+Expected: PASS — the widened union and nullable `nextRunAt` flow through without error.
+
+- [ ] **Step 2: Run the api test suites**
+
+Run: `pnpm --filter @api/app test`
+Expected: PASS — `automations-router.test.ts` and `automation-workflow.test.ts` stay green (their fixtures use `kind: "daily"`/`"hourly"` and a non-null `nextRunAt: Date`, all still valid).
+
+- [ ] **Step 3: Confirm the app still typechecks against the widened types**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS — `formatAutomationSchedule(automation)` in `automations-client.tsx` accepts the widened summary; the create form's local `z.enum(["hourly", "daily"])` and the schedule editor's `as "hourly" | "daily"` downcast still compile (the UI keeps offering only the two kinds until the UI plan).
+
+- [ ] **Step 4: No commit** — verification only. If any of the above fails, the failure points to a missed null/kind path; fix it in the owning package and amend the relevant task's commit.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `2026-06-01-automations-visual-language-design.md` §2 "Schedule-model backend expansion"):
+- Validation: `manual`/`weekdays`/`weekly` branches → Task 1. `formatAutomationSchedule` extension + day-of-week helper → Task 2. ✅
+- DB types widened → Task 3. `nextRunAt` nullable + generated migration → Task 4. ✅
+- `calculateNextRunAt` returns `Date | null`, manual→null, weekdays/weekly branches reusing tz helpers → Task 5. `createAutomation`/`updateAutomation` accept null → Task 6 (no change needed; verified). ✅
+- Scheduler `lte(nextRunAt, now)` excludes null; no other path assumes non-null → Task 6 guard + Task 7 verification. ✅
+- Tests extended for each kind + null across validation and db suites → Tasks 1, 2, 5. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `AutomationScheduleKind` and `AutomationScheduleConfig` are defined identically in the validation summary (Task 2) and the DB schema (Task 3). `calculateNextRunAt` returns `Date | null` (Task 5) and every consumer (Task 6 create/update/claim, Task 7 router) is reconciled to that signature. `dayOfWeek` is `0–6` (JS `getDay`) everywhere — validation bound (Task 1), `formatWeekday`/`getLocalWeekday` (Tasks 2/5), and test fixtures. ✅

--- a/docs/superpowers/plans/2026-06-01-automations-visual-language-ui.md
+++ b/docs/superpowers/plans/2026-06-01-automations-visual-language-ui.md
@@ -1,0 +1,1467 @@
+# Automations Visual-Language Seed + UI Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Seed Lightfast's Linear-informed visual language as **opt-in variants** on the shared `packages/ui` primitives (zero change to existing screens), then rebuild the three automations surfaces — create form, list, detail editors — on that language with the expanded 5-kind schedule control.
+
+**Architecture:** The language ships as additive cva/prop variants (`Input variant="lf"`, `Textarea variant="lf"`, `Tabs variant="underline"`, `Select variant="lf"`) whose `defaultVariants` keep every current call site byte-identical — so the look is scoped to whatever opts in (only automations). The 9px radius / 30px height / inset-hairline focus ring live **inside** the `lf` variant class strings, so no global token or `--radius` change is needed. Automations components then pass these variants and add mono labels / underline schedule tabs / native styled time input inline.
+
+**Tech Stack:** React 19, Next.js 16, Tailwind CSS v4, class-variance-authority, Radix UI, react-hook-form (`useFormCompat`), tRPC.
+
+**Depends on:** `2026-06-01-automations-schedule-model-backend.md` MUST be merged first — this plan's create form and schedule editor emit `manual`/`weekdays`/`weekly` schedules that the backend validation/calc only accept after that plan lands.
+
+**Locked token reuse (no new globals):** existing dark tokens already match the mockup — `--card` `oklch(0.2435)` = mockup `surface-1`; `--background` `oklch(0.2178)` = mockup `background`; `--ring` `oklch(0.7058)` ≈ `0.72`; `--input` `oklch(0.3092)` ≈ hairline `0.305`. The `lf` variants therefore use `bg-card` (rest fill), `focus-visible:bg-background` (focus fill), `border-input` (hairline border), and `var(--ring)` (inset ring). The only literal values are `rounded-[9px]`, `h-[30px]`, `text-[12.5px]`, `text-[11px]` — all scoped to the variant.
+
+**`lf` focus ring (uniform across all controls):** resting border unchanged; on focus the fill becomes `background` and a 1px ring is drawn *inside* the edge — `focus-visible:bg-background focus-visible:shadow-[inset_0_0_0_1px_var(--ring)]` with the outer halo ring suppressed. No layout shift; doubles as the `:focus-visible` keyboard outline.
+
+---
+
+## Phase A — Visual-language seed (`packages/ui`)
+
+Each variant is additive. After each task, run `pnpm --filter @repo/ui typecheck` (if `@repo/ui` has no `typecheck` script, run `pnpm typecheck` from the repo root). There are no unit tests for these primitives; correctness is `defaultVariants` preserving the current output exactly + the new variant compiling.
+
+### Task A1: Add the `lf` Input variant + size
+
+**Files:**
+- Modify: `packages/ui/src/components/ui/input.tsx:7-32`
+
+- [ ] **Step 1: Add the variant and size**
+
+Replace the `cva` call (lines 7-32) with:
+
+```tsx
+const inputVariants = cva(
+  "file:text-foreground selection:bg-primary selection:text-primary-foreground flex w-full min-w-0 bg-transparent outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: [
+          "placeholder:text-muted-foreground dark:bg-background border-input rounded-md border text-sm shadow-xs",
+          "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:ring-offset-0",
+          "aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        ],
+        underline: [
+          "text-foreground placeholder:text-foreground/50 border-0 border-b border-foreground/20 px-0 rounded-none dark:bg-transparent",
+          "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-foreground",
+        ],
+        lf: [
+          "placeholder:text-muted-foreground bg-card border-input rounded-[9px] border text-[12.5px] shadow-none transition-[color,box-shadow,background-color]",
+          "focus-visible:bg-background focus-visible:border-input focus-visible:shadow-[inset_0_0_0_1px_var(--ring)] focus-visible:ring-0",
+          "aria-invalid:border-destructive aria-invalid:shadow-[inset_0_0_0_1px_var(--destructive)]",
+        ],
+      },
+      size: {
+        default: "h-8 px-3 py-1",
+        lg: "h-10 px-4 py-2",
+        lf: "h-[30px] px-3",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+```
+
+No change to `InputProps` or the component body — `variant`/`size` are already threaded.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @repo/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/ui/input.tsx
+git commit -m "feat(ui): add lf Input variant and size (Lightfast language seed)"
+```
+
+### Task A2: Convert Textarea to cva with an `lf` variant
+
+**Files:**
+- Modify: `packages/ui/src/components/ui/textarea.tsx` (whole file)
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire contents of `packages/ui/src/components/ui/textarea.tsx` with:
+
+```tsx
+import * as React from "react"
+import { cva } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
+
+import { cn } from "@repo/ui/lib/utils"
+
+const textareaVariants = cva(
+  "flex field-sizing-content w-full bg-transparent transition-[color,box-shadow] outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 min-h-16 rounded-md border px-3 py-2 text-base shadow-xs focus-visible:ring-[3px] md:text-sm",
+        lf: "bg-card border-input min-h-[92px] rounded-[9px] border px-3 py-2 text-[12.5px] leading-relaxed shadow-none focus-visible:bg-background focus-visible:border-input focus-visible:shadow-[inset_0_0_0_1px_var(--ring)] aria-invalid:border-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+export interface TextareaProps
+  extends React.ComponentProps<"textarea">,
+    VariantProps<typeof textareaVariants> {}
+
+function Textarea({ className, variant, ...props }: TextareaProps) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(textareaVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }
+```
+
+The `default` variant reproduces the original single class string exactly (verified token-for-token), so the four existing `<Textarea>` call sites render identically. `ref` continues to flow through `{...props}` (React 19 treats it as a regular prop).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @repo/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/ui/textarea.tsx
+git commit -m "feat(ui): add lf Textarea variant (Lightfast language seed)"
+```
+
+### Task A3: Add the underline Tabs variant
+
+**Files:**
+- Modify: `packages/ui/src/components/ui/tabs.tsx` (whole file)
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire contents of `packages/ui/src/components/ui/tabs.tsx` with:
+
+```tsx
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@repo/ui/lib/utils"
+
+type TabsVariant = "default" | "underline"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+    variant?: TabsVariant
+  }
+>(({ className, variant = "default", ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    data-variant={variant}
+    className={cn(
+      variant === "underline"
+        ? "inline-flex items-center gap-5 border-b border-border text-muted-foreground"
+        : "inline-flex items-center justify-center rounded-md bg-card/40 backdrop-blur-md border border-border/50 p-0.5 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+    variant?: TabsVariant
+  }
+>(({ className, variant = "default", ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    data-variant={variant}
+    className={cn(
+      variant === "underline"
+        ? "inline-flex items-center justify-center whitespace-nowrap -mb-px border-b-2 border-transparent px-0.5 py-[7px] text-[11.5px] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground data-[state=active]:border-foreground"
+        : "inline-flex items-center justify-center whitespace-nowrap rounded-md h-7 px-3 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }
+```
+
+The `default` branch is the original class string verbatim, so existing pill-style tabs elsewhere are unchanged.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @repo/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/ui/tabs.tsx
+git commit -m "feat(ui): add underline Tabs variant (Lightfast language seed)"
+```
+
+### Task A4: Add the `lf` Select trigger variant
+
+**Files:**
+- Modify: `packages/ui/src/components/ui/select.tsx:27-51`
+
+- [ ] **Step 1: Add the variant prop and class branch**
+
+Replace the `SelectTrigger` function (lines 27-51) with:
+
+```tsx
+function SelectTrigger({
+  className,
+  size = "default",
+  variant = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+  variant?: "default" | "lf";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      data-variant={variant}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-transparent dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-8 data-[size=sm]:h-7 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        variant === "lf" &&
+          "bg-card dark:bg-card border-input rounded-[9px] text-[12.5px] shadow-none data-[size=default]:h-[30px] focus-visible:bg-background focus-visible:ring-0 focus-visible:border-input focus-visible:shadow-[inset_0_0_0_1px_var(--ring)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+```
+
+The `lf` classes come after the base string in `cn`, so `tailwind-merge` keeps them (height, radius, fill, inset focus all override the defaults). Omitting `variant` leaves every existing `SelectTrigger` untouched.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @repo/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/ui/select.tsx
+git commit -m "feat(ui): add lf SelectTrigger variant (Lightfast language seed)"
+```
+
+---
+
+## Phase B — Shared schedule options + create form
+
+### Task B1: Create the shared schedule-options module
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/schedule-options.ts`
+
+- [ ] **Step 1: Write the module**
+
+```ts
+export const SCHEDULE_KINDS = [
+  { value: "manual", label: "Manual" },
+  { value: "hourly", label: "Hourly" },
+  { value: "daily", label: "Daily" },
+  { value: "weekdays", label: "Weekdays" },
+  { value: "weekly", label: "Weekly" },
+] as const;
+
+export type ScheduleKind = (typeof SCHEDULE_KINDS)[number]["value"];
+
+export const TIME_BASED_KINDS: ScheduleKind[] = ["daily", "weekdays", "weekly"];
+
+export function isTimeBasedKind(kind: ScheduleKind): boolean {
+  return TIME_BASED_KINDS.includes(kind);
+}
+
+// dayOfWeek follows the JS Date.getDay() convention (0 = Sunday … 6 = Saturday).
+export const WEEKDAY_OPTIONS = [
+  { value: 1, label: "Monday" },
+  { value: 2, label: "Tuesday" },
+  { value: 3, label: "Wednesday" },
+  { value: 4, label: "Thursday" },
+  { value: 5, label: "Friday" },
+  { value: 6, label: "Saturday" },
+  { value: 0, label: "Sunday" },
+] as const;
+
+export const TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Kolkata",
+  "Australia/Sydney",
+] as const;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS (module is unused so far — no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/schedule-options.ts"
+git commit -m "feat(app): shared automation schedule options (kinds, weekdays, timezones)"
+```
+
+### Task B2: Rebuild the create form on the new language with 5 schedule kinds
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx` (whole file)
+
+- [ ] **Step 1: Replace the file**
+
+Replace the entire contents with:
+
+```tsx
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  AUTOMATION_NAME_MAX_LENGTH,
+  AUTOMATION_PROMPT_MAX_LENGTH,
+} from "@repo/app-validation/schemas";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormCompat,
+} from "@repo/ui/components/ui/form";
+import { Input } from "@repo/ui/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/ui/select";
+import { toast } from "@repo/ui/components/ui/sonner";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@repo/ui/components/ui/tabs";
+import { Textarea } from "@repo/ui/components/ui/textarea";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@vendor/clerk";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { z } from "zod";
+import { useTRPC } from "~/trpc/react";
+import { upsertInList } from "../../_components/automations-cache";
+import {
+  isTimeBasedKind,
+  SCHEDULE_KINDS,
+  type ScheduleKind,
+  TIMEZONES,
+  WEEKDAY_OPTIONS,
+} from "../../_components/schedule-options";
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(AUTOMATION_NAME_MAX_LENGTH),
+  prompt: z
+    .string()
+    .trim()
+    .min(1, "Instructions are required")
+    .max(AUTOMATION_PROMPT_MAX_LENGTH),
+  scheduleKind: z.enum(["manual", "hourly", "daily", "weekdays", "weekly"]),
+  intervalHours: z.number().int().min(1).max(24),
+  time: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:mm"),
+  dayOfWeek: z.number().int().min(0).max(6),
+  timezone: z.string().min(1),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+function buildSchedule(values: FormValues) {
+  switch (values.scheduleKind) {
+    case "manual":
+      return { kind: "manual" as const, config: {} };
+    case "hourly":
+      return {
+        kind: "hourly" as const,
+        config: { intervalHours: values.intervalHours },
+      };
+    case "daily":
+      return { kind: "daily" as const, config: { time: values.time } };
+    case "weekdays":
+      return { kind: "weekdays" as const, config: { time: values.time } };
+    case "weekly":
+      return {
+        kind: "weekly" as const,
+        config: { dayOfWeek: values.dayOfWeek, time: values.time },
+      };
+    default:
+      return { kind: "manual" as const, config: {} };
+  }
+}
+
+export function AutomationCreateForm({ slug }: { slug: string }) {
+  const router = useRouter();
+  const { has, isLoaded } = useAuth();
+  const canManageAutomations = isLoaded && !!has?.({ role: "org:admin" });
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const listHref = `/${slug}/automations` as Route;
+
+  useEffect(() => {
+    if (isLoaded && !canManageAutomations) {
+      router.replace(listHref);
+    }
+  }, [canManageAutomations, isLoaded, listHref, router]);
+
+  const form = useFormCompat<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      prompt: "",
+      scheduleKind: "daily",
+      intervalHours: 1,
+      time: "09:00",
+      dayOfWeek: 1,
+      timezone: "UTC",
+    },
+    mode: "onChange",
+  });
+
+  const scheduleKind = form.watch("scheduleKind") as ScheduleKind;
+  const dayOfWeek = form.watch("dayOfWeek");
+  const timezone = form.watch("timezone");
+  const promptValue = form.watch("prompt");
+
+  const createMutation = useMutation(
+    trpc.org.workspace.automations.create.mutationOptions({
+      meta: { errorTitle: "Failed to create automation" },
+      onSuccess: (automation) => {
+        upsertInList(queryClient, trpc, automation.publicId, () => automation);
+        queryClient.setQueryData(
+          trpc.org.workspace.automations.get.queryOptions({
+            id: automation.publicId,
+          }).queryKey,
+          automation
+        );
+        toast.success("Automation created", {
+          description: `"${automation.name}" is now scheduled.`,
+        });
+        router.push(listHref);
+      },
+    })
+  );
+
+  const onSubmit = (values: FormValues) => {
+    createMutation.mutate({
+      name: values.name,
+      prompt: values.prompt,
+      schedule: buildSchedule(values),
+      timezone: values.timezone,
+    });
+  };
+
+  const isSubmitting = createMutation.isPending;
+
+  if (!(isLoaded && canManageAutomations)) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-full bg-background text-foreground">
+      <div className="mx-auto w-full max-w-xl px-6 py-12">
+        <Link
+          className="-ml-0.5 mb-8 inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          href={listHref}
+        >
+          <ArrowLeft className="size-3.5" />
+          automations
+        </Link>
+
+        <h1 className="font-semibold text-[20px] tracking-[-0.02em]">
+          New automation
+        </h1>
+        <p className="mt-1 mb-8 text-[12px] text-muted-foreground">
+          A cloud schedule that runs your agent and records each run.
+        </p>
+
+        <Form {...form}>
+          <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem className="gap-2">
+                  <FormLabel className="font-mono text-[11px] font-normal tracking-normal text-muted-foreground">
+                    Name{" "}
+                    <span className="text-muted-foreground">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      autoFocus
+                      placeholder="Daily code review"
+                      size="lf"
+                      variant="lf"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="prompt"
+              render={({ field }) => (
+                <FormItem className="gap-2">
+                  <FormLabel className="font-mono text-[11px] font-normal tracking-normal text-muted-foreground">
+                    Instructions{" "}
+                    <span className="text-muted-foreground">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Textarea
+                        {...field}
+                        maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
+                        placeholder="Describe what the agent should do in each run."
+                        variant="lf"
+                      />
+                      <span className="pointer-events-none absolute right-2.5 bottom-2 font-mono text-[9.5px] text-muted-foreground">
+                        {promptValue.length}/{AUTOMATION_PROMPT_MAX_LENGTH}
+                      </span>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-2">
+              <FormLabel className="font-mono text-[11px] font-normal tracking-normal text-muted-foreground">
+                Schedule
+              </FormLabel>
+              <Tabs
+                onValueChange={(value) =>
+                  form.setValue("scheduleKind", value as ScheduleKind, {
+                    shouldValidate: true,
+                  })
+                }
+                value={scheduleKind}
+              >
+                <TabsList variant="underline">
+                  {SCHEDULE_KINDS.map((kind) => (
+                    <TabsTrigger
+                      key={kind.value}
+                      value={kind.value}
+                      variant="underline"
+                    >
+                      {kind.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </Tabs>
+
+              <div className="pt-3">
+                {scheduleKind === "manual" && (
+                  <p className="font-mono text-[10.5px] text-muted-foreground">
+                    Runs only when triggered — no automatic schedule.
+                  </p>
+                )}
+
+                {scheduleKind === "hourly" && (
+                  <FormField
+                    control={form.control}
+                    name="intervalHours"
+                    render={({ field }) => (
+                      <FormItem className="gap-0">
+                        <div className="flex items-center gap-2.5">
+                          <span className="font-mono text-[10.5px] text-muted-foreground">
+                            Every
+                          </span>
+                          <Input
+                            className="w-14 text-center font-mono"
+                            max={24}
+                            min={1}
+                            name={field.name}
+                            onBlur={field.onBlur}
+                            onChange={(event) =>
+                              field.onChange(
+                                Number.parseInt(event.target.value, 10) || 1
+                              )
+                            }
+                            ref={field.ref}
+                            size="lf"
+                            type="number"
+                            value={field.value}
+                            variant="lf"
+                          />
+                          <span className="font-mono text-[10.5px] text-muted-foreground">
+                            hours
+                          </span>
+                        </div>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+
+                {(scheduleKind === "daily" || scheduleKind === "weekdays") && (
+                  <FormField
+                    control={form.control}
+                    name="time"
+                    render={({ field }) => (
+                      <FormItem className="gap-0">
+                        <div className="flex items-center gap-2.5">
+                          <span className="font-mono text-[10.5px] text-muted-foreground">
+                            At
+                          </span>
+                          <Input
+                            {...field}
+                            className="w-[7rem] font-mono [&::-webkit-calendar-picker-indicator]:hidden"
+                            size="lf"
+                            type="time"
+                            variant="lf"
+                          />
+                          {scheduleKind === "weekdays" && (
+                            <span className="rounded-md border border-border px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground">
+                              Mon–Fri
+                            </span>
+                          )}
+                        </div>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+
+                {scheduleKind === "weekly" && (
+                  <FormField
+                    control={form.control}
+                    name="time"
+                    render={({ field }) => (
+                      <FormItem className="gap-0">
+                        <div className="flex flex-wrap items-center gap-2.5">
+                          <span className="font-mono text-[10.5px] text-muted-foreground">
+                            On
+                          </span>
+                          <Select
+                            onValueChange={(value) =>
+                              form.setValue("dayOfWeek", Number(value), {
+                                shouldValidate: true,
+                              })
+                            }
+                            value={String(dayOfWeek)}
+                          >
+                            <SelectTrigger className="w-36" variant="lf">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {WEEKDAY_OPTIONS.map((day) => (
+                                <SelectItem
+                                  key={day.value}
+                                  value={String(day.value)}
+                                >
+                                  {day.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <span className="font-mono text-[10.5px] text-muted-foreground">
+                            at
+                          </span>
+                          <Input
+                            {...field}
+                            className="w-[7rem] font-mono [&::-webkit-calendar-picker-indicator]:hidden"
+                            size="lf"
+                            type="time"
+                            variant="lf"
+                          />
+                        </div>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+              </div>
+            </div>
+
+            {isTimeBasedKind(scheduleKind) && (
+              <div className="space-y-2">
+                <FormLabel className="font-mono text-[11px] font-normal tracking-normal text-muted-foreground">
+                  Timezone
+                </FormLabel>
+                <Select
+                  onValueChange={(value) =>
+                    form.setValue("timezone", value, { shouldValidate: true })
+                  }
+                  value={timezone}
+                >
+                  <SelectTrigger className="w-full" variant="lf">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TIMEZONES.map((tz) => (
+                      <SelectItem key={tz} value={tz}>
+                        {tz}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="flex items-center justify-end gap-2.5 border-border border-t pt-5">
+              <Button
+                asChild
+                className="h-[30px] rounded-[9px]"
+                type="button"
+                variant="ghost"
+              >
+                <Link href={listHref}>Cancel</Link>
+              </Button>
+              <Button
+                className="h-[30px] rounded-[9px]"
+                disabled={isSubmitting || !form.formState.isValid}
+                type="submit"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="size-3.5 animate-spin" />
+                    Creating
+                  </>
+                ) : (
+                  "Create"
+                )}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+}
+```
+
+Key points: `scheduleKind` and the day/timezone selects are driven via `form.watch`/`form.setValue` (not native inputs); `time` is reused across daily/weekdays/weekly; `buildSchedule` maps flat fields → the discriminated union; the timezone block only renders for time-based kinds; the native time input hides the webkit picker indicator and uses mono digits; Create is gated on `form.formState.isValid`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS — `buildSchedule`'s return type unifies to the `createAutomationSchema` input the mutation expects.
+
+- [ ] **Step 3: Visual + behavior check in the running app**
+
+With `pnpm dev` running, open `https://[<wt>.]lightfast.localhost/<slug>/automations/new`. Verify: underline tabs switch Manual/Hourly/Daily/Weekdays/Weekly; each sub-control renders (manual note, hourly number, daily/weekdays time, weekly day+time); timezone hides for Manual/Hourly; inputs show the 30px height, 9px radius, and inset-hairline focus ring; creating a Weekly automation succeeds and redirects to the list showing "Weekly on Monday at 9:00 AM".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx"
+git commit -m "feat(app): rebuild automation create form on the Lightfast language with 5 schedule kinds"
+```
+
+---
+
+## Phase C — Detail editors
+
+### Task C1: Extract a shared `RailSection` and reskin its label to mono
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/rail-section.tsx`
+- Modify: `automation-detail-client.tsx` (import + remove local copy), `automation-schedule-editor.tsx` (import + remove local copy)
+
+`RailSection` is currently duplicated in four files (`automation-detail-client.tsx:96-110`, `automation-schedule-editor.tsx:60-75`, `automation-runs-list.tsx`, `automation-status-chip.tsx`). This task creates one shared component and switches the two files this plan already rebuilds; the runs-list and status-chip copies are switched in Task C4.
+
+- [ ] **Step 1: Create the shared component**
+
+```tsx
+import type { ReactNode } from "react";
+
+export function RailSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="border-border border-t pt-4">
+      <p className="mb-2 font-mono text-[11px] font-normal text-muted-foreground">
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+```
+
+(The label changes from `text-xs uppercase tracking-wide` to mono, no-caps, no-tracking — the locked label style.)
+
+- [ ] **Step 2: Switch `automation-detail-client.tsx`**
+
+In `automation-detail-client.tsx`: add the import near the other `./` imports (after line 15):
+
+```tsx
+import { RailSection } from "./rail-section";
+```
+
+Then delete the local `RailSection` definition (lines 96-111).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/rail-section.tsx" "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-detail-client.tsx"
+git commit -m "refactor(app): extract shared RailSection with mono label"
+```
+
+### Task C2: Rebuild the schedule editor for 5 kinds on the new language
+
+**Files:**
+- Modify: `automation-schedule-editor.tsx` (whole file)
+
+- [ ] **Step 1: Replace the file**
+
+Replace the entire contents of `automation-schedule-editor.tsx` with:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { formatAutomationSchedule } from "@repo/app-validation/schemas";
+import { Button } from "@repo/ui/components/ui/button";
+import { Input } from "@repo/ui/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@repo/ui/components/ui/tabs";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@vendor/clerk";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useTRPC } from "~/trpc/react";
+import { setOne, upsertInList } from "../../_components/automations-cache";
+import {
+  isTimeBasedKind,
+  SCHEDULE_KINDS,
+  type ScheduleKind,
+  TIMEZONES,
+  WEEKDAY_OPTIONS,
+} from "../../_components/schedule-options";
+import { RailSection } from "./rail-section";
+
+type Automation = AppRouterOutputs["org"]["workspace"]["automations"]["get"];
+
+const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function extractFormState(automation: Automation) {
+  const kind = automation.scheduleKind as ScheduleKind;
+  const config = automation.scheduleConfig as {
+    intervalHours?: number;
+    time?: string;
+    dayOfWeek?: number;
+  };
+  return {
+    kind,
+    intervalHours:
+      config.intervalHours === undefined ? "1" : String(config.intervalHours),
+    time: config.time ?? "09:00",
+    dayOfWeek: config.dayOfWeek ?? 1,
+  };
+}
+
+function buildSchedule(state: {
+  kind: ScheduleKind;
+  parsedHours: number;
+  time: string;
+  dayOfWeek: number;
+}) {
+  switch (state.kind) {
+    case "manual":
+      return { kind: "manual" as const, config: {} };
+    case "hourly":
+      return {
+        kind: "hourly" as const,
+        config: { intervalHours: state.parsedHours },
+      };
+    case "daily":
+      return { kind: "daily" as const, config: { time: state.time } };
+    case "weekdays":
+      return { kind: "weekdays" as const, config: { time: state.time } };
+    case "weekly":
+      return {
+        kind: "weekly" as const,
+        config: { dayOfWeek: state.dayOfWeek, time: state.time },
+      };
+    default:
+      return { kind: "manual" as const, config: {} };
+  }
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-muted-foreground text-[12.5px]">{label}</span>
+      <span className="text-foreground text-[12.5px]">{value}</span>
+    </div>
+  );
+}
+
+export function AutomationScheduleEditor({
+  automation,
+}: {
+  automation: Automation;
+}) {
+  const { has, isLoaded } = useAuth();
+  const canManage = isLoaded && !!has?.({ role: "org:admin" });
+  const [open, setOpen] = useState(false);
+
+  const initial = extractFormState(automation);
+  const [kind, setKind] = useState<ScheduleKind>(initial.kind);
+  const [intervalHours, setIntervalHours] = useState(initial.intervalHours);
+  const [time, setTime] = useState(initial.time);
+  const [dayOfWeek, setDayOfWeek] = useState(initial.dayOfWeek);
+  const [timezone, setTimezone] = useState(automation.timezone);
+
+  const qc = useQueryClient();
+  const trpc = useTRPC();
+  const id = automation.publicId;
+
+  const update = useMutation(
+    trpc.org.workspace.automations.update.mutationOptions({
+      meta: { errorTitle: "Failed to update schedule" },
+      onSuccess: (updated) => {
+        setOne(qc, trpc, id, () => updated);
+        upsertInList(qc, trpc, id, () => updated);
+        setOpen(false);
+      },
+    })
+  );
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) {
+      const fresh = extractFormState(automation);
+      setKind(fresh.kind);
+      setIntervalHours(fresh.intervalHours);
+      setTime(fresh.time);
+      setDayOfWeek(fresh.dayOfWeek);
+      setTimezone(automation.timezone);
+    }
+  }
+
+  const parsedHours = Number.parseInt(intervalHours, 10);
+  const hoursValid =
+    Number.isInteger(parsedHours) && parsedHours >= 1 && parsedHours <= 24;
+  const timeValid = TIME_RE.test(time);
+  const fieldValid =
+    kind === "manual"
+      ? true
+      : kind === "hourly"
+        ? hoursValid
+        : timeValid;
+
+  const isSaveDisabled = update.isPending || !fieldValid;
+
+  function handleSave() {
+    if (isSaveDisabled) {
+      return;
+    }
+    update.mutate({
+      id,
+      schedule: buildSchedule({ kind, parsedHours, time, dayOfWeek }),
+      timezone,
+    });
+  }
+
+  const display = (
+    <div className="space-y-1">
+      <DetailRow label="Repeats" value={formatAutomationSchedule(automation)} />
+      <DetailRow label="Timezone" value={automation.timezone} />
+    </div>
+  );
+
+  if (!canManage) {
+    return <RailSection label="Schedule">{display}</RailSection>;
+  }
+
+  return (
+    <RailSection label="Schedule">
+      <Popover onOpenChange={handleOpenChange} open={open}>
+        <PopoverTrigger asChild>
+          <button
+            className="-mx-1 w-full rounded-[9px] px-1 py-0.5 text-left transition-colors hover:bg-accent/50"
+            type="button"
+          >
+            {display}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-80 space-y-4 p-4">
+          <Tabs onValueChange={(v) => setKind(v as ScheduleKind)} value={kind}>
+            <TabsList variant="underline">
+              {SCHEDULE_KINDS.map((option) => (
+                <TabsTrigger
+                  key={option.value}
+                  value={option.value}
+                  variant="underline"
+                >
+                  {option.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          <div className="min-h-[30px]">
+            {kind === "manual" && (
+              <p className="font-mono text-[10.5px] text-muted-foreground">
+                Runs only when triggered — no automatic schedule.
+              </p>
+            )}
+
+            {kind === "hourly" && (
+              <div className="flex items-center gap-2.5">
+                <span className="font-mono text-[10.5px] text-muted-foreground">
+                  Every
+                </span>
+                <Input
+                  className="w-14 text-center font-mono"
+                  max={24}
+                  min={1}
+                  onChange={(e) => setIntervalHours(e.target.value)}
+                  size="lf"
+                  type="number"
+                  value={intervalHours}
+                  variant="lf"
+                />
+                <span className="font-mono text-[10.5px] text-muted-foreground">
+                  hours
+                </span>
+              </div>
+            )}
+
+            {(kind === "daily" || kind === "weekdays") && (
+              <div className="flex items-center gap-2.5">
+                <span className="font-mono text-[10.5px] text-muted-foreground">
+                  At
+                </span>
+                <Input
+                  className="w-[7rem] font-mono [&::-webkit-calendar-picker-indicator]:hidden"
+                  onChange={(e) => setTime(e.target.value)}
+                  size="lf"
+                  type="time"
+                  value={time}
+                  variant="lf"
+                />
+                {kind === "weekdays" && (
+                  <span className="rounded-md border border-border px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground">
+                    Mon–Fri
+                  </span>
+                )}
+              </div>
+            )}
+
+            {kind === "weekly" && (
+              <div className="flex flex-wrap items-center gap-2.5">
+                <span className="font-mono text-[10.5px] text-muted-foreground">
+                  On
+                </span>
+                <Select
+                  onValueChange={(v) => setDayOfWeek(Number(v))}
+                  value={String(dayOfWeek)}
+                >
+                  <SelectTrigger className="w-32" variant="lf">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {WEEKDAY_OPTIONS.map((day) => (
+                      <SelectItem key={day.value} value={String(day.value)}>
+                        {day.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <span className="font-mono text-[10.5px] text-muted-foreground">
+                  at
+                </span>
+                <Input
+                  className="w-[7rem] font-mono [&::-webkit-calendar-picker-indicator]:hidden"
+                  onChange={(e) => setTime(e.target.value)}
+                  size="lf"
+                  type="time"
+                  value={time}
+                  variant="lf"
+                />
+              </div>
+            )}
+          </div>
+
+          {isTimeBasedKind(kind) && (
+            <div className="space-y-1.5">
+              <p className="font-mono text-[11px] text-muted-foreground">
+                Timezone
+              </p>
+              <Select onValueChange={setTimezone} value={timezone}>
+                <SelectTrigger className="w-full" variant="lf">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIMEZONES.map((tz) => (
+                    <SelectItem key={tz} value={tz}>
+                      {tz}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2.5">
+            <Button
+              className="h-[30px] rounded-[9px]"
+              onClick={() => setOpen(false)}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+            <Button
+              className="h-[30px] rounded-[9px]"
+              disabled={isSaveDisabled}
+              onClick={handleSave}
+              size="sm"
+              type="button"
+            >
+              {update.isPending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                "Save"
+              )}
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </RailSection>
+  );
+}
+```
+
+Note: the previous `isUnchanged` save-gating is dropped in favor of `fieldValid` only — switching kinds is always a valid save. The mutation's optimistic-free `onSuccess` cache write is unchanged.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Visual + behavior check**
+
+In the running app, open an automation detail page, click the Schedule rail section, switch among all five kinds, change a weekly day + time, Save, and confirm the "Repeats" row re-renders (e.g. "Weekly on Wednesday at 8:15 AM"). Switch to Manual and Save → "Repeats" shows "Manual" and the "Next run" rail shows "—".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-schedule-editor.tsx"
+git commit -m "feat(app): rebuild automation schedule editor for 5 kinds on the Lightfast language"
+```
+
+### Task C3: Reskin the name + prompt editors to the `lf` primitives
+
+**Files:**
+- Modify: `automation-name-editor.tsx:113-118`
+- Modify: `automation-prompt-editor.tsx:97-108`
+
+- [ ] **Step 1: Name editor input**
+
+In `automation-name-editor.tsx`, replace the `<Input>` (lines 113-118) with:
+
+```tsx
+          <Input
+            autoFocus
+            maxLength={AUTOMATION_NAME_MAX_LENGTH + 1}
+            onChange={(e) => setValue(e.target.value)}
+            size="lf"
+            value={value}
+            variant="lf"
+          />
+```
+
+- [ ] **Step 2: Prompt editor textarea + counter**
+
+In `automation-prompt-editor.tsx`, replace the `<Textarea>` (lines 97-103) and the counter `<p>` (lines 104-108) with:
+
+```tsx
+      <Textarea
+        onChange={(e) => setValue(e.target.value)}
+        ref={textareaRef}
+        rows={6}
+        value={value}
+        variant="lf"
+      />
+      <p
+        className={`font-mono text-[9.5px] ${isTooLong ? "text-destructive" : "text-muted-foreground"}`}
+      >
+        {trimmed.length} / {AUTOMATION_PROMPT_MAX_LENGTH}
+      </p>
+```
+
+(The `min-h-32` override is dropped — the `lf` Textarea variant already sets `min-h-[92px]`; `rows={6}` keeps it taller in edit mode.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor.tsx" "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor.tsx"
+git commit -m "feat(app): reskin automation name and prompt editors to the lf primitives"
+```
+
+### Task C4: Switch the remaining `RailSection` copies to the shared one
+
+**Files:**
+- Modify: `automation-runs-list.tsx`, `automation-status-chip.tsx`
+
+- [ ] **Step 1: Switch runs-list**
+
+In `automation-runs-list.tsx`: add `import { RailSection } from "./rail-section";` near the other `./` imports and delete its local `RailSection` definition (the `function RailSection(...)` block).
+
+- [ ] **Step 2: Switch status-chip**
+
+In `automation-status-chip.tsx`: add `import { RailSection } from "./rail-section";` near the other `./` imports and delete its local `RailSection` definition.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS — no duplicate-identifier or unused warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-runs-list.tsx" "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-status-chip.tsx"
+git commit -m "refactor(app): use shared RailSection across automation detail rail"
+```
+
+---
+
+## Phase D — List page + verification
+
+### Task D1: Reskin the automations list to the new language
+
+**Files:**
+- Modify: `automations-client.tsx:42-155`
+
+- [ ] **Step 1: Restyle section labels, rows, and empty state**
+
+In `automations-client.tsx`, apply these className changes (text content and data flow unchanged — only styling):
+
+Replace the header block (lines 43-60) heading + lede:
+
+```tsx
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="font-semibold text-[20px] text-foreground tracking-[-0.02em]">
+            Automations
+          </h1>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            Cloud schedules that record scaffold runs.
+          </p>
+        </div>
+        {canManageAutomations && (
+          <Button
+            asChild
+            className="h-[30px] rounded-[9px]"
+            size="sm"
+            variant="secondary"
+          >
+            <Link href={`/${workspaceSlug}/automations/new` as Route}>
+              <Plus className="size-4" />
+              New automation
+            </Link>
+          </Button>
+        )}
+      </div>
+```
+
+Replace the empty-state `<p>` labels (lines 64-69) to use mono:
+
+```tsx
+          <p className="font-mono text-[11px] text-foreground">
+            No automations yet
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            Create a cloud schedule to start recording scaffold runs.
+          </p>
+```
+
+Replace the `AutomationSection` heading (line 106):
+
+```tsx
+      <h2 className="font-mono text-[11px] font-normal text-muted-foreground">{title}</h2>
+```
+
+Replace the `AutomationRow` `<Link>` className (line 132) and the name/schedule text sizes (lines 142-152):
+
+```tsx
+    <Link
+      className="-mx-3 flex min-h-12 items-center justify-between gap-4 rounded-[9px] border-border border-b px-3 py-3 transition-colors hover:bg-muted/40"
+      href={`/${workspaceSlug}/automations/${automation.publicId}` as Route}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <Icon
+          aria-hidden="true"
+          className="size-4 shrink-0 text-muted-foreground"
+          strokeWidth={2}
+        />
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <p className="truncate font-medium text-[13px] text-foreground">
+            {automation.name}
+          </p>
+          <p className="shrink-0 font-mono text-[10px] text-muted-foreground">
+            {workspaceSlug}
+          </p>
+        </div>
+      </div>
+      <p className="shrink-0 font-mono text-[11px] text-muted-foreground">
+        {formatAutomationSchedule(automation)}
+      </p>
+    </Link>
+```
+
+- [ ] **Step 2: Run the existing client test**
+
+Run: `pnpm --filter @lightfast/app test automations-client`
+Expected: PASS — the test asserts rendered names and `formatAutomationSchedule` labels, which are unchanged. If it queries by a class/role that changed, update the selector (not the assertion).
+
+- [ ] **Step 3: Typecheck + visual check**
+
+Run: `pnpm --filter @lightfast/app typecheck`
+Expected: PASS. In the running app, confirm the list reads in the new language (mono section labels + schedule labels, soft hover).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-client.tsx"
+git commit -m "feat(app): reskin automations list to the Lightfast language"
+```
+
+### Task D2: Full-surface verification
+
+- [ ] **Step 1: Typecheck the whole affected graph**
+
+Run: `pnpm --filter @repo/ui typecheck && pnpm --filter @lightfast/app typecheck`
+Expected: PASS.
+
+- [ ] **Step 2: Run the app test suite**
+
+Run: `pnpm --filter @lightfast/app test`
+Expected: PASS.
+
+- [ ] **Step 3: Lint/format**
+
+Run: `pnpm check`
+Expected: PASS (or apply autofixes and re-run).
+
+- [ ] **Step 4: End-to-end visual pass in the running app**
+
+Walk all three surfaces with `pnpm dev` running (auth via the seeded `lightfast` org per the e2e testing memory): create form (all 5 kinds), list (current + paused), detail (name/prompt/schedule/status/runs). Confirm a consistent 30px height, 9px radius, mono no-caps labels, inset-hairline focus ring, and underline schedule tabs across every control, and that no OTHER app screen changed (open one non-automations form to confirm the shared primitives still render their defaults).
+
+- [ ] **Step 5: No extra commit** — prior task commits cover the work. If `pnpm check` applied formatting, commit it:
+
+```bash
+git add -A
+git commit -m "chore(app): formatting for automations language rework"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `2026-06-01-automations-visual-language-design.md` §1 and §3):
+- Visual seed — Input (A1), Textarea (A2), Tabs underline (A3), Select (A4); Label mono + Button height handled inline at usage (per the inline-classes preference); focus ring = inset hairline baked into every `lf`/`underline` variant. ✅
+- Create form — full-page route kept, 5-kind underline tabs + per-kind sub-controls + timezone (time-based only) + mono counter + lf primitives → B2. ✅
+- List — mono section labels, hairline dividers, soft hover, restyled empty state → D1. ✅
+- Detail editors — schedule editor rebuilt for 5 kinds + underline tabs + timezone (C2); name/prompt reskinned (C3); `RailSection` deduped into one shared component with the mono-no-caps label (C1, C4). ✅
+- Scoped, not global — every `packages/ui` change is an additive variant with `defaultVariants` preserving current output; the 9px radius / 30px height live inside the `lf` variants; no `--radius` or token edit → D2 step 4 verifies other screens are untouched. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step is complete. ✅
+
+**Type consistency:** `ScheduleKind` is defined once in `schedule-options.ts` and imported by the create form (B2) and schedule editor (C2). `buildSchedule` exists in both forms with the same five-branch shape returning the `createAutomationSchema`/`updateAutomationSchema` union. The `lf` variant names (`variant="lf"`, `size="lf"`, `variant="underline"`) match exactly between the primitive definitions (Phase A) and every call site (Phases B–D). `dayOfWeek` uses 0–6 (JS `getDay`) consistently with the backend plan. ✅
+
+**Cross-plan dependency:** B2 and C2 emit `manual`/`weekdays`/`weekly` — gated on the backend plan (`2026-06-01-automations-schedule-model-backend.md`) landing first, as stated in the header. ✅

--- a/docs/superpowers/plans/2026-06-01-connector-detail-sheet.md
+++ b/docs/superpowers/plans/2026-06-01-connector-detail-sheet.md
@@ -1,0 +1,1083 @@
+# Connector Detail Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only, right-side detail Sheet for connected connectors that opens from the existing `?connector=` URL param (post-connect) and from a new "View details" item in the connected card's `'…'` menu.
+
+**Architecture:** Frontend-only. The sheet renders entirely from the already-loaded `org.workspace.connectors.list` row (no new tRPC/DB). Selection is driven by the `?connector=<provider>` URL param via `nuqs` (mirroring the signals `?signal=` pattern); the OAuth success callback already lands on that param, so a successful connect auto-opens the sheet (replacing the green banner). Shared display helpers move to a new `connectors-model.ts`. The sheet/content components mirror `signal-detail-sheet.tsx` / `signal-detail-content.tsx`.
+
+**Tech Stack:** Next.js (App Router), React, TypeScript, tRPC (read-only), `nuqs`, `@repo/ui` (shadcn `Sheet`, `Badge`, `Button`, `DropdownMenu`), Vitest + Testing Library, Biome.
+
+---
+
+## File Structure
+
+- **Create** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connectors-model.ts`
+  — shared connector types + display helpers (`connectionStatus`, `displayProviderName`), so the client and sheet share one source (mirrors `signals-model.ts`).
+- **Create** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-content.tsx`
+  — the inner sheet layout (header, property block, tools list, footer).
+- **Create** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-content.test.tsx`
+  — colocated component test (mirrors `signal-detail-content.test.tsx`).
+- **Create** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-sheet.tsx`
+  — the `Sheet` shell + copy-link handler.
+- **Create** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-sheet.test.tsx`
+  — colocated component test (mirrors `signal-detail-sheet.test.tsx`).
+- **Modify** `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connectors-client.tsx`
+  — import from `connectors-model`; switch URL handling to `nuqs`; drop the green success banner; add the "View details" dropdown item; render the sheet.
+- **Modify** `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/connectors-page.test.tsx`
+  — add `nuqs` + sheet-stub mocks; rewrite the callback-clearing tests; add sheet-wiring tests.
+
+`apps/app/.../connectors/page.tsx` is **unchanged** (it still passes `callbackConnector`/`callbackError` for the error banner).
+
+### Shared paths (used verbatim in steps below)
+
+- CONNECTORS_DIR = `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components`
+- PAGE_TEST = `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/connectors-page.test.tsx`
+
+All test/lint commands run from `apps/app` unless stated otherwise (`name: @lightfast/app`, `test: vitest run`, `typecheck: tsc --noEmit`). Vitest takes a filename substring filter, e.g. `pnpm test connector-detail`.
+
+---
+
+## Task 1: Extract `connectors-model.ts` (shared types + helpers)
+
+Pure refactor guarded by the existing `connectors-page.test.tsx` suite — no behavior change.
+
+**Files:**
+- Create: `CONNECTORS_DIR/connectors-model.ts`
+- Modify: `CONNECTORS_DIR/connectors-client.tsx` (top-of-file types + helpers, currently lines 52–89)
+
+- [ ] **Step 1: Create the model module**
+
+Create `CONNECTORS_DIR/connectors-model.ts`:
+
+```ts
+import type { AppRouterOutputs } from "@api/app";
+
+export type ConnectorCatalogRow =
+  AppRouterOutputs["org"]["workspace"]["connectors"]["list"][number];
+export type ConnectorProvider = ConnectorCatalogRow["provider"];
+export type ConnectorConnection = NonNullable<ConnectorCatalogRow["connection"]>;
+export type ConnectorTool = ConnectorConnection["tools"][number];
+
+export function displayProviderName(provider: string | undefined) {
+  if (!provider) {
+    return "Connector";
+  }
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+export function connectionStatus(connection: ConnectorConnection): {
+  dotClass: string;
+  label: string;
+} {
+  if (connection.status === "error") {
+    return { dotClass: "bg-destructive", label: "Needs reconnect" };
+  }
+  if (connection.lastToolRefreshErrorAt) {
+    return { dotClass: "bg-amber-500", label: "Tools stale" };
+  }
+  return { dotClass: "bg-emerald-500", label: "Connected" };
+}
+```
+
+- [ ] **Step 2: Remove the now-duplicated definitions from the client**
+
+In `CONNECTORS_DIR/connectors-client.tsx`:
+
+1. Delete the `import type { AppRouterOutputs } from "@api/app";` line (line 3) — the type now lives in the model.
+2. Delete the local type aliases and helpers (current lines 52–54 and 72–89):
+
+```ts
+type ConnectorCatalogRow =
+  AppRouterOutputs["org"]["workspace"]["connectors"]["list"][number];
+type ConnectorProvider = ConnectorCatalogRow["provider"];
+```
+
+and
+
+```ts
+function displayProviderName(provider: string | undefined) {
+  if (!provider) {
+    return "Connector";
+  }
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+function connectionStatus(
+  connection: NonNullable<ConnectorCatalogRow["connection"]>
+): { dotClass: string; label: string } {
+  if (connection.status === "error") {
+    return { dotClass: "bg-destructive", label: "Needs reconnect" };
+  }
+  if (connection.lastToolRefreshErrorAt) {
+    return { dotClass: "bg-amber-500", label: "Tools stale" };
+  }
+  return { dotClass: "bg-emerald-500", label: "Connected" };
+}
+```
+
+Keep `type StatusFilter`, `CONNECTABLE_PROVIDER`, `ADMIN_REQUIRED_MESSAGE`, `REFRESH_TOOLS_TOAST_ID`, `isConnectableProvider`, `filterMatches`, `isMutationDisabled`, `isConnectDisabled` in the client.
+
+3. Add an import near the other local imports (e.g. just above `import { ConnectorIcon } from "./connector-icons";`):
+
+```ts
+import {
+  type ConnectorCatalogRow,
+  type ConnectorProvider,
+  connectionStatus,
+  displayProviderName,
+} from "./connectors-model";
+```
+
+- [ ] **Step 3: Run the existing suite to verify no behavior change**
+
+Run (from `apps/app`): `pnpm test connectors-page`
+Expected: PASS — all existing connectors-page tests still green.
+
+- [ ] **Step 4: Typecheck**
+
+Run (from `apps/app`): `pnpm typecheck`
+Expected: PASS (no type errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -- "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connectors-model.ts" "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connectors-client.tsx"
+git commit -m "refactor(connectors): extract shared model helpers into connectors-model
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `connector-detail-content.tsx` (read-only sheet body)
+
+**Files:**
+- Create: `CONNECTORS_DIR/connector-detail-content.tsx`
+- Test: `CONNECTORS_DIR/connector-detail-content.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CONNECTORS_DIR/connector-detail-content.test.tsx` (renders the real component with real UI primitives, mirroring `signal-detail-content.test.tsx`; asserts only on date-independent text):
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectorDetailContent } from "./connector-detail-content";
+import type { ConnectorCatalogRow } from "./connectors-model";
+
+function connectedRow(
+  overrides: Partial<NonNullable<ConnectorCatalogRow["connection"]>> = {}
+): ConnectorCatalogRow {
+  return {
+    availableForAutomations: true,
+    builder: "Lightfast",
+    canManage: true,
+    catalogStatus: "available",
+    category: "Project management",
+    connectAvailability: { status: "available" },
+    connection: {
+      connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+      enabledForAutomations: true,
+      lastToolRefreshAt: new Date("2026-06-01T00:00:00.000Z"),
+      lastToolRefreshErrorAt: null,
+      lastToolRefreshErrorCode: null,
+      providerActorName: "Lightfast App",
+      providerWorkspaceName: "Acme Linear",
+      status: "active",
+      tools: [
+        {
+          availableForAutomations: true,
+          description: "Create a Linear issue",
+          name: "create_issue",
+        },
+        {
+          availableForAutomations: false,
+          description: "Search Linear issues",
+          name: "search_issues",
+        },
+      ],
+      ...overrides,
+    },
+    description: "Find, create, and manage issues, projects in Linear.",
+    displayName: "Linear",
+    provider: "linear",
+  } as ConnectorCatalogRow;
+}
+
+describe("ConnectorDetailContent", () => {
+  it("renders identity, automations, and the tools list for a connected row", () => {
+    render(
+      <ConnectorDetailContent onCopyLink={vi.fn()} row={connectedRow()} />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Linear" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Acme Linear")).toBeInTheDocument();
+    expect(screen.getByText("Lightfast App")).toBeInTheDocument();
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    // tools heading + count + rows
+    expect(screen.getByText("Tools")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("create_issue")).toBeInTheDocument();
+    expect(screen.getByText("search_issues")).toBeInTheDocument();
+  });
+
+  it("hides workspace/account rows when those fields are null", () => {
+    render(
+      <ConnectorDetailContent
+        onCopyLink={vi.fn()}
+        row={connectedRow({
+          providerActorName: null,
+          providerWorkspaceName: null,
+        })}
+      />
+    );
+
+    expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Account")).not.toBeInTheDocument();
+  });
+
+  it("renders the Disabled automations pill", () => {
+    render(
+      <ConnectorDetailContent
+        onCopyLink={vi.fn()}
+        row={connectedRow({ enabledForAutomations: false })}
+      />
+    );
+
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it("renders the tools-stale error code", () => {
+    render(
+      <ConnectorDetailContent
+        onCopyLink={vi.fn()}
+        row={connectedRow({
+          lastToolRefreshErrorAt: new Date("2026-06-01T00:05:00.000Z"),
+          lastToolRefreshErrorCode: "linear_unavailable",
+        })}
+      />
+    );
+
+    expect(screen.getAllByText("Tools stale").length).toBeGreaterThan(0);
+    expect(screen.getByText("linear_unavailable")).toBeInTheDocument();
+  });
+
+  it("invokes onCopyLink when the copy-link button is clicked", () => {
+    const onCopyLink = vi.fn();
+    render(
+      <ConnectorDetailContent onCopyLink={onCopyLink} row={connectedRow()} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
+    expect(onCopyLink).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `apps/app`): `pnpm test connector-detail-content`
+Expected: FAIL — cannot resolve `./connector-detail-content`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `CONNECTORS_DIR/connector-detail-content.tsx`:
+
+```tsx
+"use client";
+
+import { Badge } from "@repo/ui/components/ui/badge";
+import { Button } from "@repo/ui/components/ui/button";
+import { cn } from "@repo/ui/lib/utils";
+import { formatRelativeTimeToNow } from "@vendor/lib/time";
+import {
+  Activity,
+  Building2,
+  CalendarDays,
+  Link2,
+  RefreshCcw,
+  User,
+  Workflow,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { ConnectorIcon } from "./connector-icons";
+import { type ConnectorCatalogRow, connectionStatus } from "./connectors-model";
+
+function PropertyRow({
+  children,
+  icon,
+  label,
+}: {
+  children: ReactNode;
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 py-2.5">
+      <span className="flex w-36 shrink-0 items-center gap-2.5 text-muted-foreground text-sm">
+        {icon}
+        {label}
+      </span>
+      <div className="min-w-0 flex-1 text-foreground text-sm">{children}</div>
+    </div>
+  );
+}
+
+export function ConnectorDetailContent({
+  closeSlot,
+  onCopyLink,
+  row,
+}: {
+  closeSlot?: ReactNode;
+  onCopyLink: () => void;
+  row: ConnectorCatalogRow;
+}) {
+  const connection = row.connection;
+  if (!connection) {
+    return null;
+  }
+
+  const status = connectionStatus(connection);
+  const iconClass = "size-4 shrink-0";
+  const connectedAt = new Date(connection.connectedAt);
+  const lastRefreshAt = connection.lastToolRefreshAt
+    ? new Date(connection.lastToolRefreshAt)
+    : null;
+  const hasRefreshError = Boolean(connection.lastToolRefreshErrorAt);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2.5 px-5 pt-5">
+        <ConnectorIcon
+          className="size-7 rounded-[7px]"
+          provider={row.provider}
+        />
+        <span className="font-mono text-muted-foreground text-xs">
+          {row.provider}
+        </span>
+        <span className="inline-flex items-center gap-1.5 text-foreground text-sm">
+          <span className={cn("size-1.5 rounded-full", status.dotClass)} />
+          {status.label}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            aria-label="Copy link"
+            className="size-7 rounded-full text-muted-foreground hover:text-foreground"
+            onClick={onCopyLink}
+            size="icon-sm"
+            type="button"
+            variant="ghost"
+          >
+            <Link2 aria-hidden="true" className="size-4" />
+          </Button>
+          {closeSlot}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+        <h2 className="pt-4 pb-1 font-semibold text-2xl text-foreground leading-tight tracking-tight">
+          {row.displayName}
+        </h2>
+        <p className="pb-5 text-muted-foreground text-sm">{row.description}</p>
+
+        <div className="flex flex-col">
+          <PropertyRow icon={<Activity className={iconClass} />} label="Status">
+            <span className="inline-flex items-center gap-1.5">
+              <span className={cn("size-1.5 rounded-full", status.dotClass)} />
+              {status.label}
+            </span>
+          </PropertyRow>
+          {connection.providerWorkspaceName ? (
+            <PropertyRow
+              icon={<Building2 className={iconClass} />}
+              label="Workspace"
+            >
+              {connection.providerWorkspaceName}
+            </PropertyRow>
+          ) : null}
+          {connection.providerActorName ? (
+            <PropertyRow icon={<User className={iconClass} />} label="Account">
+              {connection.providerActorName}
+            </PropertyRow>
+          ) : null}
+          <PropertyRow
+            icon={<CalendarDays className={iconClass} />}
+            label="Connected"
+          >
+            <span title={connectedAt.toISOString()}>
+              {formatRelativeTimeToNow(connectedAt, { addSuffix: true })}
+            </span>
+          </PropertyRow>
+          <PropertyRow
+            icon={<Workflow className={iconClass} />}
+            label="Automations"
+          >
+            <Badge className="text-muted-foreground" variant="outline">
+              {connection.enabledForAutomations ? "Enabled" : "Disabled"}
+            </Badge>
+          </PropertyRow>
+          {lastRefreshAt ? (
+            <PropertyRow
+              icon={<RefreshCcw className={iconClass} />}
+              label="Tools refreshed"
+            >
+              {hasRefreshError ? (
+                <span className="text-amber-600">
+                  {connection.lastToolRefreshErrorCode ?? "Refresh failed"}
+                </span>
+              ) : (
+                <span title={lastRefreshAt.toISOString()}>
+                  {formatRelativeTimeToNow(lastRefreshAt, { addSuffix: true })}
+                </span>
+              )}
+            </PropertyRow>
+          ) : null}
+        </div>
+
+        <div className="my-6 border-border/60 border-t" />
+
+        <div className="flex items-center gap-2">
+          <h3 className="font-medium text-foreground text-sm">Tools</h3>
+          <Badge className="px-1.5 text-muted-foreground" variant="secondary">
+            {connection.tools.length}
+          </Badge>
+        </div>
+        <div className="mt-2 flex flex-col">
+          {connection.tools.map((tool) => (
+            <div
+              className="flex items-start gap-3 border-border/60 border-t py-2.5 first:border-t-0"
+              key={tool.name}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="font-mono text-foreground text-sm">{tool.name}</p>
+                {tool.description ? (
+                  <p className="mt-0.5 text-muted-foreground text-xs leading-relaxed">
+                    {tool.description}
+                  </p>
+                ) : null}
+              </div>
+              {tool.availableForAutomations ? (
+                <span
+                  aria-label="Available for automations"
+                  className="mt-1.5 size-1.5 shrink-0 rounded-full bg-emerald-500"
+                  title="Available for automations"
+                />
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-border/60 border-t px-5 py-3.5 text-muted-foreground text-xs">
+        <span title={connectedAt.toISOString()}>
+          Connected {formatRelativeTimeToNow(connectedAt, { addSuffix: true })}
+        </span>
+        {lastRefreshAt && !hasRefreshError ? (
+          <>
+            <span aria-hidden="true"> · </span>
+            <span title={lastRefreshAt.toISOString()}>
+              tools refreshed{" "}
+              {formatRelativeTimeToNow(lastRefreshAt, { addSuffix: true })}
+            </span>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run (from `apps/app`): `pnpm test connector-detail-content`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -- "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-content.tsx" "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-content.test.tsx"
+git commit -m "feat(connectors): add read-only connector detail content
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `connector-detail-sheet.tsx` (Sheet shell + copy-link)
+
+**Files:**
+- Create: `CONNECTORS_DIR/connector-detail-sheet.tsx`
+- Test: `CONNECTORS_DIR/connector-detail-sheet.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CONNECTORS_DIR/connector-detail-sheet.test.tsx` (mirrors `signal-detail-sheet.test.tsx`: renders the real Radix `Sheet`, mocks only `sonner`, sets up `navigator.clipboard`):
+
+```tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectorDetailSheet } from "./connector-detail-sheet";
+import type { ConnectorCatalogRow } from "./connectors-model";
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("@repo/ui/components/ui/sonner", () => ({
+  toast: { error: toastMocks.error, success: toastMocks.success },
+}));
+
+function connectedRow(): ConnectorCatalogRow {
+  return {
+    availableForAutomations: true,
+    builder: "Lightfast",
+    canManage: true,
+    catalogStatus: "available",
+    category: "Project management",
+    connectAvailability: { status: "available" },
+    connection: {
+      connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+      enabledForAutomations: true,
+      lastToolRefreshAt: new Date("2026-06-01T00:00:00.000Z"),
+      lastToolRefreshErrorAt: null,
+      lastToolRefreshErrorCode: null,
+      providerActorName: "Lightfast App",
+      providerWorkspaceName: "Acme Linear",
+      status: "active",
+      tools: [
+        {
+          availableForAutomations: true,
+          description: "Create a Linear issue",
+          name: "create_issue",
+        },
+      ],
+    },
+    description: "Find, create, and manage issues, projects in Linear.",
+    displayName: "Linear",
+    provider: "linear",
+  } as ConnectorCatalogRow;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+describe("ConnectorDetailSheet", () => {
+  it("renders the connector detail when a connected row is provided", () => {
+    render(<ConnectorDetailSheet onOpenChange={vi.fn()} row={connectedRow()} />);
+
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-describedby");
+    expect(
+      screen.getAllByRole("heading", { name: "Linear" }).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("create_issue")).toBeInTheDocument();
+  });
+
+  it("does not render the dialog when no row is provided", () => {
+    render(<ConnectorDetailSheet onOpenChange={vi.fn()} row={undefined} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast when copying the link fails", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    render(<ConnectorDetailSheet onOpenChange={vi.fn()} row={connectedRow()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
+
+    await waitFor(() =>
+      expect(toastMocks.error).toHaveBeenCalledWith("Unable to copy link")
+    );
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `apps/app`): `pnpm test connector-detail-sheet`
+Expected: FAIL — cannot resolve `./connector-detail-sheet`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `CONNECTORS_DIR/connector-detail-sheet.tsx`:
+
+```tsx
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@repo/ui/components/ui/sheet";
+import { toast } from "@repo/ui/components/ui/sonner";
+import { X } from "lucide-react";
+import { ConnectorDetailContent } from "./connector-detail-content";
+import type { ConnectorCatalogRow } from "./connectors-model";
+
+export function ConnectorDetailSheet({
+  onOpenChange,
+  row,
+}: {
+  onOpenChange: (open: boolean) => void;
+  row?: ConnectorCatalogRow;
+}) {
+  const open = Boolean(row?.connection);
+
+  function handleCopyLink() {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const clipboard = navigator.clipboard;
+    if (!clipboard) {
+      toast.error("Unable to copy link");
+      return;
+    }
+    void clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        toast.success("Link copied", {
+          description: "Anyone with access can open this connector.",
+        });
+      })
+      .catch(() => {
+        toast.error("Unable to copy link");
+      });
+  }
+
+  return (
+    <Sheet onOpenChange={onOpenChange} open={open}>
+      <SheetContent
+        className="inset-y-3 right-3 left-auto h-auto w-full max-w-[calc(100%-1.5rem)] gap-0 overflow-hidden rounded-2xl border p-0 sm:max-w-md"
+        showCloseButton={!row}
+        side="right"
+      >
+        <SheetHeader className="sr-only">
+          <SheetTitle>{row ? row.displayName : "Connector details"}</SheetTitle>
+          <SheetDescription>
+            {row?.description ?? "Connector identity, status, and tools."}
+          </SheetDescription>
+        </SheetHeader>
+
+        {row?.connection ? (
+          <ConnectorDetailContent
+            closeSlot={
+              <SheetClose asChild>
+                <Button
+                  aria-label="Close"
+                  className="size-7 rounded-full text-muted-foreground hover:text-foreground"
+                  size="icon-sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  <X aria-hidden="true" className="size-4" />
+                </Button>
+              </SheetClose>
+            }
+            onCopyLink={handleCopyLink}
+            row={row}
+          />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run (from `apps/app`): `pnpm test connector-detail-sheet`
+Expected: PASS (all 3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -- "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-sheet.tsx" "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-sheet.test.tsx"
+git commit -m "feat(connectors): add connector detail sheet shell
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire the sheet into `connectors-client.tsx` (nuqs + View details + drop success banner)
+
+This task changes client behavior, so the integration test is updated first (TDD). The real sheet is stubbed in the integration test; its rendering is already covered by Tasks 2–3.
+
+**Files:**
+- Modify: `PAGE_TEST`
+- Modify: `CONNECTORS_DIR/connectors-client.tsx`
+
+- [ ] **Step 1: Update the integration test (failing) — add mocks + new expectations**
+
+In `PAGE_TEST`:
+
+**1a.** Add nuqs state + setter mocks near the other mock declarations (after `const useSuspenseQueryMock = vi.fn();`, before the `vi.mock` calls):
+
+```tsx
+let connectorState: string | null = null;
+let errorState: string | null = null;
+const setConnectorMock = vi.fn((value: string | null) => {
+  connectorState = value;
+});
+const setErrorMock = vi.fn((value: string | null) => {
+  errorState = value;
+});
+```
+
+**1b.** Add the `nuqs` mock and the sheet stub alongside the existing `vi.mock(...)` blocks:
+
+```tsx
+vi.mock("nuqs", () => ({
+  useQueryState: (key: string) => {
+    if (key === "error") {
+      return [errorState, setErrorMock];
+    }
+    return [connectorState, setConnectorMock];
+  },
+}));
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connector-detail-sheet",
+  () => ({
+    ConnectorDetailSheet: ({
+      onOpenChange,
+      row,
+    }: {
+      onOpenChange: (open: boolean) => void;
+      row?: { provider: string };
+    }) =>
+      row ? (
+        <div data-provider={row.provider} data-testid="connector-detail-sheet">
+          <button onClick={() => onOpenChange(false)} type="button">
+            close-sheet
+          </button>
+        </div>
+      ) : null,
+  })
+);
+```
+
+**1c.** In `beforeEach`, reset the new state/mocks (add inside the existing `beforeEach` body):
+
+```tsx
+connectorState = null;
+errorState = null;
+setConnectorMock.mockClear();
+setErrorMock.mockClear();
+```
+
+**1d.** Replace the two callback-clearing tests (`renders callback errors inline and clears the callback URL` and `clears only callback params and preserves unrelated query params`) with these two:
+
+```tsx
+it("renders callback errors inline and clears the callback params", async () => {
+  connectorState = "linear";
+  errorState = "access_denied";
+  useSuspenseQueryMock.mockReturnValue({ data: [connectedLinear()] });
+
+  render(
+    <ConnectorsClient callbackConnector="linear" callbackError="access_denied" />
+  );
+
+  expect(screen.getByText(/linear connection failed/i)).toBeVisible();
+  expect(screen.getByText(/access_denied/i)).toBeVisible();
+  await waitFor(() => {
+    expect(setConnectorMock).toHaveBeenCalledWith(null);
+    expect(setErrorMock).toHaveBeenCalledWith(null);
+  });
+});
+
+it("does not open the detail sheet when a callback error is present", () => {
+  connectorState = "linear";
+  errorState = "access_denied";
+  useSuspenseQueryMock.mockReturnValue({ data: [connectedLinear()] });
+
+  render(
+    <ConnectorsClient callbackConnector="linear" callbackError="access_denied" />
+  );
+
+  expect(screen.queryByTestId("connector-detail-sheet")).toBeNull();
+});
+```
+
+**1e.** Add four new sheet-wiring tests inside the `describe("connectors page", ...)` block:
+
+```tsx
+it("opens the detail sheet from the View details action", () => {
+  renderClient([connectedLinear()]);
+
+  fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+  expect(setConnectorMock).toHaveBeenCalledWith("linear");
+});
+
+it("opens the detail sheet for the connector in the URL param", () => {
+  connectorState = "linear";
+  renderClient([connectedLinear()]);
+
+  const sheet = screen.getByTestId("connector-detail-sheet");
+  expect(sheet).toBeVisible();
+  expect(sheet).toHaveAttribute("data-provider", "linear");
+});
+
+it("does not open the detail sheet for an unconnected provider", () => {
+  connectorState = "linear";
+  renderClient([row()]);
+
+  expect(screen.queryByTestId("connector-detail-sheet")).toBeNull();
+});
+
+it("clears the connector param when the sheet is closed", () => {
+  connectorState = "linear";
+  renderClient([connectedLinear()]);
+
+  fireEvent.click(screen.getByRole("button", { name: "close-sheet" }));
+  expect(setConnectorMock).toHaveBeenCalledWith(null);
+});
+```
+
+> Note: the `next/navigation` mock and `replaceMock` stay declared (now unused) — harmless. The client no longer calls `router.replace`, so no assertions reference `replaceMock` anymore.
+
+- [ ] **Step 2: Run the integration test to verify the new expectations fail**
+
+Run (from `apps/app`): `pnpm test connectors-page`
+Expected: FAIL — no "View details" button; sheet stub never renders; `setConnectorMock`/`setErrorMock` not called (client still uses `router.replace`).
+
+- [ ] **Step 3: Update the client — imports**
+
+In `CONNECTORS_DIR/connectors-client.tsx`:
+
+1. Remove `import type { Route } from "next";`.
+2. Remove `import { usePathname, useRouter, useSearchParams } from "next/navigation";`.
+3. Remove `useEffect` from the `react` import is **not** needed — `useEffect` is still used (see Step 5); keep `useEffect`, `useMemo`, `useState`.
+4. Add `import { useQueryState } from "nuqs";` (with the other third-party imports).
+5. Add `import { ConnectorDetailSheet } from "./connector-detail-sheet";` (near `import { ConnectorIcon } from "./connector-icons";`).
+6. Add `PanelRight` to the existing `lucide-react` import:
+
+```ts
+import {
+  ArrowUpRight,
+  Loader2,
+  MoreHorizontal,
+  PanelRight,
+  RefreshCcw,
+  Search,
+} from "lucide-react";
+```
+
+- [ ] **Step 4: Update the client — replace router/searchParams state with nuqs**
+
+In `ConnectorsClient`, delete these three lines:
+
+```ts
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+```
+
+and add (near the other hook calls, after `const queryClient = useQueryClient();`):
+
+```ts
+  const [selectedProvider, setSelectedProvider] = useQueryState("connector");
+  const [, setErrorParam] = useQueryState("error");
+```
+
+- [ ] **Step 5: Update the client — error-only cleanup effect**
+
+Replace the existing cleanup effect:
+
+```ts
+  useEffect(() => {
+    if (callbackConnector || callbackError) {
+      const nextParams = new URLSearchParams(searchParams.toString());
+      nextParams.delete("connector");
+      nextParams.delete("error");
+      const queryString = nextParams.toString();
+      router.replace(
+        (queryString ? `${pathname}?${queryString}` : pathname) as Route
+      );
+    }
+  }, [callbackConnector, callbackError, pathname, router, searchParams]);
+```
+
+with:
+
+```ts
+  useEffect(() => {
+    if (!callbackState.error) {
+      return;
+    }
+    // A failed connect has no connection to show: clear both params so the
+    // sheet stays closed and the error banner does not re-trigger on refresh.
+    void setSelectedProvider(null);
+    void setErrorParam(null);
+  }, [callbackState.error, setErrorParam, setSelectedProvider]);
+```
+
+- [ ] **Step 6: Update the client — resolve the sheet row + view-details handler**
+
+Add, just after the `disconnect` function (before `const mutationPending = ...`):
+
+```ts
+  function viewDetails(row: ConnectorCatalogRow) {
+    void setSelectedProvider(row.provider);
+  }
+
+  // Never open the sheet on a failed callback (handled by the cleanup effect).
+  const sheetProvider = callbackState.error ? null : selectedProvider;
+  const sheetRow = sheetProvider
+    ? connectors.find((row) => row.provider === sheetProvider && row.connection)
+    : undefined;
+```
+
+- [ ] **Step 7: Update the client — drop the success banner, pass `onViewDetails`, render the sheet**
+
+**7a.** Delete the green success-banner block:
+
+```tsx
+      {callbackState.connector && !callbackState.error && (
+        <div className="mt-6 rounded-[9px] border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-emerald-600 text-sm">
+          {displayProviderName(callbackState.connector)} connected.
+        </div>
+      )}
+```
+
+Keep the red error banner block immediately above it unchanged.
+
+**7b.** Pass `onViewDetails` to the connected card — in the `.map` where `<ConnectedConnectorCard ... />` is rendered, add the prop:
+
+```tsx
+              <ConnectedConnectorCard
+                key={row.provider}
+                onConnect={connect}
+                onDisconnect={disconnect}
+                onRefreshTools={refreshTools}
+                onSetAutomationEnabled={setAutomationEnabled}
+                onViewDetails={viewDetails}
+                pending={mutationPending}
+                refreshing={
+                  refreshToolsMutation.isPending &&
+                  refreshToolsMutation.variables?.provider === row.provider
+                }
+                row={row}
+              />
+```
+
+**7c.** Render the sheet as the last child of the outer `<div className="mx-auto w-full max-w-3xl px-6 py-10">` (just before its closing `</div>`):
+
+```tsx
+      <ConnectorDetailSheet
+        onOpenChange={(open) => {
+          if (!open) {
+            void setSelectedProvider(null);
+          }
+        }}
+        row={sheetRow}
+      />
+```
+
+- [ ] **Step 8: Update the client — add the "View details" dropdown item**
+
+In `ConnectedConnectorCard`'s props type, add:
+
+```ts
+  onViewDetails: (row: ConnectorCatalogRow) => void;
+```
+
+and destructure `onViewDetails` in the parameter list.
+
+Then, as the first items inside `<DropdownMenuContent align="end">` (before the "Refresh tools" item), add:
+
+```tsx
+              <DropdownMenuItem onSelect={() => onViewDetails(row)}>
+                <PanelRight className="size-3.5" />
+                View details
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+```
+
+- [ ] **Step 9: Run the integration test to verify it passes**
+
+Run (from `apps/app`): `pnpm test connectors-page`
+Expected: PASS — all existing + new tests green.
+
+- [ ] **Step 10: Run the full connectors test set + typecheck**
+
+Run (from `apps/app`):
+- `pnpm test connector` (runs connectors-page + connector-detail-content + connector-detail-sheet)
+- `pnpm typecheck`
+
+Expected: PASS for both.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add -- "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/connectors/_components/connectors-client.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/connectors-page.test.tsx"
+git commit -m "feat(connectors): open detail sheet post-connect and from View details
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint/format the whole repo**
+
+Run (from repo root): `pnpm check`
+Expected: PASS (Biome reports no errors on the changed files). If Biome reports auto-fixable issues on the new files, apply them and re-run.
+
+- [ ] **Step 2: Typecheck the app**
+
+Run (from repo root): `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full app test suite once**
+
+Run (from `apps/app`): `pnpm test`
+Expected: PASS (no regressions in the broader suite).
+
+- [ ] **Step 4: Manual smoke (optional, if a dev server is running)**
+
+With `pnpm dev` running and a connected Linear connector:
+- Open the connectors page, click `'…'` → "View details" → the sheet opens, URL gains `?connector=linear`.
+- Close the sheet → `?connector` is removed.
+- Visit `…/connectors?connector=linear` directly → the sheet opens on load.
+- Simulate a failed callback (`…/connectors?connector=linear&error=access_denied`) → the red banner shows, the sheet does **not** open, and the params are cleared.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Right-side sheet modeled on the signals sheet → Tasks 2–3 (same container classes, `PropertyRow`).
+- Reuse `?connector=` via nuqs, shareable/refresh-safe → Task 4 Steps 4–7 + integration tests.
+- Post-connect auto-open, replacing the green banner → Task 4 Steps 6–7a + the URL-param test.
+- Error path keeps banner, clears params, no sheet → Task 4 Step 5 + the two callback tests.
+- "View details" in the `'…'` menu → Task 4 Step 8 + the View-details test.
+- Render from the cached `list` row (no tRPC/DB) → Tasks 2–3 take a `row` prop; no query added.
+- Connected-only → `sheetRow` requires `row.connection`; Sheet `open` gated on `row?.connection`; unconnected-provider test.
+- Read-only (no actions) → content/sheet expose no mutations; actions remain in the card.
+- "Who" = Linear identity only → Workspace/Account rows use `providerWorkspaceName`/`providerActorName`; no Clerk lookup.
+- Degraded status / null-field hiding → `connectionStatus` reuse + null guards + the tools-stale and null-field tests.
+- Extract `connectors-model.ts` → Task 1.
+
+**Placeholder scan:** none — every code/step is concrete.
+
+**Type consistency:** `ConnectorCatalogRow`/`ConnectorConnection`/`ConnectorProvider` defined once in `connectors-model.ts` (Task 1) and imported by the client (Task 1 Step 2), content (Task 2), and sheet (Task 3). `connectionStatus(connection: ConnectorConnection)` is called with a non-null connection in both the client card and the content component (each guards `if (!connection) return null;`). `ConnectorDetailSheet` prop is `row?: ConnectorCatalogRow`; `ConnectorDetailContent` prop is `row: ConnectorCatalogRow` (non-optional) — the sheet only renders content inside `row?.connection ?` so the non-optional contract holds. `viewDetails`/`onViewDetails` names match between `ConnectorsClient` and `ConnectedConnectorCard`.

--- a/docs/superpowers/plans/2026-06-01-emulator-architecture-redesign.md
+++ b/docs/superpowers/plans/2026-06-01-emulator-architecture-redesign.md
@@ -1,0 +1,1389 @@
+# Emulator Architecture Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the triplicated env/CLI/process plumbing into `@repo/emulator-kit` and split each emulator into concern modules (oauth / viewer / mcp / users / auth / failures), without changing any HTTP behavior.
+
+**Architecture:** Two tiers. The kit owns a manifest contract + env schema + env:sh CLI + start harness + shell-format + the existing listen lifecycle. Each emulator declares an `EmulatorManifest` (name/port/originEnvVar/env-projection/start) and composes its `ServicePlugin` from register-fragments. github keeps its bespoke composition (vendor plugin + 953-line compatible-routes + webhook), only relocated.
+
+**Tech Stack:** TypeScript (ESM, TS source consumed directly across `@repo/*`), `@emulators/core` (bundled Hono + Store + auth toolkit), `@t3-oss/env-core` + `zod`, `tsx` (dev/start), `vitest`, biome/ultracite (`pnpm check`).
+
+**Design spec:** `docs/superpowers/specs/2026-06-01-emulator-architecture-redesign-design.md`
+
+**Guardrails:** the existing `server.test.ts` suites (x 9, linear 10, github server 30 + oauth 5) are behavioral regression guards — they must pass after every emulator task. Commit with explicit pathspecs (a concurrent agent may pre-stage files); do not push.
+
+---
+
+## Task 1: Kit — manifest, format, env, cli + lifecycle split
+
+**Files:**
+- Create: `emulators/kit/src/manifest.ts`
+- Create: `emulators/kit/src/format.ts`
+- Create: `emulators/kit/src/env.ts`
+- Create: `emulators/kit/src/cli.ts`
+- Create: `emulators/kit/src/lifecycle.ts` (move current `index.ts` body here)
+- Modify: `emulators/kit/src/index.ts` (becomes re-exports)
+- Modify: `emulators/kit/package.json` (add `@t3-oss/env-core`, `zod`)
+
+- [ ] **Step 1: Add kit deps**
+
+In `emulators/kit/package.json`, add to `dependencies` (alphabetical, before `@emulators/core` stays first):
+
+```json
+  "dependencies": {
+    "@emulators/core": "catalog:",
+    "@t3-oss/env-core": "catalog:",
+    "zod": "catalog:"
+  },
+```
+
+Run: `pnpm install`
+
+- [ ] **Step 2: Move the current lifecycle into `lifecycle.ts`**
+
+`git mv emulators/kit/src/index.ts emulators/kit/src/lifecycle.ts`
+
+(Content is unchanged — it still exports `startEmulator`, `formatListenUrl`, `waitForListening`, `closeServer`, and the `StartedEmulator`/`StartEmulatorOptions`/`StartEmulatorContext`/`EmulatorServer` types.)
+
+- [ ] **Step 3: Create `manifest.ts`**
+
+```ts
+export interface EmulatorStartInput {
+  appOrigin?: string;
+  host?: string;
+  port?: number;
+  publicOrigin?: string;
+}
+
+export interface RunnableEmulator {
+  close(): Promise<void>;
+  listenUrl: string;
+  publicOrigin: string;
+}
+
+export interface EmulatorManifest {
+  env(appOrigin: string, emulatorOrigin: string): Record<string, string>;
+  name: string;
+  originEnvVar: string;
+  port: number;
+  start(input: EmulatorStartInput): Promise<RunnableEmulator>;
+}
+```
+
+- [ ] **Step 4: Create `format.ts`** (the block that was copy-pasted into all three `fixtures.ts`)
+
+```ts
+const ENV_ASSIGNMENT_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function formatEnvString(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([key, value]) => {
+      if (!ENV_ASSIGNMENT_NAME_RE.test(key)) {
+        throw new Error(`Invalid environment variable name: ${key}`);
+      }
+      if (value.includes("\0")) {
+        throw new Error(
+          `Environment variable ${key} contains a NUL byte and cannot be passed to env -S`
+        );
+      }
+      return `${key}=${shellQuote(value)}`;
+    })
+    .join("\n");
+}
+```
+
+- [ ] **Step 5: Create `env.ts`** (the single copy of `create*EmulatorRuntimeEnv`, computed origin key)
+
+```ts
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+import type { EmulatorManifest } from "./manifest";
+
+export interface ResolvedEmulatorEnv {
+  appOrigin: string;
+  emulatorOrigin?: string;
+  host: string;
+  port: number;
+}
+
+export function createEmulatorEnv(
+  manifest: EmulatorManifest,
+  runtimeEnv: NodeJS.ProcessEnv = process.env
+): ResolvedEmulatorEnv {
+  const env = createEnv({
+    emptyStringAsUndefined: true,
+    runtimeEnv: {
+      HOST: runtimeEnv.HOST,
+      LIGHTFAST_APP_ORIGIN: runtimeEnv.LIGHTFAST_APP_ORIGIN,
+      PORT: runtimeEnv.PORT,
+      PORTLESS_URL: runtimeEnv.PORTLESS_URL,
+      [manifest.originEnvVar]: runtimeEnv[manifest.originEnvVar],
+    },
+    server: {
+      HOST: z.string().min(1).default("127.0.0.1"),
+      LIGHTFAST_APP_ORIGIN: z
+        .string()
+        .url()
+        .default("https://lightfast.localhost"),
+      PORT: z.coerce.number().int().min(1).max(65_535).default(manifest.port),
+      PORTLESS_URL: z.string().url().optional(),
+      [manifest.originEnvVar]: z.string().url().optional(),
+    },
+    skipValidation:
+      !!runtimeEnv.SKIP_ENV_VALIDATION ||
+      runtimeEnv.npm_lifecycle_event === "lint",
+  });
+
+  const originValue = (env as Record<string, string | undefined>)[
+    manifest.originEnvVar
+  ];
+
+  return {
+    appOrigin: env.LIGHTFAST_APP_ORIGIN,
+    emulatorOrigin: originValue ?? env.PORTLESS_URL,
+    host: env.HOST,
+    port: env.PORT,
+  };
+}
+```
+
+- [ ] **Step 6: Create `cli.ts`** (single copy of `env-sh` arg parsing + `start` process harness)
+
+```ts
+import { createEmulatorEnv } from "./env";
+import { formatEnvString } from "./format";
+import type { EmulatorManifest } from "./manifest";
+
+const SENSITIVE_ENV_KEY_PATTERN = /(?:KEY|SECRET|TOKEN|PRIVATE)/i;
+
+function readOption(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return;
+  }
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function redactEnvValueForLog(key: string, value: string): string {
+  return SENSITIVE_ENV_KEY_PATTERN.test(key) ? "<redacted>" : value;
+}
+
+export function runEnvSh(manifest: EmulatorManifest): void {
+  const appOrigin = readOption("--app-origin");
+  const emulatorOrigin = readOption("--emulator-origin");
+
+  const env = createEmulatorEnv(manifest, {
+    ...process.env,
+    ...(appOrigin ? { LIGHTFAST_APP_ORIGIN: appOrigin } : {}),
+    ...(emulatorOrigin ? { [manifest.originEnvVar]: emulatorOrigin } : {}),
+  });
+
+  const origin = env.emulatorOrigin ?? `http://127.0.0.1:${env.port}`;
+  console.log(formatEnvString(manifest.env(env.appOrigin, origin)));
+}
+
+export async function runStart(manifest: EmulatorManifest): Promise<void> {
+  const env = createEmulatorEnv(manifest);
+  const emulator = await manifest.start({
+    appOrigin: env.appOrigin,
+    host: env.host,
+    port: env.port,
+    publicOrigin: env.emulatorOrigin,
+  });
+
+  const label = `[${manifest.name}-emulator]`;
+  console.log(`${label} listening on ${emulator.listenUrl}`);
+  console.log(`${label} public origin ${emulator.publicOrigin}`);
+  for (const [key, value] of Object.entries(
+    manifest.env(env.appOrigin, emulator.publicOrigin)
+  )) {
+    console.log(`${key}=${JSON.stringify(redactEnvValueForLog(key, value))}`);
+  }
+
+  const close = async (signal: NodeJS.Signals) => {
+    console.log(`${label} received ${signal}, shutting down`);
+    await emulator.close();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", (signal) => {
+    void close(signal);
+  });
+  process.on("SIGTERM", (signal) => {
+    void close(signal);
+  });
+}
+```
+
+> Behavior note: `runEnvSh`'s `?? \`http://127.0.0.1:${env.port}\`` reproduces the old per-fixture default origin (github 4567 / linear 4568 / x 4569), since `formatListenUrl("127.0.0.1", port)` equals that string.
+
+- [ ] **Step 7: Rewrite `index.ts` as re-exports**
+
+```ts
+export * from "./cli";
+export * from "./env";
+export * from "./format";
+export * from "./lifecycle";
+export * from "./manifest";
+```
+
+- [ ] **Step 8: Typecheck the kit**
+
+Run: `pnpm --filter @repo/emulator-kit typecheck`
+Expected: PASS. (If `createEnv`'s computed-key inference complains, the `as Record<string, string | undefined>` cast in `env.ts` resolves it.)
+
+- [ ] **Step 9: Run existing kit tests**
+
+Run: `pnpm --filter @repo/emulator-kit test`
+Expected: existing `start-emulator.test.ts` (3 tests) PASS — `startEmulator` re-exported via `lifecycle.ts`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add emulators/kit/src/manifest.ts emulators/kit/src/format.ts emulators/kit/src/env.ts emulators/kit/src/cli.ts emulators/kit/src/lifecycle.ts emulators/kit/src/index.ts emulators/kit/package.json pnpm-lock.yaml
+git commit -m "feat(emulator-kit): own env/cli/format + manifest contract; split lifecycle"
+```
+
+---
+
+## Task 2: Kit tests — env + cli (absorb deleted per-emulator coverage)
+
+**Files:**
+- Create: `emulators/kit/src/__tests__/env.test.ts`
+- Create: `emulators/kit/src/__tests__/cli.test.ts`
+
+- [ ] **Step 1: Write `env.test.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { createEmulatorEnv } from "../env";
+import type { EmulatorManifest } from "../manifest";
+
+const manifest: EmulatorManifest = {
+  name: "test",
+  port: 4599,
+  originEnvVar: "TEST_EMULATOR_ORIGIN",
+  env: () => ({}),
+  start: () =>
+    Promise.resolve({
+      close: () => Promise.resolve(),
+      listenUrl: "http://127.0.0.1:4599",
+      publicOrigin: "http://127.0.0.1:4599",
+    }),
+};
+
+describe("createEmulatorEnv", () => {
+  it("defaults port to the manifest port and host to loopback", () => {
+    const env = createEmulatorEnv(manifest, { SKIP_ENV_VALIDATION: "1" });
+    expect(env.port).toBe(4599);
+    expect(env.host).toBe("127.0.0.1");
+    expect(env.appOrigin).toBe("https://lightfast.localhost");
+    expect(env.emulatorOrigin).toBeUndefined();
+  });
+
+  it("reads the manifest origin var and prefers it over PORTLESS_URL", () => {
+    const env = createEmulatorEnv(manifest, {
+      SKIP_ENV_VALIDATION: "1",
+      TEST_EMULATOR_ORIGIN: "https://test.lightfast.localhost",
+      PORTLESS_URL: "https://fallback.lightfast.localhost",
+    });
+    expect(env.emulatorOrigin).toBe("https://test.lightfast.localhost");
+  });
+
+  it("falls back to PORTLESS_URL when the origin var is absent", () => {
+    const env = createEmulatorEnv(manifest, {
+      SKIP_ENV_VALIDATION: "1",
+      PORTLESS_URL: "https://fallback.lightfast.localhost",
+    });
+    expect(env.emulatorOrigin).toBe("https://fallback.lightfast.localhost");
+  });
+
+  it("coerces PORT and respects an explicit override", () => {
+    const env = createEmulatorEnv(manifest, {
+      SKIP_ENV_VALIDATION: "1",
+      PORT: "5005",
+    });
+    expect(env.port).toBe(5005);
+  });
+});
+```
+
+- [ ] **Step 2: Write `cli.test.ts`** (arg parsing + emitted env string via a real manifest)
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runEnvSh } from "../cli";
+import type { EmulatorManifest } from "../manifest";
+
+const manifest: EmulatorManifest = {
+  name: "test",
+  port: 4599,
+  originEnvVar: "TEST_EMULATOR_ORIGIN",
+  env: (_appOrigin, emulatorOrigin) => ({
+    TEST_API_ORIGIN: emulatorOrigin,
+    TEST_CLIENT_ID: "test_client",
+  }),
+  start: () =>
+    Promise.resolve({
+      close: () => Promise.resolve(),
+      listenUrl: "http://127.0.0.1:4599",
+      publicOrigin: "http://127.0.0.1:4599",
+    }),
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runEnvSh", () => {
+  it("emits shell assignments using --emulator-origin", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const argv = [
+      ...process.argv.slice(0, 2),
+      "--app-origin",
+      "https://app.lightfast.localhost",
+      "--emulator-origin",
+      "https://test.lightfast.localhost",
+    ];
+    vi.spyOn(process, "argv", "get").mockReturnValue(argv);
+
+    runEnvSh(manifest);
+
+    expect(log).toHaveBeenCalledWith(
+      "TEST_API_ORIGIN='https://test.lightfast.localhost'\nTEST_CLIENT_ID='test_client'"
+    );
+  });
+
+  it("falls back to the manifest port origin when no flags are passed", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(process, "argv", "get").mockReturnValue(process.argv.slice(0, 2));
+
+    runEnvSh(manifest);
+
+    expect(log).toHaveBeenCalledWith(
+      "TEST_API_ORIGIN='http://127.0.0.1:4599'\nTEST_CLIENT_ID='test_client'"
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run kit tests**
+
+Run: `pnpm --filter @repo/emulator-kit test`
+Expected: PASS (start-emulator 3 + env 4 + cli 2 = 9).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add emulators/kit/src/__tests__/env.test.ts emulators/kit/src/__tests__/cli.test.ts
+git commit -m "test(emulator-kit): cover createEmulatorEnv + runEnvSh"
+```
+
+---
+
+## Task 3: x — concern-split + manifest + thin bootstraps
+
+**Files:**
+- Create: `emulators/x/src/plugin/failures.ts`
+- Create: `emulators/x/src/plugin/auth.ts`
+- Create: `emulators/x/src/plugin/oauth.ts`
+- Create: `emulators/x/src/plugin/users.ts`
+- Create: `emulators/x/src/plugin/index.ts`
+- Create: `emulators/x/src/manifest.ts`
+- Modify: `emulators/x/src/server.ts` (one import line)
+- Rewrite: `emulators/x/src/start.ts`, `emulators/x/src/env-sh.ts`
+- Modify: `emulators/x/src/fixtures.ts` (drop format helpers + env projection)
+- Delete: `emulators/x/src/env.ts`, `emulators/x/src/x-plugin.ts`
+- Modify: `emulators/x/package.json` (drop now-unused deps)
+
+- [ ] **Step 1: Create `plugin/failures.ts`** (route bodies verbatim from `x-plugin.ts:173-200`)
+
+```ts
+import type { AppEnv, Hono, Store } from "@emulators/core";
+
+export interface FailureSwitches {
+  accessTokenExpired: boolean;
+  refresh: boolean;
+  usersMe: boolean;
+}
+
+const failureSwitchNames = [
+  "accessTokenExpired",
+  "refresh",
+  "usersMe",
+] as const satisfies ReadonlyArray<keyof FailureSwitches>;
+
+export function defaultFailures(): FailureSwitches {
+  return { accessTokenExpired: false, refresh: false, usersMe: false };
+}
+
+export function getFailures(store: Store): FailureSwitches {
+  return store.getData<FailureSwitches>("failures") ?? defaultFailures();
+}
+
+export function seedFailures(store: Store): void {
+  store.setData("failures", defaultFailures());
+}
+
+export function registerFailures(app: Hono<AppEnv>, store: Store): void {
+  app.post("/failures", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as Partial<
+      Record<keyof FailureSwitches, unknown>
+    > | null;
+    if (body !== null && (typeof body !== "object" || Array.isArray(body))) {
+      return c.json({ error: "invalid_failure_switches" }, 400);
+    }
+
+    const failures = getFailures(store);
+    for (const name of failureSwitchNames) {
+      const value = body?.[name];
+      if (value === undefined) {
+        continue;
+      }
+      if (typeof value !== "boolean") {
+        return c.json({ error: "invalid_failure_switch", field: name }, 400);
+      }
+      failures[name] = value;
+    }
+    store.setData("failures", failures);
+    return c.json({ failures }, 200);
+  });
+
+  app.post("/reset", (c) => {
+    const failures = defaultFailures();
+    store.setData("failures", failures);
+    return c.json({ failures }, 200);
+  });
+}
+```
+
+- [ ] **Step 2: Create `plugin/auth.ts`** (verbatim from `x-plugin.ts:64-78`)
+
+```ts
+import type { Context, Store } from "@emulators/core";
+
+import { X_EMULATOR_FIXTURES } from "../fixtures";
+import { getFailures } from "./failures";
+
+export function bearerToken(c: Context): string | undefined {
+  const authorization = c.req.header("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return;
+  }
+  return authorization.slice("Bearer ".length);
+}
+
+export function isValidBearer(c: Context, store: Store): boolean {
+  const failures = getFailures(store);
+  return (
+    !failures.accessTokenExpired &&
+    bearerToken(c) === X_EMULATOR_FIXTURES.accessToken
+  );
+}
+```
+
+- [ ] **Step 3: Create `plugin/oauth.ts`** (route bodies verbatim from `x-plugin.ts:83-161`)
+
+```ts
+import { createHash } from "node:crypto";
+
+import type { AppEnv, Hono, Store } from "@emulators/core";
+
+import {
+  X_EMULATOR_FIXTURES,
+  X_EMULATOR_OAUTH_CODE,
+  X_EMULATOR_SCOPE,
+} from "../fixtures";
+import { getFailures } from "./failures";
+
+const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 7200;
+
+function pkceChallengeFromVerifier(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function tokenResponse() {
+  return {
+    token_type: "bearer",
+    expires_in: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+    access_token: X_EMULATOR_FIXTURES.accessToken,
+    scope: X_EMULATOR_SCOPE,
+    refresh_token: X_EMULATOR_FIXTURES.refreshToken,
+  };
+}
+
+export function registerOAuth(app: Hono<AppEnv>, store: Store): void {
+  app.get("/oauth2/authorize", (c) => {
+    const clientId = c.req.query("client_id");
+    const redirectUri = c.req.query("redirect_uri");
+    const codeChallenge = c.req.query("code_challenge");
+    const codeChallengeMethod = c.req.query("code_challenge_method");
+
+    if (
+      clientId !== X_EMULATOR_FIXTURES.oauthClientId ||
+      !redirectUri ||
+      !codeChallenge ||
+      codeChallengeMethod !== "S256"
+    ) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    store.setData(`pkce:${X_EMULATOR_OAUTH_CODE}`, codeChallenge);
+
+    const redirectUrl = new URL(redirectUri);
+    redirectUrl.searchParams.set("code", X_EMULATOR_OAUTH_CODE);
+    const state = c.req.query("state");
+    if (state) {
+      redirectUrl.searchParams.set("state", state);
+    }
+    return c.redirect(redirectUrl.toString(), 302);
+  });
+
+  app.post("/oauth2/token", async (c) => {
+    const form = await c.req.parseBody();
+    const clientId = String(form.client_id ?? "");
+    const grantType = String(form.grant_type ?? "");
+
+    if (clientId !== X_EMULATOR_FIXTURES.oauthClientId) {
+      return c.json({ error: "invalid_client" }, 401);
+    }
+
+    if (grantType === "authorization_code") {
+      const code = String(form.code ?? "");
+      const codeVerifier = String(form.code_verifier ?? "");
+      const expectedChallenge = store.getData<string>(`pkce:${code}`);
+
+      if (
+        code !== X_EMULATOR_OAUTH_CODE ||
+        !codeVerifier ||
+        !expectedChallenge ||
+        pkceChallengeFromVerifier(codeVerifier) !== expectedChallenge
+      ) {
+        return c.json({ error: "invalid_grant" }, 400);
+      }
+      return c.json(tokenResponse(), 200);
+    }
+
+    if (grantType === "refresh_token") {
+      const failures = getFailures(store);
+      if (
+        failures.refresh ||
+        String(form.refresh_token ?? "") !== X_EMULATOR_FIXTURES.refreshToken
+      ) {
+        return c.json({ error: "invalid_grant" }, 400);
+      }
+      return c.json(tokenResponse(), 200);
+    }
+
+    return c.json({ error: "unsupported_grant_type" }, 400);
+  });
+
+  app.post("/oauth2/revoke", async (c) => {
+    const form = await c.req.parseBody();
+    if (String(form.client_id ?? "") !== X_EMULATOR_FIXTURES.oauthClientId) {
+      return c.json({ error: "invalid_client" }, 401);
+    }
+    const token = String(form.token ?? "");
+    if (
+      token === X_EMULATOR_FIXTURES.accessToken ||
+      token === X_EMULATOR_FIXTURES.refreshToken
+    ) {
+      return c.body(null, 200);
+    }
+    return c.json({ error: "invalid_token" }, 400);
+  });
+}
+```
+
+- [ ] **Step 4: Create `plugin/users.ts`** (route body verbatim from `x-plugin.ts:163-171`; `XUserRow`/`userResponse` from `25-29`/`53-62`)
+
+```ts
+import type { AppEnv, Entity, Hono, Store } from "@emulators/core";
+
+import { X_EMULATOR_FIXTURES } from "../fixtures";
+import { isValidBearer } from "./auth";
+import { getFailures } from "./failures";
+
+export interface XUserRow extends Entity {
+  name: string;
+  username: string;
+  x_id: string;
+}
+
+function userResponse(store: Store) {
+  const user = store.collection<XUserRow>("users").all()[0];
+  return {
+    data: {
+      id: user?.x_id ?? X_EMULATOR_FIXTURES.userId,
+      name: user?.name ?? X_EMULATOR_FIXTURES.userName,
+      username: user?.username ?? X_EMULATOR_FIXTURES.username,
+    },
+  };
+}
+
+export function registerUsers(app: Hono<AppEnv>, store: Store): void {
+  app.get("/2/users/me", (c) => {
+    if (!isValidBearer(c, store)) {
+      return c.json({ title: "Unauthorized", status: 401 }, 401);
+    }
+    if (getFailures(store).usersMe) {
+      return c.json({ title: "Internal Error", status: 500 }, 500);
+    }
+    return c.json(userResponse(store), 200);
+  });
+}
+```
+
+- [ ] **Step 5: Create `plugin/index.ts`** (composition; seed preserves `x-plugin.ts:202-209` exactly)
+
+```ts
+import type { ServicePlugin } from "@emulators/core";
+
+import { X_EMULATOR_FIXTURES } from "../fixtures";
+import { registerFailures, seedFailures } from "./failures";
+import { registerOAuth } from "./oauth";
+import { registerUsers, type XUserRow } from "./users";
+
+export const xPlugin: ServicePlugin = {
+  name: "x",
+  register(app, store) {
+    registerOAuth(app, store);
+    registerUsers(app, store);
+    registerFailures(app, store);
+  },
+  seed(store) {
+    seedFailures(store);
+    store.collection<XUserRow>("users").insert({
+      name: X_EMULATOR_FIXTURES.userName,
+      username: X_EMULATOR_FIXTURES.username,
+      x_id: X_EMULATOR_FIXTURES.userId,
+    });
+  },
+};
+```
+
+- [ ] **Step 6: Point `server.ts` at the new plugin** (one line)
+
+In `emulators/x/src/server.ts`, change:
+```ts
+import { xPlugin } from "./x-plugin";
+```
+to:
+```ts
+import { xPlugin } from "./plugin";
+```
+
+- [ ] **Step 7: Create `manifest.ts`**
+
+```ts
+import type { EmulatorManifest } from "@repo/emulator-kit";
+
+import { X_EMULATOR_FIXTURES } from "./fixtures";
+import { startXEmulator } from "./server";
+
+export const xManifest: EmulatorManifest = {
+  name: "x",
+  port: 4569,
+  originEnvVar: "X_EMULATOR_ORIGIN",
+  env: (_appOrigin, emulatorOrigin) => ({
+    X_API_ORIGIN: emulatorOrigin,
+    X_CLIENT_ID: X_EMULATOR_FIXTURES.oauthClientId,
+    X_CLIENT_SECRET: X_EMULATOR_FIXTURES.oauthClientSecret,
+    X_OAUTH_ORIGIN: emulatorOrigin,
+  }),
+  start: startXEmulator,
+};
+```
+
+- [ ] **Step 8: Rewrite `start.ts` and `env-sh.ts` as bootstraps**
+
+`emulators/x/src/start.ts`:
+```ts
+import { runStart } from "@repo/emulator-kit";
+
+import { xManifest } from "./manifest";
+
+await runStart(xManifest);
+```
+
+`emulators/x/src/env-sh.ts`:
+```ts
+import { runEnvSh } from "@repo/emulator-kit";
+
+import { xManifest } from "./manifest";
+
+runEnvSh(xManifest);
+```
+
+- [ ] **Step 9: Trim `fixtures.ts`** — delete `getXEmulatorEnv`, `formatXEmulatorEnvString`, `shellQuote`, `ENV_ASSIGNMENT_NAME_RE` (env projection now lives in `manifest.ts`, formatting in the kit). Keep `X_EMULATOR_FIXTURES`, `X_EMULATOR_OAUTH_CODE`, `X_EMULATOR_SCOPE`.
+
+- [ ] **Step 10: Delete the obsolete files**
+
+```bash
+git rm emulators/x/src/env.ts emulators/x/src/x-plugin.ts
+```
+
+- [ ] **Step 11: Drop now-unused deps from `emulators/x/package.json`**
+
+Confirm nothing else imports them:
+Run: `grep -rn "@t3-oss/env-core\|from \"zod\"\|from 'zod'" emulators/x/src` → expect no matches.
+Then remove `"@t3-oss/env-core": "catalog:"` and `"zod": "catalog:"` from `dependencies`. Run `pnpm install`.
+
+- [ ] **Step 12: Typecheck + tests (the regression guard)**
+
+Run: `pnpm --filter @repo/x-emulator typecheck`
+Run: `pnpm --filter @repo/x-emulator test`
+Expected: PASS (9 tests, unchanged — they import `startXEmulator` from `../server`).
+
+- [ ] **Step 13: Verify env:sh output is byte-identical to before**
+
+Run: `pnpm --filter @repo/x-emulator env:sh -- --app-origin https://app.lightfast.localhost --emulator-origin https://x.lightfast.localhost`
+Expected: `X_API_ORIGIN='https://x.lightfast.localhost'` … same keys/values as the pre-migration output.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add emulators/x pnpm-lock.yaml
+git commit -m "refactor(x-emulator): concern-split plugin + manifest on emulator-kit"
+```
+
+---
+
+## Task 4: linear — concern-split + manifest + thin bootstraps
+
+**Files:**
+- Create: `emulators/linear/src/plugin/{failures,auth,oauth,viewer,mcp,index}.ts`
+- Create: `emulators/linear/src/manifest.ts`
+- Modify: `emulators/linear/src/server.ts` (one import line)
+- Rewrite: `emulators/linear/src/start.ts`, `emulators/linear/src/env-sh.ts`
+- Modify: `emulators/linear/src/fixtures.ts` (drop format helpers + env projection)
+- Delete: `emulators/linear/src/env.ts`, `emulators/linear/src/linear-plugin.ts`
+- Modify: `emulators/linear/package.json` (drop now-unused deps)
+
+- [ ] **Step 1: Create `plugin/failures.ts`** (verbatim from `linear-plugin.ts:12-30,273-304`)
+
+```ts
+import type { AppEnv, Hono, Store } from "@emulators/core";
+
+export interface FailureSwitches {
+  accessTokenExpired: boolean;
+  mcpListTools: boolean;
+  refresh: boolean;
+}
+
+const failureSwitchNames = [
+  "accessTokenExpired",
+  "mcpListTools",
+  "refresh",
+] as const satisfies ReadonlyArray<keyof FailureSwitches>;
+
+export function defaultFailures(): FailureSwitches {
+  return { accessTokenExpired: false, mcpListTools: false, refresh: false };
+}
+
+export function getFailures(store: Store): FailureSwitches {
+  return store.getData<FailureSwitches>("failures") ?? defaultFailures();
+}
+
+export function seedFailures(store: Store): void {
+  store.setData("failures", defaultFailures());
+}
+
+export function registerFailures(app: Hono<AppEnv>, store: Store): void {
+  app.post("/failures", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as Partial<
+      Record<keyof FailureSwitches, unknown>
+    > | null;
+    if (body !== null && (typeof body !== "object" || Array.isArray(body))) {
+      return c.json({ error: "invalid_failure_switches" }, 400);
+    }
+
+    const failures = getFailures(store);
+    for (const name of failureSwitchNames) {
+      const value = body?.[name];
+      if (value === undefined) {
+        continue;
+      }
+      if (typeof value !== "boolean") {
+        return c.json({ error: "invalid_failure_switch", field: name }, 400);
+      }
+      failures[name] = value;
+    }
+    store.setData("failures", failures);
+    return c.json({ failures }, 200);
+  });
+
+  app.post("/reset", (c) => {
+    const failures = defaultFailures();
+    store.setData("failures", failures);
+    return c.json({ failures }, 200);
+  });
+}
+```
+
+- [ ] **Step 2: Create `plugin/auth.ts`** (verbatim from `linear-plugin.ts:68-82`)
+
+```ts
+import type { Context, Store } from "@emulators/core";
+
+import { LINEAR_EMULATOR_FIXTURES } from "../fixtures";
+import { getFailures } from "./failures";
+
+export function bearerToken(c: Context): string | undefined {
+  const authorization = c.req.header("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return;
+  }
+  return authorization.slice("Bearer ".length);
+}
+
+export function isValidBearer(c: Context, store: Store): boolean {
+  const failures = getFailures(store);
+  return (
+    !failures.accessTokenExpired &&
+    bearerToken(c) === LINEAR_EMULATOR_FIXTURES.accessToken
+  );
+}
+```
+
+- [ ] **Step 3: Create `plugin/oauth.ts`** (route bodies verbatim from `linear-plugin.ts:93-152`; helpers `32-41,58-66`)
+
+```ts
+import type { AppEnv, Hono, Store } from "@emulators/core";
+
+import { LINEAR_EMULATOR_FIXTURES, LINEAR_EMULATOR_OAUTH_CODE } from "../fixtures";
+import { getFailures } from "./failures";
+
+const TOKEN_EXPIRES_IN_SECONDS = 3600;
+const REFRESH_TOKEN_EXPIRES_IN_SECONDS = 2_592_000;
+
+function tokenResponse() {
+  return {
+    access_token: LINEAR_EMULATOR_FIXTURES.accessToken,
+    expires_in: TOKEN_EXPIRES_IN_SECONDS,
+    refresh_token: LINEAR_EMULATOR_FIXTURES.refreshToken,
+    refresh_token_expires_in: REFRESH_TOKEN_EXPIRES_IN_SECONDS,
+    scope: "read,write",
+    token_type: "Bearer",
+  };
+}
+
+function clientCredentialsValid(
+  clientId: unknown,
+  clientSecret: unknown
+): boolean {
+  return (
+    String(clientId ?? "") === LINEAR_EMULATOR_FIXTURES.oauthClientId &&
+    String(clientSecret ?? "") === LINEAR_EMULATOR_FIXTURES.oauthClientSecret
+  );
+}
+
+export function registerOAuth(app: Hono<AppEnv>, store: Store): void {
+  app.get("/oauth/authorize", (c) => {
+    const clientId = c.req.query("client_id");
+    const redirectUri = c.req.query("redirect_uri");
+    if (clientId !== LINEAR_EMULATOR_FIXTURES.oauthClientId || !redirectUri) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const redirectUrl = new URL(redirectUri);
+    redirectUrl.searchParams.set("code", LINEAR_EMULATOR_OAUTH_CODE);
+    const state = c.req.query("state");
+    if (state) {
+      redirectUrl.searchParams.set("state", state);
+    }
+    return c.redirect(redirectUrl.toString(), 302);
+  });
+
+  app.post("/oauth/token", async (c) => {
+    const form = await c.req.parseBody();
+    if (!clientCredentialsValid(form.client_id, form.client_secret)) {
+      return c.json({ error: "invalid_client" }, 401);
+    }
+
+    const grantType = String(form.grant_type ?? "");
+    if (grantType === "authorization_code") {
+      if (String(form.code ?? "") !== LINEAR_EMULATOR_OAUTH_CODE) {
+        return c.json({ error: "invalid_grant" }, 400);
+      }
+      return c.json(tokenResponse(), 200);
+    }
+
+    if (grantType === "refresh_token") {
+      const failures = getFailures(store);
+      if (
+        failures.refresh ||
+        String(form.refresh_token ?? "") !==
+          LINEAR_EMULATOR_FIXTURES.refreshToken
+      ) {
+        return c.json({ error: "invalid_grant" }, 400);
+      }
+      return c.json(tokenResponse(), 200);
+    }
+
+    return c.json({ error: "unsupported_grant_type" }, 400);
+  });
+
+  app.post("/oauth/revoke", async (c) => {
+    const form = await c.req.parseBody();
+    if (!clientCredentialsValid(form.client_id, form.client_secret)) {
+      return c.json({ error: "invalid_client" }, 401);
+    }
+
+    const token = String(form.token ?? "");
+    if (
+      token === LINEAR_EMULATOR_FIXTURES.accessToken ||
+      token === LINEAR_EMULATOR_FIXTURES.refreshToken
+    ) {
+      return c.body(null, 200);
+    }
+    return c.json({ error: "invalid_token" }, 400);
+  });
+}
+```
+
+- [ ] **Step 4: Create `plugin/viewer.ts`** (route bodies verbatim from `linear-plugin.ts:154-166`; `viewerResponse` `43-56`)
+
+```ts
+import type { AppEnv, Hono, Store } from "@emulators/core";
+
+import { LINEAR_EMULATOR_FIXTURES } from "../fixtures";
+import { isValidBearer } from "./auth";
+
+function viewerResponse() {
+  return {
+    data: {
+      viewer: {
+        id: LINEAR_EMULATOR_FIXTURES.actorId,
+        name: LINEAR_EMULATOR_FIXTURES.actorName,
+        organization: {
+          id: LINEAR_EMULATOR_FIXTURES.workspaceId,
+          name: LINEAR_EMULATOR_FIXTURES.workspaceName,
+        },
+      },
+    },
+  };
+}
+
+export function registerViewer(app: Hono<AppEnv>, store: Store): void {
+  app.get("/viewer", (c) => {
+    if (!isValidBearer(c, store)) {
+      return c.json({ error: "invalid_token" }, 401);
+    }
+    return c.json(viewerResponse(), 200);
+  });
+
+  app.post("/graphql", (c) => {
+    if (!isValidBearer(c, store)) {
+      return c.json({ error: "invalid_token" }, 401);
+    }
+    return c.json(viewerResponse(), 200);
+  });
+}
+```
+
+- [ ] **Step 5: Create `plugin/mcp.ts`** (route body verbatim from `linear-plugin.ts:168-271`; `McpRequestBody` `84-88`)
+
+```ts
+import type { AppEnv, Hono, Store } from "@emulators/core";
+
+import { LINEAR_EMULATOR_TOOLS } from "../fixtures";
+import { isValidBearer } from "./auth";
+import { getFailures } from "./failures";
+
+interface McpRequestBody {
+  id?: number | string | null;
+  method?: string;
+  params?: { name?: string; arguments?: unknown };
+}
+
+export function registerMcp(app: Hono<AppEnv>, store: Store): void {
+  app.post("/mcp", async (c) => {
+    if (!isValidBearer(c, store)) {
+      return c.json({ error: "invalid_token" }, 401);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as McpRequestBody | null;
+    if (!body?.method) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    if (body.id === undefined || body.id === null) {
+      return c.body(null, 202);
+    }
+
+    if (body.method === "initialize") {
+      return c.json(
+        {
+          id: body.id,
+          jsonrpc: "2.0",
+          result: {
+            capabilities: { tools: {} },
+            protocolVersion: "2025-06-18",
+            serverInfo: { name: "linear-emulator", version: "0.1.0" },
+          },
+        },
+        200
+      );
+    }
+
+    if (body.method === "tools/list") {
+      if (getFailures(store).mcpListTools) {
+        return c.json(
+          {
+            error: { code: -32_003, message: "Linear MCP list-tools failure" },
+            id: body.id,
+            jsonrpc: "2.0",
+          },
+          500
+        );
+      }
+      return c.json(
+        {
+          id: body.id,
+          jsonrpc: "2.0",
+          result: { tools: LINEAR_EMULATOR_TOOLS },
+        },
+        200
+      );
+    }
+
+    if (body.method === "tools/call") {
+      const name = body.params?.name;
+      const tool = LINEAR_EMULATOR_TOOLS.find((item) => item.name === name);
+      if (!tool) {
+        return c.json(
+          {
+            error: { code: -32_602, message: `Unknown tool: ${name ?? ""}` },
+            id: body.id,
+            jsonrpc: "2.0",
+          },
+          200
+        );
+      }
+
+      const structuredContent = {
+        arguments: body.params?.arguments ?? {},
+        ok: true,
+        tool: tool.name,
+      };
+      return c.json(
+        {
+          id: body.id,
+          jsonrpc: "2.0",
+          result: {
+            content: [
+              { type: "text", text: JSON.stringify(structuredContent, null, 2) },
+            ],
+            structuredContent,
+          },
+        },
+        200
+      );
+    }
+
+    return c.json(
+      {
+        error: { code: -32_601, message: `Unsupported method: ${body.method}` },
+        id: body.id,
+        jsonrpc: "2.0",
+      },
+      200
+    );
+  });
+}
+```
+
+- [ ] **Step 6: Create `plugin/index.ts`** (composition; seed = `seedFailures`, matching `linear-plugin.ts:302-304`)
+
+```ts
+import type { ServicePlugin } from "@emulators/core";
+
+import { registerFailures, seedFailures } from "./failures";
+import { registerMcp } from "./mcp";
+import { registerOAuth } from "./oauth";
+import { registerViewer } from "./viewer";
+
+export const linearPlugin: ServicePlugin = {
+  name: "linear",
+  register(app, store) {
+    registerOAuth(app, store);
+    registerViewer(app, store);
+    registerMcp(app, store);
+    registerFailures(app, store);
+  },
+  seed(store) {
+    seedFailures(store);
+  },
+};
+```
+
+- [ ] **Step 7: Point `server.ts` at the new plugin** (one line)
+
+In `emulators/linear/src/server.ts`, change `import { linearPlugin } from "./linear-plugin";` → `import { linearPlugin } from "./plugin";`.
+
+- [ ] **Step 8: Create `manifest.ts`**
+
+```ts
+import type { EmulatorManifest } from "@repo/emulator-kit";
+
+import { LINEAR_EMULATOR_FIXTURES } from "./fixtures";
+import { startLinearEmulator } from "./server";
+
+export const linearManifest: EmulatorManifest = {
+  name: "linear",
+  port: 4568,
+  originEnvVar: "LINEAR_EMULATOR_ORIGIN",
+  env: (_appOrigin, emulatorOrigin) => ({
+    LINEAR_API_ORIGIN: emulatorOrigin,
+    LINEAR_CLIENT_ID: LINEAR_EMULATOR_FIXTURES.oauthClientId,
+    LINEAR_CLIENT_SECRET: LINEAR_EMULATOR_FIXTURES.oauthClientSecret,
+    LINEAR_MCP_ENDPOINT: `${emulatorOrigin}/mcp`,
+  }),
+  start: startLinearEmulator,
+};
+```
+
+- [ ] **Step 9: Rewrite `start.ts` and `env-sh.ts` as bootstraps**
+
+`emulators/linear/src/start.ts`:
+```ts
+import { runStart } from "@repo/emulator-kit";
+
+import { linearManifest } from "./manifest";
+
+await runStart(linearManifest);
+```
+
+`emulators/linear/src/env-sh.ts`:
+```ts
+import { runEnvSh } from "@repo/emulator-kit";
+
+import { linearManifest } from "./manifest";
+
+runEnvSh(linearManifest);
+```
+
+- [ ] **Step 10: Trim `fixtures.ts`** — delete `getLinearEmulatorEnv`, `formatLinearEmulatorEnvString`, `shellQuote`, `ENV_ASSIGNMENT_NAME_RE`. Keep `LINEAR_EMULATOR_FIXTURES`, `LINEAR_EMULATOR_OAUTH_CODE`, `LINEAR_EMULATOR_TOOLS`.
+
+- [ ] **Step 11: Delete obsolete files + drop unused deps**
+
+```bash
+git rm emulators/linear/src/env.ts emulators/linear/src/linear-plugin.ts
+```
+Run: `grep -rn "@t3-oss/env-core\|from \"zod\"" emulators/linear/src` → expect no matches; then remove `@t3-oss/env-core` and `zod` from `emulators/linear/package.json` `dependencies`. `pnpm install`.
+
+- [ ] **Step 12: Typecheck + tests**
+
+Run: `pnpm --filter @repo/linear-emulator typecheck`
+Run: `pnpm --filter @repo/linear-emulator test`
+Expected: PASS (10 tests, unchanged — incl. the real `listLinearMcpTools` assertion).
+
+- [ ] **Step 13: Verify env:sh output byte-identical (incl. `LINEAR_MCP_ENDPOINT`)**
+
+Run: `pnpm --filter @repo/linear-emulator env:sh -- --app-origin https://app.lightfast.localhost --emulator-origin https://linear.lightfast.localhost`
+Expected: includes `LINEAR_MCP_ENDPOINT='https://linear.lightfast.localhost/mcp'`.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add emulators/linear pnpm-lock.yaml
+git commit -m "refactor(linear-emulator): concern-split plugin + manifest on emulator-kit"
+```
+
+---
+
+## Task 5: github — boot layer + light relocate
+
+**Files:**
+- Create: `emulators/github/src/manifest.ts`
+- Move: `server.ts` → `plugin/index.ts`; `github-compatible-routes.ts` → `plugin/compatible-routes.ts`; `push.ts` → `plugin/webhook/push.ts`; `push-webhook-payload.ts` → `plugin/webhook/push-payload.ts`
+- Rewrite: `emulators/github/src/start.ts`, `emulators/github/src/env-sh.ts`
+- Modify: `emulators/github/src/fixtures.ts` (drop format helpers)
+- Delete: `emulators/github/src/env.ts`
+- Move/replace: `__tests__/env.test.ts` coverage → kit; add `__tests__/manifest.test.ts`
+- Modify test import specifiers in `server.test.ts`, `oauth-user-account.test.ts`, `test-helpers.ts`
+- Modify: `emulators/github/package.json` (drop now-unused deps if any)
+
+- [ ] **Step 1: Relocate the composition files (logic byte-identical)**
+
+```bash
+mkdir -p emulators/github/src/plugin/webhook
+git mv emulators/github/src/server.ts emulators/github/src/plugin/index.ts
+git mv emulators/github/src/github-compatible-routes.ts emulators/github/src/plugin/compatible-routes.ts
+git mv emulators/github/src/push.ts emulators/github/src/plugin/webhook/push.ts
+git mv emulators/github/src/push-webhook-payload.ts emulators/github/src/plugin/webhook/push-payload.ts
+```
+
+- [ ] **Step 2: Fix relative imports inside the moved files** (mechanical, per the spec table)
+
+- `plugin/index.ts`: `./fixtures` → `../fixtures`; `./github-compatible-routes` → `./compatible-routes`; `./push-webhook-payload` → `./webhook/push-payload`.
+- `plugin/compatible-routes.ts`: `./fixtures` → `../fixtures`.
+- `plugin/webhook/push.ts`: `./fixtures` → `../../fixtures` (if present); `./push-webhook-payload` → `./push-payload` (if present).
+- `plugin/webhook/push-payload.ts`: `./fixtures` → `../../fixtures` (if present).
+
+Run (to find every spec to fix): `grep -rn "from \"\\.\\./\\|from \"\\./" emulators/github/src/plugin`
+
+- [ ] **Step 3: Create `manifest.ts`**
+
+```ts
+import type { EmulatorManifest } from "@repo/emulator-kit";
+
+import { getGitHubEmulatorEnv } from "./fixtures";
+import { startGitHubEmulator } from "./plugin";
+
+export const githubManifest: EmulatorManifest = {
+  name: "github",
+  port: 4567,
+  originEnvVar: "GITHUB_EMULATOR_ORIGIN",
+  env: getGitHubEmulatorEnv,
+  start: startGitHubEmulator,
+};
+```
+
+> `getGitHubEmulatorEnv(_appOrigin, emulatorOrigin)` already matches the `env(appOrigin, emulatorOrigin)` shape. `startGitHubEmulator` returns a structural superset of `RunnableEmulator`, so it satisfies `manifest.start` with no signature change.
+
+- [ ] **Step 4: Rewrite `start.ts` and `env-sh.ts` as bootstraps**
+
+`emulators/github/src/start.ts`:
+```ts
+import { runStart } from "@repo/emulator-kit";
+
+import { githubManifest } from "./manifest";
+
+await runStart(githubManifest);
+```
+
+`emulators/github/src/env-sh.ts`:
+```ts
+import { runEnvSh } from "@repo/emulator-kit";
+
+import { githubManifest } from "./manifest";
+
+runEnvSh(githubManifest);
+```
+
+- [ ] **Step 5: Trim `fixtures.ts`** — delete `formatGitHubEmulatorEnvString`, `shellQuote`, `ENV_ASSIGNMENT_NAME_RE`. Keep `GITHUB_EMULATOR_FIXTURES`, `createGitHubEmulatorSeed`, `getGitHubEmulatorEnv`, the RSA key.
+
+- [ ] **Step 6: Delete `env.ts`**
+
+```bash
+git rm emulators/github/src/env.ts
+```
+
+- [ ] **Step 7: Update test import specifiers** (assertions unchanged)
+
+- `__tests__/server.test.ts`: `../server` → `../plugin`; `../github-compatible-routes` → `../plugin/compatible-routes`.
+- `__tests__/oauth-user-account.test.ts`: `../server` → `../plugin`; `../github-compatible-routes` → `../plugin/compatible-routes`.
+- `__tests__/test-helpers.ts`: `../server` → `../plugin`.
+
+- [ ] **Step 8: Migrate `env.test.ts`**
+
+The kit's `env.test.ts` (Task 2) already covers `createEmulatorEnv` generically. Replace github's env-schema test with a manifest projection test:
+
+```bash
+git rm emulators/github/src/__tests__/env.test.ts
+```
+
+Create `emulators/github/src/__tests__/manifest.test.ts`:
+```ts
+import { describe, expect, it } from "vitest";
+
+import { GITHUB_EMULATOR_FIXTURES } from "../fixtures";
+import { githubManifest } from "../manifest";
+
+describe("githubManifest.env", () => {
+  it("projects the GitHub App env from the emulator origin", () => {
+    const env = githubManifest.env(
+      "https://app.lightfast.localhost",
+      "https://github.lightfast.localhost"
+    );
+    expect(env.GITHUB_APP_ENDPOINT_ORIGIN).toBe(
+      "https://github.lightfast.localhost"
+    );
+    expect(env.GITHUB_APP_CLIENT_ID).toBe(
+      GITHUB_EMULATOR_FIXTURES.oauthClientId
+    );
+    expect(env.GITHUB_APP_ID).toBe(String(GITHUB_EMULATOR_FIXTURES.githubAppId));
+    expect(env.GITHUB_APP_PRIVATE_KEY).toContain("\\n");
+  });
+});
+```
+
+- [ ] **Step 9: Drop now-unused deps if any**
+
+Run: `grep -rn "@t3-oss/env-core\|from \"zod\"" emulators/github/src` → if no matches, remove `@t3-oss/env-core` and `zod` from `emulators/github/package.json` `dependencies`. `pnpm install`. (If github still imports zod somewhere — e.g. a route schema — leave them.)
+
+- [ ] **Step 10: Typecheck + full github tests**
+
+Run: `pnpm --filter @repo/github-emulator typecheck`
+Run: `pnpm --filter @repo/github-emulator test`
+Expected: PASS — 35 composition tests (oauth-user-account 5 + server 30) + manifest 1.
+
+- [ ] **Step 11: Verify env:sh output byte-identical**
+
+Run: `pnpm --filter @repo/github-emulator env:sh -- --app-origin https://app.lightfast.localhost --emulator-origin https://github.lightfast.localhost`
+Expected: same `GITHUB_APP_*` keys/values as before (incl. `GITHUB_APP_PRIVATE_KEY` with escaped `\n`).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add emulators/github pnpm-lock.yaml
+git commit -m "refactor(github-emulator): adopt emulator-kit boot layer; relocate composition into plugin/"
+```
+
+---
+
+## Task 6: Full verification sweep
+
+- [ ] **Step 1: Biome/ultracite**
+
+Run: `npx ultracite@latest check emulators` — fix any sorting/formatting via `npx ultracite@latest fix emulators`, then re-check clean.
+
+- [ ] **Step 2: All emulator typechecks + tests**
+
+```bash
+pnpm --filter @repo/emulator-kit --filter @repo/x-emulator --filter @repo/linear-emulator --filter @repo/github-emulator typecheck
+pnpm --filter @repo/emulator-kit --filter @repo/x-emulator --filter @repo/linear-emulator --filter @repo/github-emulator test
+```
+Expected: kit 9 + x 9 + linear 10 + github 36 = 64 tests green.
+
+- [ ] **Step 3: Confirm `apps/app` wiring still resolves**
+
+The root `apps/app/package.json` `with-related-projects` calls each emulator's `env:sh` — unchanged. Sanity check it still parses:
+Run: `node -e "JSON.parse(require('fs').readFileSync('apps/app/package.json','utf8'))"`
+
+- [ ] **Step 4: Live smoke per service** (manual — requires `pnpm dev`)
+
+Boot `pnpm dev --ui=stream --log-order=stream --log-prefix=task --no-color`; confirm Portless serves each emulator and:
+- x: `GET https://x.lightfast.localhost/2/users/me` with the seeded bearer → user payload.
+- linear: `GET /viewer` → viewer; `POST /mcp` `tools/list` → 10 tools.
+- github: OAuth app-token + a push webhook dispatch still fire (covered by tests; spot-check via the app's connector flow if convenient).
+
+- [ ] **Step 5: Final commit (if Step 1 produced fixes)**
+
+```bash
+git add emulators
+git commit -m "chore(emulators): biome fixups after kit migration"
+```
+
+---
+
+## Notes / out of scope
+
+- No capability-composition framework (register-fragments only).
+- No webhook for linear/x (the `plugin/` folder leaves an obvious `webhook.ts` slot for later marketplace work).
+- github's `startGitHubEmulator` is not collapsed into `startEmulator` (kept byte-identical; possible future follow-up).
+- Emulator code stays dev-only; production runtime must never import it.
+- Commit with explicit pathspecs; do not push. Spec + plan docs stay uncommitted until the user asks.

--- a/docs/superpowers/plans/2026-06-01-emulator-kit-and-x-emulator.md
+++ b/docs/superpowers/plans/2026-06-01-emulator-kit-and-x-emulator.md
@@ -1,0 +1,1466 @@
+# Emulator Kit + X Emulator (auth-only) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared `@repo/emulator-kit` for emulator boot/lifecycle, build a new `@repo/x-emulator` (OAuth 2.0 PKCE auth-only slice) on top of it and `@emulators/core`, and lightly refactor the GitHub emulator to consume the kit's lifecycle primitives.
+
+**Architecture:** Two layers. Layer A is the vendor substrate `@emulators/core` (`vercel-labs/emulate` 0.6.0) — a generic Hono router + in-memory `Store` + auth/OAuth toolkit, extended via the `ServicePlugin` interface (`{ name, register(), seed() }`). Layer B is `emulators/kit` (`@repo/emulator-kit`), a thin local library exposing `startEmulator(plugin, opts)` plus the `formatListenUrl`/`waitForListening`/`closeServer` primitives that are currently copy-pasted across emulators. The X emulator is one `ServicePlugin` booted by `startEmulator`. GitHub keeps its own boot but imports the shared primitives. Linear is untouched.
+
+**Tech Stack:** TypeScript (ESM), `@emulators/core` (Hono-based), `@t3-oss/env-core` + `zod` for env parsing, `tsx` for dev/start, `vitest` for tests, pnpm workspaces (`emulators/*` glob), Turborepo, Portless dev routing.
+
+**Design doc:** `docs/superpowers/specs/2026-06-01-emulator-kit-and-x-emulator-design.md`
+
+**Conventions observed (do not deviate):**
+- Internal `@repo/*` packages export TS source directly: `"exports": { ".": { "types": "./src/index.ts", "default": "./src/index.ts" } }`. No build step.
+- Emulators live under `emulators/`; `emulators/*` is a pnpm workspace glob, so new packages auto-register (no `pnpm-workspace.yaml` edit).
+- Ports: github `4567`, linear `4568`, **x `4569`**.
+- Externals use `catalog:`; internal deps use `workspace:*`.
+- Commit with explicit pathspecs (a concurrent agent may stage unrelated files). Do **not** `git push`.
+
+---
+
+## File Structure
+
+**Create:**
+- `emulators/kit/package.json` — `@repo/emulator-kit` manifest
+- `emulators/kit/tsconfig.json` — extends `@repo/typescript-config/base.json`
+- `emulators/kit/vitest.config.ts` — merges `@repo/vitest-config`
+- `emulators/kit/src/index.ts` — lifecycle primitives + `startEmulator` + `StartedEmulator`
+- `emulators/kit/src/__tests__/start-emulator.test.ts` — kit lifecycle test
+- `emulators/x/package.json` — `@repo/x-emulator` manifest
+- `emulators/x/tsconfig.json`, `emulators/x/vitest.config.ts`
+- `emulators/x/src/fixtures.ts` — deterministic fixtures + env helpers
+- `emulators/x/src/env.ts` — runtime env parsing
+- `emulators/x/src/env-sh.ts` — `env:sh` emitter for `with-related-projects`
+- `emulators/x/src/x-plugin.ts` — the `ServicePlugin` (routes + seed)
+- `emulators/x/src/server.ts` — `startXEmulator()` wrapper over the kit
+- `emulators/x/src/start.ts` — process entrypoint
+- `emulators/x/src/__tests__/server.test.ts` — X emulator tests
+- `emulators/x/README.md`
+
+**Modify:**
+- `emulators/github/src/server.ts` — delete 3 duplicated helpers, import from kit
+- `emulators/github/package.json` — add `@repo/emulator-kit` dep
+- `package.json` (root) — add `_x_emulator` script + `//#_x_emulator` to `dev`
+- `turbo.json` — register `//#_x_emulator` root task
+- `apps/app/package.json` — append X emulator to `with-related-projects`
+
+---
+
+## Task 1: Scaffold `@repo/emulator-kit` package
+
+**Files:**
+- Create: `emulators/kit/package.json`
+- Create: `emulators/kit/tsconfig.json`
+- Create: `emulators/kit/vitest.config.ts`
+- Create: `emulators/kit/src/index.ts` (temporary empty export)
+
+- [ ] **Step 1: Create `emulators/kit/package.json`**
+
+```json
+{
+  "name": "@repo/emulator-kit",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo node_modules",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@emulators/core": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@repo/vitest-config": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}
+```
+
+- [ ] **Step 2: Create `emulators/kit/tsconfig.json`**
+
+```json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "dom", "dom.iterable"]
+  },
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+- [ ] **Step 3: Create `emulators/kit/vitest.config.ts`**
+
+```ts
+import sharedConfig from "@repo/vitest-config";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      environment: "node",
+    },
+  })
+);
+```
+
+- [ ] **Step 4: Create `emulators/kit/src/index.ts` (temporary placeholder)**
+
+```ts
+export {};
+```
+
+- [ ] **Step 5: Install workspace deps so the new package links**
+
+Run: `pnpm install`
+Expected: completes; `@repo/emulator-kit` appears in the workspace (no missing-peer errors).
+
+- [ ] **Step 6: Typecheck the empty package**
+
+Run: `pnpm --filter @repo/emulator-kit typecheck`
+Expected: PASS (no errors).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add emulators/kit/package.json emulators/kit/tsconfig.json emulators/kit/vitest.config.ts emulators/kit/src/index.ts pnpm-lock.yaml
+git commit -m "chore(emulator-kit): scaffold @repo/emulator-kit package"
+```
+
+---
+
+## Task 2: Implement kit lifecycle + `startEmulator` (TDD)
+
+**Files:**
+- Test: `emulators/kit/src/__tests__/start-emulator.test.ts`
+- Modify: `emulators/kit/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `emulators/kit/src/__tests__/start-emulator.test.ts`:
+
+```ts
+import type { ServicePlugin } from "@emulators/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { type StartedEmulator, startEmulator } from "../index";
+
+const pingPlugin: ServicePlugin = {
+  name: "ping",
+  register(app, store) {
+    app.get("/ping", (c) =>
+      c.json({ ok: true, count: store.getData<number>("count") ?? 0 })
+    );
+  },
+  seed(store) {
+    store.setData("count", 1);
+  },
+};
+
+let emulator: StartedEmulator | undefined;
+
+afterEach(async () => {
+  await emulator?.close();
+  emulator = undefined;
+});
+
+describe("@repo/emulator-kit startEmulator", () => {
+  it("boots a plugin, serves its routes, and reports a listen url", async () => {
+    emulator = await startEmulator(pingPlugin, { port: 0 });
+    expect(emulator.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+    const res = await fetch(`${emulator.url}/ping`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, count: 1 });
+  });
+
+  it("reset re-runs the plugin seed", async () => {
+    emulator = await startEmulator(pingPlugin, { port: 0 });
+    emulator.store.setData("count", 99);
+
+    const before = await (await fetch(`${emulator.url}/ping`)).json();
+    expect(before).toEqual({ ok: true, count: 99 });
+
+    emulator.reset();
+    const after = await (await fetch(`${emulator.url}/ping`)).json();
+    expect(after).toEqual({ ok: true, count: 1 });
+  });
+
+  it("close stops the server", async () => {
+    const local = await startEmulator(pingPlugin, { port: 0 });
+    const { url } = local;
+    await local.close();
+    await expect(fetch(`${url}/ping`)).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @repo/emulator-kit test`
+Expected: FAIL — `startEmulator` / `StartedEmulator` not exported from `../index`.
+
+- [ ] **Step 3: Implement the kit in `emulators/kit/src/index.ts`**
+
+Replace the entire file with:
+
+```ts
+import type { Server } from "node:http";
+
+import {
+  type AppEnv,
+  type FetchHandler,
+  type Hono,
+  type ServerOptions,
+  type ServicePlugin,
+  type Store,
+  type TokenMap,
+  type WebhookDispatcher,
+  createServer,
+  serve,
+} from "@emulators/core";
+
+export type EmulatorServer = ReturnType<typeof createServer>;
+
+export interface StartEmulatorContext {
+  appOrigin?: string;
+  publicOrigin?: string;
+}
+
+export interface StartEmulatorOptions extends ServerOptions {
+  host?: string;
+  port?: number;
+  appOrigin?: string;
+  publicOrigin?: string;
+  /** Wrap the fetch handler (e.g. host-routing shims). Default: server.app.fetch. */
+  createFetch?(server: EmulatorServer, ctx: StartEmulatorContext): FetchHandler;
+  /** Override seeding. Default: store.reset() then plugin.seed(store, publicOrigin). */
+  seed?(server: EmulatorServer, ctx: StartEmulatorContext): void;
+  /** Mutate the server before it starts listening (e.g. override webhooks.dispatch). */
+  onReady?(server: EmulatorServer): void;
+}
+
+export interface StartedEmulator {
+  app: Hono<AppEnv>;
+  store: Store;
+  webhooks: WebhookDispatcher;
+  tokenMap: TokenMap;
+  listenUrl: string;
+  publicOrigin: string;
+  url: string;
+  reset(): void;
+  close(): Promise<void>;
+}
+
+export function formatListenUrl(host: string, port: number): string {
+  const urlHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  const formattedHost = urlHost.includes(":") ? `[${urlHost}]` : urlHost;
+  return `http://${formattedHost}:${port}`;
+}
+
+export function waitForListening(httpServer: Server): Promise<void> {
+  if (httpServer.listening) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      httpServer.off("error", onError);
+      httpServer.off("listening", onListening);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onListening = () => {
+      cleanup();
+      resolve();
+    };
+
+    httpServer.once("error", onError);
+    httpServer.once("listening", onListening);
+  });
+}
+
+export function closeServer(httpServer: Server): Promise<void> {
+  if (!httpServer.listening) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    httpServer.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function startEmulator(
+  plugin: ServicePlugin,
+  options: StartEmulatorOptions = {}
+): Promise<StartedEmulator> {
+  const host = options.host ?? "127.0.0.1";
+  const port = options.port ?? 0;
+
+  const server = createServer(plugin, {
+    appKeyResolver: options.appKeyResolver,
+    baseUrl: options.publicOrigin,
+    docsUrl: options.docsUrl,
+    fallbackUser: options.fallbackUser,
+    port: port || undefined,
+    tokens: options.tokens,
+  });
+
+  const ctx: StartEmulatorContext = {
+    appOrigin: options.appOrigin,
+    publicOrigin: options.publicOrigin,
+  };
+
+  const runSeed = () => {
+    if (options.seed) {
+      options.seed(server, ctx);
+      return;
+    }
+    server.store.reset();
+    plugin.seed?.(server.store, options.publicOrigin ?? "");
+  };
+
+  runSeed();
+  options.onReady?.(server);
+
+  const fetchHandler: FetchHandler = options.createFetch
+    ? options.createFetch(server, ctx)
+    : server.app.fetch;
+
+  const httpServer = serve({
+    fetch: fetchHandler,
+    hostname: host,
+    port,
+  });
+
+  await waitForListening(httpServer).catch(async (error: unknown) => {
+    await closeServer(httpServer).catch(() => undefined);
+    throw error;
+  });
+
+  const address = httpServer.address();
+  const resolvedPort =
+    typeof address === "object" && address ? address.port : port;
+  const listenUrl = formatListenUrl(host, resolvedPort);
+  const publicOrigin = options.publicOrigin ?? listenUrl;
+
+  let closed = false;
+
+  return {
+    app: server.app,
+    store: server.store,
+    webhooks: server.webhooks,
+    tokenMap: server.tokenMap,
+    listenUrl,
+    publicOrigin,
+    url: listenUrl,
+    reset: runSeed,
+    close: async () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      await closeServer(httpServer);
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @repo/emulator-kit test`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @repo/emulator-kit typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add emulators/kit/src/index.ts emulators/kit/src/__tests__/start-emulator.test.ts
+git commit -m "feat(emulator-kit): add startEmulator + lifecycle primitives"
+```
+
+---
+
+## Task 3: Refactor GitHub emulator onto the kit primitives
+
+This is the **light** refactor: GitHub keeps its own boot function but deletes the three lifecycle helpers it duplicates and imports them from the kit. GitHub's existing tests guard the change.
+
+**Files:**
+- Modify: `emulators/github/package.json` (add dep)
+- Modify: `emulators/github/src/server.ts` (delete 3 functions, add import)
+
+- [ ] **Step 1: Add the kit dependency to `emulators/github/package.json`**
+
+In the `"dependencies"` object, add (keep alphabetical-ish ordering with the existing `@repo/github-app-contract`):
+
+```json
+    "@repo/emulator-kit": "workspace:*",
+```
+
+Resulting `"dependencies"` block:
+
+```json
+  "dependencies": {
+    "@repo/emulator-kit": "workspace:*",
+    "@repo/github-app-contract": "workspace:*",
+    "@t3-oss/env-core": "catalog:",
+    "zod": "catalog:"
+  },
+```
+
+- [ ] **Step 2: Install**
+
+Run: `pnpm install`
+Expected: completes; `@repo/emulator-kit` linked into `emulators/github`.
+
+- [ ] **Step 3: Add the kit import to `emulators/github/src/server.ts`**
+
+After the existing `@emulators/github` import block (the one importing `getGitHubStore`, `githubPlugin`, `seedFromConfig`), add:
+
+```ts
+import {
+  closeServer,
+  formatListenUrl,
+  waitForListening,
+} from "@repo/emulator-kit";
+```
+
+- [ ] **Step 4: Delete the three now-duplicated local functions from `emulators/github/src/server.ts`**
+
+Delete these three function definitions in full (they are now imported from the kit):
+- `function waitForListening(httpServer: Server) { ... }`
+- `function closeServer(httpServer: Server) { ... }`
+- `function formatListenUrl(host: string, port: number) { ... }`
+
+Leave everything else (including `import type { Server } from "node:http";`, `addOrgMembership`, `startGitHubEmulator`, the `webhooks.dispatch` override) unchanged.
+
+- [ ] **Step 5: Typecheck GitHub emulator**
+
+Run: `pnpm --filter @repo/github-emulator typecheck`
+Expected: PASS (no unused-import or missing-symbol errors).
+
+- [ ] **Step 6: Run GitHub emulator tests (regression guard)**
+
+Run: `pnpm --filter @repo/github-emulator test`
+Expected: PASS — all existing `server.test.ts` / `env.test.ts` / `oauth-user-account.test.ts` tests green, proving the kit primitives are behavior-identical.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add emulators/github/package.json emulators/github/src/server.ts pnpm-lock.yaml
+git commit -m "refactor(github-emulator): use @repo/emulator-kit lifecycle primitives"
+```
+
+---
+
+## Task 4: Scaffold `@repo/x-emulator` (configs, fixtures, env)
+
+**Files:**
+- Create: `emulators/x/package.json`, `emulators/x/tsconfig.json`, `emulators/x/vitest.config.ts`
+- Create: `emulators/x/src/fixtures.ts`, `emulators/x/src/env.ts`, `emulators/x/src/env-sh.ts`
+
+- [ ] **Step 1: Create `emulators/x/package.json`**
+
+```json
+{
+  "name": "@repo/x-emulator",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo node_modules",
+    "dev": "tsx ./src/start.ts",
+    "env:sh": "tsx ./src/env-sh.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@emulators/core": "catalog:",
+    "@repo/emulator-kit": "workspace:*",
+    "@t3-oss/env-core": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@repo/vitest-config": "workspace:*",
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}
+```
+
+- [ ] **Step 2: Create `emulators/x/tsconfig.json`**
+
+```json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "dom", "dom.iterable"]
+  },
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+- [ ] **Step 3: Create `emulators/x/vitest.config.ts`**
+
+```ts
+import sharedConfig from "@repo/vitest-config";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      environment: "node",
+    },
+  })
+);
+```
+
+- [ ] **Step 4: Create `emulators/x/src/fixtures.ts`**
+
+```ts
+export const X_EMULATOR_FIXTURES = {
+  oauthClientId: "x_lightfast_local",
+  oauthClientSecret: "x-local-secret",
+  userId: "x_user_lightfast_local",
+  userName: "Lightfast Local",
+  username: "lightfast_dev",
+  accessToken: "x_access_valid",
+  refreshToken: "x_refresh_valid",
+} as const;
+
+export const X_EMULATOR_OAUTH_CODE = "x_oauth_code_lightfast_local";
+
+export const X_EMULATOR_SCOPE = "tweet.read users.read offline.access";
+
+export function getXEmulatorEnv(
+  _appOrigin: string,
+  emulatorOrigin = "http://127.0.0.1:4569"
+) {
+  return {
+    X_CLIENT_ID: X_EMULATOR_FIXTURES.oauthClientId,
+    X_CLIENT_SECRET: X_EMULATOR_FIXTURES.oauthClientSecret,
+    X_API_ORIGIN: emulatorOrigin,
+    X_OAUTH_ORIGIN: emulatorOrigin,
+  };
+}
+
+const ENV_ASSIGNMENT_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function formatXEmulatorEnvString(env: Record<string, string>) {
+  return Object.entries(env)
+    .map(([key, value]) => {
+      if (!ENV_ASSIGNMENT_NAME_RE.test(key)) {
+        throw new Error(`Invalid environment variable name: ${key}`);
+      }
+      if (value.includes("\0")) {
+        throw new Error(
+          `Environment variable ${key} contains a NUL byte and cannot be passed to env -S`
+        );
+      }
+      return `${key}=${shellQuote(value)}`;
+    })
+    .join("\n");
+}
+```
+
+- [ ] **Step 5: Create `emulators/x/src/env.ts`**
+
+```ts
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export interface XEmulatorRuntimeEnv {
+  appOrigin: string;
+  emulatorOrigin?: string;
+  host: string;
+  port: number;
+}
+
+export function createXEmulatorRuntimeEnv(
+  runtimeEnv: NodeJS.ProcessEnv = process.env
+): XEmulatorRuntimeEnv {
+  const env = createEnv({
+    server: {
+      HOST: z.string().min(1).default("127.0.0.1"),
+      LIGHTFAST_APP_ORIGIN: z
+        .string()
+        .url()
+        .default("https://lightfast.localhost"),
+      X_EMULATOR_ORIGIN: z.string().url().optional(),
+      PORT: z.coerce.number().int().min(1).max(65_535).default(4569),
+      PORTLESS_URL: z.string().url().optional(),
+    },
+    runtimeEnv: {
+      HOST: runtimeEnv.HOST,
+      LIGHTFAST_APP_ORIGIN: runtimeEnv.LIGHTFAST_APP_ORIGIN,
+      X_EMULATOR_ORIGIN: runtimeEnv.X_EMULATOR_ORIGIN,
+      PORT: runtimeEnv.PORT,
+      PORTLESS_URL: runtimeEnv.PORTLESS_URL,
+    },
+    emptyStringAsUndefined: true,
+    skipValidation:
+      !!runtimeEnv.SKIP_ENV_VALIDATION ||
+      runtimeEnv.npm_lifecycle_event === "lint",
+  });
+
+  return {
+    appOrigin: env.LIGHTFAST_APP_ORIGIN,
+    emulatorOrigin: env.X_EMULATOR_ORIGIN ?? env.PORTLESS_URL,
+    host: env.HOST,
+    port: env.PORT,
+  };
+}
+```
+
+- [ ] **Step 6: Create `emulators/x/src/env-sh.ts`**
+
+```ts
+import { createXEmulatorRuntimeEnv } from "./env";
+import { formatXEmulatorEnvString, getXEmulatorEnv } from "./fixtures";
+
+function readOption(name: string) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return;
+  }
+
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function createRuntimeEnvWithOptions(): NodeJS.ProcessEnv {
+  const appOrigin = readOption("--app-origin");
+  const emulatorOrigin = readOption("--emulator-origin");
+
+  return {
+    ...process.env,
+    ...(appOrigin ? { LIGHTFAST_APP_ORIGIN: appOrigin } : {}),
+    ...(emulatorOrigin ? { X_EMULATOR_ORIGIN: emulatorOrigin } : {}),
+  };
+}
+
+const env = createXEmulatorRuntimeEnv(createRuntimeEnvWithOptions());
+
+console.log(
+  formatXEmulatorEnvString(getXEmulatorEnv(env.appOrigin, env.emulatorOrigin))
+);
+```
+
+- [ ] **Step 7: Install + typecheck**
+
+Run: `pnpm install`
+Then: `pnpm --filter @repo/x-emulator typecheck`
+Expected: install completes; typecheck FAILS only because `server.ts`/`start.ts`/`x-plugin.ts` referenced by later tasks don't exist yet — but `fixtures.ts`/`env.ts`/`env-sh.ts` themselves must have no type errors. (If typecheck errors come only from missing `./server`/`./start` imports, that's fine because those files aren't created yet; there are no such imports in this task's files, so typecheck should actually PASS here.)
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add emulators/x/package.json emulators/x/tsconfig.json emulators/x/vitest.config.ts emulators/x/src/fixtures.ts emulators/x/src/env.ts emulators/x/src/env-sh.ts pnpm-lock.yaml
+git commit -m "chore(x-emulator): scaffold @repo/x-emulator package and env wiring"
+```
+
+---
+
+## Task 5: Implement the X plugin + server wrapper (TDD)
+
+**Files:**
+- Test: `emulators/x/src/__tests__/server.test.ts`
+- Create: `emulators/x/src/x-plugin.ts`
+- Create: `emulators/x/src/server.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `emulators/x/src/__tests__/server.test.ts`:
+
+```ts
+import { createHash } from "node:crypto";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { X_EMULATOR_FIXTURES, X_EMULATOR_OAUTH_CODE } from "../fixtures";
+import { type StartedXEmulator, startXEmulator } from "../server";
+
+const VERIFIER = "x_pkce_verifier_lightfast_local_0123456789";
+const CHALLENGE = createHash("sha256").update(VERIFIER).digest("base64url");
+const REDIRECT_URI = "https://app.lightfast.localhost/api/connectors/x/callback";
+
+let emulator: StartedXEmulator | undefined;
+
+async function start() {
+  emulator = await startXEmulator({ port: 0 });
+  return emulator;
+}
+
+async function postForm(path: string, body: Record<string, string>) {
+  const active = emulator ?? (await start());
+  return await fetch(`${active.url}${path}`, {
+    body: new URLSearchParams(body),
+    headers: {
+      accept: "application/json",
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    method: "POST",
+  });
+}
+
+async function authorize(extra: Record<string, string> = {}) {
+  const active = emulator ?? (await start());
+  const url = new URL("/oauth2/authorize", active.url);
+  url.searchParams.set("client_id", X_EMULATOR_FIXTURES.oauthClientId);
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("code_challenge", CHALLENGE);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", "state_123");
+  for (const [key, value] of Object.entries(extra)) {
+    url.searchParams.set(key, value);
+  }
+  return await fetch(url, { redirect: "manual" });
+}
+
+afterEach(async () => {
+  await emulator?.close();
+  emulator = undefined;
+});
+
+describe("@repo/x-emulator", () => {
+  it("completes the OAuth 2.0 PKCE authorization code flow", async () => {
+    const authorizeRes = await authorize();
+    expect(authorizeRes.status).toBe(302);
+
+    const redirectUrl = new URL(authorizeRes.headers.get("location") ?? "");
+    expect(redirectUrl.searchParams.get("code")).toBe(X_EMULATOR_OAUTH_CODE);
+    expect(redirectUrl.searchParams.get("state")).toBe("state_123");
+
+    const tokenRes = await postForm("/oauth2/token", {
+      client_id: X_EMULATOR_FIXTURES.oauthClientId,
+      code: X_EMULATOR_OAUTH_CODE,
+      code_verifier: VERIFIER,
+      grant_type: "authorization_code",
+      redirect_uri: REDIRECT_URI,
+    });
+    expect(tokenRes.status).toBe(200);
+    await expect(tokenRes.json()).resolves.toMatchObject({
+      access_token: X_EMULATOR_FIXTURES.accessToken,
+      refresh_token: X_EMULATOR_FIXTURES.refreshToken,
+      token_type: "bearer",
+      expires_in: 7200,
+    });
+  });
+
+  it("rejects a token exchange with an invalid PKCE verifier", async () => {
+    await authorize();
+    const res = await postForm("/oauth2/token", {
+      client_id: X_EMULATOR_FIXTURES.oauthClientId,
+      code: X_EMULATOR_OAUTH_CODE,
+      code_verifier: "wrong-verifier",
+      grant_type: "authorization_code",
+      redirect_uri: REDIRECT_URI,
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_grant" });
+  });
+
+  it("rejects an authorize request missing the PKCE challenge", async () => {
+    const active = await start();
+    const url = new URL("/oauth2/authorize", active.url);
+    url.searchParams.set("client_id", X_EMULATOR_FIXTURES.oauthClientId);
+    url.searchParams.set("redirect_uri", REDIRECT_URI);
+    const res = await fetch(url, { redirect: "manual" });
+    expect(res.status).toBe(400);
+  });
+
+  it("refreshes tokens and supports a forced refresh failure", async () => {
+    const active = await start();
+
+    const refreshRes = await postForm("/oauth2/token", {
+      client_id: X_EMULATOR_FIXTURES.oauthClientId,
+      grant_type: "refresh_token",
+      refresh_token: X_EMULATOR_FIXTURES.refreshToken,
+    });
+    expect(refreshRes.status).toBe(200);
+
+    await fetch(`${active.url}/failures`, {
+      body: JSON.stringify({ refresh: true }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    const failedRes = await postForm("/oauth2/token", {
+      client_id: X_EMULATOR_FIXTURES.oauthClientId,
+      grant_type: "refresh_token",
+      refresh_token: X_EMULATOR_FIXTURES.refreshToken,
+    });
+    expect(failedRes.status).toBe(400);
+  });
+
+  it("serves the authenticated user and revokes valid tokens", async () => {
+    const active = await start();
+    const authorization = `Bearer ${X_EMULATOR_FIXTURES.accessToken}`;
+
+    const meRes = await fetch(`${active.url}/2/users/me`, {
+      headers: { authorization },
+    });
+    expect(meRes.status).toBe(200);
+    await expect(meRes.json()).resolves.toMatchObject({
+      data: {
+        id: X_EMULATOR_FIXTURES.userId,
+        username: X_EMULATOR_FIXTURES.username,
+      },
+    });
+
+    const revokeRes = await postForm("/oauth2/revoke", {
+      client_id: X_EMULATOR_FIXTURES.oauthClientId,
+      token: X_EMULATOR_FIXTURES.accessToken,
+    });
+    expect(revokeRes.status).toBe(200);
+  });
+
+  it("rejects missing and invalid bearer tokens on /2/users/me", async () => {
+    const active = await start();
+
+    const missingRes = await fetch(`${active.url}/2/users/me`);
+    expect(missingRes.status).toBe(401);
+
+    const invalidRes = await fetch(`${active.url}/2/users/me`, {
+      headers: { authorization: "Bearer invalid-token" },
+    });
+    expect(invalidRes.status).toBe(401);
+  });
+
+  it("supports the accessTokenExpired switch and reset", async () => {
+    const active = await start();
+    const authorization = `Bearer ${X_EMULATOR_FIXTURES.accessToken}`;
+
+    await fetch(`${active.url}/failures`, {
+      body: JSON.stringify({ accessTokenExpired: true }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const expiredRes = await fetch(`${active.url}/2/users/me`, {
+      headers: { authorization },
+    });
+    expect(expiredRes.status).toBe(401);
+
+    const resetRes = await fetch(`${active.url}/reset`, { method: "POST" });
+    expect(resetRes.status).toBe(200);
+
+    const okRes = await fetch(`${active.url}/2/users/me`, {
+      headers: { authorization },
+    });
+    expect(okRes.status).toBe(200);
+  });
+
+  it("supports the usersMe failure switch", async () => {
+    const active = await start();
+    await fetch(`${active.url}/failures`, {
+      body: JSON.stringify({ usersMe: true }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const res = await fetch(`${active.url}/2/users/me`, {
+      headers: { authorization: `Bearer ${X_EMULATOR_FIXTURES.accessToken}` },
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("rejects non-boolean failure switch values", async () => {
+    const active = await start();
+    const res = await fetch(`${active.url}/failures`, {
+      body: JSON.stringify({ refresh: "false" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "invalid_failure_switch",
+      field: "refresh",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @repo/x-emulator test`
+Expected: FAIL — `../server` (and `startXEmulator`) does not exist.
+
+- [ ] **Step 3: Implement `emulators/x/src/x-plugin.ts`**
+
+```ts
+import { createHash } from "node:crypto";
+
+import type { Context, Entity, ServicePlugin, Store } from "@emulators/core";
+
+import {
+  X_EMULATOR_FIXTURES,
+  X_EMULATOR_OAUTH_CODE,
+  X_EMULATOR_SCOPE,
+} from "./fixtures";
+
+const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 7200;
+
+interface FailureSwitches {
+  accessTokenExpired: boolean;
+  refresh: boolean;
+  usersMe: boolean;
+}
+
+const failureSwitchNames = [
+  "accessTokenExpired",
+  "refresh",
+  "usersMe",
+] as const satisfies ReadonlyArray<keyof FailureSwitches>;
+
+interface XUserRow extends Entity {
+  x_id: string;
+  name: string;
+  username: string;
+}
+
+function defaultFailures(): FailureSwitches {
+  return { accessTokenExpired: false, refresh: false, usersMe: false };
+}
+
+function getFailures(store: Store): FailureSwitches {
+  return store.getData<FailureSwitches>("failures") ?? defaultFailures();
+}
+
+function pkceChallengeFromVerifier(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function tokenResponse() {
+  return {
+    token_type: "bearer",
+    expires_in: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+    access_token: X_EMULATOR_FIXTURES.accessToken,
+    scope: X_EMULATOR_SCOPE,
+    refresh_token: X_EMULATOR_FIXTURES.refreshToken,
+  };
+}
+
+function userResponse(store: Store) {
+  const user = store.collection<XUserRow>("users").all()[0];
+  return {
+    data: {
+      id: user?.x_id ?? X_EMULATOR_FIXTURES.userId,
+      name: user?.name ?? X_EMULATOR_FIXTURES.userName,
+      username: user?.username ?? X_EMULATOR_FIXTURES.username,
+    },
+  };
+}
+
+function bearerToken(c: Context): string | undefined {
+  const authorization = c.req.header("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return undefined;
+  }
+  return authorization.slice("Bearer ".length);
+}
+
+function isValidBearer(c: Context, store: Store): boolean {
+  const failures = getFailures(store);
+  return (
+    !failures.accessTokenExpired &&
+    bearerToken(c) === X_EMULATOR_FIXTURES.accessToken
+  );
+}
+
+export const xPlugin: ServicePlugin = {
+  name: "x",
+  register(app, store) {
+    app.get("/oauth2/authorize", (c) => {
+      const clientId = c.req.query("client_id");
+      const redirectUri = c.req.query("redirect_uri");
+      const codeChallenge = c.req.query("code_challenge");
+      const codeChallengeMethod = c.req.query("code_challenge_method");
+
+      if (
+        clientId !== X_EMULATOR_FIXTURES.oauthClientId ||
+        !redirectUri ||
+        !codeChallenge ||
+        codeChallengeMethod !== "S256"
+      ) {
+        return c.json({ error: "invalid_request" }, 400);
+      }
+
+      store.setData(`pkce:${X_EMULATOR_OAUTH_CODE}`, codeChallenge);
+
+      const redirectUrl = new URL(redirectUri);
+      redirectUrl.searchParams.set("code", X_EMULATOR_OAUTH_CODE);
+      const state = c.req.query("state");
+      if (state) {
+        redirectUrl.searchParams.set("state", state);
+      }
+      return c.redirect(redirectUrl.toString(), 302);
+    });
+
+    app.post("/oauth2/token", async (c) => {
+      const form = await c.req.parseBody();
+      const clientId = String(form.client_id ?? "");
+      const grantType = String(form.grant_type ?? "");
+
+      if (clientId !== X_EMULATOR_FIXTURES.oauthClientId) {
+        return c.json({ error: "invalid_client" }, 401);
+      }
+
+      if (grantType === "authorization_code") {
+        const code = String(form.code ?? "");
+        const codeVerifier = String(form.code_verifier ?? "");
+        const expectedChallenge = store.getData<string>(`pkce:${code}`);
+
+        if (
+          code !== X_EMULATOR_OAUTH_CODE ||
+          !codeVerifier ||
+          !expectedChallenge ||
+          pkceChallengeFromVerifier(codeVerifier) !== expectedChallenge
+        ) {
+          return c.json({ error: "invalid_grant" }, 400);
+        }
+        return c.json(tokenResponse(), 200);
+      }
+
+      if (grantType === "refresh_token") {
+        const failures = getFailures(store);
+        if (
+          failures.refresh ||
+          String(form.refresh_token ?? "") !== X_EMULATOR_FIXTURES.refreshToken
+        ) {
+          return c.json({ error: "invalid_grant" }, 400);
+        }
+        return c.json(tokenResponse(), 200);
+      }
+
+      return c.json({ error: "unsupported_grant_type" }, 400);
+    });
+
+    app.post("/oauth2/revoke", async (c) => {
+      const form = await c.req.parseBody();
+      if (String(form.client_id ?? "") !== X_EMULATOR_FIXTURES.oauthClientId) {
+        return c.json({ error: "invalid_client" }, 401);
+      }
+      const token = String(form.token ?? "");
+      if (
+        token === X_EMULATOR_FIXTURES.accessToken ||
+        token === X_EMULATOR_FIXTURES.refreshToken
+      ) {
+        return c.body(null, 200);
+      }
+      return c.json({ error: "invalid_token" }, 400);
+    });
+
+    app.get("/2/users/me", (c) => {
+      if (!isValidBearer(c, store)) {
+        return c.json({ title: "Unauthorized", status: 401 }, 401);
+      }
+      if (getFailures(store).usersMe) {
+        return c.json({ title: "Internal Error", status: 500 }, 500);
+      }
+      return c.json(userResponse(store), 200);
+    });
+
+    app.post("/failures", async (c) => {
+      const body = (await c.req.json().catch(() => null)) as
+        | Partial<Record<keyof FailureSwitches, unknown>>
+        | null;
+      if (body !== null && (typeof body !== "object" || Array.isArray(body))) {
+        return c.json({ error: "invalid_failure_switches" }, 400);
+      }
+
+      const failures = getFailures(store);
+      for (const name of failureSwitchNames) {
+        const value = body?.[name];
+        if (value === undefined) {
+          continue;
+        }
+        if (typeof value !== "boolean") {
+          return c.json({ error: "invalid_failure_switch", field: name }, 400);
+        }
+        failures[name] = value;
+      }
+      store.setData("failures", failures);
+      return c.json({ failures }, 200);
+    });
+
+    app.post("/reset", (c) => {
+      const failures = defaultFailures();
+      store.setData("failures", failures);
+      return c.json({ failures }, 200);
+    });
+  },
+  seed(store) {
+    store.setData("failures", defaultFailures());
+    store.collection<XUserRow>("users").insert({
+      x_id: X_EMULATOR_FIXTURES.userId,
+      name: X_EMULATOR_FIXTURES.userName,
+      username: X_EMULATOR_FIXTURES.username,
+    });
+  },
+};
+```
+
+- [ ] **Step 4: Implement `emulators/x/src/server.ts`**
+
+```ts
+import { type StartedEmulator, startEmulator } from "@repo/emulator-kit";
+
+import { xPlugin } from "./x-plugin";
+
+export interface StartXEmulatorInput {
+  appOrigin?: string;
+  host?: string;
+  port?: number;
+  publicOrigin?: string;
+}
+
+export type StartedXEmulator = StartedEmulator;
+
+export function startXEmulator(
+  input: StartXEmulatorInput = {}
+): Promise<StartedXEmulator> {
+  return startEmulator(xPlugin, {
+    appOrigin: input.appOrigin,
+    host: input.host,
+    port: input.port ?? 4569,
+    publicOrigin: input.publicOrigin,
+  });
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm --filter @repo/x-emulator test`
+Expected: PASS (all `@repo/x-emulator` tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @repo/x-emulator typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add emulators/x/src/x-plugin.ts emulators/x/src/server.ts emulators/x/src/__tests__/server.test.ts
+git commit -m "feat(x-emulator): OAuth 2.0 PKCE auth-only plugin on @repo/emulator-kit"
+```
+
+---
+
+## Task 6: Add the process entrypoint + README
+
+**Files:**
+- Create: `emulators/x/src/start.ts`
+- Create: `emulators/x/README.md`
+
+- [ ] **Step 1: Create `emulators/x/src/start.ts`**
+
+```ts
+import { createXEmulatorRuntimeEnv } from "./env";
+import { getXEmulatorEnv } from "./fixtures";
+import { startXEmulator } from "./server";
+
+const env = createXEmulatorRuntimeEnv();
+
+const sensitiveEnvKeyPattern = /(?:KEY|SECRET|TOKEN|PRIVATE)/i;
+
+function redactEnvValueForLog(key: string, value: string): string {
+  if (sensitiveEnvKeyPattern.test(key)) {
+    return "<redacted>";
+  }
+
+  return value;
+}
+
+const emulator = await startXEmulator({
+  appOrigin: env.appOrigin,
+  host: env.host,
+  port: env.port,
+  publicOrigin: env.emulatorOrigin,
+});
+
+console.log(`[x-emulator] listening on ${emulator.listenUrl}`);
+console.log(`[x-emulator] public origin ${emulator.publicOrigin}`);
+for (const [key, value] of Object.entries(
+  getXEmulatorEnv(env.appOrigin, emulator.publicOrigin)
+)) {
+  console.log(`${key}=${JSON.stringify(redactEnvValueForLog(key, value))}`);
+}
+
+async function close(signal: NodeJS.Signals) {
+  console.log(`[x-emulator] received ${signal}, shutting down`);
+  await emulator.close();
+  process.exit(0);
+}
+
+process.on("SIGINT", (signal) => {
+  void close(signal);
+});
+
+process.on("SIGTERM", (signal) => {
+  void close(signal);
+});
+```
+
+- [ ] **Step 2: Create `emulators/x/README.md`**
+
+```markdown
+# X Emulator
+
+Local development harness for the X (Twitter) connector slice. This package is
+dev-only; production runtime code must not import it.
+
+Built on `@emulators/core` (vercel-labs/emulate) via the shared
+`@repo/emulator-kit`. Scoped to an OAuth 2.0 PKCE auth-only slice.
+
+## Run
+
+From the repository root, `pnpm dev` starts the emulator through Portless
+alongside app, www, platform, Inngest, QStash, GitHub, Linear, and the MFE
+proxy:
+
+```bash
+pnpm dev
+```
+
+The emulator is routed at:
+
+```text
+https://x.lightfast.localhost
+```
+
+The app dev process receives deterministic `X_*` values from `@lightfast/app`'s
+`with-related-projects` wrapper. Do not copy worktree-specific emulator URLs
+into `.vercel/.env.development.local`.
+
+To run only the emulator:
+
+```bash
+pnpm --filter @repo/x-emulator dev
+```
+
+## Endpoints
+
+- `GET /oauth2/authorize` (OAuth 2.0 PKCE, `S256`)
+- `POST /oauth2/token` (`authorization_code` + `refresh_token` grants)
+- `POST /oauth2/revoke`
+- `GET /2/users/me`
+- `POST /failures`
+- `POST /reset`
+
+`POST /failures` accepts JSON booleans for `accessTokenExpired`, `refresh`, and
+`usersMe`. `POST /reset` clears all failure switches.
+
+## Configuration
+
+Optional environment variables:
+
+```bash
+PORT=4569
+HOST=127.0.0.1
+LIGHTFAST_APP_ORIGIN=https://lightfast.localhost
+X_EMULATOR_ORIGIN=https://x.lightfast.localhost
+```
+
+## Test
+
+```bash
+pnpm --filter @repo/x-emulator test -- src/__tests__/server.test.ts
+pnpm --filter @repo/x-emulator typecheck
+```
+```
+
+- [ ] **Step 3: Smoke-test the dev entrypoint boots**
+
+Run: `PORT=4569 pnpm --filter @repo/x-emulator dev`
+Expected: prints `[x-emulator] listening on http://127.0.0.1:4569` and the `X_*` lines (secrets redacted). In another shell, `curl -s http://127.0.0.1:4569/2/users/me -H "authorization: Bearer x_access_valid"` returns the user JSON. Stop with Ctrl-C.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add emulators/x/src/start.ts emulators/x/README.md
+git commit -m "feat(x-emulator): add dev entrypoint and README"
+```
+
+---
+
+## Task 7: Wire the X emulator into the dev orchestration
+
+**Files:**
+- Modify: `package.json` (root)
+- Modify: `turbo.json`
+- Modify: `apps/app/package.json`
+
+- [ ] **Step 1: Add the `_x_emulator` root script in `package.json`**
+
+Immediately after the `"_linear_emulator": "...",` line, add:
+
+```json
+    "_x_emulator": "portless run --name x.lightfast sh -c 'LIGHTFAST_APP_ORIGIN=\"$(portless get app.lightfast)\" X_EMULATOR_ORIGIN=\"$(portless get x.lightfast)\" pnpm --filter @repo/x-emulator dev'",
+```
+
+- [ ] **Step 2: Add `//#_x_emulator` to the root `dev` task in `package.json`**
+
+Change the `dev` script from:
+
+```json
+    "dev": "portless proxy start && turbo run dev:next @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator --concurrency=15 -F @lightfast/www -F @lightfast/app -F @lightfast/platform --continue",
+```
+
+to (insert `//#_x_emulator` after `//#_linear_emulator`):
+
+```json
+    "dev": "portless proxy start && turbo run dev:next @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator //#_x_emulator --concurrency=15 -F @lightfast/www -F @lightfast/app -F @lightfast/platform --continue",
+```
+
+- [ ] **Step 3: Register the `//#_x_emulator` task in `turbo.json`**
+
+Immediately after the `"//#_linear_emulator": { ... },` block, add:
+
+```json
+    "//#_x_emulator": {
+      "cache": false,
+      "persistent": true
+    },
+```
+
+- [ ] **Step 4: Append the X emulator to `with-related-projects` in `apps/app/package.json`**
+
+Replace the existing `"with-related-projects"` value so the `env -S` argument
+concatenates a third emulator env block (a `\n` then the x-emulator `env:sh`
+output), inserted after the linear block and before the closing `\"`:
+
+```json
+    "with-related-projects": "env -S \"$(pnpm --silent --filter @repo/github-emulator env:sh -- --app-origin \"$(portless get app.lightfast)\" --emulator-origin \"$(portless get github.lightfast)\")\n$(pnpm --silent --filter @repo/linear-emulator env:sh -- --app-origin \"$(portless get app.lightfast)\" --emulator-origin \"$(portless get linear.lightfast)\")\n$(pnpm --silent --filter @repo/x-emulator env:sh -- --app-origin \"$(portless get app.lightfast)\" --emulator-origin \"$(portless get x.lightfast)\")\" INNGEST_SERVE_ORIGIN=$(portless get app.lightfast) NEXT_PUBLIC_APP_URL=$(portless get app.lightfast) NEXT_PUBLIC_WWW_URL=$(portless get www.lightfast) NEXT_PUBLIC_PLATFORM_URL=$(portless get platform.lightfast) INNGEST_DEV=$(portless get inngest.lightfast) QSTASH_URL=$(portless get qstash.lightfast)",
+```
+
+- [ ] **Step 5: Verify `env:sh` emits valid `env -S` assignments**
+
+Run: `pnpm --silent --filter @repo/x-emulator env:sh -- --app-origin https://lightfast.localhost --emulator-origin http://127.0.0.1:4569`
+Expected output (exact):
+
+```text
+X_CLIENT_ID='x_lightfast_local'
+X_CLIENT_SECRET='x-local-secret'
+X_API_ORIGIN='http://127.0.0.1:4569'
+X_OAUTH_ORIGIN='http://127.0.0.1:4569'
+```
+
+- [ ] **Step 6: Verify the JSON edits parse**
+
+Run: `node -e "require('./package.json'); require('./turbo.json'); require('./apps/app/package.json'); console.log('json ok')"`
+Expected: `json ok` (no SyntaxError from the edited files).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json turbo.json apps/app/package.json
+git commit -m "feat(dev): wire @repo/x-emulator into pnpm dev + with-related-projects"
+```
+
+---
+
+## Task 8: Final verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck the three touched/created packages**
+
+Run: `pnpm --filter @repo/emulator-kit --filter @repo/x-emulator --filter @repo/github-emulator typecheck`
+Expected: PASS for all three.
+
+- [ ] **Step 2: Run all three emulator test suites**
+
+Run: `pnpm --filter @repo/emulator-kit --filter @repo/x-emulator --filter @repo/github-emulator test`
+Expected: PASS for all three (kit lifecycle, X plugin, GitHub regression).
+
+- [ ] **Step 3: Lint/format check on changed files**
+
+Run: `pnpm check`
+Expected: PASS (Biome reports no errors on the new/edited files). If Biome reports formatting fixes, apply them, then re-run and re-stage.
+
+- [ ] **Step 4: Confirm Linear was not touched**
+
+Run: `git status --porcelain emulators/linear`
+Expected: empty output (no changes under `emulators/linear`).
+
+- [ ] **Step 5: Boot the full dev stack and confirm the X route resolves (manual)**
+
+Run: `pnpm dev` (in a scratch terminal), then once Portless is up:
+`curl -s https://x.lightfast.localhost/2/users/me -H "authorization: Bearer x_access_valid"`
+Expected: returns `{"data":{"id":"x_user_lightfast_local","name":"Lightfast Local","username":"lightfast_dev"}}`. Stop the dev stack afterward (`pkill -f "next dev"` / Ctrl-C).
+
+> Note: nothing in the app consumes `X_*` yet (no X connector exists). This step proves the emulator boots and routes under Portless — the deliverable is connector-ready infrastructure, matching how the Linear slice is scoped.
+
+- [ ] **Step 6: Final commit (only if `pnpm check` applied formatting)**
+
+```bash
+git add emulators/kit emulators/x
+git commit -m "style(emulators): apply biome formatting"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layer A substrate (`@emulators/core` + `ServicePlugin`) → Tasks 2, 5 (kit wraps `createServer`; X is a `ServicePlugin`). ✓
+- Layer B kit at `emulators/kit` → Tasks 1–2. ✓
+- X auth-only slice (PKCE authorize/token/revoke, `/2/users/me`, failures, reset) → Task 5 routes + tests. ✓
+- Three failure switches `accessTokenExpired`/`refresh`/`usersMe` → Task 5 (`x-plugin.ts` + tests). ✓
+- Real S256 PKCE validation → Task 5 (`pkceChallengeFromVerifier`, invalid-verifier test). ✓
+- Self-contained fixtures, no `@repo/x-app-*` dep → Task 4 (`fixtures.ts`; package.json has no such dep). ✓
+- GitHub light refactor onto kit primitives → Task 3. ✓
+- Linear untouched → Task 8 Step 4 guard. ✓
+- Dev wiring (port 4569, `x.lightfast`, root `dev` task, turbo task, `with-related-projects`) → Task 7. ✓
+- Testing (X suite, kit lifecycle, github regression) → Tasks 2, 5, 8. ✓
+- "X env injected but unconsumed" honesty → Task 8 Step 5 note. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full file or exact edit; every command has expected output. ✓
+
+**Type consistency:** `StartedEmulator` (kit) is reused as `StartedXEmulator` (server.ts) and imported in the X test. `startEmulator(plugin, options)` signature matches its call in `server.ts`. `FailureSwitches` keys (`accessTokenExpired`/`refresh`/`usersMe`) are identical across `x-plugin.ts` and `server.test.ts`. `X_EMULATOR_FIXTURES` field names (`oauthClientId`, `accessToken`, `refreshToken`, `userId`, `userName`, `username`) match between `fixtures.ts`, `x-plugin.ts`, and `server.test.ts`. `getXEmulatorEnv` keys match the Task 7 Step 5 expected output. ✓

--- a/docs/superpowers/plans/2026-06-01-linear-emulator-kit-migration.md
+++ b/docs/superpowers/plans/2026-06-01-linear-emulator-kit-migration.md
@@ -1,0 +1,522 @@
+# Linear Emulator → Kit Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `@repo/linear-emulator` from a standalone `node:http` server onto the shared `@repo/emulator-kit` by rewriting it as a `ServicePlugin` on `@emulators/core`, booted by `startEmulator` — exactly mirroring the X emulator — while preserving 100% of its current behavior (guarded by the existing test suite).
+
+**Architecture:** Linear today is a ~450-line hand-rolled `node:http` server with duplicated lifecycle helpers and closure-held failure switches. After this migration it becomes `linear-plugin.ts` (a `ServicePlugin` whose routes are Hono handlers and whose failure switches live in the `Store`) plus a thin `server.ts` wrapper that calls `startEmulator(linearPlugin, …)`. The public `StartedLinearEmulator` becomes an alias of the kit's `StartedEmulator` (the previously-exposed `failures` field is dropped — no consumer reads it). Linear keeps its own `/failures` + `/reset` routes self-contained in the plugin (matching X; no kit promotion).
+
+**Tech Stack:** TypeScript (ESM), `@emulators/core` (Hono `Context`/`ServicePlugin`/`Store`), `@repo/emulator-kit` (`startEmulator`), `vitest`, pnpm workspaces, Turborepo.
+
+**Design context:** Extends `docs/superpowers/specs/2026-06-01-emulator-kit-and-x-emulator-design.md` (the deferred "Migrate Linear onto the kit" item). Failure-switch promotion into the kit is explicitly **out of scope** (only two consumers; YAGNI).
+
+**Conventions observed (do not deviate):**
+- Internal `@repo/*` packages export TS source directly; no build step.
+- Linear's port stays **4568**; routes and wire-level responses are unchanged.
+- Externals use `catalog:`; internal deps use `workspace:*`.
+- Commit with explicit pathspecs (a concurrent agent may stage unrelated files). Do **not** `git push`.
+- The existing `emulators/linear/src/__tests__/server.test.ts` (10 tests) is the regression guard and **must not be modified**.
+
+---
+
+## File Structure
+
+**Create:**
+- `emulators/linear/src/linear-plugin.ts` — the `ServicePlugin` (all 8 routes as Hono handlers + seed)
+
+**Modify:**
+- `emulators/linear/package.json` — add `@emulators/core` + `@repo/emulator-kit` deps
+- `emulators/linear/src/server.ts` — replace the ~450-line server with a thin `startEmulator` wrapper
+
+**Unchanged (verified):**
+- `emulators/linear/src/start.ts` — uses `.listenUrl` / `.publicOrigin` / `.close()`, all present on `StartedEmulator`
+- `emulators/linear/src/fixtures.ts`, `src/env.ts`, `src/env-sh.ts`
+- `emulators/linear/src/__tests__/server.test.ts` — the behavior guard
+- Dev wiring (`package.json` `_linear_emulator`, `turbo.json`, `apps/app` `with-related-projects`) — Linear already wired; port/route unchanged
+
+---
+
+## Task 1: Add kit + core dependencies to the Linear emulator
+
+**Files:**
+- Modify: `emulators/linear/package.json`
+
+- [ ] **Step 1: Add the two dependencies**
+
+In `emulators/linear/package.json`, replace the `"dependencies"` block:
+
+```json
+  "dependencies": {
+    "@repo/linear-app-node": "workspace:*",
+    "@t3-oss/env-core": "catalog:",
+    "zod": "catalog:"
+  },
+```
+
+with:
+
+```json
+  "dependencies": {
+    "@emulators/core": "catalog:",
+    "@repo/emulator-kit": "workspace:*",
+    "@repo/linear-app-node": "workspace:*",
+    "@t3-oss/env-core": "catalog:",
+    "zod": "catalog:"
+  },
+```
+
+- [ ] **Step 2: Install**
+
+Run: `pnpm install`
+Expected: completes; `@emulators/core` and `@repo/emulator-kit` linked into `emulators/linear` (lockfile gains the two entries under `emulators/linear:`).
+
+- [ ] **Step 3: Verify the lockfile diff is only the Linear dep additions**
+
+Run: `git --no-pager diff pnpm-lock.yaml`
+Expected: the only changes are `'@emulators/core'` and `'@repo/emulator-kit': link:../kit` added under the `emulators/linear:` importer. If anything else changed, stop and investigate before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add emulators/linear/package.json pnpm-lock.yaml
+git commit -m "chore(linear-emulator): add @emulators/core + @repo/emulator-kit deps" -- emulators/linear/package.json pnpm-lock.yaml
+```
+
+---
+
+## Task 2: Create the Linear `ServicePlugin`
+
+**Files:**
+- Create: `emulators/linear/src/linear-plugin.ts`
+
+- [ ] **Step 1: Create `emulators/linear/src/linear-plugin.ts`**
+
+This ports every route from the old `server.ts` to Hono handlers, with failure switches moved into the `Store`. Behavior is identical: confidential-client validation (`client_id` **and** `client_secret`), no PKCE, and the full MCP JSON-RPC dispatch.
+
+```ts
+import type { Context, ServicePlugin, Store } from "@emulators/core";
+
+import {
+  LINEAR_EMULATOR_FIXTURES,
+  LINEAR_EMULATOR_OAUTH_CODE,
+  LINEAR_EMULATOR_TOOLS,
+} from "./fixtures";
+
+const TOKEN_EXPIRES_IN_SECONDS = 3600;
+const REFRESH_TOKEN_EXPIRES_IN_SECONDS = 2_592_000;
+
+interface FailureSwitches {
+  accessTokenExpired: boolean;
+  mcpListTools: boolean;
+  refresh: boolean;
+}
+
+const failureSwitchNames = [
+  "accessTokenExpired",
+  "mcpListTools",
+  "refresh",
+] as const satisfies ReadonlyArray<keyof FailureSwitches>;
+
+function defaultFailures(): FailureSwitches {
+  return { accessTokenExpired: false, mcpListTools: false, refresh: false };
+}
+
+function getFailures(store: Store): FailureSwitches {
+  return store.getData<FailureSwitches>("failures") ?? defaultFailures();
+}
+
+function tokenResponse() {
+  return {
+    access_token: LINEAR_EMULATOR_FIXTURES.accessToken,
+    expires_in: TOKEN_EXPIRES_IN_SECONDS,
+    refresh_token: LINEAR_EMULATOR_FIXTURES.refreshToken,
+    refresh_token_expires_in: REFRESH_TOKEN_EXPIRES_IN_SECONDS,
+    scope: "read,write",
+    token_type: "Bearer",
+  };
+}
+
+function viewerResponse() {
+  return {
+    data: {
+      viewer: {
+        id: LINEAR_EMULATOR_FIXTURES.actorId,
+        name: LINEAR_EMULATOR_FIXTURES.actorName,
+        organization: {
+          id: LINEAR_EMULATOR_FIXTURES.workspaceId,
+          name: LINEAR_EMULATOR_FIXTURES.workspaceName,
+        },
+      },
+    },
+  };
+}
+
+function clientCredentialsValid(clientId: unknown, clientSecret: unknown): boolean {
+  return (
+    String(clientId ?? "") === LINEAR_EMULATOR_FIXTURES.oauthClientId &&
+    String(clientSecret ?? "") === LINEAR_EMULATOR_FIXTURES.oauthClientSecret
+  );
+}
+
+function bearerToken(c: Context): string | undefined {
+  const authorization = c.req.header("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return;
+  }
+  return authorization.slice("Bearer ".length);
+}
+
+function isValidBearer(c: Context, store: Store): boolean {
+  const failures = getFailures(store);
+  return (
+    !failures.accessTokenExpired &&
+    bearerToken(c) === LINEAR_EMULATOR_FIXTURES.accessToken
+  );
+}
+
+interface McpRequestBody {
+  id?: number | string | null;
+  method?: string;
+  params?: { name?: string; arguments?: unknown };
+}
+
+export const linearPlugin: ServicePlugin = {
+  name: "linear",
+  register(app, store) {
+    app.get("/oauth/authorize", (c) => {
+      const clientId = c.req.query("client_id");
+      const redirectUri = c.req.query("redirect_uri");
+      if (clientId !== LINEAR_EMULATOR_FIXTURES.oauthClientId || !redirectUri) {
+        return c.json({ error: "invalid_request" }, 400);
+      }
+
+      const redirectUrl = new URL(redirectUri);
+      redirectUrl.searchParams.set("code", LINEAR_EMULATOR_OAUTH_CODE);
+      const state = c.req.query("state");
+      if (state) {
+        redirectUrl.searchParams.set("state", state);
+      }
+      return c.redirect(redirectUrl.toString(), 302);
+    });
+
+    app.post("/oauth/token", async (c) => {
+      const form = await c.req.parseBody();
+      if (!clientCredentialsValid(form.client_id, form.client_secret)) {
+        return c.json({ error: "invalid_client" }, 401);
+      }
+
+      const grantType = String(form.grant_type ?? "");
+      if (grantType === "authorization_code") {
+        if (String(form.code ?? "") !== LINEAR_EMULATOR_OAUTH_CODE) {
+          return c.json({ error: "invalid_grant" }, 400);
+        }
+        return c.json(tokenResponse(), 200);
+      }
+
+      if (grantType === "refresh_token") {
+        const failures = getFailures(store);
+        if (
+          failures.refresh ||
+          String(form.refresh_token ?? "") !== LINEAR_EMULATOR_FIXTURES.refreshToken
+        ) {
+          return c.json({ error: "invalid_grant" }, 400);
+        }
+        return c.json(tokenResponse(), 200);
+      }
+
+      return c.json({ error: "unsupported_grant_type" }, 400);
+    });
+
+    app.post("/oauth/revoke", async (c) => {
+      const form = await c.req.parseBody();
+      if (!clientCredentialsValid(form.client_id, form.client_secret)) {
+        return c.json({ error: "invalid_client" }, 401);
+      }
+
+      const token = String(form.token ?? "");
+      if (
+        token === LINEAR_EMULATOR_FIXTURES.accessToken ||
+        token === LINEAR_EMULATOR_FIXTURES.refreshToken
+      ) {
+        return c.body(null, 200);
+      }
+      return c.json({ error: "invalid_token" }, 400);
+    });
+
+    app.get("/viewer", (c) => {
+      if (!isValidBearer(c, store)) {
+        return c.json({ error: "invalid_token" }, 401);
+      }
+      return c.json(viewerResponse(), 200);
+    });
+
+    app.post("/graphql", (c) => {
+      if (!isValidBearer(c, store)) {
+        return c.json({ error: "invalid_token" }, 401);
+      }
+      return c.json(viewerResponse(), 200);
+    });
+
+    app.post("/mcp", async (c) => {
+      if (!isValidBearer(c, store)) {
+        return c.json({ error: "invalid_token" }, 401);
+      }
+
+      const body = (await c.req.json().catch(() => null)) as McpRequestBody | null;
+      if (!body?.method) {
+        return c.json({ error: "invalid_request" }, 400);
+      }
+
+      if (body.id === undefined || body.id === null) {
+        return c.body(null, 202);
+      }
+
+      if (body.method === "initialize") {
+        return c.json(
+          {
+            id: body.id,
+            jsonrpc: "2.0",
+            result: {
+              capabilities: { tools: {} },
+              protocolVersion: "2025-06-18",
+              serverInfo: { name: "linear-emulator", version: "0.1.0" },
+            },
+          },
+          200
+        );
+      }
+
+      if (body.method === "tools/list") {
+        if (getFailures(store).mcpListTools) {
+          return c.json(
+            {
+              error: { code: -32_003, message: "Linear MCP list-tools failure" },
+              id: body.id,
+              jsonrpc: "2.0",
+            },
+            500
+          );
+        }
+        return c.json(
+          {
+            id: body.id,
+            jsonrpc: "2.0",
+            result: { tools: LINEAR_EMULATOR_TOOLS },
+          },
+          200
+        );
+      }
+
+      if (body.method === "tools/call") {
+        const name = body.params?.name;
+        const tool = LINEAR_EMULATOR_TOOLS.find((item) => item.name === name);
+        if (!tool) {
+          return c.json(
+            {
+              error: { code: -32_602, message: `Unknown tool: ${name ?? ""}` },
+              id: body.id,
+              jsonrpc: "2.0",
+            },
+            200
+          );
+        }
+
+        const structuredContent = {
+          arguments: body.params?.arguments ?? {},
+          ok: true,
+          tool: tool.name,
+        };
+        return c.json(
+          {
+            id: body.id,
+            jsonrpc: "2.0",
+            result: {
+              content: [
+                { type: "text", text: JSON.stringify(structuredContent, null, 2) },
+              ],
+              structuredContent,
+            },
+          },
+          200
+        );
+      }
+
+      return c.json(
+        {
+          error: { code: -32_601, message: `Unsupported method: ${body.method}` },
+          id: body.id,
+          jsonrpc: "2.0",
+        },
+        200
+      );
+    });
+
+    app.post("/failures", async (c) => {
+      const body = (await c.req.json().catch(() => null)) as
+        | Partial<Record<keyof FailureSwitches, unknown>>
+        | null;
+      if (body !== null && (typeof body !== "object" || Array.isArray(body))) {
+        return c.json({ error: "invalid_failure_switches" }, 400);
+      }
+
+      const failures = getFailures(store);
+      for (const name of failureSwitchNames) {
+        const value = body?.[name];
+        if (value === undefined) {
+          continue;
+        }
+        if (typeof value !== "boolean") {
+          return c.json({ error: "invalid_failure_switch", field: name }, 400);
+        }
+        failures[name] = value;
+      }
+      store.setData("failures", failures);
+      return c.json({ failures }, 200);
+    });
+
+    app.post("/reset", (c) => {
+      const failures = defaultFailures();
+      store.setData("failures", failures);
+      return c.json({ failures }, 200);
+    });
+  },
+  seed(store) {
+    store.setData("failures", defaultFailures());
+  },
+};
+```
+
+- [ ] **Step 2: Typecheck the plugin in isolation (server.ts still old)**
+
+Run: `pnpm --filter @repo/linear-emulator typecheck`
+Expected: PASS. (The old `server.ts` still compiles; the new `linear-plugin.ts` adds no errors. If `clientCredentialsValid` or `Context` usage errors, fix before continuing.)
+
+---
+
+## Task 3: Rewrite `server.ts` as a thin kit wrapper + verify behavior parity
+
+**Files:**
+- Modify: `emulators/linear/src/server.ts`
+
+- [ ] **Step 1: Replace the entire contents of `emulators/linear/src/server.ts`**
+
+```ts
+import { type StartedEmulator, startEmulator } from "@repo/emulator-kit";
+
+import { linearPlugin } from "./linear-plugin";
+
+export interface StartLinearEmulatorInput {
+  appOrigin?: string;
+  host?: string;
+  port?: number;
+  publicOrigin?: string;
+}
+
+export type StartedLinearEmulator = StartedEmulator;
+
+export function startLinearEmulator(
+  input: StartLinearEmulatorInput = {}
+): Promise<StartedLinearEmulator> {
+  return startEmulator(linearPlugin, {
+    appOrigin: input.appOrigin,
+    host: input.host,
+    port: input.port ?? 4568,
+    publicOrigin: input.publicOrigin,
+  });
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @repo/linear-emulator typecheck`
+Expected: PASS — no leftover references to the deleted helpers; `start.ts` and the test still compile against `StartLinearEmulatorInput` / `StartedLinearEmulator` / `startLinearEmulator`.
+
+- [ ] **Step 3: Run the existing test suite (the regression guard) — must stay green**
+
+Run: `pnpm --filter @repo/linear-emulator test`
+Expected: PASS — all 10 tests green, including:
+- OAuth authorization-code flow (302 with code + state, token exchange)
+- invalid client credentials → 401
+- refresh + forced refresh-failure switch → 200 then 400
+- `/viewer` + `/graphql` viewer payload, `/oauth/revoke` → 200
+- missing/invalid MCP bearer → 401
+- deterministic `tools/list` (raw POST) → tools array
+- deterministic `tools/list` **through the real `listLinearMcpTools` client** → equals `LINEAR_EMULATOR_TOOLS`
+- `mcpListTools` failure switch → 500 with `-32003`
+- non-boolean failure switch → 400 `invalid_failure_switch`
+- `/reset` clears switches → `/viewer` 200 again
+
+If the real-MCP-client test fails, that is the highest-risk parity point — inspect the JSON-RPC response shape against the old `handleMcp` before changing anything else.
+
+- [ ] **Step 4: Biome check on the changed files; apply fixes if any**
+
+Run: `npx ultracite@latest check emulators/linear/src/linear-plugin.ts emulators/linear/src/server.ts`
+Expected: no errors. If Biome reports formatting/sorting fixes, run:
+`npx ultracite@latest fix emulators/linear/src/linear-plugin.ts emulators/linear/src/server.ts`
+then re-run the check (expect clean) and re-run the test suite (expect 10 green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add emulators/linear/src/linear-plugin.ts emulators/linear/src/server.ts
+git commit -m "refactor(linear-emulator): migrate onto @repo/emulator-kit as a ServicePlugin" -- emulators/linear/src/linear-plugin.ts emulators/linear/src/server.ts
+```
+
+---
+
+## Task 4: Final verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck all four emulator packages**
+
+Run: `pnpm --filter @repo/emulator-kit --filter @repo/x-emulator --filter @repo/github-emulator --filter @repo/linear-emulator typecheck`
+Expected: PASS for all four.
+
+- [ ] **Step 2: Run all four emulator test suites**
+
+Run: `pnpm --filter @repo/emulator-kit --filter @repo/x-emulator --filter @repo/github-emulator --filter @repo/linear-emulator test`
+Expected: PASS — kit 3, X 9, GitHub 36, Linear 10.
+
+- [ ] **Step 3: Confirm the dev wiring for Linear is unchanged**
+
+Run: `pnpm --silent --filter @repo/linear-emulator env:sh -- --app-origin https://lightfast.localhost --emulator-origin http://127.0.0.1:4568`
+Expected output (exact — proves the env contract is untouched):
+
+```text
+LINEAR_CLIENT_ID='linear_lightfast_local'
+LINEAR_CLIENT_SECRET='linear-local-secret'
+LINEAR_API_ORIGIN='http://127.0.0.1:4568'
+LINEAR_MCP_ENDPOINT='http://127.0.0.1:4568/mcp'
+```
+
+- [ ] **Step 4: Smoke-test the dev entrypoint boots and serves**
+
+Run (background): `PORT=4568 pnpm --filter @repo/linear-emulator dev > /tmp/linear-emulator-smoke.log 2>&1 &`
+Then once `listening on` appears in the log:
+`curl -s http://127.0.0.1:4568/viewer -H "authorization: Bearer linear_access_valid"`
+Expected: `{"data":{"viewer":{"id":"linear_actor_lightfast_local","name":"Lightfast Local","organization":{"id":"linear_workspace_lightfast_emulated","name":"lightfast-emulated"}}}}`
+Then stop it: `pkill -f "emulators/linear/src/start.ts"`
+
+- [ ] **Step 5: Confirm GitHub/X/kit were not touched by this migration**
+
+Run: `git status --porcelain emulators/github emulators/x emulators/kit`
+Expected: empty output (this migration only changed `emulators/linear` + the lockfile).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Migrate Linear onto the kit as a `ServicePlugin` on `@emulators/core` → Tasks 2–3. ✓
+- Preserve all 8 routes + exact wire responses → Task 2 (ported verbatim), guarded by Task 3 Step 3. ✓
+- Confidential client (id + secret), no PKCE → `clientCredentialsValid` in Task 2. ✓
+- Failure switches into the `Store`, self-contained `/failures` + `/reset` (no kit promotion) → Task 2 plugin; chosen scope. ✓
+- `StartedLinearEmulator = StartedEmulator`, drop unused `failures` field → Task 3 (verified no consumer reads it). ✓
+- Port 4568, dev wiring untouched → Task 3 Step 1 (`?? 4568`), Task 4 Step 3. ✓
+- Existing tests unchanged + green → Task 3 Step 3, Task 4 Step 2. ✓
+- GitHub/X/kit untouched → Task 4 Step 5. ✓
+
+**Placeholder scan:** No TBD/TODO; `linear-plugin.ts` and `server.ts` are shown in full; every command has expected output. ✓
+
+**Type consistency:** `StartedEmulator` (kit) ← `StartedLinearEmulator` (server.ts) ← used by `start.ts`/test. `startEmulator(plugin, options)` matches its call. `FailureSwitches` keys (`accessTokenExpired`/`mcpListTools`/`refresh`) are identical to the old server and the test's switch names. `LINEAR_EMULATOR_FIXTURES` field names (`oauthClientId`, `oauthClientSecret`, `accessToken`, `refreshToken`, `actorId`, `actorName`, `workspaceId`, `workspaceName`), `LINEAR_EMULATOR_OAUTH_CODE`, and `LINEAR_EMULATOR_TOOLS` match `fixtures.ts`. The `?? 4568` default preserves both the production port and the `port: 0` test path (`0 ?? 4568 === 0`). ✓

--- a/docs/superpowers/plans/2026-06-01-source-control-git-settings-redesign.md
+++ b/docs/superpowers/plans/2026-06-01-source-control-git-settings-redesign.md
@@ -1,0 +1,2077 @@
+# Source Control & Git Settings — UI Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the `/[slug]/settings/source-control` sub-tab into three stacked Connector-style sections — Organization, Lightfast repository, Repositories — splitting one ~450-line file into focused components, with one safe backend change (surface `syncStatus`).
+
+**Architecture:** The page keeps its two suspense queries (`get`, `listRepositories`) and `HydrateClient` prefetch. The client orchestrates layout and the bound/unbound branch. Three section components (`OrganizationCard`, `LightfastRepositoryCard`, `RepositoryList`) render the connected GitHub org, the `.lightfast` repo, and the imported-repository list. `RepositoryList` composes one `RepositoryCard` per imported repo (expandable watched-paths, sync status, Open-on-GitHub) plus an extracted `AddRepositoryDialog`. A tiny shared `source-control-format.ts` holds date helpers. Everything uses locked Lightfast tokens (`bg-background`, `rounded-[8px]`/`[9px]`/`[7px]`, `h-7`, `font-mono text-[11px]`/`text-[10px]`, emerald accents).
+
+**Tech Stack:** Next.js App Router (client components), tRPC (`useTRPC` + `useSuspenseQuery`/`useMutation`/`useQueryClient`), Clerk `useAuth`, Radix-based `@repo/ui` primitives (Dialog, DropdownMenu, Tooltip, Badge, Button), Vitest + Testing Library, Drizzle/PlanetScale (read-only here).
+
+**Reference design spec:** `docs/superpowers/specs/2026-06-01-source-control-git-settings-redesign-design.md`
+
+---
+
+## Conventions for this plan
+
+- **Commits:** This repo commits **only when the user asks** (see project memory + concurrent-git-writer note). Treat the "Commit" steps as reviewable checkpoints. When committing, ALWAYS stage with an **explicit pathspec** (`git add <exact paths>`) — never `git add -A`/`git add .` — and never push. If the user has not asked to commit, complete the step's work and leave it staged-or-unstaged for their review instead.
+- **Tests run from the package dir:**
+  - App: `cd apps/app && pnpm test "<filename-substring>"` (runs `vitest run <filter>`).
+  - API: `cd api/app && pnpm test "<filename-substring>"`.
+- **No new workspace deps.** `apps/app` does not depend on `@repo/source-control-contract`; the one literal we need (`"**"`) is inlined with a comment. The API service reuses the existing `SourceControlRepository["syncStatus"]` type — no new import.
+- **Tailwind classes inline** at the JSX site (project preference). Do not hoist class strings to consts.
+
+## File structure
+
+New files under `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/`:
+
+| File | Responsibility |
+|------|----------------|
+| `source-control-format.ts` | Pure date/string helpers (`formatStatusSubtitle`, `displayValue`) shared by the two cards. |
+| `organization-card.tsx` | Connected GitHub org card + disabled "Connected ⌄" dropdown + tooltip. |
+| `lightfast-repository-card.tsx` | `.lightfast` repo card — verified / unverified states. |
+| `repository-card.tsx` | One imported repo: header (icon, fullName, Private/Public, sync status), expandable Watched paths, ⋯ → Open on GitHub. |
+| `add-repository-dialog.tsx` | Extracted import dialog (search/select/mutate/cache-update). |
+| `repository-list.tsx` | "Repositories" section header (Refresh + Add), imported-only list, empty + error states, admin gating. |
+
+Reworked:
+
+| File | Change |
+|------|--------|
+| `source-control-settings-client.tsx` | Compose the three sections; bound vs unbound branch; keep header + both queries. |
+| `api/app/src/services/github/source-control/repositories.ts` | Add `syncStatus` to the row type + mapping. |
+
+Deleted:
+
+| File | Reason |
+|------|--------|
+| `_components/source-control-connection-section.tsx` | Replaced by the new components. |
+| `__tests__/.../settings-source-control-connection-section.test.tsx` | Replaced by per-component tests. |
+
+New tests under `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/`:
+`settings-source-control-format.test.ts`, `settings-source-control-organization-card.test.tsx`, `settings-source-control-lightfast-repository-card.test.tsx`, `settings-source-control-repository-card.test.tsx`, `settings-source-control-add-repository-dialog.test.tsx`, `settings-source-control-repository-list.test.tsx`. Reworked: `settings-source-control-client.test.tsx`. Unchanged: `settings-source-control-page.test.tsx`.
+
+---
+
+## Task 1: Backend — surface `syncStatus` in the repository row
+
+**Files:**
+- Modify: `api/app/src/services/github/source-control/repositories.ts`
+- Test: `api/app/src/services/github/source-control/repositories.test.ts`
+
+- [ ] **Step 1: Update the failing test to expect `syncStatus`**
+
+In `repositories.test.ts`, the "merges live GitHub repositories with watched rows and excludes .lightfast" assertion currently expects an object without `syncStatus`. Update the expected array so the merged row carries the watched row's sync status. Replace the existing `.toEqual([...])` block (lines ~128–138) with:
+
+```ts
+    ).toEqual([
+      {
+        fullName: "acme/workspace",
+        id: "200",
+        imported: true,
+        name: "workspace",
+        owner: { id: "20", login: "acme" },
+        private: true,
+        syncStatus: "disabled",
+        watchedPathGlobs: ["**"],
+      },
+    ]);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd api/app && pnpm test "repositories"`
+Expected: FAIL — received object is missing the `syncStatus` key (`toEqual` mismatch).
+
+- [ ] **Step 3: Add `syncStatus` to the row type**
+
+In `repositories.ts`, extend the `SourceControlRepositoryRow` interface (reuse the DB type already imported as `SourceControlRepository` — no new import):
+
+```ts
+export interface SourceControlRepositoryRow {
+  fullName: string;
+  id: string;
+  imported: boolean;
+  name: string;
+  owner: {
+    id: string;
+    login: string;
+  };
+  private: boolean;
+  syncStatus: SourceControlRepository["syncStatus"];
+  watchedPathGlobs: string[] | null;
+}
+```
+
+- [ ] **Step 4: Map `syncStatus` in `buildSourceControlRepositoryResponse`**
+
+In the `.map((repository) => { ... })` return object (inside `buildSourceControlRepositoryResponse`), add the `syncStatus` field. The full returned object becomes:
+
+```ts
+      return {
+        fullName: repository.fullName,
+        id: repository.id,
+        imported: Boolean(watched),
+        name: repository.name,
+        owner: {
+          id: repository.ownerId,
+          login: repository.ownerLogin,
+        },
+        private: repository.private,
+        syncStatus: watched?.syncStatus ?? "disabled",
+        watchedPathGlobs: watched?.watchedPathGlobs ?? null,
+      };
+```
+
+- [ ] **Step 5: Run the service test to verify it passes**
+
+Run: `cd api/app && pnpm test "repositories"`
+Expected: PASS (all cases).
+
+- [ ] **Step 6: Typecheck the API package**
+
+Run: `pnpm --filter @api/app build`
+Expected: success (the `org.settings.sourceControl.listRepositories` output type now includes `syncStatus`, which the frontend will consume).
+
+- [ ] **Step 7: Commit (checkpoint — see Conventions)**
+
+```bash
+git add "api/app/src/services/github/source-control/repositories.ts" "api/app/src/services/github/source-control/repositories.test.ts"
+git commit -m "feat(source-control): surface repository syncStatus in list payload"
+```
+
+---
+
+## Task 2: Shared date helpers (`source-control-format.ts`)
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-format.ts`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-format.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `settings-source-control-format.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+const { displayValue, formatStatusSubtitle } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-format"
+);
+
+describe("source-control-format", () => {
+  it("prefixes the verb and formats a valid date", () => {
+    expect(
+      formatStatusSubtitle("Connected on", new Date("2026-06-01T00:00:00.000Z"))
+    ).toMatch(/^Connected on /);
+  });
+
+  it("returns null for an invalid date", () => {
+    expect(formatStatusSubtitle("Verified", new Date(Number.NaN))).toBeNull();
+  });
+
+  it("falls back to a placeholder for empty values", () => {
+    expect(displayValue(null)).toBe("Not available");
+    expect(displayValue("  ")).toBe("Not available");
+    expect(displayValue("acme")).toBe("acme");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-format"`
+Expected: FAIL — cannot resolve the `source-control-format` module.
+
+- [ ] **Step 3: Create the module**
+
+Create `source-control-format.ts`:
+
+```ts
+const shortDateFormatter = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+});
+
+function isValidDate(value: Date): boolean {
+  return value instanceof Date && !Number.isNaN(value.getTime());
+}
+
+export function displayValue(value: string | null): string {
+  return value && value.trim().length > 0 ? value : "Not available";
+}
+
+export function formatStatusSubtitle(verb: string, value: Date): string | null {
+  if (!isValidDate(value)) {
+    return null;
+  }
+  return `${verb} ${shortDateFormatter.format(value)}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-format"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-format.ts" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-format.test.ts"
+git commit -m "feat(source-control): add shared settings date helpers"
+```
+
+---
+
+## Task 3: `OrganizationCard`
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/organization-card.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-organization-card.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `settings-source-control-organization-card.test.tsx`. The test mocks the DropdownMenu and Tooltip primitives so the menu contents render inline (mirrors how the existing source-control test mocks `dialog`):
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    disabled,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+  }) => (
+    <button disabled={disabled} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@repo/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipContent: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const { OrganizationCard } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/organization-card"
+);
+
+const connection = {
+  accountLogin: "acme-live",
+  connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+  importedRepositoryCount: 1,
+  lightfastRepository: {
+    fullName: "acme-live/.lightfast",
+    id: "301",
+    verifiedAt: new Date("2026-05-29T01:02:03.000Z"),
+  },
+  provider: "github" as const,
+  providerLabel: "GitHub",
+};
+
+describe("OrganizationCard", () => {
+  it("shows the connected org login and a connected-on subtitle", () => {
+    render(<OrganizationCard connection={connection} />);
+
+    expect(screen.getByText("acme-live")).toBeVisible();
+    expect(screen.getByText(/^Connected on /)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /Connected/ })
+    ).toBeInTheDocument();
+  });
+
+  it("renders disabled Configure and Disconnect actions with an explanatory tooltip", () => {
+    render(<OrganizationCard connection={connection} />);
+
+    expect(
+      screen.getByRole("button", { name: "Configure in GitHub" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Disconnect" })
+    ).toBeDisabled();
+    expect(
+      screen.getByText("Connection is set up once and can't be disconnected.")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to a placeholder when the account login is missing", () => {
+    render(
+      <OrganizationCard connection={{ ...connection, accountLogin: null }} />
+    );
+
+    expect(screen.getByText("Not available")).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-organization-card"`
+Expected: FAIL — cannot resolve the `organization-card` module.
+
+- [ ] **Step 3: Create the component**
+
+Create `organization-card.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { Icons } from "@repo/ui/components/icons";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@repo/ui/components/ui/tooltip";
+import { ChevronDown, Settings, Unplug } from "lucide-react";
+import { displayValue, formatStatusSubtitle } from "./source-control-format";
+
+type SourceControlConnection = NonNullable<
+  AppRouterOutputs["org"]["settings"]["sourceControl"]["get"]["binding"]
+>;
+
+const DISCONNECT_TOOLTIP =
+  "Connection is set up once and can't be disconnected.";
+
+export function OrganizationCard({
+  connection,
+}: {
+  connection: SourceControlConnection;
+}) {
+  const subtitle = formatStatusSubtitle("Connected on", connection.connectedAt);
+
+  return (
+    <section className="flex items-center justify-between gap-4 rounded-[8px] border border-border bg-background p-4">
+      <div className="flex min-w-0 items-center gap-2.5">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-[8px] border border-input bg-background">
+          <Icons.github aria-hidden="true" className="size-4 text-foreground" />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-foreground text-sm">
+            {displayValue(connection.accountLogin)}
+          </p>
+          {subtitle ? (
+            <p className="text-muted-foreground text-xs">{subtitle}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className="h-7 rounded-[9px]"
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <span
+              aria-hidden="true"
+              className="size-1.5 rounded-full bg-emerald-500"
+            />
+            Connected
+            <ChevronDown aria-hidden="true" className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <DropdownMenuItem disabled>
+                  <Settings aria-hidden="true" className="size-4" />
+                  Configure in GitHub
+                </DropdownMenuItem>
+                <DropdownMenuItem disabled variant="destructive">
+                  <Unplug aria-hidden="true" className="size-4" />
+                  Disconnect
+                </DropdownMenuItem>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>{DISCONNECT_TOOLTIP}</TooltipContent>
+          </Tooltip>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-organization-card"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/organization-card.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-organization-card.test.tsx"
+git commit -m "feat(source-control): add Organization card with disabled connection menu"
+```
+
+---
+
+## Task 4: `LightfastRepositoryCard`
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/lightfast-repository-card.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-lightfast-repository-card.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `settings-source-control-lightfast-repository-card.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children?: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const { LightfastRepositoryCard } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/lightfast-repository-card"
+);
+
+const baseConnection = {
+  accountLogin: "acme-live",
+  connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+  importedRepositoryCount: 1,
+  provider: "github" as const,
+  providerLabel: "GitHub",
+};
+
+describe("LightfastRepositoryCard", () => {
+  it("renders the verified repository with a Verified badge and date", () => {
+    render(
+      <LightfastRepositoryCard
+        connection={{
+          ...baseConnection,
+          lightfastRepository: {
+            fullName: "acme-live/.lightfast",
+            id: "301",
+            verifiedAt: new Date("2026-05-30T10:00:00.000Z"),
+          },
+        }}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText("acme-live/.lightfast")).toBeVisible();
+    expect(screen.getByText("Verified")).toBeVisible();
+    expect(screen.getByText(/^Verified /)).toBeVisible();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("links to repo setup when the repository is not yet verified", () => {
+    render(
+      <LightfastRepositoryCard
+        connection={{ ...baseConnection, lightfastRepository: null }}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText("acme-live/.lightfast")).toBeVisible();
+    expect(screen.getByRole("link", { name: "Open setup" })).toHaveAttribute(
+      "href",
+      "/acme/tasks/github/lightfast-repo"
+    );
+  });
+
+  it("keeps the Verified badge but drops the subtitle for an invalid date", () => {
+    render(
+      <LightfastRepositoryCard
+        connection={{
+          ...baseConnection,
+          lightfastRepository: {
+            fullName: "acme-live/.lightfast",
+            id: "301",
+            verifiedAt: new Date(Number.NaN),
+          },
+        }}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText("Verified")).toBeVisible();
+    expect(screen.queryByText(/^Verified /)).toBeNull();
+    expect(
+      screen.getByText(
+        "The repository Lightfast uses to coordinate workspace automation."
+      )
+    ).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-lightfast-repository-card"`
+Expected: FAIL — cannot resolve the `lightfast-repository-card` module.
+
+- [ ] **Step 3: Create the component**
+
+Create `lightfast-repository-card.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { LIGHTFAST_REPOSITORY_NAME } from "@repo/app-setup-contract";
+import { Icons } from "@repo/ui/components/icons";
+import { Button } from "@repo/ui/components/ui/button";
+import { ExternalLink } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { formatStatusSubtitle } from "./source-control-format";
+
+type SourceControlConnection = NonNullable<
+  AppRouterOutputs["org"]["settings"]["sourceControl"]["get"]["binding"]
+>;
+
+function StatusBadge({ label }: { label: string }) {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 font-medium text-emerald-700 text-xs dark:text-emerald-300">
+      <span className="size-1.5 rounded-full bg-current" />
+      {label}
+    </span>
+  );
+}
+
+export function LightfastRepositoryCard({
+  connection,
+  orgSlug,
+}: {
+  connection: SourceControlConnection;
+  orgSlug: string;
+}) {
+  const repository = connection.lightfastRepository;
+  const name = repository
+    ? repository.fullName
+    : `${connection.accountLogin}/${LIGHTFAST_REPOSITORY_NAME}`;
+  const description = repository
+    ? "The repository Lightfast uses to coordinate workspace automation."
+    : `Create and verify the ${LIGHTFAST_REPOSITORY_NAME} repository to unlock workspace automation.`;
+  const subtitle = repository
+    ? formatStatusSubtitle("Verified", repository.verifiedAt)
+    : null;
+
+  return (
+    <section className="flex items-center justify-between gap-4 rounded-[8px] border border-border bg-background p-4">
+      <div className="flex min-w-0 items-center gap-2.5">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-[8px] border border-input bg-background">
+          <Icons.logoShort
+            aria-hidden="true"
+            className="size-4 text-foreground"
+          />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate font-mono text-foreground text-sm">{name}</p>
+          <p className="text-muted-foreground text-xs">
+            {subtitle ?? description}
+          </p>
+        </div>
+      </div>
+
+      {repository ? (
+        <StatusBadge label="Verified" />
+      ) : (
+        <Button
+          asChild
+          className="h-7 rounded-[9px]"
+          size="sm"
+          variant="outline"
+        >
+          <Link href={`/${orgSlug}/tasks/github/lightfast-repo` as Route}>
+            <ExternalLink aria-hidden="true" className="size-3.5" />
+            Open setup
+          </Link>
+        </Button>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-lightfast-repository-card"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/lightfast-repository-card.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-lightfast-repository-card.test.tsx"
+git commit -m "feat(source-control): add Lightfast repository card with verified/unverified states"
+```
+
+---
+
+## Task 5: `RepositoryCard`
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-card.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-repository-card.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `settings-source-control-repository-card.test.tsx`. It mocks the DropdownMenu primitive so the menu item link renders inline:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+const { RepositoryCard } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-card"
+);
+
+const baseRepository = {
+  fullName: "acme-live/web",
+  id: "101",
+  imported: true,
+  name: "web",
+  owner: { id: "987654", login: "acme-live" },
+  private: true,
+  syncStatus: "disabled" as const,
+  watchedPathGlobs: null,
+};
+
+describe("RepositoryCard", () => {
+  it("renders the repository name, visibility, sync status and GitHub link", () => {
+    render(<RepositoryCard repository={baseRepository} />);
+
+    expect(screen.getByText("acme-live/web")).toBeVisible();
+    expect(screen.getByText("Private")).toBeVisible();
+    expect(screen.getByText("Not syncing")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Open on GitHub" })
+    ).toHaveAttribute("href", "https://github.com/acme-live/web");
+  });
+
+  it("shows the syncing label for enabled repositories", () => {
+    render(
+      <RepositoryCard
+        repository={{ ...baseRepository, syncStatus: "enabled" }}
+      />
+    );
+
+    expect(screen.getByText("Syncing")).toBeVisible();
+  });
+
+  it("reveals the empty watched-paths message when expanded", () => {
+    render(<RepositoryCard repository={baseRepository} />);
+
+    expect(screen.queryByText("No watched paths configured")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Watched paths" }));
+    expect(screen.getByText("No watched paths configured")).toBeVisible();
+  });
+
+  it("describes the all-paths glob in human terms", () => {
+    render(
+      <RepositoryCard
+        repository={{ ...baseRepository, watchedPathGlobs: ["**"] }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Watched paths" }));
+    expect(screen.getByText("Watching all paths")).toBeVisible();
+  });
+
+  it("lists each specific watched glob as a chip", () => {
+    render(
+      <RepositoryCard
+        repository={{
+          ...baseRepository,
+          watchedPathGlobs: ["apps/**", "packages/**"],
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Watched paths" }));
+    expect(screen.getByText("apps/**")).toBeVisible();
+    expect(screen.getByText("packages/**")).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-repository-card"`
+Expected: FAIL — cannot resolve the `repository-card` module.
+
+- [ ] **Step 3: Create the component**
+
+Create `repository-card.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { Badge } from "@repo/ui/components/ui/badge";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/ui/dropdown-menu";
+import { cn } from "@repo/ui/lib/utils";
+import {
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  MoreHorizontal,
+} from "lucide-react";
+import { useState } from "react";
+
+type SourceControlRepositoryRow =
+  AppRouterOutputs["org"]["settings"]["sourceControl"]["listRepositories"]["repositories"][number];
+
+// Mirror of SOURCE_CONTROL_ALL_PATHS_GLOB from @repo/source-control-contract.
+// Inlined to avoid adding a workspace dependency to the app for one literal.
+const ALL_PATHS_GLOB = "**";
+
+const SYNC_STATUS_LABEL: Record<
+  SourceControlRepositoryRow["syncStatus"],
+  string
+> = {
+  enabled: "Syncing",
+  disabled: "Not syncing",
+};
+
+function SyncStatusIndicator({
+  status,
+}: {
+  status: SourceControlRepositoryRow["syncStatus"];
+}) {
+  const enabled = status === "enabled";
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 font-mono text-[10px]",
+        enabled
+          ? "text-emerald-700 dark:text-emerald-300"
+          : "text-muted-foreground"
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "size-1.5 rounded-full",
+          enabled ? "bg-emerald-500" : "bg-muted-foreground/50"
+        )}
+      />
+      {SYNC_STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function WatchedPaths({ globs }: { globs: string[] | null }) {
+  if (globs === null) {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        No watched paths configured
+      </p>
+    );
+  }
+
+  if (globs.includes(ALL_PATHS_GLOB)) {
+    return (
+      <p className="text-[11px] text-muted-foreground">Watching all paths</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {globs.map((glob) => (
+        <span
+          className="inline-flex items-center rounded-[7px] border border-border px-2 py-1 font-mono text-[10px] text-muted-foreground"
+          key={glob}
+        >
+          {glob}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function RepositoryCard({
+  repository,
+}: {
+  repository: SourceControlRepositoryRow;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const watchedRegionId = `repository-${repository.id}-watched`;
+
+  return (
+    <div className="rounded-[8px] border border-border bg-background p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 gap-2.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-[8px] border border-input bg-background">
+            <GitBranch
+              aria-hidden="true"
+              className="size-3.5 text-foreground"
+            />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="truncate font-mono text-foreground text-sm">
+                {repository.fullName}
+              </p>
+              <Badge
+                className="rounded-[7px] px-1.5 py-0 font-mono text-[10px]"
+                variant="outline"
+              >
+                {repository.private ? "Private" : "Public"}
+              </Badge>
+              <SyncStatusIndicator status={repository.syncStatus} />
+            </div>
+            <button
+              aria-controls={watchedRegionId}
+              aria-expanded={expanded}
+              className="mt-2 inline-flex items-center gap-1 font-mono text-[11px] text-muted-foreground hover:text-foreground"
+              onClick={() => setExpanded((value) => !value)}
+              type="button"
+            >
+              {expanded ? (
+                <ChevronDown aria-hidden="true" className="size-3" />
+              ) : (
+                <ChevronRight aria-hidden="true" className="size-3" />
+              )}
+              Watched paths
+            </button>
+          </div>
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label={`Repository actions for ${repository.fullName}`}
+              className="size-7 rounded-[9px] p-0"
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <MoreHorizontal aria-hidden="true" className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild>
+              <a
+                href={`https://github.com/${repository.fullName}`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open on GitHub
+              </a>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {expanded ? (
+        <div
+          className="mt-3 rounded-[8px] border border-border bg-background/50 p-3"
+          id={watchedRegionId}
+        >
+          <WatchedPaths globs={repository.watchedPathGlobs} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-repository-card"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-card.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-repository-card.test.tsx"
+git commit -m "feat(source-control): add repository card with watched paths and sync status"
+```
+
+---
+
+## Task 6: `AddRepositoryDialog`
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/add-repository-dialog.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-add-repository-dialog.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `settings-source-control-add-repository-dialog.test.tsx`. It reuses the `dialog` mock pattern from the (soon-removed) connection-section test and asserts the import flow + admin gating via the `disabled` prop:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const importRepositoryMutateMock = vi.fn();
+const importRepositoryMutationOptionsMock = vi.fn((options: unknown) => options);
+const setQueryDataMock = vi.fn();
+const listRepositoriesQueryOptionsMock = vi.fn(() => ({
+  queryKey: ["org", "settings", "sourceControl", "listRepositories"],
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: vi.fn((options: unknown) => ({
+    isPending: false,
+    mutate: importRepositoryMutateMock,
+    options,
+  })),
+  useQueryClient: () => ({
+    setQueryData: setQueryDataMock,
+  }),
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      settings: {
+        sourceControl: {
+          importRepository: {
+            mutationOptions: importRepositoryMutationOptionsMock,
+          },
+          listRepositories: {
+            queryOptions: listRepositoriesQueryOptionsMock,
+          },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("@repo/ui/components/ui/dialog", async () => {
+  const React = await import("react");
+  const DialogContext = React.createContext<{
+    onOpenChange?: (open: boolean) => void;
+    open?: boolean;
+  } | null>(null);
+
+  return {
+    Dialog: ({
+      children,
+      onOpenChange,
+      open,
+    }: {
+      children?: ReactNode;
+      onOpenChange?: (open: boolean) => void;
+      open?: boolean;
+    }) => (
+      <DialogContext.Provider value={{ onOpenChange, open }}>
+        {children}
+      </DialogContext.Provider>
+    ),
+    DialogContent: ({ children }: { children?: ReactNode }) => {
+      const context = React.useContext(DialogContext);
+      if (!context?.open) {
+        return null;
+      }
+      return (
+        <div role="dialog">
+          {children}
+          <button onClick={() => context.onOpenChange?.(false)} type="button">
+            Close
+          </button>
+        </div>
+      );
+    },
+    DialogDescription: ({ children }: { children?: ReactNode }) => (
+      <p>{children}</p>
+    ),
+    DialogFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h3>{children}</h3>,
+    DialogTrigger: ({ children }: { children?: ReactNode }) => {
+      const context = React.useContext(DialogContext);
+      if (!React.isValidElement(children)) {
+        return <>{children}</>;
+      }
+      const child = children as React.ReactElement<{
+        onClick?: React.MouseEventHandler;
+      }>;
+      return React.cloneElement(child, {
+        onClick: (event) => {
+          child.props.onClick?.(event);
+          context?.onOpenChange?.(true);
+        },
+      });
+    },
+  };
+});
+
+const { AddRepositoryDialog } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/add-repository-dialog"
+);
+
+const repositories = [
+  {
+    fullName: "acme-live/app",
+    id: "101",
+    imported: true,
+    name: "app",
+    owner: { id: "987654", login: "acme-live" },
+    private: true,
+    syncStatus: "disabled" as const,
+    watchedPathGlobs: ["**"],
+  },
+  {
+    fullName: "acme-live/docs",
+    id: "201",
+    imported: false,
+    name: "docs",
+    owner: { id: "987654", login: "acme-live" },
+    private: false,
+    syncStatus: "disabled" as const,
+    watchedPathGlobs: null,
+  },
+];
+
+function renderDialog(disabled = false) {
+  return render(
+    <AddRepositoryDialog disabled={disabled} repositories={repositories} />
+  );
+}
+
+beforeEach(() => {
+  importRepositoryMutateMock.mockClear();
+  importRepositoryMutationOptionsMock.mockClear();
+  setQueryDataMock.mockClear();
+  listRepositoriesQueryOptionsMock.mockClear();
+});
+
+describe("AddRepositoryDialog", () => {
+  it("disables the trigger when the parent says so", () => {
+    renderDialog(true);
+    expect(
+      screen.getByRole("button", { name: "Add repository" })
+    ).toBeDisabled();
+  });
+
+  it("opens the dialog and disables already-added rows", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+
+    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /acme-live\/app/i })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /acme-live\/docs/i })
+    ).not.toBeDisabled();
+  });
+
+  it("excludes the .lightfast repository from the picker", () => {
+    render(
+      <AddRepositoryDialog
+        disabled={false}
+        repositories={[
+          ...repositories,
+          {
+            fullName: "acme-live/.lightfast",
+            id: "301",
+            imported: false,
+            name: ".lightfast",
+            owner: { id: "987654", login: "acme-live" },
+            private: true,
+            syncStatus: "disabled" as const,
+            watchedPathGlobs: null,
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+    expect(
+      screen.queryByRole("button", { name: /acme-live\/\.lightfast/i })
+    ).toBeNull();
+  });
+
+  it("selects an available repository and submits the import mutation", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+    fireEvent.click(screen.getByRole("button", { name: /acme-live\/docs/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add selected repository" })
+    );
+
+    expect(importRepositoryMutateMock).toHaveBeenCalledWith({
+      repositoryId: "201",
+    });
+  });
+
+  it("drops a selection that is filtered out before submit", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+    fireEvent.click(screen.getByRole("button", { name: /acme-live\/docs/i }));
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Search repositories" }),
+      { target: { value: "app" } }
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add selected repository" })
+    ).toBeDisabled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add selected repository" })
+    );
+    expect(importRepositoryMutateMock).not.toHaveBeenCalled();
+  });
+
+  it("resets search and selection after the dialog closes", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Search repositories" }),
+      { target: { value: "docs" } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /acme-live\/docs/i }));
+    expect(
+      screen.getByRole("button", { name: "Add selected repository" })
+    ).not.toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+
+    expect(
+      screen.getByRole("textbox", { name: "Search repositories" })
+    ).toHaveValue("");
+    expect(
+      screen.getByRole("button", { name: "Add selected repository" })
+    ).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-add-repository-dialog"`
+Expected: FAIL — cannot resolve the `add-repository-dialog` module.
+
+- [ ] **Step 3: Create the component**
+
+Create `add-repository-dialog.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { LIGHTFAST_REPOSITORY_NAME } from "@repo/app-setup-contract";
+import { Badge } from "@repo/ui/components/ui/badge";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@repo/ui/components/ui/dialog";
+import { Input } from "@repo/ui/components/ui/input";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { GitBranch, Loader2, Plus, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTRPC } from "~/trpc/react";
+
+type SourceControlRepositoryRow =
+  AppRouterOutputs["org"]["settings"]["sourceControl"]["listRepositories"]["repositories"][number];
+
+export function AddRepositoryDialog({
+  disabled,
+  repositories,
+}: {
+  disabled: boolean;
+  repositories: SourceControlRepositoryRow[];
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const listQueryOptions =
+    trpc.org.settings.sourceControl.listRepositories.queryOptions();
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [selectedRepositoryId, setSelectedRepositoryId] = useState<
+    string | null
+  >(null);
+
+  const importRepository = useMutation(
+    trpc.org.settings.sourceControl.importRepository.mutationOptions({
+      meta: { errorTitle: "Failed to add repository" },
+      onSuccess: (data) => {
+        queryClient.setQueryData(listQueryOptions.queryKey, data);
+        setSelectedRepositoryId(null);
+        setSearch("");
+        setIsOpen(false);
+      },
+    })
+  );
+
+  const selectableRepositories = useMemo(
+    () =>
+      repositories.filter(
+        (repository) => repository.name !== LIGHTFAST_REPOSITORY_NAME
+      ),
+    [repositories]
+  );
+  const filteredRepositories = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return selectableRepositories.filter((repository) => {
+      if (!term) {
+        return true;
+      }
+      return (
+        repository.name.toLowerCase().includes(term) ||
+        repository.fullName.toLowerCase().includes(term)
+      );
+    });
+  }, [selectableRepositories, search]);
+
+  const selectedRepository = filteredRepositories.find(
+    (repository) => repository.id === selectedRepositoryId
+  );
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setSearch("");
+      setSelectedRepositoryId(null);
+    }
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setSelectedRepositoryId(null);
+  };
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={isOpen}>
+      <DialogTrigger asChild>
+        <Button
+          className="h-7 rounded-[9px]"
+          disabled={disabled}
+          size="sm"
+          type="button"
+        >
+          <Plus aria-hidden="true" className="size-4" />
+          Add repository
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add repository</DialogTitle>
+          <DialogDescription>
+            Select one GitHub repository to add to this workspace.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="relative">
+            <Search
+              aria-hidden="true"
+              className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground"
+            />
+            <Input
+              aria-label="Search repositories"
+              className="pl-9"
+              onChange={(event) => handleSearchChange(event.target.value)}
+              placeholder="Search repositories"
+              value={search}
+            />
+          </div>
+          <div className="max-h-80 space-y-2 overflow-y-auto">
+            {filteredRepositories.length > 0 ? (
+              filteredRepositories.map((repository) => (
+                <button
+                  className="flex w-full items-center justify-between gap-3 rounded-[8px] border border-border bg-background p-3 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={repository.imported}
+                  key={repository.id}
+                  onClick={() => setSelectedRepositoryId(repository.id)}
+                  type="button"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate font-medium text-foreground text-sm">
+                      {repository.fullName}
+                    </span>
+                    <span className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
+                      <GitBranch aria-hidden="true" className="size-3" />
+                      {repository.imported
+                        ? "Already added"
+                        : selectedRepositoryId === repository.id
+                          ? "Selected"
+                          : "Available"}
+                    </span>
+                  </span>
+                  <Badge variant="outline">
+                    {repository.private ? "Private" : "Public"}
+                  </Badge>
+                </button>
+              ))
+            ) : (
+              <p className="rounded-[8px] border border-border bg-muted/30 p-4 text-muted-foreground text-sm">
+                No repositories match your search.
+              </p>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            disabled={
+              !selectedRepository ||
+              selectedRepository.imported ||
+              importRepository.isPending
+            }
+            onClick={() => {
+              if (!selectedRepositoryId) {
+                return;
+              }
+              importRepository.mutate({ repositoryId: selectedRepositoryId });
+            }}
+            type="button"
+          >
+            {importRepository.isPending ? (
+              <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+            ) : null}
+            Add selected repository
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-add-repository-dialog"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/add-repository-dialog.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-add-repository-dialog.test.tsx"
+git commit -m "feat(source-control): extract add-repository dialog component"
+```
+
+---
+
+## Task 7: `RepositoryList`
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-list.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-repository-list.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `settings-source-control-repository-list.test.tsx`. It stubs the two children (`repository-card`, `add-repository-dialog`) so the list logic is tested in isolation:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useAuthMock = vi.fn();
+const invalidateQueriesMock = vi.fn();
+const listRepositoriesQueryOptionsMock = vi.fn(() => ({
+  queryKey: ["org", "settings", "sourceControl", "listRepositories"],
+}));
+
+vi.mock("@vendor/clerk", () => ({
+  useAuth: useAuthMock,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      settings: {
+        sourceControl: {
+          listRepositories: {
+            queryOptions: listRepositoriesQueryOptionsMock,
+          },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-card",
+  () => ({
+    RepositoryCard: ({
+      repository,
+    }: {
+      repository: { fullName: string };
+    }) => <div data-testid="repository-card">{repository.fullName}</div>,
+  })
+);
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/add-repository-dialog",
+  () => ({
+    AddRepositoryDialog: ({ disabled }: { disabled: boolean }) => (
+      <div data-disabled={String(disabled)} data-testid="add-repository-dialog">
+        Add repository
+      </div>
+    ),
+  })
+);
+
+const { RepositoryList } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-list"
+);
+
+const importedRepo = {
+  fullName: "acme-live/app",
+  id: "101",
+  imported: true,
+  name: "app",
+  owner: { id: "987654", login: "acme-live" },
+  private: true,
+  syncStatus: "disabled" as const,
+  watchedPathGlobs: ["**"],
+};
+const availableRepo = {
+  fullName: "acme-live/docs",
+  id: "201",
+  imported: false,
+  name: "docs",
+  owner: { id: "987654", login: "acme-live" },
+  private: false,
+  syncStatus: "disabled" as const,
+  watchedPathGlobs: null,
+};
+
+const baseRepositories = {
+  binding: {
+    accountLogin: "acme-live",
+    connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+    importedRepositoryCount: 1,
+    lightfastRepository: null,
+    provider: "github" as const,
+    providerLabel: "GitHub",
+  },
+  lightfastRepository: null,
+  organization: {
+    id: "987654",
+    installationManageUrl:
+      "https://github.com/apps/lightfast/installations/1001",
+    login: "acme-live",
+  },
+  repositories: [importedRepo, availableRepo],
+  repositoriesError: null,
+  status: "bound" as const,
+};
+
+function renderList(
+  overrides: Partial<typeof baseRepositories> = {}
+) {
+  return render(
+    <RepositoryList repositories={{ ...baseRepositories, ...overrides }} />
+  );
+}
+
+beforeEach(() => {
+  useAuthMock.mockReturnValue({
+    has: ({ role }: { role: string }) => role === "org:admin",
+    isLoaded: true,
+  });
+  invalidateQueriesMock.mockClear();
+  listRepositoriesQueryOptionsMock.mockClear();
+});
+
+describe("RepositoryList", () => {
+  it("renders the section header, refresh and add controls", () => {
+    renderList();
+
+    expect(screen.getByRole("heading", { name: "Repositories" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Refresh repositories" })
+    ).toBeVisible();
+    expect(screen.getByTestId("add-repository-dialog")).toBeVisible();
+  });
+
+  it("renders a card only for imported repositories", () => {
+    renderList();
+
+    const cards = screen.getAllByTestId("repository-card");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toHaveTextContent("acme-live/app");
+  });
+
+  it("shows the empty prompt when no repositories are imported", () => {
+    renderList({ repositories: [availableRepo] });
+
+    expect(screen.queryByTestId("repository-card")).toBeNull();
+    expect(
+      screen.getByText(/No repositories added yet\./)
+    ).toBeVisible();
+  });
+
+  it("shows the listing error in place of the cards", () => {
+    renderList({
+      repositories: [],
+      repositoriesError: {
+        code: "github_repository_listing_failed",
+        message: "GitHub repositories could not be refreshed.",
+      },
+    });
+
+    expect(
+      screen.getByText("GitHub repositories could not be refreshed.")
+    ).toBeVisible();
+    expect(screen.queryByTestId("repository-card")).toBeNull();
+  });
+
+  it("invalidates the repository query when refreshed", () => {
+    renderList();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh repositories" })
+    );
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ["org", "settings", "sourceControl", "listRepositories"],
+    });
+  });
+
+  it("disables adding for non-admins", () => {
+    useAuthMock.mockReturnValue({ has: () => false, isLoaded: true });
+    renderList();
+
+    expect(screen.getByTestId("add-repository-dialog")).toHaveAttribute(
+      "data-disabled",
+      "true"
+    );
+  });
+
+  it("disables adding when the repository listing failed", () => {
+    renderList({
+      repositories: [importedRepo],
+      repositoriesError: {
+        code: "github_repository_listing_failed",
+        message: "GitHub repositories could not be refreshed.",
+      },
+    });
+
+    expect(screen.getByTestId("add-repository-dialog")).toHaveAttribute(
+      "data-disabled",
+      "true"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-repository-list"`
+Expected: FAIL — cannot resolve the `repository-list` module.
+
+- [ ] **Step 3: Create the component**
+
+Create `repository-list.tsx`:
+
+```tsx
+"use client";
+
+import type { AppRouterOutputs } from "@api/app";
+import { Button } from "@repo/ui/components/ui/button";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@vendor/clerk";
+import { RefreshCw } from "lucide-react";
+import { useMemo } from "react";
+import { useTRPC } from "~/trpc/react";
+import { AddRepositoryDialog } from "./add-repository-dialog";
+import { RepositoryCard } from "./repository-card";
+
+type SourceControlRepositories =
+  AppRouterOutputs["org"]["settings"]["sourceControl"]["listRepositories"];
+
+export function RepositoryList({
+  repositories,
+}: {
+  repositories: SourceControlRepositories;
+}) {
+  const { has, isLoaded } = useAuth();
+  const isAdmin = isLoaded && !!has?.({ role: "org:admin" });
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const listQueryOptions =
+    trpc.org.settings.sourceControl.listRepositories.queryOptions();
+
+  const importedRepositories = useMemo(
+    () => repositories.repositories.filter((repository) => repository.imported),
+    [repositories.repositories]
+  );
+
+  const addDisabled =
+    !isAdmin ||
+    repositories.repositoriesError !== null ||
+    repositories.status !== "bound";
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="font-mono font-normal text-[11px] text-muted-foreground">
+          Repositories
+        </h3>
+        <div className="flex items-center gap-2">
+          <Button
+            aria-label="Refresh repositories"
+            className="h-7 rounded-[9px]"
+            onClick={() =>
+              queryClient.invalidateQueries({
+                queryKey: listQueryOptions.queryKey,
+              })
+            }
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <RefreshCw aria-hidden="true" className="size-4" />
+          </Button>
+          <AddRepositoryDialog
+            disabled={addDisabled}
+            repositories={repositories.repositories}
+          />
+        </div>
+      </div>
+
+      {repositories.repositoriesError ? (
+        <div className="rounded-[8px] border border-destructive/30 bg-destructive/5 p-3 text-destructive text-sm">
+          {repositories.repositoriesError.message}
+        </div>
+      ) : importedRepositories.length > 0 ? (
+        <div className="space-y-3">
+          {importedRepositories.map((repository) => (
+            <RepositoryCard key={repository.id} repository={repository} />
+          ))}
+        </div>
+      ) : (
+        <p className="rounded-[8px] border border-border bg-background p-4 text-muted-foreground text-sm">
+          No repositories added yet. Use{" "}
+          <span className="font-medium text-foreground">Add repository</span> to
+          connect one.
+        </p>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-repository-list"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-list.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-repository-list.test.tsx"
+git commit -m "feat(source-control): add repository list section"
+```
+
+---
+
+## Task 8: Rework the client + remove the old section file
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-settings-client.tsx`
+- Modify (rework test): `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-client.test.tsx`
+- Delete: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-connection-section.tsx`
+- Delete: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-connection-section.test.tsx`
+
+- [ ] **Step 1: Confirm the old section file has no other importers**
+
+Run:
+```bash
+grep -rn "source-control-connection-section" "apps/app/src" || echo "no importers"
+```
+Expected: only the client (`source-control-settings-client.tsx`) and the connection-section test reference it. Both are handled in this task. If any other file imports it, stop and reassess.
+
+- [ ] **Step 2: Rewrite the client test to cover the new structure**
+
+Replace the entire contents of `settings-source-control-client.test.tsx` with:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sourceControlGetQueryOptionsMock = vi.fn(() => ({
+  queryKey: ["org", "settings", "sourceControl", "get"],
+}));
+const sourceControlListRepositoriesQueryOptionsMock = vi.fn(() => ({
+  queryKey: ["org", "settings", "sourceControl", "listRepositories"],
+}));
+const useSuspenseQueryMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      settings: {
+        sourceControl: {
+          get: { queryOptions: sourceControlGetQueryOptionsMock },
+          listRepositories: {
+            queryOptions: sourceControlListRepositoriesQueryOptionsMock,
+          },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: useSuspenseQueryMock,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children?: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/organization-card",
+  () => ({
+    OrganizationCard: ({
+      connection,
+    }: {
+      connection: { accountLogin: string };
+    }) => (
+      <div data-testid="organization-card">{connection.accountLogin}</div>
+    ),
+  })
+);
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/lightfast-repository-card",
+  () => ({
+    LightfastRepositoryCard: ({ orgSlug }: { orgSlug: string }) => (
+      <div data-testid="lightfast-repository-card">{orgSlug}</div>
+    ),
+  })
+);
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/repository-list",
+  () => ({
+    RepositoryList: ({
+      repositories,
+    }: {
+      repositories: { organization: { login: string } | null };
+    }) => (
+      <div data-testid="repository-list">
+        {repositories.organization?.login ?? "no-org"}
+      </div>
+    ),
+  })
+);
+
+const { SourceControlSettingsClient } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-settings-client"
+);
+
+const boundBinding = {
+  accountLogin: "acme-live",
+  connectedAt: new Date("2026-05-29T01:02:03.000Z"),
+  importedRepositoryCount: 2,
+  lightfastRepository: null,
+  provider: "github" as const,
+  providerLabel: "GitHub",
+};
+
+const boundRepositories = {
+  binding: boundBinding,
+  lightfastRepository: null,
+  organization: {
+    id: "987654",
+    installationManageUrl:
+      "https://github.com/apps/lightfast/installations/1001",
+    login: "acme-live",
+  },
+  repositories: [],
+  repositoriesError: null,
+  status: "bound" as const,
+};
+
+function mockQueries(options: {
+  binding: typeof boundBinding | null;
+  repositories: typeof boundRepositories;
+}) {
+  useSuspenseQueryMock.mockImplementation(
+    (queryOptions: { queryKey: readonly unknown[] }) => {
+      if (queryOptions.queryKey.includes("listRepositories")) {
+        return { data: options.repositories };
+      }
+      return { data: { binding: options.binding, status: "bound" } };
+    }
+  );
+}
+
+beforeEach(() => {
+  sourceControlGetQueryOptionsMock.mockClear();
+  sourceControlListRepositoriesQueryOptionsMock.mockClear();
+  useSuspenseQueryMock.mockReset();
+});
+
+describe("SourceControlSettingsClient", () => {
+  it("renders the three sections when bound", () => {
+    mockQueries({ binding: boundBinding, repositories: boundRepositories });
+    render(<SourceControlSettingsClient slug="acme" />);
+
+    expect(sourceControlGetQueryOptionsMock).toHaveBeenCalled();
+    expect(sourceControlListRepositoriesQueryOptionsMock).toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", { name: "Source Control & Git" })
+    ).toBeVisible();
+    expect(screen.getByTestId("organization-card")).toHaveTextContent(
+      "acme-live"
+    );
+    expect(screen.getByTestId("lightfast-repository-card")).toHaveTextContent(
+      "acme"
+    );
+    expect(screen.getByTestId("repository-list")).toHaveTextContent(
+      "acme-live"
+    );
+  });
+
+  it("renders only the empty state when unbound", () => {
+    mockQueries({
+      binding: null,
+      repositories: {
+        ...boundRepositories,
+        binding: null as unknown as typeof boundBinding,
+        organization: null,
+        status: "unbound" as unknown as "bound",
+      },
+    });
+    render(<SourceControlSettingsClient slug="acme" />);
+
+    expect(
+      screen.getByText("No GitHub organization connected")
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: "Open setup" })).toHaveAttribute(
+      "href",
+      "/acme/tasks/bind"
+    );
+    expect(screen.queryByTestId("organization-card")).toBeNull();
+    expect(screen.queryByTestId("lightfast-repository-card")).toBeNull();
+    expect(screen.queryByTestId("repository-list")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run the reworked client test to verify it fails**
+
+Run: `cd apps/app && pnpm test "settings-source-control-client"`
+Expected: FAIL — the client still imports `./source-control-connection-section` (old `SourceControlSection`/`SourceControlConnectionSection`) and does not yet branch on `connection`, so the new child mocks/test-ids don't match.
+
+- [ ] **Step 4: Rewrite the client component**
+
+Replace the entire contents of `source-control-settings-client.tsx` with:
+
+```tsx
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ExternalLink } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { useTRPC } from "~/trpc/react";
+import { LightfastRepositoryCard } from "./lightfast-repository-card";
+import { OrganizationCard } from "./organization-card";
+import { RepositoryList } from "./repository-list";
+
+interface SourceControlSettingsClientProps {
+  slug: string;
+}
+
+export function SourceControlSettingsClient({
+  slug,
+}: SourceControlSettingsClientProps) {
+  const trpc = useTRPC();
+
+  const { data: sourceControlConnection } = useSuspenseQuery(
+    trpc.org.settings.sourceControl.get.queryOptions()
+  );
+  const { data: sourceControlRepositories } = useSuspenseQuery(
+    trpc.org.settings.sourceControl.listRepositories.queryOptions()
+  );
+
+  const connection = sourceControlConnection.binding;
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <h2 className="font-medium font-pp text-2xl text-foreground">
+          Source Control &amp; Git
+        </h2>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Manage your GitHub connection and the repositories Lightfast can
+          access.
+        </p>
+      </div>
+
+      {connection ? (
+        <>
+          <OrganizationCard connection={connection} />
+          <LightfastRepositoryCard connection={connection} orgSlug={slug} />
+          <RepositoryList repositories={sourceControlRepositories} />
+        </>
+      ) : (
+        <div className="rounded-[8px] border border-border bg-background p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="font-medium text-foreground text-sm">
+                No GitHub organization connected
+              </p>
+              <p className="text-muted-foreground text-sm">
+                Connect GitHub from setup before workspace features can use
+                source-control data.
+              </p>
+            </div>
+            <Button
+              asChild
+              className="h-7 rounded-[9px]"
+              size="sm"
+              variant="secondary"
+            >
+              <Link href={`/${slug}/tasks/bind` as Route}>
+                <ExternalLink aria-hidden="true" className="size-4" />
+                Open setup
+              </Link>
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run the reworked client test to verify it passes**
+
+Run: `cd apps/app && pnpm test "settings-source-control-client"`
+Expected: PASS (both bound + unbound cases).
+
+- [ ] **Step 6: Delete the old section file and its test**
+
+```bash
+git rm "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-connection-section.tsx"
+git rm "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-connection-section.test.tsx"
+```
+
+(If not committing yet, use `rm` instead of `git rm` and let the user stage the deletions.)
+
+- [ ] **Step 7: Confirm nothing references the deleted module**
+
+Run:
+```bash
+grep -rn "source-control-connection-section\|SourceControlConnectionSection\|SourceControlSection" "apps/app/src" || echo "clean"
+```
+Expected: `clean`.
+
+- [ ] **Step 8: Commit (checkpoint)**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/_components/source-control-settings-client.tsx" "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-source-control-client.test.tsx"
+git commit -m "feat(source-control): compose redesigned settings sections and drop legacy file"
+```
+
+---
+
+## Task 9: Full verification
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run the full source-control + settings test surface**
+
+Run: `cd apps/app && pnpm test "settings-source-control"`
+Expected: PASS for `format`, `organization-card`, `lightfast-repository-card`, `repository-card`, `add-repository-dialog`, `repository-list`, `client`, and `page` (unchanged page test still passes).
+
+- [ ] **Step 2: Run the API service test**
+
+Run: `cd api/app && pnpm test "repositories"`
+Expected: PASS.
+
+- [ ] **Step 3: Typecheck the app**
+
+Run: `cd apps/app && pnpm with-env next typegen` then `pnpm typecheck`
+Expected: no type errors. The `listRepositories` output type now includes `syncStatus`; `RepositoryCard`/`AddRepositoryDialog`/`RepositoryList` consume it.
+
+- [ ] **Step 4: Lint/format the changed files**
+
+Run: `pnpm check`
+Expected: clean (or auto-fixable formatting only). Address any reported issues.
+
+- [ ] **Step 5: Manual smoke (optional but recommended)**
+
+With `pnpm dev` running, open `https://[<wt>.]lightfast.localhost/<slug>/settings/source-control` for a bound org and verify: Organization card with disabled "Connected ⌄" menu + tooltip; Lightfast repository card (Verified or Open setup); Repositories section listing only imported repos, each expandable to Watched paths, with sync status and a working "Open on GitHub". Then verify an unbound org shows only the empty state.
+
+- [ ] **Step 6: Final commit (checkpoint, if anything changed during verification)**
+
+```bash
+git add <exact paths touched by check/format>
+git commit -m "chore(source-control): formatting and verification fixups"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Three sections (Tasks 3/4/7) ✓; bg-background tokens ✓; bound vs unbound composition (Task 8 client) ✓; Organization disabled dropdown + tooltip (Task 3) ✓; "Connected on {date}" default (Task 2 + 3) ✓; Lightfast verified/unverified (Task 4) ✓; imported-only list (Task 7) ✓; Refresh + Add header (Task 7) ✓; repo card watched paths/sync status/Open-on-GitHub (Task 5) ✓; error + no-imported states (Task 7) ✓; single backend `syncStatus` change (Task 1) ✓; component split + delete legacy (Tasks 2–8) ✓; testing plan (every component + reworked client + API) ✓.
+- **Open item (from spec):** Org card subtitle uses **"Connected on {date}"** (binding exposes only `connectedByUserId`, no display name). No "Enabled by {name}" Clerk lookup in this plan.
+- **Type consistency:** `SourceControlRepositoryRow` (API) gains `syncStatus: SourceControlRepository["syncStatus"]`; the frontend derives the same shape via `AppRouterOutputs[...]["listRepositories"]["repositories"][number]`, so `syncStatus`/`watchedPathGlobs`/`imported`/`private` line up across Tasks 1, 5, 6, 7. `SourceControlConnection = NonNullable<...["get"]["binding"]>` is used identically in Tasks 3 and 4.
+- **No placeholders:** every code/test step contains full content; commands include expected outcomes.

--- a/docs/superpowers/plans/2026-06-02-linear-mcp-endpoint-ui.md
+++ b/docs/superpowers/plans/2026-06-02-linear-mcp-endpoint-ui.md
@@ -1,0 +1,138 @@
+# Linear Emulator MCP Endpoint UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a browser-facing `GET /mcp` HTML page to the Linear emulator without changing the existing `POST /mcp` MCP JSON-RPC endpoint.
+
+**Architecture:** Keep the existing Linear plugin split. Add a small `mcp-ui.ts` renderer for static HTML and register `GET /mcp` from `mcp.ts` before the existing `POST /mcp` handler. The renderer reads from `LINEAR_EMULATOR_FIXTURES` and `LINEAR_EMULATOR_TOOLS`, derives the current endpoint from the request origin, and escapes dynamic text before interpolation.
+
+**Tech Stack:** TypeScript ESM, Hono via `@emulators/core`, Vitest, pnpm workspaces.
+
+---
+
+## File Structure
+
+- Modify `emulators/linear/src/__tests__/server.test.ts`: add a failing regression test for browser `GET /mcp`.
+- Create `emulators/linear/src/plugin/mcp-ui.ts`: static HTML renderer plus minimal escaping helper.
+- Modify `emulators/linear/src/plugin/mcp.ts`: register `GET /mcp` and keep existing `POST /mcp` unchanged.
+
+## Task 1: Add the regression test
+
+- [ ] **Step 1: Add the failing test**
+
+Add a test near the other MCP tests:
+
+```ts
+  it("renders a browser UI for the MCP endpoint", async () => {
+    const active = await start();
+
+    const res = await fetch(`${active.url}/mcp`, {
+      headers: { accept: "text/html" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("Linear MCP");
+    expect(html).toContain("Lightfast local emulator");
+    expect(html).toContain(LINEAR_EMULATOR_FIXTURES.workspaceName);
+    expect(html).toContain(LINEAR_EMULATOR_FIXTURES.actorName);
+    expect(html).toContain(`${active.url}/mcp`);
+    expect(html).toContain(`npx mcp-remote ${active.url}/mcp`);
+    expect(html).toContain(`${LINEAR_EMULATOR_TOOLS.length} tools`);
+    expect(html).toContain("list_issues");
+    expect(html).toContain("create_issue");
+  });
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @repo/linear-emulator test -- src/__tests__/server.test.ts
+```
+
+Expected: fail because `GET /mcp` does not yet return the HTML page.
+
+## Task 2: Implement the static page
+
+- [ ] **Step 1: Add `mcp-ui.ts`**
+
+Create `emulators/linear/src/plugin/mcp-ui.ts` with:
+
+```ts
+import {
+  LINEAR_EMULATOR_FIXTURES,
+  LINEAR_EMULATOR_TOOLS,
+} from "../fixtures";
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function renderLinearMcpPage(endpoint: string): string {
+  const escapedEndpoint = escapeHtml(endpoint);
+  const tools = LINEAR_EMULATOR_TOOLS.map(
+    (tool) => `
+      <li>
+        <span>${escapeHtml(tool.name)}</span>
+        <small>${escapeHtml(tool.description)}</small>
+      </li>`
+  ).join("");
+
+  return `<!doctype html>
+<html lang="en">
+...
+</html>`;
+}
+```
+
+The final HTML should include inline CSS only, no scripts, and the text asserted
+by the test.
+
+- [ ] **Step 2: Register `GET /mcp`**
+
+In `emulators/linear/src/plugin/mcp.ts`, import `renderLinearMcpPage`, derive
+the endpoint from `new URL(c.req.url)`, and return HTML with
+`content-type: text/html; charset=utf-8`.
+
+- [ ] **Step 3: Verify green**
+
+Run:
+
+```bash
+pnpm --filter @repo/linear-emulator test -- src/__tests__/server.test.ts
+pnpm --filter @repo/linear-emulator typecheck
+```
+
+Expected: all Linear emulator tests pass and TypeScript reports no errors.
+
+## Task 3: Final check
+
+- [ ] **Step 1: Run formatting/lint check**
+
+Run:
+
+```bash
+pnpm dlx ultracite@latest check emulators/linear/src/plugin/mcp-ui.ts emulators/linear/src/plugin/mcp.ts emulators/linear/src/__tests__/server.test.ts
+```
+
+Expected: no errors. If fixes are needed, run `pnpm dlx ultracite@latest fix`
+on the same paths, then rerun Linear emulator tests.
+
+- [ ] **Step 2: Manual smoke**
+
+Run the emulator and open or curl `GET /mcp`:
+
+```bash
+PORT=4568 pnpm --filter @repo/linear-emulator dev
+curl -s http://127.0.0.1:4568/mcp | rg "Linear MCP|Lightfast local emulator|list_issues"
+```
+
+Expected: the HTML contains the asserted UI text. Stop the emulator afterward.

--- a/docs/superpowers/plans/2026-06-02-skills-page-redesign.md
+++ b/docs/superpowers/plans/2026-06-02-skills-page-redesign.md
@@ -1,0 +1,1121 @@
+# Skills Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the verbose Skills row-list + standalone detail page with a centered hero, a search + validity filter, a single "Team" grid of compact skill cells, and a centered dialog (deep-linked via `?skill=<slug>`) for reading a skill.
+
+**Architecture:** Pure UI/structural change in `apps/app`. The page keeps its existing `prefetch` → `HydrateClient` → client shape and the existing `skills.list` tRPC payload (every skill already carries `bodyMarkdown`, `diagnostics`, `resources`, `path`, `indexedCommitSha`), so the dialog reads from data already in the client — no new fetch, no router/schema changes. Detail moves from a route to a `?skill` query-param dialog (nuqs `useQueryState`, mirroring the connectors sheet). The old `[skillSlug]` route, `skill-row.tsx`, and `skill-detail.tsx` are deleted.
+
+**Tech Stack:** Next.js (App Router), React, TypeScript, tRPC + TanStack Query, nuqs, Radix UI (`@repo/ui` Dialog/Select/Input/Button), Tailwind, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-skills-page-redesign-design.md`
+
+**Conventions for every commit step:**
+- Stage with explicit pathspecs only (a concurrent agent may have other files staged — never `git add -A` / `git add .`).
+- End every commit message body with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## File Structure
+
+```
+apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/
+  page.tsx                          UNCHANGED  (prefetch + HydrateClient + Suspense + SkillsClient)
+  _components/
+    skills-client.tsx               REWRITE    hero + controls + freshness/repo link + diagnostics banner + grid + dialog wiring + query-state
+    skill-grid.tsx                  NEW        "Team" header + visible count + 2-col grid + empty state
+    skill-cell.tsx                  NEW        one compact clickable cell (glyph/name/desc + Invalid pill)
+    skill-glyph.tsx                 NEW        shared skill glyph (size via className)
+    skill-dialog.tsx                NEW        centered dialog: header, description, diagnostics, markdown, footer
+    skill-markdown.tsx              KEEP       renders SKILL.md (SkillMarkdown + getSkillSourceUrl)
+    skill-status.tsx                KEEP       freshness badge (now placed in the controls row)
+    skills-loading.tsx              UPDATE     skeleton matching hero + controls + grid
+    skill-row.tsx                   DELETE     replaced by skill-cell
+    skill-detail.tsx                DELETE     replaced by skill-dialog
+  [skillSlug]/page.tsx              DELETE     detail is now a dialog
+
+apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/
+  fixtures.ts                       NEW        createSkill() + createListData() shared test factories
+  skill-cell.test.tsx               NEW
+  skill-grid.test.tsx               NEW
+  skill-dialog.test.tsx             NEW
+  skills-client.test.tsx            REWRITE    grid render, search, invalid pill, cell-click sets ?skill, dialog open
+  page.test.tsx                     UNCHANGED  (mocks SkillsClient; still asserts prefetch-before-hydrate)
+  skill-markdown.test.tsx           UNCHANGED
+```
+
+Notes:
+- `skill-glyph.tsx` has no dedicated test — it is pure SVG markup, mirroring `connectors/_components/connector-icons.tsx` (also untested). It is exercised through `skill-cell.test.tsx`.
+- `skills-loading.tsx` has no dedicated test — `page.test.tsx` mocks it; consistent with the current repo (no skills-loading test exists).
+- Radix Select's open/keyboard interaction is not unit-tested (portal/pointer behavior is brittle in jsdom and untested elsewhere in this app). Filter wiring is trivial; the Invalid-pill path is covered via the cell.
+
+---
+
+## Task 1: Shared test fixtures
+
+**Files:**
+- Create: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/fixtures.ts`
+
+- [ ] **Step 1: Create the fixtures module**
+
+These factories return fully-typed objects matching the `skills.list` payload, so every later test stays DRY and type-safe. (Mirrors the inline factory that currently lives in `skills-client.test.tsx`, now extracted.)
+
+```ts
+import type { AppRouterOutputs } from "@api/app";
+
+type SkillsListResult = AppRouterOutputs["org"]["workspace"]["skills"]["list"];
+export type Skill = SkillsListResult["skills"][number];
+
+export function createSkill(overrides: Partial<Skill> = {}): Skill {
+  const now = new Date("2026-06-01T00:00:00.000Z");
+  return {
+    allowedTools: null,
+    bodyMarkdown: "Body",
+    compatibility: null,
+    contentSha: "content-sha",
+    contentSize: 100,
+    createdAt: now,
+    description: "Review code changes",
+    diagnostics: [],
+    id: 1,
+    indexedCommitSha: "a".repeat(40),
+    license: null,
+    metadata: {},
+    name: "code-review",
+    nonStandardResourceCount: 0,
+    path: "skills/code-review/SKILL.md",
+    resources: { assets: [], references: [], scripts: [], truncated: false },
+    resourcesTruncated: 0,
+    skillIndexStateId: 1,
+    slug: "code-review",
+    sourceMarkdown: "---\nname: code-review\n---\nBody",
+    updatedAt: now,
+    validationStatus: "valid",
+    ...overrides,
+  };
+}
+
+export function createListData(
+  input: {
+    indexDiagnostics?: SkillsListResult["indexDiagnostics"];
+    repositoryUrl?: string;
+    skills?: Skill[];
+  } = {}
+): SkillsListResult {
+  return {
+    freshness: {
+      checkedAt: new Date("2026-06-01T00:00:00.000Z"),
+      errorCode: null,
+      errorMessage: null,
+      githubCommitSha: "a".repeat(40),
+      indexedAt: new Date("2026-06-01T00:00:00.000Z"),
+      indexedCommitSha: "a".repeat(40),
+      status: "fresh",
+    },
+    indexDiagnostics: input.indexDiagnostics ?? [],
+    repositoryUrl: input.repositoryUrl ?? "https://github.com/acme/.lightfast",
+    skills: input.skills ?? [createSkill()],
+  };
+}
+```
+
+- [ ] **Step 2: Verify it type-checks (no test runner — it's a helper)**
+
+Run: `cd apps/app && pnpm with-env tsc --noEmit -p tsconfig.json 2>&1 | grep -i "skills/fixtures" || echo "no fixtures type errors"`
+Expected: `no fixtures type errors`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/fixtures.ts"
+git commit -m "test(skills): add shared skill fixtures for redesign tests
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: SkillGlyph (shared glyph)
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-glyph.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { cn } from "@repo/ui/lib/utils";
+
+export function SkillGlyph({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex size-9 shrink-0 items-center justify-center rounded-[9px] border border-border bg-transparent text-muted-foreground",
+        className
+      )}
+    >
+      <svg
+        aria-hidden="true"
+        className="size-[18px]"
+        fill="none"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth={1.6}
+        viewBox="0 0 24 24"
+      >
+        <path d="m12 3 8 4.5v9L12 21l-8-4.5v-9L12 3Z" />
+        <path d="m12 3 8 4.5-8 4.5-8-4.5L12 3Z" opacity={0.5} />
+        <path d="M12 12v9" opacity={0.5} />
+      </svg>
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-glyph.tsx"
+git commit -m "feat(skills): add shared skill glyph
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: SkillCell
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-cell.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-cell.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createSkill } from "./fixtures";
+
+const { SkillCell } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-cell"
+);
+
+describe("SkillCell", () => {
+  it("renders the name and description and selects on click", () => {
+    const onSelect = vi.fn();
+    render(
+      <SkillCell
+        onSelect={onSelect}
+        skill={createSkill({ name: "Code Review", slug: "code-review" })}
+      />
+    );
+
+    expect(screen.getByText("Code Review")).toBeInTheDocument();
+    expect(screen.getByText("Review code changes")).toBeInTheDocument();
+    expect(screen.queryByText("Invalid")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Code Review/i }));
+    expect(onSelect).toHaveBeenCalledWith("code-review");
+  });
+
+  it("marks invalid skills", () => {
+    render(
+      <SkillCell
+        onSelect={vi.fn()}
+        skill={createSkill({ validationStatus: "invalid" })}
+      />
+    );
+
+    expect(screen.getByText("Invalid")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-cell.test.tsx"`
+Expected: FAIL — cannot resolve `skill-cell` module.
+
+- [ ] **Step 3: Create the shared `Skill` type module**
+
+`skill-cell`, `skill-grid`, `skill-dialog`, and `skills-client` all need the same `Skill` row type. Define it once to keep them in sync.
+
+File: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-types.ts`
+
+```ts
+import type { AppRouterOutputs } from "@api/app";
+
+export type SkillsListResult =
+  AppRouterOutputs["org"]["workspace"]["skills"]["list"];
+export type Skill = SkillsListResult["skills"][number];
+```
+
+- [ ] **Step 4: Write the implementation**
+
+```tsx
+"use client";
+
+import { SkillGlyph } from "./skill-glyph";
+import type { Skill } from "./skills-types";
+
+export function SkillCell({
+  onSelect,
+  skill,
+}: {
+  onSelect: (slug: string) => void;
+  skill: Skill;
+}) {
+  const isInvalid = skill.validationStatus === "invalid";
+
+  return (
+    <button
+      className="flex w-full items-center gap-3 rounded-[9px] px-2.5 py-3 text-left hover:bg-muted/50"
+      onClick={() => onSelect(skill.slug)}
+      type="button"
+    >
+      <SkillGlyph />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground text-sm">
+          {skill.name ?? skill.slug}
+        </span>
+        {skill.description && (
+          <span className="mt-0.5 block truncate text-muted-foreground text-xs">
+            {skill.description}
+          </span>
+        )}
+      </span>
+      {isInvalid && (
+        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-amber-500/35 px-2 py-0.5 text-amber-500 text-xs">
+          <span className="size-1.5 rounded-full bg-amber-500" />
+          Invalid
+        </span>
+      )}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-cell.test.tsx"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-cell.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-types.ts" \
+  "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-cell.test.tsx"
+git commit -m "feat(skills): add SkillCell grid item
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: SkillGrid
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-grid.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-grid.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createSkill } from "./fixtures";
+
+const { SkillGrid } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-grid"
+);
+
+describe("SkillGrid", () => {
+  it("renders the Team header with the visible count and one cell per skill", () => {
+    render(
+      <SkillGrid
+        emptyState="No matching skills."
+        onSelect={vi.fn()}
+        skills={[
+          createSkill({ name: "Alpha", slug: "alpha" }),
+          createSkill({ name: "Bravo", slug: "bravo" }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Team")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+
+  it("forwards the selected slug", () => {
+    const onSelect = vi.fn();
+    render(
+      <SkillGrid
+        emptyState="No matching skills."
+        onSelect={onSelect}
+        skills={[createSkill({ name: "Alpha", slug: "alpha" })]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Alpha/i }));
+    expect(onSelect).toHaveBeenCalledWith("alpha");
+  });
+
+  it("renders the empty state when there are no skills", () => {
+    render(
+      <SkillGrid emptyState="No skills indexed." onSelect={vi.fn()} skills={[]} />
+    );
+
+    expect(screen.getByText("No skills indexed.")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-grid.test.tsx"`
+Expected: FAIL — cannot resolve `skill-grid` module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+"use client";
+
+import type { ReactNode } from "react";
+import { SkillCell } from "./skill-cell";
+import type { Skill } from "./skills-types";
+
+export function SkillGrid({
+  emptyState,
+  onSelect,
+  skills,
+}: {
+  emptyState: ReactNode;
+  onSelect: (slug: string) => void;
+  skills: Skill[];
+}) {
+  return (
+    <section className="mt-9">
+      <div className="flex items-center gap-2 border-border border-b pb-2.5">
+        <span className="font-medium text-foreground text-sm">Team</span>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+          {skills.length}
+        </span>
+      </div>
+      {skills.length === 0 ? (
+        <div className="py-10 text-muted-foreground text-sm">{emptyState}</div>
+      ) : (
+        <div className="mt-1 grid grid-cols-1 gap-x-2 sm:grid-cols-2">
+          {skills.map((skill) => (
+            <SkillCell key={skill.slug} onSelect={onSelect} skill={skill} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-grid.test.tsx"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-grid.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-grid.test.tsx"
+git commit -m "feat(skills): add SkillGrid with Team group
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: SkillDialog
+
+**Files:**
+- Create: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-dialog.tsx`
+- Test: `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-dialog.test.tsx`
+
+Note: the dialog uses the Dialog's built-in top-right close (`showCloseButton`). It carries a single `View source` link in the footer — the approved mockup also drew a header source icon, but two identical source links is redundant, so this consolidates to one labeled link (the only deviation from the mockup; flag to the user during review if undesired).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createSkill } from "./fixtures";
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-markdown",
+  () => ({
+    SkillMarkdown: () => <div>Markdown preview</div>,
+    getSkillSourceUrl: () =>
+      "https://github.com/acme/.lightfast/blob/main/skills/code-review/SKILL.md",
+  })
+);
+
+const { SkillDialog } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-dialog"
+);
+
+describe("SkillDialog", () => {
+  it("renders the skill content with a source link", () => {
+    render(
+      <SkillDialog
+        onOpenChange={vi.fn()}
+        repositoryUrl="https://github.com/acme/.lightfast"
+        skill={createSkill({ name: "Code Review" })}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /Code Review/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Skill")).toBeInTheDocument();
+    expect(screen.getByText("Review code changes")).toBeInTheDocument();
+    expect(screen.getByText("Markdown preview")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View source/i })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/.lightfast/blob/main/skills/code-review/SKILL.md"
+    );
+  });
+
+  it("surfaces diagnostics for invalid skills", () => {
+    render(
+      <SkillDialog
+        onOpenChange={vi.fn()}
+        repositoryUrl="https://github.com/acme/.lightfast"
+        skill={createSkill({
+          diagnostics: [
+            {
+              code: "frontmatter_missing",
+              message: "Skill file must begin with YAML frontmatter.",
+              severity: "error",
+            },
+          ],
+          validationStatus: "invalid",
+        })}
+      />
+    );
+
+    expect(screen.getByText("1 diagnostic")).toBeInTheDocument();
+    expect(
+      screen.getByText("Skill file must begin with YAML frontmatter.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when no skill is selected", () => {
+    render(
+      <SkillDialog
+        onOpenChange={vi.fn()}
+        repositoryUrl="https://github.com/acme/.lightfast"
+        skill={undefined}
+      />
+    );
+
+    expect(screen.queryByText("Skill")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-dialog.test.tsx"`
+Expected: FAIL — cannot resolve `skill-dialog` module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/ui/dialog";
+import { ExternalLink } from "lucide-react";
+import { SkillGlyph } from "./skill-glyph";
+import { getSkillSourceUrl, SkillMarkdown } from "./skill-markdown";
+import type { Skill } from "./skills-types";
+
+export function SkillDialog({
+  onOpenChange,
+  repositoryUrl,
+  skill,
+}: {
+  onOpenChange: (open: boolean) => void;
+  repositoryUrl: string;
+  skill?: Skill;
+}) {
+  const sourceUrl = skill ? getSkillSourceUrl({ repositoryUrl, skill }) : "";
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={Boolean(skill)}>
+      <DialogContent className="flex max-h-[82vh] flex-col gap-0 sm:max-w-2xl">
+        {skill && (
+          <>
+            <DialogHeader className="flex-row items-start gap-3 space-y-0 text-left">
+              <SkillGlyph className="size-10 rounded-full" />
+              <div className="min-w-0 flex-1">
+                <DialogTitle className="flex items-center gap-2 text-lg">
+                  <span className="truncate">{skill.name ?? skill.slug}</span>
+                  <span className="font-normal text-base text-muted-foreground">
+                    Skill
+                  </span>
+                </DialogTitle>
+                {skill.description && (
+                  <DialogDescription className="mt-2">
+                    {skill.description}
+                  </DialogDescription>
+                )}
+              </div>
+            </DialogHeader>
+
+            {skill.diagnostics.length > 0 && (
+              <div className="mt-4 rounded-[9px] border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-amber-500/90 text-xs">
+                <span className="font-medium text-amber-500">
+                  {skill.diagnostics.length}{" "}
+                  {skill.diagnostics.length === 1 ? "diagnostic" : "diagnostics"}
+                </span>
+                <ul className="mt-1 space-y-1">
+                  {skill.diagnostics.map((diagnostic) => (
+                    <li key={`${diagnostic.code}:${diagnostic.message}`}>
+                      {diagnostic.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="mt-4 min-h-0 flex-1 overflow-y-auto rounded-[12px] border border-border bg-muted/20 p-4">
+              <SkillMarkdown repositoryUrl={repositoryUrl} skill={skill} />
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-3 border-border border-t pt-4">
+              <span className="truncate font-mono text-muted-foreground text-xs">
+                {skill.path}
+              </span>
+              {sourceUrl && (
+                <Button asChild size="lf" variant="outline">
+                  <a href={sourceUrl} rel="noopener noreferrer" target="_blank">
+                    <ExternalLink className="size-3.5" />
+                    View source
+                  </a>
+                </Button>
+              )}
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-dialog.test.tsx"`
+Expected: PASS (3 tests). (The third asserts the closed dialog renders no content — Radix keeps it unmounted while `open` is false. The connectors sheet test establishes that Radix dialog components render in jsdom.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-dialog.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skill-dialog.test.tsx"
+git commit -m "feat(skills): add centered SkillDialog detail view
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Rewrite SkillsClient
+
+**Files:**
+- Modify (rewrite): `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-client.tsx`
+- Modify (rewrite): `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skills-client.test.tsx`
+
+- [ ] **Step 1: Rewrite the test (it will fail against the old client)**
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createListData, createSkill } from "./fixtures";
+
+const listQueryOptionsMock = vi.fn(() => ({
+  queryKey: ["org", "workspace", "skills", "list"],
+}));
+
+let listData = createListData();
+
+let skillParam: string | null = null;
+const setSkillParamMock = vi.fn((next: string | null) => {
+  skillParam = next;
+});
+
+vi.mock("nuqs", () => ({
+  useQueryState: () => [skillParam, setSkillParamMock] as const,
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      workspace: {
+        skills: { list: { queryOptions: listQueryOptionsMock } },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: () => ({ data: listData }),
+}));
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-markdown",
+  () => ({
+    SkillMarkdown: () => <div>Markdown preview</div>,
+    getSkillSourceUrl: () =>
+      "https://github.com/acme/.lightfast/blob/main/skills/code-review/SKILL.md",
+  })
+);
+
+const { SkillsClient } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-client"
+);
+
+beforeEach(() => {
+  listData = createListData();
+  skillParam = null;
+  setSkillParamMock.mockClear();
+  listQueryOptionsMock.mockClear();
+});
+
+describe("SkillsClient", () => {
+  it("renders the hero and a Team grid cell per skill", () => {
+    render(<SkillsClient />);
+
+    expect(
+      screen.getByRole("heading", { name: "Make Lightfast work your way" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeInTheDocument();
+    expect(screen.getByText("code-review")).toBeInTheDocument();
+  });
+
+  it("filters to a no-match empty state when the search misses", () => {
+    render(<SkillsClient />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search skills" }), {
+      target: { value: "does-not-match" },
+    });
+
+    expect(screen.getByText("No matching skills.")).toBeInTheDocument();
+    expect(screen.queryByText("No skills indexed.")).not.toBeInTheDocument();
+  });
+
+  it("shows the indexed empty state only when the index has no skills", () => {
+    listData = createListData({ skills: [] });
+
+    render(<SkillsClient />);
+
+    expect(screen.getByText("No skills indexed.")).toBeInTheDocument();
+  });
+
+  it("marks invalid skills in the grid", () => {
+    listData = createListData({
+      skills: [createSkill({ slug: "broken", validationStatus: "invalid" })],
+    });
+
+    render(<SkillsClient />);
+
+    expect(screen.getByText("Invalid")).toBeInTheDocument();
+  });
+
+  it("opens the dialog by setting the skill query param", () => {
+    render(<SkillsClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: /code-review/i }));
+
+    expect(setSkillParamMock).toHaveBeenCalledWith("code-review");
+  });
+
+  it("renders the dialog for the skill named in the query param", () => {
+    skillParam = "code-review";
+
+    render(<SkillsClient />);
+
+    expect(
+      screen.getByRole("heading", { name: /code-review/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Markdown preview")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skills-client.test.tsx"`
+Expected: FAIL — old client has no "Make Lightfast work your way" heading / no nuqs usage.
+
+- [ ] **Step 3: Rewrite the client**
+
+```tsx
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { Input } from "@repo/ui/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/ui/select";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ExternalLink, Search } from "lucide-react";
+import { useQueryState } from "nuqs";
+import { useDeferredValue, useMemo, useState } from "react";
+import { useTRPC } from "~/trpc/react";
+import { SkillDialog } from "./skill-dialog";
+import { SkillGrid } from "./skill-grid";
+import { SkillStatus } from "./skill-status";
+import type { Skill } from "./skills-types";
+
+type SkillFilter = "all" | "invalid" | "valid";
+
+export function SkillsClient() {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(
+    trpc.org.workspace.skills.list.queryOptions(undefined, { staleTime: 0 })
+  );
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<SkillFilter>("all");
+  const [skillParam, setSkillParam] = useQueryState("skill");
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
+
+  const visibleSkills = useMemo(
+    () =>
+      data.skills
+        .filter((skill) => matchesFilter(skill, filter))
+        .filter((skill) => matchesQuery(skill, deferredQuery))
+        .sort((a, b) => {
+          if (a.validationStatus !== b.validationStatus) {
+            return a.validationStatus === "invalid" ? -1 : 1;
+          }
+          return a.slug.localeCompare(b.slug);
+        }),
+    [data.skills, deferredQuery, filter]
+  );
+
+  const selectedSkill = skillParam
+    ? data.skills.find((skill) => skill.slug === skillParam)
+    : undefined;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-10">
+      <div className="pt-6 text-center">
+        <h1 className="font-semibold text-3xl text-foreground tracking-[-0.02em]">
+          Make Lightfast work your way
+        </h1>
+        <p className="mx-auto mt-3 max-w-[30rem] text-muted-foreground text-sm">
+          Reusable instructions your agents load on demand, indexed from your
+          team&apos;s connected GitHub repository.
+        </p>
+      </div>
+
+      <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            aria-label="Search skills"
+            className="pl-8"
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Search skills"
+            size="lf"
+            value={query}
+            variant="lf"
+          />
+        </div>
+        <Select
+          onValueChange={(value) => setFilter(value as SkillFilter)}
+          value={filter}
+        >
+          <SelectTrigger
+            aria-label="Filter skills"
+            className="h-7 shrink-0 rounded-[9px] sm:w-32"
+            size="sm"
+          >
+            <SelectValue placeholder="All" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="valid">Valid</SelectItem>
+            <SelectItem value="invalid">Invalid</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <SkillStatus freshness={data.freshness} />
+        {data.repositoryUrl && (
+          <Button asChild size="lf" variant="ghost">
+            <a
+              href={data.repositoryUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Open repository
+              <ExternalLink className="size-3.5" />
+            </a>
+          </Button>
+        )}
+      </div>
+
+      {data.indexDiagnostics.length > 0 && (
+        <div className="mt-4 rounded-[9px] border border-border bg-muted/20 px-3 py-2">
+          <p className="font-medium text-foreground text-sm">
+            Index diagnostics
+          </p>
+          <ul className="mt-1 space-y-1">
+            {data.indexDiagnostics.map((diagnostic) => (
+              <li
+                className="text-muted-foreground text-xs"
+                key={`${diagnostic.code}:${diagnostic.message}`}
+              >
+                {diagnostic.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <SkillGrid
+        emptyState={
+          data.skills.length === 0
+            ? "No skills indexed."
+            : "No matching skills."
+        }
+        onSelect={(slug) => {
+          void setSkillParam(slug);
+        }}
+        skills={visibleSkills}
+      />
+
+      <SkillDialog
+        onOpenChange={(open) => {
+          if (!open) {
+            void setSkillParam(null);
+          }
+        }}
+        repositoryUrl={data.repositoryUrl}
+        skill={selectedSkill}
+      />
+    </div>
+  );
+}
+
+function matchesFilter(skill: Skill, filter: SkillFilter): boolean {
+  return filter === "all" || skill.validationStatus === filter;
+}
+
+function matchesQuery(skill: Skill, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+
+  return [skill.slug, skill.name ?? "", skill.description ?? "", skill.path]
+    .join(" ")
+    .toLowerCase()
+    .includes(query);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skills-client.test.tsx"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-client.tsx" \
+  "apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/skills-client.test.tsx"
+git commit -m "feat(skills): rewrite SkillsClient as hero + grid + dialog
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Update the loading skeleton
+
+**Files:**
+- Modify: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-loading.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+```tsx
+import { Skeleton } from "@repo/ui/components/ui/skeleton";
+
+export function SkillsLoading() {
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-10">
+      <div className="flex flex-col items-center pt-6">
+        <Skeleton className="h-8 w-80 max-w-full rounded-md" />
+        <Skeleton className="mt-3 h-4 w-96 max-w-full rounded-md" />
+      </div>
+
+      <div className="mt-10 flex items-center gap-3">
+        <Skeleton className="h-7 flex-1 rounded-[9px]" />
+        <Skeleton className="h-7 w-32 rounded-[9px]" />
+      </div>
+
+      <div className="mt-9 border-border border-b pb-2.5">
+        <Skeleton className="h-4 w-16 rounded-md" />
+      </div>
+
+      <div className="mt-1 grid grid-cols-1 gap-x-2 sm:grid-cols-2">
+        {Array.from({ length: 8 }).map((_, index) => (
+          <div className="flex items-center gap-3 px-2.5 py-3" key={index}>
+            <Skeleton className="size-9 rounded-[9px]" />
+            <div className="min-w-0 flex-1">
+              <Skeleton className="h-3.5 w-28 rounded-md" />
+              <Skeleton className="mt-2 h-3 w-40 rounded-md" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the app test suite still imports/builds the loader (page.test mocks it)**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/page.test.tsx"`
+Expected: PASS (1 test) — unchanged, still asserts prefetch-before-hydrate and the mocked heading.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skills-loading.tsx"
+git commit -m "feat(skills): match loading skeleton to redesigned page
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Delete the obsolete detail route + components
+
+**Files:**
+- Delete: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/[skillSlug]/page.tsx`
+- Delete: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-row.tsx`
+- Delete: `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-detail.tsx`
+
+- [ ] **Step 1: Confirm nothing else references the deleted files or the detail route**
+
+Run:
+```bash
+cd /Users/jeevanpillay/Code/@lightfastai/lightfast
+grep -rn "skill-row\|skill-detail\|skills/\[skillSlug\]\|skills/\${" apps/app/src --include="*.ts" --include="*.tsx" | grep -v "/skills/\[skillSlug\]/page.tsx"
+grep -rn "/skills/" apps/app/src --include="*.tsx" | grep -i "slug.*skill\|skillSlug"
+```
+Expected: no remaining references to `skill-row`, `skill-detail`, or a `/skills/<slug>` link (the only link to the detail route lived inside the now-deleted `skill-row.tsx`). If any reference remains, replace it with a `?skill=<slug>` interaction before deleting.
+
+- [ ] **Step 2: Delete the files**
+
+```bash
+cd /Users/jeevanpillay/Code/@lightfastai/lightfast
+git rm \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/[skillSlug]/page.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-row.tsx" \
+  "apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/_components/skill-detail.tsx"
+```
+
+- [ ] **Step 3: Verify the skills test suite still passes**
+
+Run: `cd apps/app && pnpm with-env vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills"`
+Expected: PASS — page.test, skill-markdown.test, fixtures-backed cell/grid/dialog/client tests all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "refactor(skills): remove standalone detail route and row list
+
+Detail now lives in the ?skill dialog.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck the app and api**
+
+Run: `pnpm --filter @api/app build && cd apps/app && pnpm with-env next typegen && pnpm with-env tsc --noEmit -p tsconfig.json`
+Expected: no type errors. (`@api/app` build first so tRPC output types are current; `next typegen` refreshes route types after deleting `[skillSlug]`.)
+
+- [ ] **Step 2: Lint / format check**
+
+Run: `pnpm check`
+Expected: passes (Biome/lint clean). If the formatter rewrites any new file, re-stage and amend the relevant commit.
+
+- [ ] **Step 3: Run the full app test suite**
+
+Run: `cd apps/app && pnpm with-env vitest run`
+Expected: PASS, including all `skills` tests.
+
+- [ ] **Step 4: Build the app**
+
+Run: `pnpm build:app`
+Expected: build succeeds with no route/type errors from the removed `[skillSlug]` page.
+
+- [ ] **Step 5: Manual smoke (optional but recommended)**
+
+With `pnpm dev` running, open `https://<wt>.app.lightfast.localhost/<org-slug>/skills`:
+- Hero centered, search + `All` filter + freshness + `Open repository` link visible.
+- "Team" group with a count; 2-column grid of cells; invalid skills show the amber `Invalid` pill.
+- Click a cell → centered dialog with markdown + `View source`; URL gains `?skill=<slug>`.
+- Close (X / Esc / overlay) → `?skill` clears.
+- Filter to `Invalid` → only invalid skills; search narrows the count.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Centered hero + subtitle → Task 6 (client).
+- Search + validity filter (All/Valid/Invalid) → Task 6.
+- Freshness badge relocated to controls row → Task 6 (`SkillStatus`).
+- `Open repository ↗` ghost link in controls row → Task 6 (decision: keep small link).
+- Single "Team" group + **visible** count → Task 4 (`SkillGrid`, `skills.length`).
+- 2-column compact grid of cells, no `+`/`✓` trailing action → Tasks 3–4.
+- Invalid skills marked on the cell → Task 3.
+- Centered dialog, visual-only (no toggle/uninstall/try-in-chat), markdown + diagnostics + View source → Task 5.
+- Deep-link via `?skill=<slug>` → Task 6 (nuqs).
+- Remove `[skillSlug]` route, `skill-row`, `skill-detail` → Task 8.
+- Index-diagnostics banner preserved → Task 6.
+- Empty vs no-match messaging preserved → Tasks 4 + 6.
+- Router/services/`skills.get` untouched → no task touches them (confirmed).
+- Loading skeleton updated → Task 7.
+
+**Placeholder scan:** none — every step has full code or an exact command + expected output.
+
+**Type consistency:** the shared `Skill` type lives in `skills-types.ts` (Task 3, Step 4) and is imported by `skill-cell`, `skill-grid`, `skill-dialog`, and `skills-client`. `SkillDialog` prop is `skill?: Skill`; `SkillGrid`/`SkillCell` use non-optional `skill: Skill`. `onSelect: (slug: string) => void` and `onOpenChange: (open: boolean) => void` signatures match across producer/consumer. Fixtures return `Skill` / `SkillsListResult`, matching `useSuspenseQuery` data and component props. `getSkillSourceUrl` / `SkillMarkdown` signatures are unchanged from the kept `skill-markdown.tsx`.

--- a/docs/superpowers/specs/2026-06-01-account-settings-source-control-design.md
+++ b/docs/superpowers/specs/2026-06-01-account-settings-source-control-design.md
@@ -1,0 +1,145 @@
+# Account settings: connector-style General + new "Source Control & Git" route
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorm)
+**Scope:** `apps/app` — account-level settings under `(app)/(pending-allowed)/account/settings`
+
+## Problem
+
+The account-level settings (`/account/settings/general`) predate the recent workspace
+settings redesign. The General page is a single stacked component using large `text-xl`
+headings, full-width inputs, and an inline "GitHub account" block. Meanwhile the workspace
+settings (`[slug]/(workspace)/(manage)/settings`) were reworked into a connector-style
+system: a left sidebar with discrete routes, compact `SettingsGroup`/`SettingRow`
+primitives, and connector cards (e.g. `OrganizationCard` for the GitHub org connection).
+
+Two gaps:
+
+1. The personal GitHub identity lives inline on the General page, instead of in a dedicated
+   "Source Control & Git" area like the workspace has.
+2. The General page visual language is inconsistent with the workspace settings.
+
+## Goals
+
+- Move the personal GitHub connection out of General into a **new account-level
+  `Source Control & Git` route**, mirroring the workspace settings structure exactly.
+- Render that connection as a **connector card** matching the workspace `OrganizationCard`.
+- **Upgrade the General page** to the workspace `SettingsGroup`/`SettingRow` pattern.
+- Keep behavior parity: the only real action today is routing to the GitHub setup task.
+
+## Non-goals
+
+- Wiring an editable display name (no mutation exists today; stays read-only).
+- Wiring a real GitHub disconnect flow (the `viewer.githubAccount.disconnect` mutation
+  exists but is intentionally left as a disabled menu item to match the workspace card).
+- Any change to the GitHub user-account binding services or tRPC routers.
+
+## Decisions (resolved during brainstorm)
+
+| Decision | Choice |
+| --- | --- |
+| Structure of "Source Control & Git" | **Separate sidebar route** (`account/settings/source-control`), mirroring the workspace layout. |
+| GitHub connection visual style | **Connector card** (workspace `OrganizationCard` look): icon tile + `github:{providerUserId}` + "Connected on {date}" + "● Connected ▾" pill. |
+| Disconnect action | **Disabled** menu item with workspace-style tooltip. Only "View GitHub setup" is enabled. |
+| `SettingsGroup`/`SettingRow` primitives | **Promote to shared** `apps/app/src/components/settings-section.tsx` (beside `settings-sidebar.tsx`); update the workspace import. |
+
+## Architecture
+
+### Existing reference points
+
+- Workspace layout sidebar: `[slug]/(workspace)/(manage)/settings/layout.tsx`
+  (`{ name: "Source Control & Git", path: "source-control" }`).
+- Workspace source-control page: `.../settings/source-control/page.tsx` prefetches
+  `org.settings.sourceControl.*` then renders `SourceControlSettingsClient`.
+- Connector card: `.../source-control/_components/organization-card.tsx` (`OrganizationCard`).
+- Row primitives: `.../settings/_components/settings-section.tsx` (`SettingsGroup`, `SettingRow`).
+- Account GitHub data: `trpc.viewer.githubAccount.status` →
+  `{ account: null | { provider: "github", providerUserId, connectedAt, status: "active", accessTokenExpiresAt, refreshTokenExpiresAt } }`.
+- Setup task route: `/account/tasks/github`.
+
+### Components & files
+
+**1. Promote shared row primitives**
+- New: `apps/app/src/components/settings-section.tsx` — move `SettingsGroup` + `SettingRow`
+  verbatim from the workspace `_components/settings-section.tsx`.
+- Update `team-general-settings-client.tsx` import to the shared path.
+- Delete the workspace `_components/settings-section.tsx`.
+
+**2. Account settings layout** (`account/settings/layout.tsx`)
+- Add sidebar item `{ name: "Source Control & Git", path: "source-control" }` after General.
+- Add `max-w-4xl` to the main content wrapper to match the workspace content column.
+- Leave the `Your Account` header markup (`pt-2 pb-8`, `pl-3`) unchanged — layout tests
+  assert on it.
+
+**3. General page upgrade**
+- `general/_components/profile-data-display.tsx`:
+  - Header: `<h2 className="font-medium font-pp text-foreground text-xl">General</h2>` +
+    muted description.
+  - `SettingsGroup title="Profile"` with `SettingRow`s:
+    - **Avatar** → `Avatar size-7` with initials fallback.
+    - **Display Name** → `Input size="lf" variant="lf"` width-capped, `disabled` (read-only).
+    - **Email** → `Input` `disabled` (read-only).
+  - Remove the `<GithubAccountConnectionSection />` render and import.
+- `general/page.tsx`: drop the `trpc.viewer.githubAccount.status` prefetch; keep
+  `trpc.viewer.account.get`.
+- Delete `general/_components/github-account-connection-section.tsx` (moved/replaced).
+
+**4. New Source Control & Git route**
+- `account/settings/source-control/page.tsx`: `prefetch(trpc.viewer.githubAccount.status...)`
+  inside `HydrateClient`, render `<AccountSourceControlClient />`.
+- `account/settings/source-control/_components/account-source-control-client.tsx`:
+  - `useSuspenseQuery(trpc.viewer.githubAccount.status...)`.
+  - Header `"Source Control & Git"` + description (personal GitHub identity copy).
+  - Connected → `<GithubAccountCard account={account} />`.
+  - Not connected → empty-state card mirroring the workspace empty state, with a
+    "Connect GitHub account" button → `/account/tasks/github`.
+- `account/settings/source-control/_components/github-account-card.tsx` (`GithubAccountCard`):
+  - Mirrors `OrganizationCard`: icon tile (`Icons.github`), title `github:{providerUserId}`,
+    subtitle `Connected on {connectedAt}`, and a `DropdownMenu` trigger
+    `"● Connected ▾"`.
+  - Dropdown: enabled **"View GitHub setup"** (`Link` → `/account/tasks/github`), disabled
+    **"Disconnect"** with tooltip `"Connection is managed from the GitHub setup task."`
+  - Local short-date helper (`Intl.DateTimeFormat`) — the workspace `source-control-format.ts`
+    is route-local and not imported across the route tree.
+
+### Data flow
+
+```
+account/settings/source-control/page.tsx
+  prefetch viewer.githubAccount.status  ── HydrateClient ──▶ AccountSourceControlClient
+                                                              useSuspenseQuery(status)
+                                              account ? GithubAccountCard : EmptyState
+```
+
+No new server code. `page.tsx` for General drops one prefetch; the source-control page adds
+the same prefetch. The `viewer.githubAccount.status` query options key is unchanged
+(`[["viewer","githubAccount","status"]]`).
+
+### Error / empty handling
+
+- Not connected (`account === null`): empty-state card + "Connect GitHub account" CTA.
+- Connected: connector card. The disabled "Disconnect" item carries an explanatory tooltip.
+- Loading: page uses the existing prefetch + `HydrateClient` pattern; no spinner needed
+  (the workspace source-control page has no extra Suspense boundary either).
+
+## Testing
+
+- **`__tests__/.../account/settings-layout.test.tsx`** — update the
+  "setup-only pass" expectation: assert the sidebar now shows "Source Control & Git"
+  alongside "General". Keep the existing header (`pl-3`, `pt-2 pb-8`) assertions.
+- **`__tests__/.../account/settings-general-github-section.test.tsx`** — split:
+  - General: `profile-data-display` renders Avatar/Display Name/Email and **no** GitHub
+    section; `general/page.tsx` prefetches only `viewer.account.get`.
+  - New `account/settings-source-control.test.tsx`: the source-control page prefetches
+    `viewer.githubAccount.status`; `GithubAccountCard` shows `github:{id}` + "Connected"
+    when connected and an enabled "View GitHub setup" link; empty state shows
+    "Connect GitHub account" when `account === null`.
+- Run `pnpm --filter @lightfast/app test` (or the app's test command) plus `pnpm typecheck`.
+
+## Risks / notes
+
+- Promoting `settings-section.tsx` touches one workspace import. Low risk; verified the only
+  importer is `team-general-settings-client.tsx`.
+- Layout test asserts absence of literal text "GitHub"; the new sidebar label is
+  "Source Control & Git" (no standalone "GitHub" text node), so the assertion needs updating
+  to reflect intent but won't false-fail.

--- a/docs/superpowers/specs/2026-06-01-automations-markdown-inline-edit-design.md
+++ b/docs/superpowers/specs/2026-06-01-automations-markdown-inline-edit-design.md
@@ -1,0 +1,133 @@
+# Automations: markdown instructions + inline auto-save — design
+
+**Date:** 2026-06-01
+**Status:** Approved (design); pending implementation plan
+**Area:** `apps/app` — automations workspace routes
+
+## Summary
+
+Upgrade the automation **instructions** to render as markdown, and convert the
+automation **name** and **instructions** editors on the detail page from
+popover / Edit-button-toggle interactions to **inline click-to-edit** controls
+that **auto-save on blur / ⌘↵**.
+
+The `/new` create form keeps its plain textarea and gains a small "Markdown
+supported" hint. The schedule editor is unchanged.
+
+## Key insight: no data-layer change
+
+`prompt` is already a plain `string` (max 4000) in
+`packages/app-validation/src/schemas/automations.ts`, and the agent runtime
+consumes it as raw text. **Markdown is just text.** Therefore:
+
+- No DB / Drizzle schema change.
+- No tRPC procedure change (`automations.update` already accepts `prompt`).
+- No runtime change — the agent already receives the raw string.
+- No markdown-specific validation; existing plain-text prompts render fine
+  (as paragraphs) — fully backward-compatible.
+
+This is purely a **render + edit-UX** change in `apps/app`.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Edit interaction | **Click-to-edit toggle** — view shows rendered markdown; click flips to a raw-markdown editor; the view *is* the preview |
+| Commit trigger | **Blur** or **⌘↵**; **Esc** reverts |
+| Markdown renderer | Existing `Markdown` from `@repo/ui/components/markdown` (react-markdown + remark-gfm) |
+| `/new` form | Plain textarea + "Markdown supported" hint; **no** preview |
+| Schedule editor | **Out of scope** — keeps its popover |
+
+`Markdown` (react-markdown) is chosen over `Response` (Streamdown): the prompt
+is static, not streamed.
+
+## Detailed behavior — detail page
+
+Both editors replace their current UI (name = Popover; instructions = Edit
+button + textarea). Both are gated on `org:admin` exactly as today; non-admins
+see read-only output with no edit affordance.
+
+| | Name | Instructions |
+|---|---|---|
+| View state | `<h1>` heading (`font-medium font-pp text-2xl`) | `<Markdown>` rendering `automation.prompt` |
+| Hover (admin) | subtle `hover:bg-accent/50` + text cursor | same |
+| Edit control | `<Input variant="lf">`, autofocused | auto-sizing `<Textarea variant="lf">`, autofocused, `{len}/{MAX}` counter + "Markdown supported" hint |
+| Commit keys | **Enter** or **blur** | **⌘↵** or **blur** (plain Enter inserts a newline) |
+| Cancel | **Esc** → revert to last saved | **Esc** → revert to last saved |
+| `maxLength` | `AUTOMATION_NAME_MAX_LENGTH` | `AUTOMATION_PROMPT_MAX_LENGTH` |
+
+### Commit rules (both fields)
+
+1. Trim the draft.
+2. If the trimmed draft is **empty** or **unchanged**, silently revert to the
+   view state — no mutation fired.
+3. Otherwise: optimistically update the query cache, flip to the view state
+   immediately, and run `automations.update` in the background.
+4. On error: revert the cache to the snapshot and surface a toast
+   (`meta.errorTitle`).
+
+`maxLength` on the input/textarea prevents over-limit entry, so "too long" is
+not a runtime commit path.
+
+### Esc / blur ordering
+
+Pressing **Esc** must cancel *without* the trailing `blur` event also
+committing. Implementation captures a "cancel intent" ref that the blur handler
+checks before committing.
+
+## Shared structure (targeted cleanup)
+
+Today the name, prompt, and schedule editors each re-implement the same
+optimistic `onMutate / onError / onSuccess` against `setOne` / `upsertInList`.
+Two small extractions keep the new editors focused and DRY:
+
+- **`use-inline-edit.ts`** (new, headless hook) — owns
+  `{ editing, draft, setDraft, begin, inputProps }` plus the blur / keyboard /
+  Esc commit logic. A `multiline` flag switches the commit key between
+  **Enter** (single-line) and **⌘↵** (multiline). Each editor supplies its own
+  render (Input vs Textarea + Markdown) and its own mutation callback.
+- **`automationUpdateMutationOptions(qc, trpc, id, { errorTitle })`** — a
+  factory in `automations-cache.ts` returning the shared optimistic
+  `mutationOptions`, reused by name + prompt (and trivially adoptable by the
+  schedule editor later, though not required by this change).
+
+## `/new` create form
+
+Keep the react-hook-form `Textarea` and its char counter unchanged. Add a small
+muted "Markdown supported" hint under the **Instructions** label. No preview,
+no interaction-model change.
+
+## Non-goals
+
+- Converting the schedule editor.
+- Any DB / schema / tRPC / runtime change.
+- Markdown-specific validation or sanitization beyond what the renderer does.
+- A live-preview or split-pane editor on either route.
+- Changing the create-form interaction model.
+
+## Testing
+
+Follow the existing vitest + React Testing Library pattern (mocked `useTRPC`,
+`useAuth`, and `@tanstack/react-query`, as in `automations-client.test.tsx`).
+New tests for both inline editors cover:
+
+- view ↔ edit toggle on click (admin only)
+- commit on blur
+- commit on ⌘↵ (instructions) / Enter (name)
+- Esc reverts without committing
+- empty draft → no-op revert
+- unchanged draft → no-op revert
+- non-admin → read-only (markdown rendered for instructions; no edit affordance)
+
+## Files touched
+
+- `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-name-editor.tsx` — rewrite to inline
+- `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-prompt-editor.tsx` — rewrite to inline + `Markdown`
+- `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/use-inline-edit.ts` — **new** headless hook
+- `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/_components/automations-cache.ts` — add `automationUpdateMutationOptions` factory
+- `apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx` — add "Markdown supported" hint
+- New test files for the two editors under `apps/app/src/__tests__/...`
+
+## Open questions
+
+None outstanding.

--- a/docs/superpowers/specs/2026-06-01-automations-visual-language-design.md
+++ b/docs/superpowers/specs/2026-06-01-automations-visual-language-design.md
@@ -1,0 +1,149 @@
+# Automations rework + Lightfast visual-language seed — Design
+
+Date: 2026-06-01
+Status: Approved (design); pending implementation plan
+Driver: Rework `automations/page.tsx` (list) and `automations/new/page.tsx` (create form) UI; the work expanded into seeding a custom Lightfast visual language.
+
+## Problem & intent
+
+The automations create form and list pages use stock shadcn primitives at default scale.
+The user wants (a) a nicer, more deliberate UI, (b) better react-hook-form integration, and
+(c) to stop riding stock shadcn and define **Lightfast's own visual language** — Linear-informed,
+precise, technical — proven first on automations, then expanded surface by surface.
+
+This is **not** a full `packages/ui` overhaul. We seed the language (tokens + the handful of
+primitives automations needs), restyle stock shadcn with those tokens (no bespoke component
+logic), and apply it to the automations surfaces.
+
+## Scope decomposition
+
+Two coupled bodies of work, one spec:
+
+1. **Lightfast visual language v1 (seed)** — tokens + restyled primitives. No Storybook
+   (decided): iterate via the running app. Restyle stock shadcn primitives; do not build
+   bespoke component mechanics.
+2. **Automations rework** — schedule-model backend expansion + the three UI surfaces
+   (create form, list, detail editors) built on the seed.
+
+Non-goals: overhauling every `packages/ui` component; redesigning other app surfaces;
+adding a `description` field to automations; building a custom segmented time picker
+(explicitly rejected — use shadcn-default native time input).
+
+## Decisions locked during brainstorming
+
+| Topic | Decision |
+|---|---|
+| Direction | Linear-informed / precise / technical |
+| Storybook | No — iterate in the running app |
+| Reach | Seed language + apply to create form, list page, AND detail editors |
+| Create-form surface | Keep full-page route (`/[slug]/automations/new`), not a modal |
+| Schedule kinds | Expand to `manual / hourly / daily / weekdays / weekly` |
+| Weekly config | Single day per week |
+| Manual "no next run" | Make `nextRunAt` nullable (clean semantics) |
+| Radius | Soft — `--radius` 9px |
+| Labels | Monospace, **no caps**, no tracking, no field-index numbers |
+| Accent | Neutral; brand orange reserved (not used in interactions yet) |
+| Density / type | Smaller — heading 20px, input text 12.5px, mono labels 11px |
+| Input height | 30px |
+| Resting input | Fill (`surface-1`) + hairline border (`input-line`) |
+| Focus ring ("outline") | **Inset hairline** — `box-shadow: inset 0 0 0 1px ring`, bg→`background` |
+| Schedule control | **Underline tabs** (not segmented pill) + sub-control panel below |
+| Time input | shadcn-default **native styled `type="time"`** — `appearance-none`, hidden webkit indicator, `bg-background`, mono digits. No custom picker. |
+| Day-of-week (weekly) | Styled `Select` |
+| Form integration | Keep `Form`/`FormField` (react-hook-form); restyle primitives via tokens |
+
+## 1 · Visual language seed
+
+### Tokens (dark theme; values are the agreed mockup values, to be reconciled with `packages/ui/src/globals.css`)
+
+- Surfaces: `background` oklch(0.2178 0 0), `surface-1`/card oklch(0.2435 0 0), `surface-2` oklch(0.27 0 0)
+- Foreground oklch(0.8853 0 0), muted-foreground oklch(0.62 0 0)
+- Lines: `hairline` oklch(0.305 0 0), `input-line` oklch(0.34 0 0), `border` oklch(0.329 0 0)
+- `ring` oklch(0.72 0 0); brand (reserved) oklch(0.5913 0.2286 31.28)
+- Radius: `--radius` 9px (soft). Existing scale maps `rounded-md = radius-2`, `rounded-lg = radius`.
+- Type: body 13px; heading 20px/600/-0.02em; input text 12.5px; labels mono 11px; counters/status mono 9.5–10px
+- Fonts: sans = system UI; mono = ui-monospace stack (labels, counters, time digits, status lines, kicker/meta)
+
+### Primitives to restyle (the seed)
+
+1. **Input** — h-30px, fill+hairline rest, inset-hairline focus, 12.5px text. New token-driven look (likely a Lightfast variant or restyle of the default).
+2. **Textarea** — same skin; min-h ~92px; supports an absolutely-positioned mono character counter (`n/max`).
+3. **Label** — mono, no caps, 11px, muted-foreground; required marker is a muted mono `*`.
+4. **Tabs (underline)** — restyle existing `tabs.tsx` to the underline idiom: row with bottom hairline, active tab gets a 2px foreground underline (`margin-bottom:-1px`), muted→foreground on hover/active. Sub-control panel sits beneath.
+5. **Select** — styled `appearance-none` with chevron bg, inset-hairline focus. Used for day-of-week and timezone.
+6. **Button** — h-30px; ghost (cancel) + primary (foreground/white) submit. Confirm primary vs secondary for submit during implementation.
+
+Focus ring is uniform across all controls: resting border unchanged, focus = `background` fill + `inset 0 0 0 1px ring` (no halo, no layout shift). This doubles as the `:focus-visible` keyboard outline (inset hairline meets ~3:1 contrast).
+
+Time input: native `<input type="time">` with `appearance-none`, `bg-background`, `::-webkit-calendar-picker-indicator{display:none}`, mono digits, inset-hairline focus. (The general date case keeps the shadcn `Popover + Calendar` recipe — already vendored via `Calendar`/react-day-picker — but automations needs only time-of-day, so no calendar here.)
+
+## 2 · Schedule-model backend expansion
+
+Today (in `packages/app-validation/src/schemas/automations.ts`, `db/app/src/schema/tables/automations.ts`,
+`db/app/src/utils/automations.ts`): a discriminated union of `hourly | daily`, `nextRunAt` is `NOT NULL`,
+and `calculateNextRunAt` handles those two kinds. Scheduler (`automation-scheduler.ts`) claims rows via
+`status='active' AND nextRunAt <= now` (`claimDueAutomationRuns`); `runNow` fires a manual run independent
+of schedule.
+
+### Target model
+
+`scheduleKind` → config (Zod discriminated union, mirrored in DB `$type`s):
+
+| Kind | Config | Runs | nextRunAt |
+|---|---|---|---|
+| `manual` | `{}` | only via Run now | `null` |
+| `hourly` | `{ intervalHours: 1–24 }` | every N hours | as today |
+| `daily` | `{ time: "HH:mm" }` | daily at time | as today |
+| `weekdays` | `{ time: "HH:mm" }` | Mon–Fri at time | next weekday occurrence |
+| `weekly` | `{ dayOfWeek: 0–6, time: "HH:mm" }` | once a week | next that-weekday occurrence |
+
+### Changes required
+
+- **Validation** (`app-validation`): add `manual`, `weekdays`, `weekly` branches; extend
+  `formatAutomationSchedule` ("Manual" / "Weekdays at …" / "Weekly on Monday at …"); export day-of-week helper.
+- **DB types** (`schema/tables/automations.ts`): widen `AutomationScheduleKind` and `AutomationScheduleConfig`;
+  make `nextRunAt` **nullable** (`datetime(...).` drop `.notNull()`). Generated migration only (`pnpm db:generate`);
+  follow `db/CLAUDE.md` staging→main deploy pipeline. Indexes on `nextRunAt` remain valid with NULLs.
+- **next-run calc** (`utils/automations.ts`): `calculateNextRunAt` returns `Date | null`; `null` for `manual`;
+  add `weekdays` (next daily time landing Mon–Fri) and `weekly` (next `dayOfWeek` at time) branches, reusing the
+  existing tz-aware `zonedTimeToUtc` helpers. `createAutomation`/`updateAutomation` accept null `nextRunAt`.
+- **Scheduler**: `claimDueAutomationRuns`'s `lte(nextRunAt, now)` already excludes NULL — manual never auto-claims.
+  Verify no other path assumes non-null `nextRunAt`. `runNow` unaffected.
+- **Tests**: extend `automations.test.ts` (validation), `db` automations tests (next-run for each kind + null),
+  router tests. Keep TDD per repo norms.
+
+## 3 · UI surfaces (built on the seed)
+
+### Create form — `automations/new/_components/automation-create-form.tsx`
+Full-page route. Back link (mono) → list. Heading + lede. Fields via `Form`/`FormField`:
+**Name** (input, required), **Instructions** (textarea + mono counter, required), **Schedule**
+(underline tabs over the 5 kinds; sub-control panel: manual note / hourly number / daily time /
+weekdays time + "Mon–Fri" pill / weekly day-Select + time), **Timezone** (Select; shown only for
+time-based kinds). Footer: mono status line + Cancel (ghost) + Create (primary, disabled until valid).
+Submit builds the `schedule` discriminated union and calls the existing
+`org.workspace.automations.create` mutation; cache upsert unchanged.
+
+### List page — `automations/_components/automations-client.tsx`
+Same language: header + "New automation" action, Current/Paused sections, rows showing name +
+`formatAutomationSchedule(...)`. Restyle to mono section labels, hairline dividers, inset-ring-consistent
+hover. Empty state restyled.
+
+### Detail editors — `[automationId]/_components/*`
+Unify name editor, prompt editor, and schedule editor to the same primitives and the underline-tab
+schedule control (the schedule editor currently uses a `ToggleGroup` in a `Popover` with only hourly/daily;
+it must support all 5 kinds + the new sub-controls + timezone). Right-rail `RailSection` labels already use
+uppercase tracked mono — reconcile toward the new mono-no-caps label style for consistency.
+
+## Risks / open items
+
+- **Migration sensitivity**: `nextRunAt` nullability rides the staging→main PlanetScale deploy pipeline
+  (`db/CLAUDE.md`); memory notes `db:push` is broken on worktree branches — apply generated migrations per runbook.
+- **Token reconciliation**: mockup oklch values are close to `globals.css` but must be reconciled rather than
+  duplicated; radius bump (4px→9px) is app-wide via `--radius` and should be sanity-checked against other surfaces,
+  or scoped if it regresses them. Resolve during planning.
+- **Submit button** primary vs secondary — confirm against list "New automation" button.
+- **Native `type="time"`** rendering still varies slightly by OS even when styled; accepted (shadcn-default, user-locked).
+
+## Reference
+Interactive mockups (companion, gitignored): `.superpowers/brainstorm/20440-1780281095/content/`
+(`05`-smaller-tabgroup, `06`-outline-datetime, `07`-focus-ring, `08`-final-form).

--- a/docs/superpowers/specs/2026-06-01-connector-detail-sheet-design.md
+++ b/docs/superpowers/specs/2026-06-01-connector-detail-sheet-design.md
@@ -1,0 +1,259 @@
+# Connector Detail Sheet Design
+
+## Context
+
+The Connectors workspace page (`connectors/page.tsx` → `connectors-client.tsx`)
+lists MCP connectors from `org.workspace.connectors.list`. Connected connectors
+render a `ConnectedConnectorCard` with an inline tools badge cloud, an
+automations toggle, and a `'…'` dropdown (Refresh tools / Reconnect /
+Disconnect). Post-connect, the OAuth callback redirects back to
+`…/connectors?connector=linear` (or `&error=…`); the client shows a transient
+green "connected" banner (or a red error banner) and then strips the params from
+the URL.
+
+There is no way to inspect a connection's details. The card surfaces tool
+*names* only, and nothing tells you who/where the connection is bound (the
+Linear workspace and account), when it was connected, or when tools were last
+refreshed.
+
+The `list` procedure already returns the full connection for each connected row,
+so no new data fetch is needed. Each `connection` carries: `status`
+(`active` | `error` | `revoked`), `connectedAt`, `providerWorkspaceName`,
+`providerActorName`, `lastToolRefreshAt`, `lastToolRefreshErrorAt`,
+`lastToolRefreshErrorCode`, `enabledForAutomations`, and `tools[]` (each
+`{ name, description?, availableForAutomations }`).
+
+This design adds a right-side detail **Sheet**, modeled on the signals detail
+sheet (`signal-detail-sheet.tsx` / `signal-detail-content.tsx`): an icon/title
+header, a metadata property block, a tools list, and a timestamp footer. The
+sheet is **read-only** — all mutations stay in the card's `'…'` menu.
+
+## Goals
+
+- Open a right-side sheet with full connection detail, modeled on the signals
+  detail sheet's container and `PropertyRow` layout.
+- Reuse the existing `?connector=<provider>` URL parameter so the open sheet is
+  shareable and refresh-safe, driven via `nuqs` (matching the signals
+  `?signal=` pattern).
+- Auto-open the sheet for the freshly-connected connector after a successful
+  OAuth callback, **replacing** the green success banner — the open sheet is the
+  post-connect confirmation.
+- Add a "View details" item to the connected card's `'…'` dropdown that opens
+  the sheet.
+- Render entirely from the already-loaded `list` row (no new tRPC query, no DB
+  read).
+
+## Non-Goals
+
+- No backend, tRPC, or DB changes. `org.workspace.connectors.list` is unchanged;
+  no `get` procedure is added (unlike signals, the list row is always present).
+- No exposure of the Clerk teammate who connected it (`connectedByUserId` stays
+  unexposed). "Who" is the Linear-side identity only
+  (`providerActorName` / `providerWorkspaceName`).
+- No actions inside the sheet — no Refresh tools, Reconnect, Disconnect, or
+  automations toggle. These remain in the card's `'…'` menu. The sheet mirrors
+  the automations state as a read-only pill.
+- No sheet for available (not-yet-connected) connectors; they keep their inline
+  Connect button untouched.
+- No tool input-schema display (the `list` row's `DisplayConnectorTool` omits
+  `inputSchema`).
+- No change to the public oRPC API.
+
+## Recommended Approach
+
+Drive the sheet from the existing `?connector=` URL parameter, resolving the row
+synchronously from the cached `list` query.
+
+`ConnectorsClient` reads `connector` via `nuqs` `useQueryState`. Because the page
+prefetches `list` server-side and the client uses `useSuspenseQuery`, the list is
+always loaded before the client renders — so the selected row resolves
+synchronously and no skeleton/not-found/`get` fallback is required.
+
+The OAuth callback already lands on `?connector=<provider>`, so a successful
+connect opens the sheet for free. On error (`&error=…` present), the sheet must
+*not* open — a failed connect has no connection to show — so the error path
+keeps the inline banner and clears both params on mount.
+
+This is a frontend-only change that reuses the param the callback already sets;
+the only behavior change to existing flows is dropping the green success banner
+in favor of the auto-opening sheet.
+
+## UX
+
+Two entry points open the sheet, both setting `?connector=<provider>`:
+
+1. **Post-connect (success):** the OAuth callback redirects to
+   `…/connectors?connector=linear`. The sheet auto-opens on the now-connected
+   Linear row. The green "connected" banner is removed.
+2. **"View details":** a new first item in the connected card's `'…'` dropdown.
+
+Closing the sheet (close button, overlay click, or Escape) clears `?connector`.
+A copy-link button writes the current `?connector=` URL to the clipboard with a
+confirmation toast.
+
+If `?connector=` names a provider with no current connection (available,
+disconnected, or unknown), the sheet stays closed.
+
+Sheet contents, top to bottom (mirroring the signals sheet):
+
+- **Header:** the `ConnectorIcon`, the provider id (`linear`, monospace), and a
+  status badge (dot + label) from the shared `connectionStatus()` helper.
+  Right-aligned actions: copy-link and close. A visually-hidden `SheetTitle`
+  carries the connector display name for accessibility.
+- **Title:** the connector `displayName` (e.g. "Linear"), with `description` as a
+  one-line subtitle.
+- **Property block** (`PropertyRow`: icon + `w-36` label + value):
+  - **Status** — Connected / Tools stale / Needs reconnect, from
+    `connectionStatus()` (dot + label).
+  - **Workspace** — `providerWorkspaceName` (hidden when null).
+  - **Account** — `providerActorName` (hidden when null).
+  - **Connected** — relative time from `connectedAt` (absolute on `title` hover).
+  - **Automations** — read-only pill: "Enabled" / "Disabled" from
+    `enabledForAutomations`.
+  - **Tools refreshed** — relative time from `lastToolRefreshAt`; when
+    `lastToolRefreshErrorAt` is set, show a warning treatment with
+    `lastToolRefreshErrorCode`. Hidden when never refreshed.
+- **Divider**, then **Tools** section:
+  - A "Tools" heading with a count badge (`connection.tools.length`).
+  - One row per tool: the tool `name` (monospace) and `description` (muted),
+    with a small green dot when `availableForAutomations` is true. The list
+    scrolls within the sheet body.
+- **Footer:** "Connected {relative}" and, when present, "tools refreshed
+  {relative}" (absolute on `title` hover).
+
+The sheet is read-only; no field is editable and there are no mutation controls.
+
+## Architecture
+
+### URL / selection state — `connectors-client.tsx`
+
+- Read the selected provider via `useQueryState("connector")` (nullable string).
+  `setConnector(provider)` opens; `setConnector(null)` closes.
+- **"View details"** dropdown item calls `setConnector(row.provider)`.
+- **Resolve the row:** `connectors.find((r) => r.provider === selectedProvider && r.connection)`.
+  Pass the matched row (or `undefined`) to the sheet; `undefined` means closed.
+- **Post-connect / banner handling:**
+  - Drop the green success-banner JSX. On success the `connector` param drives
+    the sheet open; the param is *not* stripped (so it stays deep-linkable),
+    and is cleared only when the sheet is closed.
+  - Keep the red error banner (its content still comes from the one-time
+    `callbackState` capture so it survives param clearing). Change the cleanup
+    effect to run only when `callbackState.error` is set, and to clear *both*
+    `connector` and `error` from the URL (so the sheet does not open on error
+    and the banner does not re-trigger on refresh). Use `nuqs` setters for both
+    params to avoid mixing with `router.replace`.
+- `page.tsx` is unchanged — it still passes `callbackConnector` (for the error
+  banner's provider label) and `callbackError`.
+
+### Component — `connector-detail-sheet.tsx`
+
+Lives in the connectors `_components/`. Uses `Sheet`, `SheetContent`,
+`SheetHeader`, `SheetTitle`, `SheetDescription`, `SheetClose` from
+`@repo/ui/components/ui/sheet`, with the same floating-right container classes as
+`signal-detail-sheet.tsx`
+(`inset-y-3 right-3 left-auto … rounded-2xl border p-0 sm:max-w-md`).
+
+Props:
+
+```ts
+{
+  row?: ConnectorCatalogRow;          // the matched connected row; undefined = closed
+  onOpenChange: (open: boolean) => void;
+}
+```
+
+- Open when `row` is defined and `row.connection` is non-null.
+- Renders `ConnectorDetailContent` directly from `row` (no query, no loading
+  state). Owns the copy-link handler (copies `window.location.href`), matching
+  the signals sheet.
+
+### Component — `connector-detail-content.tsx`
+
+The inner layout, mirroring `signal-detail-content.tsx`. Reuses local
+`PropertyRow` (icon + `w-36` label + value) and a small `Tool` row. Props:
+
+```ts
+{
+  row: ConnectorCatalogRow;           // guaranteed connected
+  closeSlot?: ReactNode;
+  onCopyLink: () => void;
+}
+```
+
+Renders header, property block, tools list, and footer as described in UX.
+Uses `formatRelativeTimeToNow` from `@vendor/lib/time` for timestamps and
+`ConnectorIcon` for the header glyph.
+
+### Model helpers — `connectors-model.ts` (new)
+
+Extract the display helpers currently inline in `connectors-client.tsx` into a
+shared model module, so the client and the sheet share one source (mirroring
+`signals-model.ts`):
+
+- Types: `ConnectorCatalogRow`, `ConnectorConnection`, `ConnectorProvider`,
+  `ConnectorTool` (derived from `AppRouterOutputs["org"]["workspace"]["connectors"]["list"]`).
+- `connectionStatus(connection) → { dotClass, label }` (moved verbatim).
+- `displayProviderName(provider)` (moved verbatim).
+
+`connectors-client.tsx` imports these instead of defining them locally; its
+behavior is otherwise unchanged. The connect-availability / mutation-gating
+helpers (`isConnectableProvider`, `isMutationDisabled`, etc.) stay in the client
+since the read-only sheet does not use them.
+
+## Error Handling
+
+- A `?connector=` param naming a provider with no current connection resolves to
+  `undefined` and the sheet stays closed; the param is left inspectable (no
+  auto-clear), matching the signals sheet's not-found behavior.
+- The OAuth error path (`&error=…`) shows the inline error banner, clears both
+  params on mount, and never opens the sheet.
+- Degraded connections render their status via `connectionStatus()`: amber
+  "Tools stale" when `lastToolRefreshErrorAt` is set, red "Needs reconnect" when
+  `status === "error"`. The "Tools refreshed" row surfaces
+  `lastToolRefreshErrorCode` in the warning treatment.
+- Null `providerWorkspaceName` / `providerActorName` / `lastToolRefreshAt` rows
+  are hidden rather than shown empty (matching the signals sheet's absent-row
+  behavior).
+
+## Testing
+
+Vitest + Testing Library, matching the existing app/connectors tests.
+
+### Component tests — `connector-detail-content.test.tsx` (new)
+
+- Renders all property rows and the tools list for a fully connected fixture
+  (workspace, account, connected, automations enabled, tools refreshed, N tool
+  rows with the correct count badge).
+- Hides Workspace/Account/Tools-refreshed rows when those fields are null.
+- Renders the "Disabled" automations pill when `enabledForAutomations` is false.
+- Renders the degraded status (amber "Tools stale" with `lastToolRefreshErrorCode`,
+  red "Needs reconnect") for the respective fixtures.
+- Marks automation-available tools with the indicator dot and omits it
+  otherwise.
+
+### Client/integration tests — extend the connectors client/page tests
+
+In `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/connectors-page.test.tsx`
+(and/or the connectors client test):
+
+- "View details" in the `'…'` menu opens the sheet and sets `?connector=`.
+- Closing the sheet clears `?connector`.
+- An initial `?connector=linear` (success callback) opens the sheet on mount and
+  no longer renders the green success banner.
+- An initial `?connector=linear&error=…` renders the error banner, clears both
+  params, and does not open the sheet.
+- A `?connector=` for an available (unconnected) provider does not open the
+  sheet.
+- Copy-link writes the current URL to the clipboard.
+
+The existing assertion for the green success banner is replaced by the
+sheet-opens assertion.
+
+## Rollout
+
+Ships behind the normal bound-org workspace gate with no feature flag.
+Frontend-only: no tRPC, DB, or public-API change. Existing list/card behavior,
+the connect/refresh/disconnect mutations, and the error banner are unchanged; the
+only behavior change is replacing the post-connect success banner with the
+auto-opening sheet, plus the small extraction of display helpers into
+`connectors-model.ts`.

--- a/docs/superpowers/specs/2026-06-01-emulator-architecture-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-01-emulator-architecture-redesign-design.md
@@ -1,0 +1,356 @@
+# Emulator Architecture Redesign — Design Spec
+
+> Status: design approved in brainstorming; awaiting spec review before writing-plans.
+> Date: 2026-06-01
+
+## Goal
+
+Eliminate the triplicated boot plumbing across the three owned emulators (github, linear, x) and give every emulator a structure where concerns — **oauth / viewer / mcp / webhook / seed / failures** — are first-class and addable, **without rewriting github's working, 36-test-covered composition logic**.
+
+## Problem statement
+
+Two distinct kinds of mess are tangled together today.
+
+### 1. Triplicated boot plumbing
+
+`env.ts`, `env-sh.ts`, and `start.ts` are ~95% byte-identical across all three emulators. The only genuine per-service differences are:
+
+| file | what actually differs |
+|---|---|
+| `env.ts` | the `{SERVICE}_EMULATOR_ORIGIN` var name + default port (4567 / 4568 / 4569) |
+| `env-sh.ts` | the same origin var name |
+| `start.ts` | the `[service-emulator]` log prefix |
+| `fixtures.ts` | nothing — the `shellQuote` + `format*EnvString` + `ENV_ASSIGNMENT_NAME_RE` block is **byte-for-byte identical** in all three |
+
+`@repo/emulator-kit` today owns only the **listen lifecycle** (`startEmulator`, `formatListenUrl`, `waitForListening`, `closeServer`). It does **not** own the env / CLI / process lifecycle, so three copies of that drift independently.
+
+### 2. No expression of "concerns / capabilities"
+
+Each emulator is a flat folder. Nothing in the structure reveals that:
+
+| capability | github | linear | x |
+|---|---|---|---|
+| OAuth | app + user (PKCE) | yes (no PKCE) | yes (PKCE S256) |
+| App / installations | yes | — | — |
+| Webhook | yes (`push.ts`, `push-webhook-payload.ts`) | future | future |
+| MCP | — | yes (`/mcp` JSON-RPC) | — |
+| rich seed | `GitHubSeedConfig` | minimal | minimal |
+| failure switches | — | yes | yes |
+
+Capabilities are smeared into one `*-plugin.ts` (linear/x) or split ad-hoc (github). When webhook is added to linear/x later, there is no slot for it.
+
+### 3. Two structural facts the design must respect
+
+- **github is the odd one out**: it wraps the *published* `@emulators/github` plugin and hand-wires `createServer` + a 953-line `github-compatible-routes.ts` fetch wrapper + an `appKeyResolver` + a monkey-patch of `server.webhooks.dispatch`. It does **not** go through `startEmulator`. It must keep its bespoke composition.
+- **Fixtures have no shared contract**: every emulator invents its own export shape, and the env-projection (`get*EmulatorEnv`) + shell-format helpers sit next to genuinely per-service data with no boundary.
+
+## Decisions (from brainstorming)
+
+1. **Scope:** Own the boot layer + standardize structure. Kit owns env/cli/format/manifest/lifecycle; each emulator = manifest + fixtures(data) + plugin/(concerns) + 2-line bootstraps. **No** capability-composition framework yet (YAGNI — webhooks are "not now").
+2. **github:** Boot layer + light relocate. github adopts the shared boot layer (kills its triplication) and its plugin composition is **relocated, not rewritten**. Logic stays byte-identical.
+3. **env-projection:** lives in `manifest.ts`. `fixtures.ts` becomes pure data.
+4. **Failure switches:** kept self-contained — each emulator owns its own `plugin/failures.ts`. No kit promotion.
+5. **Execution:** spec → plan → user confirm → execute task-by-task.
+
+## Architecture
+
+```
+TIER 1 — @repo/emulator-kit        (owns ALL shared plumbing)
+   manifest contract · env schema · env:sh CLI · start harness
+   · shell-format · startEmulator lifecycle
+
+TIER 2 — per-emulator               (owns ONLY what is service-specific)
+   manifest.ts  ·  fixtures.ts (data)  ·  plugin/ (concern fragments)
+   ·  2-line start.ts + env-sh.ts bootstraps
+```
+
+## Tier 1 — `@repo/emulator-kit` (concern-split)
+
+The kit is a single `src/index.ts` monolith today. Split it:
+
+```
+emulators/kit/src/
+  manifest.ts    EmulatorManifest + RunnableEmulator + EmulatorStartInput   ← NEW (the seam)
+  env.ts         createEmulatorEnv(manifest, runtimeEnv?) → ResolvedEmulatorEnv
+  cli.ts         runEnvSh(manifest) · runStart(manifest)
+  format.ts      formatEnvString() + shellQuote() (+ ENV_ASSIGNMENT_NAME_RE)
+  lifecycle.ts   startEmulator, formatListenUrl, waitForListening, closeServer,
+                 StartedEmulator, StartEmulatorOptions, StartEmulatorContext, EmulatorServer
+  index.ts       re-exports all of the above
+  __tests__/
+    start-emulator.test.ts   (existing — unchanged)
+    env.test.ts              (NEW — createEmulatorEnv via a test manifest)
+    cli.test.ts              (NEW — runEnvSh arg parsing + output; optional runStart smoke)
+```
+
+### `manifest.ts` — the contract (the heart of the redesign)
+
+```ts
+export interface RunnableEmulator {        // minimal surface the start harness consumes
+  close(): Promise<void>;
+  listenUrl: string;
+  publicOrigin: string;
+}
+
+export interface EmulatorStartInput {
+  appOrigin?: string;
+  host?: string;
+  port?: number;
+  publicOrigin?: string;
+}
+
+export interface EmulatorManifest {
+  name: string;          // "x"  → ServicePlugin name + "[x-emulator]" log prefix
+  port: number;          // 4569 → default PORT
+  originEnvVar: string;  // "X_EMULATOR_ORIGIN" → dynamic env-schema key
+  env(appOrigin: string, emulatorOrigin: string): Record<string, string>; // app-facing projection
+  start(input: EmulatorStartInput): Promise<RunnableEmulator>;
+}
+```
+
+Both linear/x (`StartedEmulator`) and github (`StartedGitHubEmulator`) returns are structural supersets of `RunnableEmulator`, so **github's `startGitHubEmulator` needs zero logic changes** to satisfy `manifest.start`.
+
+### `env.ts` — schema factory with a computed key
+
+```ts
+export interface ResolvedEmulatorEnv {
+  appOrigin: string;
+  emulatorOrigin?: string;
+  host: string;
+  port: number;
+}
+
+export function createEmulatorEnv(
+  manifest: EmulatorManifest,
+  runtimeEnv: NodeJS.ProcessEnv = process.env
+): ResolvedEmulatorEnv;
+```
+
+Builds the `@t3-oss/env-core` schema with a **computed property key** `[manifest.originEnvVar]: z.string().url().optional()`, plus the shared `HOST` / `LIGHTFAST_APP_ORIGIN` / `PORTLESS_URL` / `PORT` (default `manifest.port`). Returns `emulatorOrigin = env[originEnvVar] ?? env.PORTLESS_URL`. This is the single copy of what was three identical `create*EmulatorRuntimeEnv` functions.
+
+### `cli.ts` — the process harness (one copy)
+
+```ts
+export function runEnvSh(manifest: EmulatorManifest): void;   // replaces every src/env-sh.ts body
+export function runStart(manifest: EmulatorManifest): Promise<void>; // replaces every src/start.ts body
+```
+
+- `runEnvSh`: parses `--app-origin` / `--emulator-origin` from `process.argv`, layers them onto `process.env`, calls `createEmulatorEnv`, then `console.log(formatEnvString(manifest.env(appOrigin, emulatorOrigin)))`.
+- `runStart`: `createEmulatorEnv` → `manifest.start({ appOrigin, host, port, publicOrigin: emulatorOrigin })` → logs `[<name>-emulator] listening on …` / `public origin …`, then the redacted `manifest.env(...)` assignments (the `/(?:KEY|SECRET|TOKEN|PRIVATE)/i` → `<redacted>` rule moves here), then installs `SIGINT`/`SIGTERM` handlers calling `emulator.close()`.
+
+### `format.ts` — the de-duplicated shell formatter
+
+```ts
+export function formatEnvString(env: Record<string, string>): string;
+```
+
+The exact `ENV_ASSIGNMENT_NAME_RE` + `shellQuote` + NUL-byte guard block currently copy-pasted into all three `fixtures.ts`. Each `fixtures.ts` loses `format*EnvString`, `shellQuote`, and `ENV_ASSIGNMENT_NAME_RE`.
+
+### `lifecycle.ts`
+
+Today's `src/index.ts` content verbatim (`startEmulator`, `formatListenUrl`, `waitForListening`, `closeServer`, and the `Started*`/`StartEmulator*`/`EmulatorServer` types). Pure file move; `index.ts` re-exports it.
+
+## Tier 2 — per-emulator layouts
+
+### x — full concern-split (reference for the simplest case)
+
+```
+x/src/
+  manifest.ts    name "x", port 4569, originEnvVar "X_EMULATOR_ORIGIN", env(), start: startXEmulator
+  server.ts      KEPT — startXEmulator wrapper; ONE-LINE change: import xPlugin from "./plugin"
+  fixtures.ts    DATA ONLY: X_EMULATOR_FIXTURES, X_EMULATOR_OAUTH_CODE, X_EMULATOR_SCOPE
+  plugin/
+    oauth.ts     registerOAuth   — /oauth2/authorize (PKCE S256), /oauth2/token, /oauth2/revoke
+    users.ts     registerUsers   — /2/users/me (usersMe failure switch); owns XUserRow + userResponse
+    auth.ts      bearerToken, isValidBearer (imports getFailures from ./failures)
+    failures.ts  registerFailures, FailureSwitches, defaultFailures, getFailures, seedFailures
+                 — /failures, /reset; switches: accessTokenExpired, refresh, usersMe
+    index.ts     xPlugin: ServicePlugin (name "x") composing oauth+users+failures + seed(store)
+  start.ts       2 lines (runStart(xManifest))
+  env-sh.ts      2 lines (runEnvSh(xManifest))
+  __tests__/server.test.ts   UNCHANGED (imports startXEmulator from ../server; 9-test guard)
+```
+
+Tests import `startXEmulator` and `X_EMULATOR_FIXTURES`/`X_EMULATOR_OAUTH_CODE` from `../server`/`../fixtures` — both survive, so the suite is **literally unchanged**.
+
+`manifest.ts` references the kept `startXEmulator` (uniform with github's `startGitHubEmulator`):
+
+```ts
+import type { EmulatorManifest } from "@repo/emulator-kit";
+import { X_EMULATOR_FIXTURES } from "./fixtures";
+import { startXEmulator } from "./server";
+
+export const xManifest: EmulatorManifest = {
+  name: "x",
+  port: 4569,
+  originEnvVar: "X_EMULATOR_ORIGIN",
+  env: (_appOrigin, emulatorOrigin) => ({
+    X_CLIENT_ID: X_EMULATOR_FIXTURES.oauthClientId,
+    X_CLIENT_SECRET: X_EMULATOR_FIXTURES.oauthClientSecret,
+    X_API_ORIGIN: emulatorOrigin,
+    X_OAUTH_ORIGIN: emulatorOrigin,
+  }),
+  start: startXEmulator,
+};
+```
+
+`plugin/index.ts` (composition):
+
+```ts
+import type { ServicePlugin } from "@emulators/core";
+import { X_EMULATOR_FIXTURES } from "../fixtures";
+import { registerFailures, seedFailures } from "./failures";
+import { registerOAuth } from "./oauth";
+import { registerUsers, type XUserRow } from "./users";
+
+export const xPlugin: ServicePlugin = {
+  name: "x",
+  register(app, store) {
+    registerOAuth(app, store);
+    registerUsers(app, store);
+    registerFailures(app, store);
+  },
+  seed(store) {
+    seedFailures(store);
+    store.collection<XUserRow>("users").insert({
+      x_id: X_EMULATOR_FIXTURES.userId,
+      name: X_EMULATOR_FIXTURES.userName,
+      username: X_EMULATOR_FIXTURES.username,
+    });
+  },
+};
+```
+
+Each `register*` fragment is a `(app: Hono<AppEnv>, store: Store) => void` that owns its routes and route-local helpers (PKCE hashing + `tokenResponse` stay in `oauth.ts`). The seed preserves the original behavior exactly (set default failures + insert the seeded user).
+
+**Dependency direction (no cycles):** `failures.ts` → (none) · `auth.ts` → `failures` · `oauth.ts` → `failures` · `users.ts` → `auth` + `failures` · `index.ts` → all.
+
+### linear — full concern-split (same shape as x, + viewer + mcp)
+
+```
+linear/src/
+  manifest.ts    name "linear", port 4568, originEnvVar "LINEAR_EMULATOR_ORIGIN", env(), start: startLinearEmulator
+  server.ts      KEPT — startLinearEmulator wrapper; ONE-LINE change: import linearPlugin from "./plugin"
+  fixtures.ts    DATA ONLY: LINEAR_EMULATOR_FIXTURES, LINEAR_EMULATOR_OAUTH_CODE, LINEAR_EMULATOR_TOOLS
+  plugin/
+    oauth.ts     registerOAuth   — /oauth/authorize (no PKCE), /oauth/token, /oauth/revoke;
+                 owns tokenResponse + clientCredentialsValid
+    viewer.ts    registerViewer  — /viewer, /graphql (bearer → viewerResponse); owns viewerResponse
+    mcp.ts       registerMcp     — /mcp JSON-RPC (initialize / tools/list / tools/call / 202 / -32601);
+                 honors mcpListTools failure (-32003, 500); owns McpRequestBody
+    auth.ts      bearerToken, isValidBearer (imports getFailures from ./failures)
+    failures.ts  registerFailures, FailureSwitches, defaultFailures, getFailures, seedFailures
+                 — /failures, /reset; switches: accessTokenExpired, mcpListTools, refresh
+    index.ts     linearPlugin: ServicePlugin (name "linear") composing oauth+viewer+mcp+failures + seed(store)
+  start.ts       2 lines (runStart(linearManifest))
+  env-sh.ts      2 lines (runEnvSh(linearManifest))
+  __tests__/server.test.ts   UNCHANGED (imports startLinearEmulator from ../server; 10-test guard,
+                              incl. the real listLinearMcpTools assertion from @repo/linear-app-node)
+```
+
+`manifest.env` returns `LINEAR_CLIENT_ID`, `LINEAR_CLIENT_SECRET`, `LINEAR_API_ORIGIN`, `LINEAR_MCP_ENDPOINT: \`${emulatorOrigin}/mcp\``.
+
+The deferred `shared.ts`-vs-co-location decision is now resolved: a per-emulator `auth.ts` holds `bearerToken`/`isValidBearer`; the `FailureSwitches` machinery + `getFailures` live in `failures.ts`. Route-local helpers (`tokenResponse`, `clientCredentialsValid`, `viewerResponse`, `McpRequestBody`) co-locate with the concern that uses them.
+
+**Dependency direction (no cycles):** `failures.ts` → (none) · `auth.ts` → `failures` · `oauth.ts` → `failures` · `viewer.ts` → `auth` · `mcp.ts` → `auth` + `failures` · `index.ts` → all.
+
+### github — boot layer + light relocate (logic byte-identical)
+
+```
+github/src/
+  manifest.ts    NEW — name "github", port 4567, originEnvVar "GITHUB_EMULATOR_ORIGIN",
+                 env: getGitHubEmulatorEnv, start: startGitHubEmulator
+  fixtures.ts    DATA ONLY — GITHUB_EMULATOR_FIXTURES, createGitHubEmulatorSeed, getGitHubEmulatorEnv,
+                 RSA private key; LOSES formatGitHubEmulatorEnvString/shellQuote/ENV_ASSIGNMENT_NAME_RE (→ kit)
+  plugin/
+    index.ts            ← server.ts, SAME logic: startGitHubEmulator, addOrgMembership, appKeyResolver,
+                          createServer(githubPlugin, …), webhooks.dispatch patch, seed()
+    compatible-routes.ts ← github-compatible-routes.ts, moved unchanged (953 L)
+    webhook/
+      push.ts            ← push.ts, moved unchanged (188 L)
+      push-payload.ts    ← push-webhook-payload.ts, moved unchanged (166 L)
+  start.ts       2 lines (runStart(githubManifest))
+  env-sh.ts      2 lines (runEnvSh(githubManifest))
+  __tests__/
+    server.test.ts             (30 tests) import specifiers → ../plugin, ../plugin/compatible-routes
+    oauth-user-account.test.ts (5 tests)  import specifiers → ../plugin, ../plugin/compatible-routes
+    test-helpers.ts            import specifier → ../plugin
+    env.test.ts                (3 tests) REMOVED here; its env-schema coverage moves to
+                               kit/__tests__/env.test.ts, replaced by a small manifest.test.ts
+                               (asserts githubManifest.env(...) → GITHUB_APP_* vars)
+```
+
+**Relative-import updates when files move into `plugin/`** (mechanical, not logic — but required or the build breaks):
+
+| file | import was | becomes |
+|---|---|---|
+| `plugin/index.ts` (←server.ts) | `./fixtures` | `../fixtures` |
+| `plugin/index.ts` | `./github-compatible-routes` | `./compatible-routes` |
+| `plugin/index.ts` | `./push-webhook-payload` | `./webhook/push-payload` |
+| `plugin/compatible-routes.ts` | `./fixtures` | `../fixtures` |
+| `plugin/webhook/push.ts` | `./fixtures` / `./push-webhook-payload` | `../../fixtures` / `./push-payload` |
+| `plugin/webhook/push-payload.ts` | `./fixtures` (if any) | `../../fixtures` |
+
+`startGitHubEmulator` is **not** rewritten to use `startEmulator` (even though every hook it needs — `appKeyResolver`, `tokens`, `createFetch`, `onReady`, `seed` override — already exists on `StartEmulatorOptions`). That collapse is explicitly **out of scope** for this pass to keep the 35-test composition guard (5 oauth-user-account + 30 server) byte-identical; it is noted as a possible future follow-up.
+
+## The 2-line bootstraps (identical pattern in all three)
+
+```ts
+// <svc>/src/start.ts
+import { runStart } from "@repo/emulator-kit";
+import { <svc>Manifest } from "./manifest";
+await runStart(<svc>Manifest);
+```
+
+```ts
+// <svc>/src/env-sh.ts
+import { runEnvSh } from "@repo/emulator-kit";
+import { <svc>Manifest } from "./manifest";
+runEnvSh(<svc>Manifest);
+```
+
+`package.json` scripts (`"dev": "tsx ./src/start.ts"`, `"env:sh": "tsx ./src/env-sh.ts"`) and the root `apps/app/package.json` `with-related-projects` wiring are **unchanged** — the entrypoint files just get thinner.
+
+## File-by-file disposition
+
+| current | becomes |
+|---|---|
+| `kit/src/index.ts` | split → `lifecycle.ts` + re-export `index.ts`; gains `manifest.ts`, `env.ts`, `cli.ts`, `format.ts` |
+| `{github,linear,x}/src/env.ts` | **deleted** → `kit/createEmulatorEnv` |
+| `{github,linear,x}/src/env-sh.ts` | **2-line bootstrap** → `kit/runEnvSh` |
+| `{github,linear,x}/src/start.ts` | **2-line bootstrap** → `kit/runStart` |
+| `*/fixtures.ts` format helpers | **deleted** → `kit/formatEnvString` |
+| `*/fixtures.ts` `get*EmulatorEnv` | **moved** → `manifest.ts` `env()` |
+| `{linear,x}/src/server.ts` | **kept**; one-line import change (`./*-plugin` → `./plugin`) |
+| `x/src/x-plugin.ts` | split → `x/src/plugin/{oauth,users,auth,failures,index}.ts` (bodies verbatim) |
+| `linear/src/linear-plugin.ts` | split → `linear/src/plugin/{oauth,viewer,mcp,auth,failures,index}.ts` (bodies verbatim) |
+| `github/src/server.ts` | moved → `github/src/plugin/index.ts` (logic unchanged; relative imports updated) |
+| `github/src/github-compatible-routes.ts` | moved → `github/src/plugin/compatible-routes.ts` (unchanged) |
+| `github/src/push.ts` | moved → `github/src/plugin/webhook/push.ts` (unchanged) |
+| `github/src/push-webhook-payload.ts` | moved → `github/src/plugin/webhook/push-payload.ts` (unchanged) |
+
+## Migration order (tests guard every step)
+
+1. **Kit** — add `manifest.ts`, `env.ts`, `cli.ts`, `format.ts`; split `index.ts` → `lifecycle.ts`; add kit env/cli tests. Kit tests green.
+2. **x** (simplest) — manifest + `plugin/` split + 2-line bootstraps; delete `env.ts`. 9 tests green.
+3. **linear** — same pattern + `mcp.ts`/`viewer.ts`. 10 tests green.
+4. **github** — add manifest; relocate `server.ts`/routes/webhook into `plugin/` (with the relative-import updates above); delete `env.ts`, thin `env-sh.ts`/`start.ts` to bootstraps; migrate `env.test.ts`'s 3 tests to kit + add `manifest.test.ts`; update test import specifiers. The 35 composition tests (5 oauth-user-account + 30 server) stay green.
+5. **Full sweep** — `pnpm check` (biome/ultracite) + `pnpm typecheck` + all tests + one live `pnpm dev` smoke per service (x `/2/users/me`, linear `/viewer` + `/mcp tools/list`, github OAuth/webhook).
+
+## Testing strategy
+
+- Existing per-emulator `server.test.ts` suites are the **regression guard** and stay behaviorally unchanged (only github's import specifiers move). They must pass after each step.
+- Kit gains `env.test.ts` (computed-key schema, port defaulting, `PORTLESS_URL` fallback) and `cli.test.ts` (arg parsing + emitted env string; redaction). These absorb the coverage deleted from each emulator's `env.ts`/`env-sh.ts`.
+- github gains a small `manifest.test.ts` asserting the `env()` projection emits the expected `GITHUB_APP_*` keys (the part of the old `env.test.ts` that is github-specific).
+
+## Out of scope (explicit YAGNI)
+
+- No capability-composition framework (`withOAuth()`/`withMcp()` kit modules). Concerns are plain register-fragments, not a framework.
+- No webhook for linear/x now — but `plugin/` leaves an obvious slot (`plugin/webhook.ts` + one line in `index.ts`) for the marketplace-integration work later.
+- No promotion of failure switches to the kit (kept self-contained per decision 4).
+- No rewrite of github's `startGitHubEmulator` to route through `startEmulator` (kept byte-identical; possible future follow-up).
+
+## Constraints (carried)
+
+- Emulator code is **dev-only**; production runtime must never import it.
+- Commit only when asked; commit with explicit pathspecs (a concurrent agent may pre-stage unrelated files); do not push.

--- a/docs/superpowers/specs/2026-06-01-emulator-kit-and-x-emulator-design.md
+++ b/docs/superpowers/specs/2026-06-01-emulator-kit-and-x-emulator-design.md
@@ -1,0 +1,264 @@
+# Emulator Kit + X Emulator (auth-only slice) — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (design); pending implementation plan
+**Author:** Jeevan Pillay (with Claude)
+
+## Goal
+
+Establish a consistent architecture for local service emulators so that every
+emulator Lightfast owns is built the same way: on top of the
+`@emulators/core` vendor substrate, with our own store collections, routes, and
+seed piped in as a `ServicePlugin`. Introduce a thin local kit to remove the
+boot/lifecycle duplication the substrate leaves to each caller, and prove the
+pattern end-to-end by adding a new X (Twitter) emulator scoped to an auth-only
+slice.
+
+This is infrastructure work. All emulator code is dev-only; production runtime
+must never import it.
+
+## Background / current state
+
+There is **no** local `emulators/core` package. The `core` that the GitHub
+emulator imports is the third-party **`@emulators/core`** package from
+**`vercel-labs/emulate`** (homepage `emulate.dev`), catalog-pinned at `0.6.0`
+with two small local patches (`patches/@emulators__core@0.6.0.patch`,
+`patches/emulate@0.6.0.patch`, both touching `authMiddleware`/`parseJsonBody`).
+
+Two emulators exist today:
+
+| | `@repo/github-emulator` | `@repo/linear-emulator` |
+|---|---|---|
+| Base | `@emulators/core` + official `@emulators/github` plugin | none — hand-rolled `node:http` server (~450 lines) |
+| Why | GitHub has a published plugin and a large REST resource model | no published `@emulators/linear` plugin; small bespoke surface (OAuth + GraphQL + MCP) |
+
+The split is incidental, not a missing abstraction. GitHub adopts a vendor
+framework that happened to ship a GitHub plugin; Linear was hand-rolled because
+that framework ships nothing for Linear and its surface was small.
+
+### Feasibility verdict
+
+`@emulators/core` is a **generic** emulator kernel, not GitHub-specific:
+
+1. `@emulators/github` is literally `declare const githubPlugin: ServicePlugin` —
+   the entire GitHub emulator is one plugin on the generic kernel.
+2. `Store` is a generic in-memory DB: `store.collection<T>(name, indexFields)`
+   defines arbitrary typed collections; `getData`/`setData` for loose state.
+3. The router is a bundled Hono — `app.get/post/on(method, path, …)` accept
+   arbitrary routes, so bespoke surfaces (GraphQL, MCP, OAuth) fit as plain
+   handlers. It is not REST-resource-locked.
+
+Core also ships an OAuth/auth toolkit we would otherwise hand-roll:
+`authMiddleware`, `requireAuth`, `TokenMap`, `matchesRedirectUri`,
+`constantTimeSecretEqual`, `parseCookies`, `renderFormPostPage`,
+`WebhookDispatcher`, `filePersistence`, and pagination helpers.
+
+**Conclusion:** Yes — every emulator we own can always depend on
+`@emulators/core` and pipe in our own store/plugin/seed via the `ServicePlugin`
+interface. That is the framework's intended extension model.
+
+### Known caveats (designed-around, not blockers)
+
+- `WebhookDispatcher` is GitHub-shaped (`{ owner, repo?, events[] }`); other
+  services repurpose `owner` as a tenant key and ignore `repo`.
+- `Entity` forces `{ id: number, created_at, updated_at }`; services with string
+  IDs store the real id as a field and keep the numeric `id` internal.
+- Auth `TokenMap` uses `login`/`id`/`scopes` (GitHub-ish field names).
+- Pre-1.0 vendor with local patches: each version bump requires re-basing two
+  small patches.
+- The substrate does **not** solve boot/lifecycle duplication
+  (`formatListenUrl`, `waitForListening`, `closeServer`, the `Started*` return
+  shape are copied verbatim between the two emulators today). That is the gap
+  the kit fills.
+
+## Decisions
+
+- **Substrate (Layer A):** standardize on `@emulators/core` for every emulator
+  we own.
+- **Kit (Layer B):** introduce `@repo/emulator-kit` for the boot/lifecycle code.
+- **Kit location:** `emulators/kit` — all emulator-related code stays under
+  `emulators/`, nothing leaks into `packages/` (emulators are not part of the
+  app).
+- **X emulator:** new `@repo/x-emulator`, built as a `ServicePlugin` on the kit.
+  Scoped to an **auth-only slice**.
+- **GitHub:** light refactor onto the kit (its existing tests guard the change).
+- **Linear:** standalone, untouched for now; migrate onto the kit later.
+
+## Architecture
+
+```
+Layer A (vendor):   @emulators/core  (vercel-labs/emulate 0.6.0)
+                    Hono router · generic Store · auth/OAuth/webhook toolkit
+                    ServicePlugin = { name, register(), seed() }
+
+Layer B (ours):     @repo/emulator-kit  (emulators/kit)
+                    startEmulator(plugin, opts) · formatListenUrl /
+                    waitForListening / closeServer · StartedEmulator
+
+Emulators:          @repo/x-emulator      = xPlugin + fixtures (NEW, on kit)
+                    @repo/github-emulator = githubPlugin (light refactor onto kit)
+                    @repo/linear-emulator = standalone (untouched)
+```
+
+## Component 1 — `@repo/emulator-kit` (`emulators/kit`)
+
+A library package (not a runnable emulator). Owns only the genuinely-duplicated
+lifecycle code.
+
+```ts
+// emulators/kit/src/index.ts
+export interface StartedEmulator {
+  app: Hono<AppEnv>;
+  store: Store;
+  webhooks: WebhookDispatcher;
+  tokenMap: TokenMap;
+  listenUrl: string;
+  publicOrigin: string;
+  url: string;
+  reset(): void;
+  close(): Promise<void>;
+}
+
+export interface StartEmulatorOptions extends ServerOptions {
+  host?: string;
+  port?: number;
+  appOrigin?: string;
+  publicOrigin?: string;
+  // Escape hatches so GitHub's quirks fit without bending the kit:
+  createFetch?(server, ctx): FetchHandler; // default: server.app.fetch
+  seed?(server, ctx): void;                // default: plugin.seed?.(store, publicOrigin)
+  onReady?(server): void;                  // GitHub overrides webhooks.dispatch here
+}
+
+export function startEmulator(
+  plugin: ServicePlugin,
+  opts?: StartEmulatorOptions,
+): Promise<StartedEmulator>;
+
+// Exported primitives (escape hatch if the hooks get ugly):
+export { formatListenUrl, waitForListening, closeServer };
+```
+
+`startEmulator` wires `core.createServer(plugin, serverOptions)` →
+`serve({ fetch, hostname, port })` → `waitForListening` → returns a
+`StartedEmulator`. The `createFetch`/`seed`/`onReady` hooks exist so the GitHub
+emulator (which wraps `app.fetch` with `createGitHubCompatibleFetch`, overrides
+`webhooks.dispatch`, and seeds in multiple steps) can route through the same
+entrypoint.
+
+**Scope discipline:** kit v1 is lifecycle only. The `/failures` + `/reset`
+failure-switch convention stays in the X plugin for now; it is promoted into the
+kit when Linear migrates (rule of three — two consumers today is not enough to
+fix the shared shape).
+
+**Risk:** if the three hooks turn into hook-soup during the GitHub refactor,
+GitHub falls back to the exported primitives and keeps its own boot function.
+Decided during implementation, not now.
+
+## Component 2 — `@repo/x-emulator` (`emulators/x`)
+
+Structure mirrors `emulators/linear`. Auth-only slice.
+
+```ts
+// emulators/x/src/x-plugin.ts
+export const xPlugin: ServicePlugin = {
+  name: "x",
+  register(app, store, _webhooks, baseUrl, tokenMap) {
+    app.get ("/oauth2/authorize", c => /* validate client_id + redirect_uri + S256 challenge -> 302 ?code&state */);
+    app.post("/oauth2/token",     c => /* authorization_code (verify PKCE S256) + refresh_token grants */);
+    app.post("/oauth2/revoke",    c => /* 200 / invalid_token */);
+    app.get ("/2/users/me",       requireAuth(), c => /* { data: { id, name, username } } */);
+    app.post("/failures",         c => store.setData("failures", merge(...)));
+    app.post("/reset",            c => store.setData("failures", defaults()));
+  },
+  seed(store) {
+    store.collection("users").insert(X_FIXTURES.user);
+    // + token fixtures
+  },
+};
+```
+
+Routes (auth-only slice):
+
+- `GET  /oauth2/authorize` — OAuth 2.0 PKCE; validate `client_id`,
+  `redirect_uri`, `code_challenge` (`S256`), `state`; 302 to `redirect_uri` with
+  `code` + `state`.
+- `POST /oauth2/token` — `authorization_code` grant verifies PKCE
+  (`sha256(code_verifier)` base64url === stored `code_challenge`) via
+  `node:crypto`; `refresh_token` grant issues new tokens.
+- `POST /oauth2/revoke` — 200 for known tokens, `invalid_token` otherwise.
+- `GET  /2/users/me` — bearer-validated; returns X v2 shape
+  `{ data: { id, name, username } }`.
+- `POST /failures` — set failure switches.
+- `POST /reset` — clear failure switches.
+
+Baked-in decisions (approved):
+
+- **OAuth 2.0 + PKCE, public client** (`client_id` in body, no secret). Real
+  S256 validation, because connectors get PKCE wrong and the emulator should
+  enforce it. Confidential/Basic-auth variant deferred.
+- **Failure switches:** `accessTokenExpired` (→ `/2/users/me` 401), `refresh`
+  (→ refresh grant `invalid_grant`), `usersMe` (→ 500). Mirrors Linear's switches
+  and exists to test the connector's token-refresh path.
+- **Auth via core's toolkit:** seed `tokens` into `createServer`, guard
+  `/2/users/me` with `requireAuth()` plus a thin failure-switch check in front,
+  rather than re-hand-rolling bearer validation.
+- **No `@repo/x-app-*` dependency.** GitHub/Linear emulators import a production
+  contract package to share fixtures; there is no X connector yet, so X's
+  fixtures are self-contained and migrate into a contract package when the real
+  connector lands.
+
+## Component 3 — GitHub light refactor
+
+Move `formatListenUrl`/`waitForListening`/`closeServer` and the `Started*` shape
+out of `emulators/github/src/server.ts` into the kit; boot through
+`startEmulator` using the `createFetch`/`seed`/`onReady` hooks. Service-specific
+logic (`github-compatible-routes.ts`, `push-webhook-payload.ts`) stays in the
+GitHub package. Guarded by the existing `server.test.ts` / `env.test.ts`.
+
+## Dev / infra wiring
+
+| Seam | File | Change |
+|---|---|---|
+| Port | — | github 4567, linear 4568 → **x = 4569** |
+| Route | Portless | `https://x.lightfast.localhost`, name `x.lightfast` |
+| Dev task | root `package.json` | add `_x_emulator` script (clone `_linear_emulator`, swap names/filter); append `//#_x_emulator` to `dev` |
+| Turbo | `turbo.json` | register the `_x_emulator` root task (mirror `_linear_emulator`) |
+| Env inject | `apps/app/package.json` → `with-related-projects` | append `@repo/x-emulator env:sh` with `--app-origin` / `--emulator-origin` |
+
+`emulators/*` is a pnpm workspace glob, so both `emulators/kit` and `emulators/x`
+auto-register; no `pnpm-workspace.yaml` edit needed.
+
+**Honest gap:** the emulator boots and serves at `x.lightfast.localhost`, and
+`X_*` env is injected into the app dev process, but **nothing in the app consumes
+it yet** (no X connector). The deliverable is proven emulator infrastructure
+ready for the connector — the same state Linear's slice was scoped to. The kit
+refactor of GitHub is verifiable immediately via its existing tests.
+
+## Testing
+
+- `emulators/x/src/__tests__/server.test.ts` — mirror Linear's: OAuth happy
+  path, PKCE rejection on bad verifier, refresh grant, each failure switch,
+  `/2/users/me` bearer + 401.
+- `emulators/kit/src/__tests__/` — small `startEmulator` lifecycle test
+  (listen → reset → close).
+- GitHub refactor guarded by existing `server.test.ts` / `env.test.ts` (green =
+  no regression).
+
+## File layout
+
+```
+emulators/kit/    package.json, tsconfig.json, vitest.config.ts,
+                  src/index.ts, src/__tests__/
+emulators/x/      package.json, tsconfig.json, vitest.config.ts, README.md,
+                  src/{x-plugin.ts, server.ts, start.ts, env.ts, env-sh.ts,
+                       fixtures.ts, __tests__/server.test.ts}
+```
+
+## Out of scope (YAGNI)
+
+- Migrating Linear onto the kit.
+- X read/write endpoints (mentions, search, posting) — added when a connector
+  needs them.
+- An `@repo/x-app-node` contract package — lands with the real connector.
+- Promoting failure-switches into the kit — waits for the second kit consumer.

--- a/docs/superpowers/specs/2026-06-01-skills-page-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-01-skills-page-redesign-design.md
@@ -1,0 +1,189 @@
+# Skills page redesign — design
+
+Date: 2026-06-01
+Status: Approved (visuals approved via `/tmp/skills-redesign-mockup.html`)
+Area: `apps/app` — workspace Skills surface
+
+## Problem
+
+The current Skills page is more complex than the feature warrants. It renders a
+flush full-width header, a tabbed validity filter, an index-diagnostics block,
+and a vertical list of `Collapsible` rows that each carry badges, resource
+counts, a path, a Source button, and an inline markdown preview. A *separate*
+full detail page (`[skillSlug]/page.tsx`) duplicates that information with a
+metadata/diagnostics/resources sidebar. Skills are read-only (indexed from a
+connected GitHub repo), so this is a lot of chrome for "browse the catalog, read
+one skill."
+
+We want a calmer, denser surface modeled on the connectors page and the Codex
+"skills" reference: a centered hero, a search + filter row, one grouped grid of
+compact skill cells, and a centered dialog for reading a single skill.
+
+## Goals
+
+- Replace the row list + standalone detail page with a **2-column grid** of
+  compact skill cells under a single **Team** group.
+- Centered **hero** ("Make Lightfast work your way") + subtitle.
+- Reading a skill happens in a **centered dialog**, deep-linkable via
+  `?skill=<slug>`. The dialog is the single home for a skill's markdown and
+  (when invalid) its diagnostics.
+- Keep the **validity filter** (All / Valid / Invalid) and mark invalid skills
+  on their cell.
+- Match the existing "precise" visual language (connectors tokens: `h-7`
+  controls, `rounded-[9px]` / `rounded-[12px]`, muted palette, `size="lf"`
+  inputs).
+
+## Non-goals
+
+- **No** enable/disable toggle, **no** install/uninstall, **no** "Try in chat".
+  These appear in the Codex reference but have no backend (skills are read-only).
+  This is a visual/structural redesign only — no API, schema, or router changes.
+- No new skill grouping. Only "Team" exists; "Recommended" / "System" are out.
+- No per-skill icons in the data model. Use one shared glyph for every skill.
+- No changes to the skills index/refresh services or the tRPC `list` / `get`
+  procedures (we may stop calling `get` from a page — see Routing).
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+| --- | --- |
+| Dialog actions (toggle/uninstall/try-in-chat) | Visual-only — omit them. Keep the working "View source" GitHub link. |
+| Detail view | Replace the `[skillSlug]` route with a centered dialog keyed by `?skill=<slug>`. Remove the route page. |
+| Icons | One shared glyph for every team skill. |
+| Filter | Keep validity filter (All / Valid / Invalid); mark invalid cells with a small pill. |
+| Hero copy | "Make Lightfast work your way" + descriptive subtitle. |
+| Header alignment | Centered hero (not left-aligned). |
+| Trailing cell action | None (no `+` / `✓`). Whole cell is the click target. |
+| Group label | "Team". |
+
+## Architecture
+
+### Routing & data
+
+- `skills/page.tsx` keeps the prefetch → `HydrateClient` → client shape. It
+  already prefetches `trpc.org.workspace.skills.list`. No change needed beyond
+  rendering the new client. (Mirrors `connectors/page.tsx`.)
+- Detail is **not** a route anymore. The dialog reads from the same `list`
+  payload already in the client (every skill in `list` carries `bodyMarkdown` /
+  `sourceMarkdown`, `diagnostics`, `resources`, `path`, `indexedCommitSha`), so
+  the dialog needs **no** extra fetch. We select the open skill by `?skill=<slug>`
+  via `useQueryState("skill")` (nuqs), exactly like connectors' `?connector=`.
+- **Remove** `skills/[skillSlug]/page.tsx` and `skill-detail.tsx`. The
+  `skills.get` procedure stays in the router (still useful / tested) but is no
+  longer called by a page. This keeps the change scoped to the UI.
+
+### Component breakdown
+
+```
+skills/
+  page.tsx                         (unchanged shape; renders SkillsClient)
+  _components/
+    skills-client.tsx             (REWRITE) hero + controls + group + grid + dialog state
+    skill-grid.tsx                (NEW)     "Team" group header + 2-col grid; maps cells
+    skill-cell.tsx                (NEW)     one compact clickable cell (glyph/name/desc/invalid pill)
+    skill-glyph.tsx               (NEW)     shared skill glyph (size variants)
+    skill-dialog.tsx              (NEW)     centered Dialog: header, desc, diagnostics, markdown, footer
+    skill-markdown.tsx            (KEEP)    renders SKILL.md via MarkdownContent (already exists)
+    skill-status.tsx              (KEEP)    freshness badge; relocated into the controls row
+    skills-loading.tsx            (UPDATE)  skeleton matching hero + grid
+    skill-row.tsx                 (DELETE)  replaced by skill-cell
+    skill-detail.tsx              (DELETE)  replaced by skill-dialog
+```
+
+Each unit has one job:
+- `SkillGlyph` — visual identity only; no data.
+- `SkillCell` — pure presentation + `onSelect(slug)`; no data fetching, no
+  query-state. Receives a `skill` and renders glyph/name/truncated description
+  and an Invalid pill when `validationStatus === "invalid"`.
+- `SkillGrid` — group header ("Team" + count), divider, the `grid grid-cols-1
+  sm:grid-cols-2` layout, empty state. Receives the filtered list + `onSelect`.
+- `SkillDialog` — receives the selected `skill` (or `undefined`), `repositoryUrl`,
+  and `onOpenChange`. Renders the centered dialog. Open state is derived from
+  whether a skill is selected (mirrors connectors' sheet).
+- `SkillsClient` — owns search state, filter state, `?skill` query-state, the
+  `useSuspenseQuery`, filtering/sorting, and wiring `onSelect` → set `?skill`.
+
+### Layout (matches the approved mockup)
+
+- Container: `mx-auto w-full max-w-3xl px-6 py-10` (connectors container; 2 cols
+  fit comfortably). `WorkspaceSurface variant="contained"` is `max-w-6xl` so we
+  use a bespoke wrapper or pass a `max-w-3xl` className.
+- Hero: centered. `h1` `font-semibold text-3xl tracking-[-0.02em]`, subtitle
+  `text-muted-foreground text-sm` centered, `max-w-[30rem] mx-auto`.
+- Controls row: search `Input` (`variant="lf" size="lf"` with leading Search
+  icon, `pl-8`) + `Select` validity filter (`h-7 rounded-[9px]`). The
+  `SkillStatus` freshness badge sits at the end of this row (small, muted). A
+  subtle ghost `Open repository ↗` link (uses `repositoryUrl`) also lives in this
+  row so the source repo stays one click from the list.
+- Group: header line — `Team` (`text-sm font-medium`) + **visible-count** pill
+  (`text-xs text-muted-foreground`, counts the filtered result set so it tracks
+  search/filter) — over a `border-b border-border` divider, then the grid.
+- Cell: `flex items-center gap-3 rounded-[9px] px-2.5 py-3 hover:bg-muted/50`,
+  glyph `size-9 rounded-[9px] border`, name `text-sm font-medium truncate`,
+  desc `text-xs text-muted-foreground truncate`, trailing Invalid pill only
+  when invalid.
+- Dialog (`@repo/ui/components/ui/dialog`): `DialogContent` ~`sm:max-w-2xl`,
+  `max-h-[82vh]`, internal column with a scrollable markdown body.
+  - Header: `SkillGlyph` (rounded) + title (`name` bold + `Skill` muted) +
+    GitHub source `icon-btn` + `DialogClose`.
+  - `DialogDescription` = skill description.
+  - Invalid: amber diagnostics callout above the body.
+  - Body: bordered `rounded-[12px] bg-muted/20` scroll region rendering
+    `SkillMarkdown`. When markdown is unavailable, the existing fallback copy.
+  - Footer: skill `path` (mono, muted) on the left, `View source` outline button
+    on the right (uses `getSkillSourceUrl`).
+
+### Data flow
+
+1. `page.tsx` prefetches `skills.list` → hydrate.
+2. `SkillsClient` `useSuspenseQuery(skills.list)` → `{ freshness,
+   indexDiagnostics, repositoryUrl, skills }`.
+3. Local `query` (deferred) + `filter` derive `visibleSkills` via the existing
+   `matchesFilter` / `matchesQuery` helpers (carried over), sorted invalid-first
+   then by slug (current behavior).
+4. Grid renders cells; clicking sets `?skill=<slug>`.
+5. `selectedSkill = skills.find(s => s.slug === skillParam)`; passed to
+   `SkillDialog`. Closing clears `?skill`.
+
+### Edge cases
+
+- **Empty catalog** vs **no matches**: same two-message split the current client
+  uses ("No skills indexed." / "No matching skills."), shown inside the group.
+- **Invalid skill**: Invalid pill on the cell; dialog shows the diagnostics
+  callout and the markdown fallback when `bodyMarkdown`/`sourceMarkdown` is
+  absent.
+- **Index diagnostics** (repo-level): keep as a subtle banner above the group
+  when `indexDiagnostics.length > 0` (carried from current client).
+- **Freshness**: `SkillStatus` relocated into the controls row (stale /
+  refreshing / unavailable still visible).
+- **`?skill` for an unknown/filtered-out slug**: `find` returns `undefined` →
+  dialog stays closed; param is harmless. (We do not force-clear it, matching
+  connectors' tolerance of stale params.)
+- **Repo-level "Open in GitHub"**: the prominent header button becomes a subtle
+  ghost `Open repository ↗` link in the controls row; per-skill `View source`
+  covers the per-skill case.
+
+## Testing
+
+- Update `apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/skills/*`
+  to the new structure. Cover:
+  - Grid renders one cell per skill; search filters; validity filter filters.
+  - Invalid skill shows the Invalid pill.
+  - Clicking a cell sets `?skill` and opens the dialog with the right
+    name/description/markdown; closing clears `?skill`.
+  - Invalid skill dialog renders diagnostics + fallback copy.
+  - Empty vs no-match messaging.
+- Remove tests tied to the deleted `[skillSlug]` route / `skill-detail`.
+- `pnpm --filter @api/app build` (types), `pnpm check`, `pnpm typecheck`, and the
+  app test suite.
+
+## Files
+
+- **Rewrite**: `skills-client.tsx`.
+- **New**: `skill-grid.tsx`, `skill-cell.tsx`, `skill-glyph.tsx`,
+  `skill-dialog.tsx`.
+- **Update**: `skills-loading.tsx`, `skill-status.tsx` (placement only), skills
+  test file(s).
+- **Delete**: `skills/[skillSlug]/page.tsx`, `skill-row.tsx`, `skill-detail.tsx`,
+  and the corresponding detail test(s).
+- **Keep untouched**: `page.tsx` (shape), `skill-markdown.tsx`, router/services.

--- a/docs/superpowers/specs/2026-06-01-source-control-git-settings-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-01-source-control-git-settings-redesign-design.md
@@ -1,0 +1,156 @@
+# Source Control & Git settings — UI redesign
+
+**Date:** 2026-06-01
+**Surface:** `/[slug]/settings/source-control` (Settings sub-tab)
+**Status:** Design approved (mockup + decisions); pending spec review
+
+## Context
+
+The Source Control & Git sub-tab currently renders two stacked blocks from a
+single `source-control-connection-section.tsx` (~450 lines):
+
+1. A **"Source control"** `SettingsGroup` — a GitHub-connection row and a
+   Lightfast-repository row (`SourceControlSection`).
+2. A **"Repositories"** section — a flat `divide-y` list of *every* accessible
+   GitHub repo, each tagged imported / not-imported (`SourceControlConnectionSection`).
+
+We are reworking it to the in-app **Connector** card language
+(`connectors-client.tsx`) and the account-card pattern from the user's
+Connectors / Mail-and-Calendar references: discrete `bg-background` cards,
+border-only separation, one box per repository.
+
+## Goals
+
+- Three stacked sections, in order: **Organization → Lightfast repository → Repositories**.
+- Card language matches connectors: `bg-background` boxes (no `bg-card`),
+  border-only separation, locked Lightfast tokens (`rounded-[8px]`, `h-7`,
+  `text-[11px]` mono labels, emerald accents).
+- Repositories become **individual cards** (one box each), **imported-only**,
+  each expandable to show real per-repo data (**Watched paths**).
+- Exactly one small, safe backend change: surface `syncStatus` in the list payload.
+
+## Non-goals
+
+- Editing watched paths — **read-only** this pass.
+- Per-repo permissions display — not in the data model; dropped.
+- Org disconnect / removal — the binding is a one-time event and immutable;
+  surfaced only as a **disabled** control.
+- Resolving "Enabled by {name}" — see Open Items.
+
+## Design
+
+### Layout & tokens
+
+- Settings content column. Page header: **"Source Control & Git"**
+  (`text-2xl` / 20px, `font-medium`) + subtitle (`text-sm` / 12px,
+  `text-muted-foreground`). Sections separated by `space-y-10`.
+- Every box: `border border-border bg-background rounded-[8px]`.
+- Icon boxes: `border-input bg-background`, rounded; `size-10` for section cards,
+  `size-7` for repo rows (matches connectors' `ConnectionStatus` icon).
+- Section labels: `font-mono text-[11px] text-muted-foreground`.
+- "Connected" / "Verified" accents reuse the existing emerald `StatusBadge` style.
+
+### Bound vs. unbound composition
+
+- **Bound** (active binding): render Organization card + Lightfast repository card
+  + Repositories section.
+- **Unbound** (no active binding): render the page header + a **single** empty
+  state only ("No GitHub organization connected" + "Open setup" →
+  `/{slug}/tasks/bind`). The Organization and Lightfast repository cards do **not**
+  render — avoids stacking multiple "connect" prompts.
+
+### 1. Organization
+
+- Card: GitHub mark + org login (`binding.accountLogin`) + subtitle, with a
+  **"● Connected ⌄"** dropdown trigger (emerald dot) on the right.
+- Subtitle: **"Connected on {connectedAt}"** (formatted via existing
+  `shortDateFormatter`). See Open Items for "Enabled by {name}".
+- Dropdown menu, both items **disabled**: **"Configure in GitHub"** and
+  **"Disconnect"**. A **tooltip** on the disabled items reads
+  *"Connection is set up once and can't be disconnected."* — no inline hint text.
+- Only renders when bound; the unbound case is covered by the Repositories empty state.
+
+### 2. Lightfast repository
+
+- Card: logo mark + `{org}/.lightfast` (mono) + description + status, derived
+  from `binding.lightfastRepository`.
+- States (always within the bound composition):
+  - **Verified** → emerald "Verified" pill + `verifiedAt`.
+  - **Unverified** → "Open setup" → `/{slug}/tasks/github/lightfast-repo`.
+
+### 3. Repositories
+
+- Section header: "Repositories" label + **Refresh** (icon button; invalidates
+  the `listRepositories` query) + **"+ Add repository"** (opens the existing
+  import dialog; disabled for non-admins, on `repositoriesError`, or when unbound).
+- List = **imported repos only**: `repositories.filter((r) => r.imported)`
+  (`.lightfast` is already excluded by the API). The Add dialog surfaces the
+  not-yet-imported repos.
+- Repo card header: git-branch icon + `{fullName}` (mono) + **Private/Public**
+  badge + **sync-status** indicator (`enabled` / `disabled`) + **"Watched paths"**
+  expand toggle + **⋯ menu** → **"Open on GitHub"** (`https://github.com/{fullName}`).
+- Expanded body — **"Watched paths"** from `watchedPathGlobs`:
+  - `null` → "No watched paths configured".
+  - array containing `**` (`SOURCE_CONTROL_ALL_PATHS_GLOB`) → "all paths".
+  - otherwise → one mono chip per glob.
+- **Error** state (bound but list failed): render `repositoriesError.message`
+  (e.g. installation metadata refresh failure / account mismatch) in the existing
+  destructive block, in place of the card list.
+- **No imported repos** (bound, list OK, nothing imported yet): a quiet inline
+  prompt — "No repositories added yet. Use **Add repository** to connect one."
+
+## Backend change (single, approved)
+
+`api/app/src/services/github/source-control/repositories.ts`:
+
+- Add `syncStatus: SourceControlRepositorySyncStatus` to `SourceControlRepositoryRow`.
+- In `buildSourceControlRepositoryResponse`, map `watched?.syncStatus ?? "disabled"`.
+
+Not-imported repos have no watched row; the imported-only filter guarantees every
+rendered card has a real `syncStatus`. No schema change — the column already exists
+on `lightfast_source_control_repositories`.
+
+## Component structure (frontend)
+
+Split the current single file into focused units under
+`settings/source-control/_components/`:
+
+- `source-control-settings-client.tsx` — orchestrates the two suspense queries
+  (`get`, `listRepositories`) + page header + section layout.
+- `organization-card.tsx` — org card, disabled dropdown, tooltip.
+- `lightfast-repository-card.tsx` — verified / unverified / unbound states.
+- `repository-list.tsx` — section header (Refresh + Add), imported-only map,
+  empty + error states.
+- `repository-card.tsx` — single repo card, expandable watched paths, sync status,
+  ⋯ menu.
+- `add-repository-dialog.tsx` — the existing import search/select dialog, extracted
+  intact (search, filter, select, `importRepository` mutation, list cache update).
+
+Remove the old `SourceControlSection` + `SourceControlConnectionSection` exports.
+Keep the shared `settings-section.tsx` (`SettingsGroup` / `SettingRow`) — still used
+by the General settings client.
+
+## Testing
+
+- Component tests per new card:
+  - `organization-card` — disabled dropdown items + tooltip present; emerald
+    Connected status.
+  - `lightfast-repository-card` — verified / unverified / unbound branches.
+  - `repository-card` — watched-paths states (null / `**` / specific globs),
+    sync-status indicator, Open-on-GitHub href.
+  - `add-repository-dialog` — import flow preserved (search, select, mutate,
+    cache update, admin gating).
+  - `repository-list` — imported-only filtering; empty + error states.
+- Client test: renders the three sections; runs both suspense queries.
+- API: `repositories` service test asserts `syncStatus` mapping; router test
+  covers the imported-only-relevant fields.
+- Rework existing `settings-source-control-connection-section.test.tsx` and
+  `settings-source-control-client.test.tsx` to the new component structure.
+
+## Open items (decide at review)
+
+- **Org "Enabled by {name}":** the mockup showed "Enabled by Jeevan Pillay". The
+  binding exposes `connectedByUserId` (a Clerk user id) and `connectedAt`, but not
+  a display name — rendering the name needs a Clerk user lookup (extra backend).
+  **Default in this spec:** show **"Connected on {connectedAt}"** using available
+  data. Promote to "Enabled by {name}" only if the lookup is worth it.

--- a/docs/superpowers/specs/2026-06-02-linear-mcp-endpoint-ui-design.md
+++ b/docs/superpowers/specs/2026-06-02-linear-mcp-endpoint-ui-design.md
@@ -1,0 +1,53 @@
+# Linear Emulator MCP Endpoint UI
+
+**Date:** 2026-06-02
+**Status:** Approved scope
+
+## Goal
+
+Make the local Linear emulator's MCP endpoint useful when opened in a browser.
+`GET /mcp` should render a lightweight Linear-inspired status page, while
+`POST /mcp` remains the unchanged machine-facing JSON-RPC endpoint used by the
+connector flow.
+
+## Decisions
+
+- Add the UI only to `@repo/linear-emulator`.
+- Serve static HTML from the emulator route layer; do not introduce React,
+  Next.js, a bundler, or client-side JavaScript.
+- Keep the existing `POST /mcp` behavior and tests intact.
+- The page may mimic the practical feel of Linear's public MCP endpoint, but it
+  must clearly identify itself as the Lightfast local emulator.
+
+## UI Content
+
+The page should show:
+
+- "Linear MCP" as the primary title.
+- Local emulator status.
+- Workspace name and id from `LINEAR_EMULATOR_FIXTURES`.
+- Actor name and id from `LINEAR_EMULATOR_FIXTURES`.
+- The current endpoint URL, derived from the incoming request origin plus
+  `/mcp`.
+- Transport/protocol copy for Streamable HTTP JSON-RPC.
+- Tool count and deterministic tool list from `LINEAR_EMULATOR_TOOLS`.
+- A short local setup command using `npx mcp-remote <endpoint>`.
+
+## Non-Goals
+
+- No auth UI.
+- No OAuth state changes.
+- No connector page dependency on the emulator UI.
+- No pixel-perfect clone of Linear's private authenticated page.
+- No changes to real Linear provider config.
+
+## Testing
+
+Add a focused regression test in the existing Linear emulator server test suite:
+
+- `GET /mcp` returns `200`.
+- `content-type` includes `text/html`.
+- The body includes the expected title, local workspace, actor, endpoint, setup
+  command, tool count, and representative tool names.
+
+Existing MCP JSON-RPC tests remain the compatibility guard for `POST /mcp`.


### PR DESCRIPTION
## Summary

Design + plan docs that grew alongside the connectors work, split out of #769 so that PR stays code-only.

Covers: connector architecture, account-settings source-control, emulator-kit + x-emulator redesign, skills source-control git settings, and automations (visual language + schedule model).

These live under `docs/`, which CodeRabbit ignores via `.coderabbit.yaml` path filters — pure documentation, no code.

> Split from #769. Close this if you'd rather these design docs not land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
