### PR TITLE
fix: remove invalid primary key rebuild from migration

### DIFF
--- a/db/app/src/__tests__/migrations.test.ts
+++ b/db/app/src/__tests__/migrations.test.ts
@@ -18,4 +18,18 @@ describe("migration SQL", () => {
 
     expect(offenders).toEqual([]);
   });
+
+  it("does not emit primary key rebuild statements", () => {
+    const migrationsDir = join(process.cwd(), "src/migrations");
+    const offenders = readdirSync(migrationsDir)
+      .filter((file) => file.endsWith(".sql"))
+      .flatMap((file) => {
+        const sql = readFileSync(join(migrationsDir, file), "utf8");
+        const invalid = sql.match(/\b(?:DROP|ADD)\s+PRIMARY\s+KEY\b/gi);
+
+        return invalid ? [file] : [];
+      });
+
+    expect(offenders).toEqual([]);
+  });
 });

--- a/db/app/src/migrations/0016_normal_gabe_jones.sql
+++ b/db/app/src/migrations/0016_normal_gabe_jones.sql
@@ -6,8 +6,6 @@ DROP INDEX `integration_calls_org_created_idx` ON `lightfast_provider_routine_ca
 DROP INDEX `integration_calls_org_caller_created_idx` ON `lightfast_provider_routine_calls`;--> statement-breakpoint
 DROP INDEX `integration_calls_connection_created_idx` ON `lightfast_provider_routine_calls`;--> statement-breakpoint
 DROP INDEX `integration_calls_provider_routine_created_idx` ON `lightfast_provider_routine_calls`;--> statement-breakpoint
-ALTER TABLE `lightfast_provider_routine_calls` DROP PRIMARY KEY;--> statement-breakpoint
-ALTER TABLE `lightfast_provider_routine_calls` ADD PRIMARY KEY(`id`);--> statement-breakpoint
 ALTER TABLE `lightfast_provider_routine_calls` ADD `provider_attempted` boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE `lightfast_provider_routine_calls` ADD `source_surface` varchar(32) DEFAULT 'system' NOT NULL;--> statement-breakpoint
 ALTER TABLE `lightfast_provider_routine_calls` ADD `source_ref` varchar(128);--> statement-breakpoint


### PR DESCRIPTION
## Summary
- removes the no-op DROP/ADD PRIMARY KEY pair from 0016_normal_gabe_jones that failed on PlanetScale staging
- adds a migration SQL regression test that rejects primary-key rebuild statements

## Test Plan
- pnpm check
- pnpm --filter @db/app exec vitest run src/__tests__/migrations.test.ts src/__tests__/provider-routine-calls.test.ts src/__tests__/org-connector-connections.test.ts
- pnpm --filter @db/app typecheck

## Context
The PR #776 DB workflow failed in run 26824249196 at run-migrations-on-branch on ALTER TABLE lightfast_provider_routine_calls DROP PRIMARY KEY. The staging branch had already applied the table and column renames before that failure, so this PR fixes the repo migration before rerunning deployment.
