### PR TITLE
chore(codex): make cloud sandbox env ID-free via setup shim

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -9,54 +9,5 @@ set -eu
 
 cd "${CODEX_WORKTREE_PATH:?}"
 
-corepack enable
-corepack prepare pnpm@11.1.3 --activate
-
-mkdir -p .vercel
-cat > .vercel/repo.json <<'JSON'
-{
-  "remoteName": "origin",
-  "projects": [
-    {
-      "id": "prj_JRXRxBruTvB5Bs99JjA63TLek6GT",
-      "name": "lightfast-www",
-      "directory": "apps/www",
-      "orgId": "team_oOLHPMLVuBjXyFafgsGKEZxl"
-    },
-    {
-      "id": "prj_xCPWTpgHXaGOJdNry3D8vyfQhwt0",
-      "name": "lightfast-app",
-      "directory": "apps/app",
-      "orgId": "team_oOLHPMLVuBjXyFafgsGKEZxl"
-    },
-    {
-      "id": "prj_fCNbgzrn0hHuJRVvM7EZuUvFyGgW",
-      "name": "lightfast-platform",
-      "directory": "apps/platform",
-      "orgId": "team_oOLHPMLVuBjXyFafgsGKEZxl"
-    }
-  ]
-}
-JSON
-
-pnpm install --frozen-lockfile
-
-pull_vercel_env() {
-  app_path="$1"
-  env_file="$app_path/.vercel/.env.development.local"
-
-  if [ "${LIGHTFAST_FORCE_VERCEL_PULL:-0}" != "1" ] && [ -s "$env_file" ]; then
-    echo "Skipping existing env file: $env_file"
-    return 0
-  fi
-
-  pnpm dlx vercel@latest pull "$app_path" \
-    --yes \
-    --non-interactive \
-    --environment=development
-}
-
-pull_vercel_env apps/app
-pull_vercel_env apps/www
-pull_vercel_env apps/platform
+bash scripts/cloud/setup.sh
 '''


### PR DESCRIPTION
## What

Convert the autogenerated `.codex/environments/environment.toml` from an inline `.vercel/repo.json` heredoc (which hardcoded all three Vercel project ids **and** the team/org id) into a thin shim that runs `bash scripts/cloud/setup.sh`. The shared script rebuilds `repo.json` from `LIGHTFAST_VERCEL_*` env secrets at setup time.

## Why

Removes the team/org id (`team_…`) from the tracked tree entirely — the "tree scrub" in the cloud web-sandbox spec. MFE-required project ids in `apps/{app,www,platform}/vercel.json` are intentionally left unchanged (removing them breaks Vercel Microfrontends).

See `docs/superpowers/specs/2026-06-03-claude-cloud-web-sandbox-design.md` (§ID-exposure model, §Components, §87).

## ⚠️ Required follow-up (operator)

This file is **autogenerated by Codex cloud**. To keep it ID-free, the Codex cloud environment's setup command must be reconfigured to `bash scripts/cloud/setup.sh` — otherwise Codex regenerates it with the inline ids on next sync. Both clouds also need the 6 environment secrets (`VERCEL_TOKEN`, `LIGHTFAST_VERCEL_ORG_ID`, `LIGHTFAST_VERCEL_PROJECT_ID_{APP,WWW,PLATFORM,MCP}`) set in their UI. See spec §"Cloud configuration checklist".

## Note

The deep git-history rewrite (redacting the org id from past commits) is a separate coordinated operation.
