### PR TITLE
feat: let workspace chat call connector tools

### DIFF
--- a/ai/package.json
+++ b/ai/package.json
@@ -40,6 +40,7 @@
     "@repo/api-contract": "workspace:*",
     "@repo/app-validation": "workspace:*",
     "@repo/identity-contract": "workspace:*",
+    "@repo/provider-routine-contract": "workspace:*",
     "@vendor/ai": "workspace:*",
     "server-only": "catalog:",
     "zod": "catalog:"

--- a/ai/src/__tests__/workspace-assistant/message-schema.test.ts
+++ b/ai/src/__tests__/workspace-assistant/message-schema.test.ts
@@ -55,4 +55,46 @@ describe("Lightfast workspace assistant message schema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("validates persisted provider routine tool parts", async () => {
+    const validResult = await safeValidateLightfastUIMessages({
+      messages: [
+        {
+          id: "msg_123",
+          parts: [
+            {
+              input: { includeSchema: true, query: "issue" },
+              output: { routines: [] },
+              state: "output-available",
+              toolCallId: "tool_call_123",
+              type: "tool-findProviderRoutines",
+            },
+          ],
+          role: "assistant",
+        },
+      ],
+    });
+
+    expect(validResult.success).toBe(true);
+
+    const invalidResult = await safeValidateLightfastUIMessages({
+      messages: [
+        {
+          id: "msg_123",
+          parts: [
+            {
+              input: { limit: 1000 },
+              output: { routines: [] },
+              state: "output-available",
+              toolCallId: "tool_call_123",
+              type: "tool-findProviderRoutines",
+            },
+          ],
+          role: "assistant",
+        },
+      ],
+    });
+
+    expect(invalidResult.success).toBe(false);
+  });
 });

--- a/ai/src/workspace-assistant/message-schema.ts
+++ b/ai/src/workspace-assistant/message-schema.ts
@@ -1,9 +1,17 @@
 import {
   type FlexibleSchema,
+  type InferUITools,
   type SafeValidateUIMessagesResult,
   safeValidateUIMessages,
+  tool,
   type UIMessage,
 } from "@vendor/ai";
+import {
+  providerRoutineCallInputSchema,
+  providerRoutineCallSuccessSchema,
+  providerRoutineFindInputSchema,
+  providerRoutineFindOutputSchema,
+} from "@repo/provider-routine-contract";
 import { z } from "zod";
 
 const lightfastWorkspaceAssistantMessageMetadataObjectSchema = z
@@ -56,7 +64,24 @@ export const lightfastWorkspaceAssistantDataPartSchemas = {
   >;
 };
 
-export const lightfastWorkspaceAssistantTools = {};
+export const lightfastWorkspaceAssistantTools = {
+  callProviderRoutine: tool({
+    description:
+      "Call one connected provider routine by routineId using this workspace's enabled connector.",
+    inputSchema: providerRoutineCallInputSchema,
+    outputSchema: providerRoutineCallSuccessSchema,
+  }),
+  findProviderRoutines: tool({
+    description:
+      "Find connected provider routines available to this workspace through enabled connectors.",
+    inputSchema: providerRoutineFindInputSchema,
+    outputSchema: providerRoutineFindOutputSchema,
+  }),
+};
+
+type LightfastWorkspaceAssistantTools = InferUITools<
+  typeof lightfastWorkspaceAssistantTools
+>;
 
 export type LightfastWorkspaceAssistantMessageMetadata = z.infer<
   typeof lightfastWorkspaceAssistantMessageMetadataObjectSchema
@@ -64,7 +89,8 @@ export type LightfastWorkspaceAssistantMessageMetadata = z.infer<
 
 export type LightfastUIMessage = UIMessage<
   LightfastWorkspaceAssistantMessageMetadata,
-  LightfastWorkspaceAssistantDataPartsWithUnknownKeys
+  LightfastWorkspaceAssistantDataPartsWithUnknownKeys,
+  LightfastWorkspaceAssistantTools
 >;
 
 export type LightfastWorkspaceAssistantMessagePart =

--- a/ai/src/workspace-assistant/message-schema.ts
+++ b/ai/src/workspace-assistant/message-schema.ts
@@ -1,4 +1,10 @@
 import {
+  providerRoutineCallInputSchema,
+  providerRoutineCallSuccessSchema,
+  providerRoutineFindInputSchema,
+  providerRoutineFindOutputSchema,
+} from "@repo/provider-routine-contract";
+import {
   type FlexibleSchema,
   type InferUITools,
   type SafeValidateUIMessagesResult,
@@ -6,12 +12,6 @@ import {
   tool,
   type UIMessage,
 } from "@vendor/ai";
-import {
-  providerRoutineCallInputSchema,
-  providerRoutineCallSuccessSchema,
-  providerRoutineFindInputSchema,
-  providerRoutineFindOutputSchema,
-} from "@repo/provider-routine-contract";
 import { z } from "zod";
 
 const lightfastWorkspaceAssistantMessageMetadataObjectSchema = z

--- a/apps/app/src/__tests__/app/api/chat/route.test.ts
+++ b/apps/app/src/__tests__/app/api/chat/route.test.ts
@@ -484,18 +484,18 @@ describe("chat route", () => {
     expect(response).toBe(streamResponse);
   });
 
-  it("exposes connector provider routines to the workspace assistant as server tools", async () => {
+  it("exposes read-only connector provider routines to the workspace assistant as server tools", async () => {
     const uiMessages = [
       {
         id: "client-message-1",
-        parts: [{ text: "Create a Linear issue for this bug", type: "text" }],
+        parts: [{ text: "Summarize my Linear issues", type: "text" }],
         role: "user",
       },
     ];
     const streamResponse = new Response("stream");
 
     convertToModelMessagesMock.mockResolvedValue([
-      { content: "Create a Linear issue for this bug", role: "user" },
+      { content: "Summarize my Linear issues", role: "user" },
     ]);
     gatewayMock.mockReturnValue("gateway:anthropic/claude-sonnet-4.6");
     streamTextMock.mockReturnValue({
@@ -517,11 +517,13 @@ describe("chat route", () => {
         stopWhen: { count: 5, kind: "step-count" },
         tools: {
           callProviderRoutine: expect.objectContaining({
-            description: expect.stringContaining("Call one connected"),
+            description: expect.stringContaining(
+              "Call one read-only connected"
+            ),
             execute: expect.any(Function),
           }),
           findProviderRoutines: expect.objectContaining({
-            description: expect.stringContaining("Find connected"),
+            description: expect.stringContaining("Find read-only connected"),
             execute: expect.any(Function),
           }),
         },
@@ -539,7 +541,7 @@ describe("chat route", () => {
         db: { kind: "mock-db" },
         scopes: {
           providerRoutineRead: true,
-          providerRoutineWrite: true,
+          providerRoutineWrite: false,
         },
         source: {
           clientId: null,
@@ -550,12 +552,13 @@ describe("chat route", () => {
       {
         includeSchema: true,
         query: "issue",
+        readOnly: true,
       }
     );
 
     await streamOptions.tools.callProviderRoutine.execute({
-      input: { title: "Bug" },
-      routineId: "linear__create_issue",
+      input: { id: "issue_123" },
+      routineId: "linear__get_issue",
     });
     expect(callProviderRoutineMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -566,6 +569,10 @@ describe("chat route", () => {
           warn: expect.any(Function),
         }),
         now: expect.any(Function),
+        scopes: {
+          providerRoutineRead: true,
+          providerRoutineWrite: false,
+        },
         source: {
           clientId: null,
           ref: "conv_123",
@@ -573,8 +580,8 @@ describe("chat route", () => {
         },
       }),
       {
-        input: { title: "Bug" },
-        routineId: "linear__create_issue",
+        input: { id: "issue_123" },
+        routineId: "linear__get_issue",
       }
     );
     expect(response).toBe(streamResponse);

--- a/apps/app/src/__tests__/app/api/chat/route.test.ts
+++ b/apps/app/src/__tests__/app/api/chat/route.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const appendWorkspaceAssistantMessageMock = vi.fn();
+const callProviderRoutineMock = vi.fn();
 const createNewResumableStreamMock = vi.fn();
 const createWorkspaceAssistantGenerationMock = vi.fn();
 const createWorkspaceAssistantConversationMock = vi.fn();
 const convertToModelMessagesMock = vi.fn();
 const ensureFreshSkillIndexForReadMock = vi.fn();
+const findProviderRoutinesMock = vi.fn();
 const gatewayMock = vi.fn();
 const getWorkspaceAssistantConversationByPublicIdMock = vi.fn();
 const getVerifiedLightfastSkillSourceRepositoryIdMock = vi.fn();
@@ -20,8 +22,14 @@ const markWorkspaceAssistantMessageFailedMock = vi.fn();
 const setWorkspaceAssistantConversationActiveStreamMock = vi.fn();
 const resolveAuthContextFromClerkMock = vi.fn();
 const safeValidateUIMessagesMock = vi.fn();
+const stepCountIsMock = vi.fn();
 const toUIMessageStreamResponseMock = vi.fn();
+const toolMock = vi.fn();
 const streamTextMock = vi.fn();
+const workspaceAssistantToolsMock = {
+  callProviderRoutine: { inputSchema: { kind: "call-input" } },
+  findProviderRoutines: { inputSchema: { kind: "find-input" } },
+};
 
 vi.mock("@api/app/auth/identity", () => ({
   resolveAuthContextFromClerk: resolveAuthContextFromClerkMock,
@@ -62,7 +70,14 @@ vi.mock("@vendor/ai", () => ({
   convertToModelMessages: convertToModelMessagesMock,
   gateway: gatewayMock,
   safeValidateUIMessages: safeValidateUIMessagesMock,
+  stepCountIs: stepCountIsMock,
   streamText: streamTextMock,
+  tool: toolMock,
+}));
+
+vi.mock("@repo/provider-routines", () => ({
+  callProviderRoutine: callProviderRoutineMock,
+  findProviderRoutines: findProviderRoutinesMock,
 }));
 
 vi.mock("@repo/ai/workspace-assistant", () => ({
@@ -70,7 +85,7 @@ vi.mock("@repo/ai/workspace-assistant", () => ({
     opportunities: { kind: "schema" },
   },
   lightfastWorkspaceAssistantMessageMetadataSchema: { kind: "metadata-schema" },
-  lightfastWorkspaceAssistantTools: {},
+  lightfastWorkspaceAssistantTools: workspaceAssistantToolsMock,
 }));
 
 vi.mock("@vendor/observability/log/next", () => ({
@@ -91,11 +106,13 @@ const { POST } = await import("~/app/(chat)/api/chat/route");
 
 beforeEach(() => {
   appendWorkspaceAssistantMessageMock.mockReset();
+  callProviderRoutineMock.mockReset();
   createNewResumableStreamMock.mockReset();
   createWorkspaceAssistantGenerationMock.mockReset();
   createWorkspaceAssistantConversationMock.mockReset();
   convertToModelMessagesMock.mockReset();
   ensureFreshSkillIndexForReadMock.mockReset();
+  findProviderRoutinesMock.mockReset();
   gatewayMock.mockReset();
   getWorkspaceAssistantConversationByPublicIdMock.mockReset();
   getVerifiedLightfastSkillSourceRepositoryIdMock.mockReset();
@@ -110,7 +127,9 @@ beforeEach(() => {
   setWorkspaceAssistantConversationActiveStreamMock.mockReset();
   resolveAuthContextFromClerkMock.mockReset();
   safeValidateUIMessagesMock.mockReset();
+  stepCountIsMock.mockReset();
   toUIMessageStreamResponseMock.mockReset();
+  toolMock.mockReset();
   streamTextMock.mockReset();
 
   resolveAuthContextFromClerkMock.mockResolvedValue({
@@ -167,6 +186,20 @@ beforeEach(() => {
     ],
   });
   createNewResumableStreamMock.mockResolvedValue(new ReadableStream<string>());
+  callProviderRoutineMock.mockResolvedValue({
+    provider: "linear",
+    providerRoutineCallId: "prc_123",
+    providerToolName: "create_issue",
+    result: { id: "issue_123" },
+    routineId: "linear__create_issue",
+    status: "succeeded",
+  });
+  findProviderRoutinesMock.mockResolvedValue({ routines: [] });
+  stepCountIsMock.mockImplementation((count) => ({
+    count,
+    kind: "step-count",
+  }));
+  toolMock.mockImplementation((definition) => definition);
 });
 
 describe("chat route", () => {
@@ -302,7 +335,7 @@ describe("chat route", () => {
       dataSchemas: { opportunities: { kind: "schema" } },
       messages: uiMessages,
       metadataSchema: { kind: "metadata-schema" },
-      tools: {},
+      tools: workspaceAssistantToolsMock,
     });
 
     expect(
@@ -447,6 +480,102 @@ describe("chat route", () => {
         requestedByUserId: "user_123",
         usage: { inputTokens: 10, outputTokens: 12, totalTokens: 22 },
       })
+    );
+    expect(response).toBe(streamResponse);
+  });
+
+  it("exposes connector provider routines to the workspace assistant as server tools", async () => {
+    const uiMessages = [
+      {
+        id: "client-message-1",
+        parts: [{ text: "Create a Linear issue for this bug", type: "text" }],
+        role: "user",
+      },
+    ];
+    const streamResponse = new Response("stream");
+
+    convertToModelMessagesMock.mockResolvedValue([
+      { content: "Create a Linear issue for this bug", role: "user" },
+    ]);
+    gatewayMock.mockReturnValue("gateway:anthropic/claude-sonnet-4.6");
+    streamTextMock.mockReturnValue({
+      toUIMessageStreamResponse: toUIMessageStreamResponseMock,
+    });
+    toUIMessageStreamResponseMock.mockReturnValue(streamResponse);
+
+    const response = await POST(
+      createJsonRequest({
+        idempotencyKey: "idem_user_1",
+        messages: uiMessages,
+        conversationId: "conv_123",
+      })
+    );
+
+    const streamOptions = streamTextMock.mock.calls[0]?.[0];
+    expect(streamOptions).toEqual(
+      expect.objectContaining({
+        stopWhen: { count: 5, kind: "step-count" },
+        tools: {
+          callProviderRoutine: expect.objectContaining({
+            description: expect.stringContaining("Call one connected"),
+            execute: expect.any(Function),
+          }),
+          findProviderRoutines: expect.objectContaining({
+            description: expect.stringContaining("Find connected"),
+            execute: expect.any(Function),
+          }),
+        },
+      })
+    );
+    expect(stepCountIsMock).toHaveBeenCalledWith(5);
+
+    await streamOptions.tools.findProviderRoutines.execute({
+      includeSchema: true,
+      query: "issue",
+    });
+    expect(findProviderRoutinesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { orgId: "org_123", userId: "user_123" },
+        db: { kind: "mock-db" },
+        scopes: {
+          providerRoutineRead: true,
+          providerRoutineWrite: true,
+        },
+        source: {
+          clientId: null,
+          ref: "conv_123",
+          surface: "chat",
+        },
+      }),
+      {
+        includeSchema: true,
+        query: "issue",
+      }
+    );
+
+    await streamOptions.tools.callProviderRoutine.execute({
+      input: { title: "Bug" },
+      routineId: "linear__create_issue",
+    });
+    expect(callProviderRoutineMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { orgId: "org_123", userId: "user_123" },
+        log: expect.objectContaining({
+          error: expect.any(Function),
+          info: expect.any(Function),
+          warn: expect.any(Function),
+        }),
+        now: expect.any(Function),
+        source: {
+          clientId: null,
+          ref: "conv_123",
+          surface: "chat",
+        },
+      }),
+      {
+        input: { title: "Bug" },
+        routineId: "linear__create_issue",
+      }
     );
     expect(response).toBe(streamResponse);
   });

--- a/apps/app/src/app/(chat)/api/chat/route.ts
+++ b/apps/app/src/app/(chat)/api/chat/route.ts
@@ -76,7 +76,8 @@ const baseSystemPrompt = [
   "Help the user understand and operate their workspace with concise, direct answers.",
   "When asked about skills, explain what the listed skills can do and suggest the next concrete action.",
   "When connector tools are useful, first find connected provider routines, then call the selected routine by routineId.",
-  "Only call provider routines for the active workspace, and only perform externally visible write actions when the user has clearly requested them.",
+  "Only call provider routines for the active workspace.",
+  "Connected provider routines in chat are read-only; do not use them to create, update, delete, post, assign, archive, or move external records.",
 ].join(" ");
 
 export const maxDuration = 30;
@@ -426,7 +427,7 @@ function createWorkspaceAssistantProviderRoutineTools(input: {
   return {
     callProviderRoutine: tool({
       description:
-        "Call one connected provider routine by routineId using this workspace's enabled connector. Use routineIds returned by findProviderRoutines.",
+        "Call one read-only connected provider routine by routineId using this workspace's enabled connector. Use routineIds returned by findProviderRoutines.",
       inputSchema: providerRoutineCallInputSchema,
       outputSchema: providerRoutineCallSuccessSchema,
       execute: async (toolInput) =>
@@ -434,11 +435,14 @@ function createWorkspaceAssistantProviderRoutineTools(input: {
     }),
     findProviderRoutines: tool({
       description:
-        "Find connected provider routines available to this workspace through enabled connectors. Use this before calling callProviderRoutine.",
+        "Find read-only connected provider routines available to this workspace through enabled connectors. Use this before calling callProviderRoutine.",
       inputSchema: providerRoutineFindInputSchema,
       outputSchema: providerRoutineFindOutputSchema,
       execute: async (toolInput) =>
-        findProviderRoutines(providerRoutineContext(input), toolInput),
+        findProviderRoutines(providerRoutineContext(input), {
+          ...toolInput,
+          readOnly: true,
+        }),
     }),
   };
 }
@@ -458,7 +462,7 @@ function providerRoutineContext(input: {
     now: () => new Date(),
     scopes: {
       providerRoutineRead: true,
-      providerRoutineWrite: true,
+      providerRoutineWrite: false,
     },
     source: {
       clientId: null,

--- a/apps/app/src/app/(chat)/api/chat/route.ts
+++ b/apps/app/src/app/(chat)/api/chat/route.ts
@@ -31,10 +31,23 @@ import {
   lightfastWorkspaceAssistantTools,
 } from "@repo/ai/workspace-assistant";
 import {
+  providerRoutineCallInputSchema,
+  providerRoutineCallSuccessSchema,
+  providerRoutineFindInputSchema,
+  providerRoutineFindOutputSchema,
+} from "@repo/provider-routine-contract";
+import {
+  callProviderRoutine,
+  findProviderRoutines,
+  type ProviderRoutineServiceContext,
+} from "@repo/provider-routines";
+import {
   convertToModelMessages,
   gateway,
   safeValidateUIMessages,
+  stepCountIs,
   streamText,
+  tool,
 } from "@vendor/ai";
 import { log } from "@vendor/observability/log/next";
 import { z } from "zod";
@@ -42,6 +55,7 @@ import { getLightfastResumableStreamContext } from "~/app/(chat)/api/chat/resuma
 
 const WORKSPACE_ASSISTANT_MODEL = "anthropic/claude-sonnet-4.6";
 const WORKSPACE_ASSISTANT_FALLBACK_MODELS = ["openai/gpt-5.4"] as const;
+const WORKSPACE_ASSISTANT_MAX_TOOL_STEPS = 5;
 
 const chatRequestSchema = z
   .object({
@@ -61,6 +75,8 @@ const baseSystemPrompt = [
   "You are Lightfield, the Lightfast workspace assistant.",
   "Help the user understand and operate their workspace with concise, direct answers.",
   "When asked about skills, explain what the listed skills can do and suggest the next concrete action.",
+  "When connector tools are useful, first find connected provider routines, then call the selected routine by routineId.",
+  "Only call provider routines for the active workspace, and only perform externally visible write actions when the user has clearly requested them.",
 ].join(" ");
 
 export const maxDuration = 30;
@@ -284,7 +300,13 @@ export async function POST(req: Request) {
         user: identity.userId,
       },
     },
+    stopWhen: stepCountIs(WORKSPACE_ASSISTANT_MAX_TOOL_STEPS),
     system,
+    tools: createWorkspaceAssistantProviderRoutineTools({
+      conversation,
+      orgId: identity.orgId,
+      userId: identity.userId,
+    }),
   });
 
   return result.toUIMessageStreamResponse({
@@ -394,6 +416,56 @@ export async function POST(req: Request) {
     },
     originalMessages,
   });
+}
+
+function createWorkspaceAssistantProviderRoutineTools(input: {
+  conversation: WorkspaceAssistantConversation;
+  orgId: string;
+  userId: string;
+}) {
+  return {
+    callProviderRoutine: tool({
+      description:
+        "Call one connected provider routine by routineId using this workspace's enabled connector. Use routineIds returned by findProviderRoutines.",
+      inputSchema: providerRoutineCallInputSchema,
+      outputSchema: providerRoutineCallSuccessSchema,
+      execute: async (toolInput) =>
+        callProviderRoutine(providerRoutineContext(input), toolInput),
+    }),
+    findProviderRoutines: tool({
+      description:
+        "Find connected provider routines available to this workspace through enabled connectors. Use this before calling callProviderRoutine.",
+      inputSchema: providerRoutineFindInputSchema,
+      outputSchema: providerRoutineFindOutputSchema,
+      execute: async (toolInput) =>
+        findProviderRoutines(providerRoutineContext(input), toolInput),
+    }),
+  };
+}
+
+function providerRoutineContext(input: {
+  conversation: WorkspaceAssistantConversation;
+  orgId: string;
+  userId: string;
+}): ProviderRoutineServiceContext {
+  return {
+    actor: {
+      orgId: input.orgId,
+      userId: input.userId,
+    },
+    db,
+    log,
+    now: () => new Date(),
+    scopes: {
+      providerRoutineRead: true,
+      providerRoutineWrite: true,
+    },
+    source: {
+      clientId: null,
+      ref: input.conversation.publicId,
+      surface: "chat",
+    },
+  };
 }
 
 async function readJson(req: Request) {

--- a/db/app/src/__tests__/provider-routine-calls.test.ts
+++ b/db/app/src/__tests__/provider-routine-calls.test.ts
@@ -197,6 +197,81 @@ describe("provider routine call helpers", () => {
     );
   });
 
+  it("creates chat-sourced provider routine calls", async () => {
+    const inserted = {
+      id: 1,
+      publicId: "provider_routine_call_123e4567-e89b-12d3-a456-426614174000",
+      clerkOrgId: "org_123",
+      calledByKind: "user",
+      calledById: "user_123",
+      calledByUserId: "user_123",
+      provider: "linear",
+      routineId: "linear__list_issues",
+      providerToolName: "list_issues",
+      providerConnectionId: 42,
+      providerWorkspaceId: "workspace_123",
+      providerActorId: "actor_123",
+      providerAttempted: false,
+      sourceClientId: null,
+      sourceRef: "conv_123",
+      sourceSurface: "chat",
+      status: "running",
+      inputRedacted: { present: true },
+      outputRedacted: null,
+      errorCode: null,
+      errorMessage: null,
+      startedAt,
+      finishedAt: null,
+      createdAt: startedAt,
+      updatedAt: startedAt,
+    };
+    const valuesMock = vi.fn(() => ({
+      $returningId: () => Promise.resolve([{ id: 1 }]),
+    }));
+    const db = {
+      insert: vi.fn(() => ({ values: valuesMock })),
+      select: vi.fn(() => selectRows([inserted])),
+    } as unknown as Database;
+
+    await expect(
+      createProviderRoutineCall(db, {
+        calledById: "user_123",
+        calledByKind: "user",
+        calledByUserId: "user_123",
+        clerkOrgId: "org_123",
+        providerConnectionId: 42,
+        inputRedacted: { present: true },
+        provider: "linear",
+        providerActorId: "actor_123",
+        providerToolName: "list_issues",
+        providerWorkspaceId: "workspace_123",
+        routineId: "linear__list_issues",
+        sourceClientId: null,
+        sourceRef: "conv_123",
+        sourceSurface: "chat",
+        startedAt,
+      })
+    ).resolves.toMatchObject({
+      publicId: expect.stringMatching(/^provider_routine_call_[0-9a-f-]{36}$/),
+      sourceRef: "conv_123",
+      sourceSurface: "chat",
+      status: "running",
+    });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calledById: "user_123",
+        calledByKind: "user",
+        calledByUserId: "user_123",
+        clerkOrgId: "org_123",
+        sourceClientId: null,
+        sourceRef: "conv_123",
+        sourceSurface: "chat",
+        status: "running",
+      })
+    );
+  });
+
   it("marks running provider routine calls as provider attempted", async () => {
     const whereMock = vi.fn((_condition: unknown) =>
       Promise.resolve({ affectedRows: 1 })

--- a/db/app/src/schema/tables/org-provider-routine-calls.ts
+++ b/db/app/src/schema/tables/org-provider-routine-calls.ts
@@ -27,6 +27,7 @@ export type ProviderRoutineCallCalledByKind = "automation" | "system" | "user";
 export type ProviderRoutineCallProvider = "linear" | "x";
 export type ProviderRoutineCallSourceSurface =
   | "automation"
+  | "chat"
   | "hosted_mcp"
   | "native_cli"
   | "system";

--- a/packages/provider-routine-contract/src/__tests__/provider-routine-contract.test.ts
+++ b/packages/provider-routine-contract/src/__tests__/provider-routine-contract.test.ts
@@ -5,6 +5,7 @@ import {
   providerRoutineFindInputSchema,
   providerRoutineId,
   providerRoutineIdSchema,
+  providerRoutineSourceSurfaceSchema,
 } from "../index";
 
 describe("provider routine ids", () => {
@@ -34,6 +35,10 @@ describe("provider routine ids", () => {
 });
 
 describe("proxy schemas", () => {
+  it("accepts chat as a provider routine source surface", () => {
+    expect(providerRoutineSourceSurfaceSchema.parse("chat")).toBe("chat");
+  });
+
   it("parses compact find input", () => {
     expect(
       providerRoutineFindInputSchema.parse({

--- a/packages/provider-routine-contract/src/index.ts
+++ b/packages/provider-routine-contract/src/index.ts
@@ -62,6 +62,7 @@ export const providerRoutineSourceSurfaceSchema = z.enum([
   "hosted_mcp",
   "native_cli",
   "automation",
+  "chat",
   "system",
 ]);
 export type ProviderRoutineSourceSurface = z.infer<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       '@repo/identity-contract':
         specifier: workspace:*
         version: link:../packages/identity-contract
+      '@repo/provider-routine-contract':
+        specifier: workspace:*
+        version: link:../packages/provider-routine-contract
       '@vendor/ai':
         specifier: workspace:*
         version: link:../vendor/ai

--- a/vendor/ai/src/index.ts
+++ b/vendor/ai/src/index.ts
@@ -4,13 +4,13 @@ export type {
   DynamicToolUIPart,
   FileUIPart,
   FlexibleSchema,
+  InferUITools,
   LanguageModel,
   LanguageModelUsage,
-  InferUITools,
   SafeValidateUIMessagesResult,
   SourceDocumentUIPart,
-  ToolUIPart,
   Tool,
+  ToolUIPart,
   UIMessage,
 } from "ai";
 export {

--- a/vendor/ai/src/index.ts
+++ b/vendor/ai/src/index.ts
@@ -6,9 +6,11 @@ export type {
   FlexibleSchema,
   LanguageModel,
   LanguageModelUsage,
+  InferUITools,
   SafeValidateUIMessagesResult,
   SourceDocumentUIPart,
   ToolUIPart,
+  Tool,
   UIMessage,
 } from "ai";
 export {
@@ -20,7 +22,9 @@ export {
   Output,
   RetryError,
   safeValidateUIMessages,
+  stepCountIs,
   streamText,
+  tool,
   UI_MESSAGE_STREAM_HEADERS,
 } from "ai";
 export {


### PR DESCRIPTION
## Summary
- add workspace-assistant server tools for finding and calling connected provider routines
- record chat as a provider routine source surface for call auditing
- validate persisted provider-routine tool parts in workspace assistant messages

## Verification
- pnpm --filter @repo/provider-routine-contract test -- src/__tests__/provider-routine-contract.test.ts
- pnpm --filter @repo/ai test -- src/__tests__/workspace-assistant/message-schema.test.ts
- pnpm --dir apps/app exec vitest run src/__tests__/app/api/chat/route.test.ts
- pnpm --filter @db/app test -- src/__tests__/provider-routine-calls.test.ts
- pnpm --filter @vendor/ai typecheck
- pnpm --filter @repo/ai typecheck
- pnpm --filter @repo/provider-routine-contract typecheck
- pnpm --filter @db/app typecheck
- pnpm --filter @repo/provider-routines typecheck
- pnpm --filter @lightfast/app typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace Assistant now supports discovering and executing connected provider routines directly within chat conversations, enabling more powerful workflow automation integrated into your chat experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->