### PR TITLE
Require GitHub app env configuration

### DIFF
--- a/api/app/src/__tests__/env.test.ts
+++ b/api/app/src/__tests__/env.test.ts
@@ -1,15 +1,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const ORIGINAL_ENV = {
-  CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
-  ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
-  INNGEST_APP_NAME: process.env.INNGEST_APP_NAME,
-  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
-    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
-  SKIP_ENV_VALIDATION: process.env.SKIP_ENV_VALIDATION,
-  UNKEY_API_ID: process.env.UNKEY_API_ID,
-  UNKEY_ROOT_KEY: process.env.UNKEY_ROOT_KEY,
-};
+const GITHUB_APP_ENV_KEYS = [
+  "GITHUB_APP_CLIENT_ID",
+  "GITHUB_APP_CLIENT_SECRET",
+  "GITHUB_APP_ID",
+  "GITHUB_APP_PRIVATE_KEY",
+  "GITHUB_APP_SLUG",
+  "GITHUB_APP_WEBHOOK_SECRET",
+] as const;
+
+const MUTATED_ENV_KEYS = [
+  "CLERK_SECRET_KEY",
+  "CONNECTOR_MCP_AUTH_SECRET",
+  "ENCRYPTION_KEY",
+  "INNGEST_APP_NAME",
+  "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+  "SKIP_ENV_VALIDATION",
+  "UNKEY_API_ID",
+  "UNKEY_ROOT_KEY",
+  "VERCEL_ENV",
+  ...GITHUB_APP_ENV_KEYS,
+] as const;
+
+const ORIGINAL_ENV = Object.fromEntries(
+  MUTATED_ENV_KEYS.map((key) => [key, process.env[key]])
+);
 
 describe("api app env", () => {
   afterEach(() => {
@@ -43,6 +58,27 @@ describe("api app env", () => {
       )
     ).toBe(true);
   });
+
+  it.each([
+    "development",
+    "preview",
+    "production",
+  ] as const)("requires GitHub App env during %s env module evaluation", async (vercelEnv) => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    setValidBaseEnv(vercelEnv);
+    unsetGitHubAppEnv();
+    vi.resetModules();
+
+    await expect(import("../env")).rejects.toThrow(
+      "Invalid environment variables"
+    );
+    const loggedErrors = JSON.stringify(consoleErrorSpy.mock.calls);
+    for (const key of GITHUB_APP_ENV_KEYS) {
+      expect(loggedErrors).toContain(key);
+    }
+  });
 });
 
 function restoreEnv(name: string, value: string | undefined) {
@@ -51,4 +87,23 @@ function restoreEnv(name: string, value: string | undefined) {
     return;
   }
   process.env[name] = value;
+}
+
+function setValidBaseEnv(vercelEnv: "development" | "preview" | "production") {
+  process.env.CLERK_SECRET_KEY = "sk_test_fake-secret-key-for-tests";
+  process.env.CONNECTOR_MCP_AUTH_SECRET = "x".repeat(32);
+  process.env.ENCRYPTION_KEY = "0".repeat(64);
+  process.env.INNGEST_APP_NAME = "lightfast-test";
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+    "pk_test_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk";
+  delete process.env.SKIP_ENV_VALIDATION;
+  process.env.UNKEY_API_ID = "api_test";
+  process.env.UNKEY_ROOT_KEY = "root_test";
+  process.env.VERCEL_ENV = vercelEnv;
+}
+
+function unsetGitHubAppEnv() {
+  for (const key of GITHUB_APP_ENV_KEYS) {
+    delete process.env[key];
+  }
 }

--- a/api/app/src/__tests__/github-config.test.ts
+++ b/api/app/src/__tests__/github-config.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_GITHUB_APP_ENDPOINTS,
-  getGitHubAppConfig,
+  type getGitHubAppConfig,
   normalizeGitHubPrivateKey,
+  parseGitHubAppConfig,
   resolveGitHubAppEndpoints,
   resolveGitHubAppOrigin,
 } from "../services/github/config";
@@ -120,40 +121,32 @@ describe("GitHub config", () => {
     );
   });
 
-  it("treats env undefined as runtime config for legacy guard resolution", async () => {
-    vi.stubEnv(
-      "GITHUB_INSTALL_URL_OVERRIDE",
-      "https://app.lightfast.localhost/api/dev/github/install?installation_id=1001"
-    );
-    vi.resetModules();
+  it("keeps getGitHubAppConfig ambient-only at the type interface", () => {
+    const runtimeConfigIsAmbientOnly: Parameters<
+      typeof getGitHubAppConfig
+    > extends []
+      ? true
+      : never = true;
 
-    const { getGitHubAppConfig: getRuntimeGitHubAppConfig } = await import(
-      "../services/github/config"
-    );
-
-    expect(() => getRuntimeGitHubAppConfig({ env: undefined })).toThrow(
-      /GITHUB_INSTALL_URL_OVERRIDE is no longer supported/
-    );
+    expect(runtimeConfigIsAmbientOnly).toBe(true);
   });
 
-  it("uses explicit config env instead of ambient legacy install override", () => {
+  it("uses explicit parsed config env instead of ambient legacy install override", () => {
     vi.stubEnv(
       "GITHUB_INSTALL_URL_OVERRIDE",
       "https://app.lightfast.localhost/api/dev/github/install?installation_id=1001"
     );
 
-    const config = getGitHubAppConfig({
-      env: {
-        GITHUB_API_VERSION: "2022-11-28",
-        GITHUB_APP_CLIENT_ID: "github_client_test",
-        GITHUB_APP_CLIENT_SECRET: "github_secret_test",
-        GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
-        GITHUB_APP_ID: "12345",
-        GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
-        GITHUB_APP_SLUG: "lightfast-test",
-        GITHUB_INSTALL_URL_OVERRIDE: undefined,
-        VERCEL_ENV: "development",
-      },
+    const config = parseGitHubAppConfig({
+      GITHUB_API_VERSION: "2022-11-28",
+      GITHUB_APP_CLIENT_ID: "github_client_test",
+      GITHUB_APP_CLIENT_SECRET: "github_secret_test",
+      GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
+      GITHUB_APP_SLUG: "lightfast-test",
+      GITHUB_INSTALL_URL_OVERRIDE: undefined,
+      VERCEL_ENV: "development",
     });
 
     expect(config.endpoints.apiBaseUrl).toBe(
@@ -167,16 +160,14 @@ describe("GitHub config", () => {
       "https://github.lightfast.localhost"
     );
 
-    const config = getGitHubAppConfig({
-      env: {
-        GITHUB_API_VERSION: "2022-11-28",
-        GITHUB_APP_CLIENT_ID: "github_client_test",
-        GITHUB_APP_CLIENT_SECRET: "github_secret_test",
-        GITHUB_APP_ID: "12345",
-        GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
-        GITHUB_APP_SLUG: "lightfast-test",
-        VERCEL_ENV: "development",
-      },
+    const config = parseGitHubAppConfig({
+      GITHUB_API_VERSION: "2022-11-28",
+      GITHUB_APP_CLIENT_ID: "github_client_test",
+      GITHUB_APP_CLIENT_SECRET: "github_secret_test",
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
+      GITHUB_APP_SLUG: "lightfast-test",
+      VERCEL_ENV: "development",
     });
 
     expect(config.endpoints).toEqual(DEFAULT_GITHUB_APP_ENDPOINTS);
@@ -185,16 +176,14 @@ describe("GitHub config", () => {
   it("defaults omitted explicit VERCEL_ENV to development", () => {
     vi.stubEnv("VERCEL_ENV", "production");
 
-    const config = getGitHubAppConfig({
-      env: {
-        GITHUB_API_VERSION: "2022-11-28",
-        GITHUB_APP_CLIENT_ID: "github_client_test",
-        GITHUB_APP_CLIENT_SECRET: "github_secret_test",
-        GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
-        GITHUB_APP_ID: "12345",
-        GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
-        GITHUB_APP_SLUG: "lightfast-test",
-      },
+    const config = parseGitHubAppConfig({
+      GITHUB_API_VERSION: "2022-11-28",
+      GITHUB_APP_CLIENT_ID: "github_client_test",
+      GITHUB_APP_CLIENT_SECRET: "github_secret_test",
+      GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
+      GITHUB_APP_SLUG: "lightfast-test",
     });
 
     expect(config.endpoints.apiBaseUrl).toBe(
@@ -204,11 +193,9 @@ describe("GitHub config", () => {
 
   it("rejects incomplete explicit config env", () => {
     expect(() =>
-      getGitHubAppConfig({
-        env: {
-          GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
-          VERCEL_ENV: "development",
-        },
+      parseGitHubAppConfig({
+        GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
+        VERCEL_ENV: "development",
       })
     ).toThrow("GitHub App environment is incomplete.");
   });
@@ -216,26 +203,9 @@ describe("GitHub config", () => {
   it.each([
     "preview",
     "production",
-  ] as const)("getGitHubAppConfig rejects custom endpoint origins in %s", (vercelEnv) => {
+  ] as const)("parseGitHubAppConfig rejects custom endpoint origins in %s", (vercelEnv) => {
     expect(() =>
-      getGitHubAppConfig({
-        env: {
-          GITHUB_API_VERSION: "2022-11-28",
-          GITHUB_APP_CLIENT_ID: "github_client_test",
-          GITHUB_APP_CLIENT_SECRET: "github_secret_test",
-          GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
-          GITHUB_APP_ID: "12345",
-          GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
-          GITHUB_APP_SLUG: "lightfast-test",
-          VERCEL_ENV: vercelEnv,
-        },
-      })
-    ).toThrow(/custom GitHub endpoints are allowed only in local development/);
-  });
-
-  it("returns complete GitHub App config when required values are present", () => {
-    const config = getGitHubAppConfig({
-      env: {
+      parseGitHubAppConfig({
         GITHUB_API_VERSION: "2022-11-28",
         GITHUB_APP_CLIENT_ID: "github_client_test",
         GITHUB_APP_CLIENT_SECRET: "github_secret_test",
@@ -243,8 +213,21 @@ describe("GitHub config", () => {
         GITHUB_APP_ID: "12345",
         GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
         GITHUB_APP_SLUG: "lightfast-test",
-        VERCEL_ENV: "development",
-      },
+        VERCEL_ENV: vercelEnv,
+      })
+    ).toThrow(/custom GitHub endpoints are allowed only in local development/);
+  });
+
+  it("returns complete GitHub App config when required values are present", () => {
+    const config = parseGitHubAppConfig({
+      GITHUB_API_VERSION: "2022-11-28",
+      GITHUB_APP_CLIENT_ID: "github_client_test",
+      GITHUB_APP_CLIENT_SECRET: "github_secret_test",
+      GITHUB_APP_ENDPOINT_ORIGIN: "https://github.lightfast.localhost",
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_PRIVATE_KEY: "line1\\nline2",
+      GITHUB_APP_SLUG: "lightfast-test",
+      VERCEL_ENV: "development",
     });
 
     expect(config).toMatchObject({

--- a/api/app/src/__tests__/github-config.test.ts
+++ b/api/app/src/__tests__/github-config.test.ts
@@ -121,6 +121,28 @@ describe("GitHub config", () => {
     );
   });
 
+  it("rejects incomplete ambient config when env validation is skipped", async () => {
+    vi.stubEnv("GITHUB_API_VERSION", "2022-11-28");
+    vi.stubEnv("GITHUB_APP_CLIENT_ID", "github_client_test");
+    vi.stubEnv("GITHUB_APP_CLIENT_SECRET", "github_secret_test");
+    vi.stubEnv("GITHUB_APP_ENDPOINT_ORIGIN", "");
+    vi.stubEnv("GITHUB_APP_ID", "12345");
+    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+    vi.stubEnv("GITHUB_APP_SLUG", "lightfast-test");
+    vi.stubEnv("GITHUB_INSTALL_URL_OVERRIDE", "");
+    vi.stubEnv("SKIP_ENV_VALIDATION", "1");
+    vi.stubEnv("VERCEL_ENV", "development");
+    vi.resetModules();
+
+    const { getGitHubAppConfig: getRuntimeGitHubAppConfig } = await import(
+      "../services/github/config"
+    );
+
+    expect(() => getRuntimeGitHubAppConfig()).toThrow(
+      "GitHub App environment is incomplete."
+    );
+  });
+
   it("keeps getGitHubAppConfig ambient-only at the type interface", () => {
     const runtimeConfigIsAmbientOnly: Parameters<
       typeof getGitHubAppConfig

--- a/api/app/src/env.ts
+++ b/api/app/src/env.ts
@@ -24,12 +24,12 @@ export const env = createEnv({
         "ENCRYPTION_KEY must be 32 bytes as 64 hex chars or 44 base64 chars"
       ),
     GITHUB_API_VERSION: z.string().min(1).default("2022-11-28"),
-    GITHUB_APP_CLIENT_ID: z.string().min(1).optional(),
-    GITHUB_APP_CLIENT_SECRET: z.string().min(1).optional(),
-    GITHUB_APP_ID: z.string().min(1).optional(),
-    GITHUB_APP_PRIVATE_KEY: z.string().min(1).optional(),
-    GITHUB_APP_SLUG: z.string().min(1).optional(),
-    GITHUB_APP_WEBHOOK_SECRET: z.string().min(1).optional(),
+    GITHUB_APP_CLIENT_ID: z.string().min(1),
+    GITHUB_APP_CLIENT_SECRET: z.string().min(1),
+    GITHUB_APP_ID: z.string().min(1),
+    GITHUB_APP_PRIVATE_KEY: z.string().min(1),
+    GITHUB_APP_SLUG: z.string().min(1),
+    GITHUB_APP_WEBHOOK_SECRET: z.string().min(1),
     GITHUB_APP_ENDPOINT_ORIGIN: z.string().url().optional(),
     CONNECTOR_MCP_AUTH_SECRET: isConnectorMcpAuthSecretRequired
       ? z.string().min(32)

--- a/api/app/src/services/github/config.ts
+++ b/api/app/src/services/github/config.ts
@@ -36,6 +36,15 @@ interface GitHubAppConfigEnv {
   VERCEL_ENV?: "development" | "preview" | "production";
 }
 
+interface RequiredGitHubAppConfigValues {
+  apiVersion: string;
+  appId: string;
+  appSlug: string;
+  clientId: string;
+  clientSecret: string;
+  privateKey: string;
+}
+
 export function normalizeGitHubPrivateKey(value: string): string {
   return value.replace(/\\n/g, "\n");
 }
@@ -116,18 +125,6 @@ export function parseGitHubAppConfig(
 
   const required = parseRequiredGitHubAppConfig(configEnv);
 
-  if (
-    !(
-      required.appId &&
-      required.appSlug &&
-      required.clientId &&
-      required.clientSecret &&
-      required.privateKey
-    )
-  ) {
-    throw new Error("GitHub App environment is incomplete.");
-  }
-
   return {
     apiVersion: required.apiVersion,
     appId: required.appId,
@@ -144,25 +141,42 @@ export function getGitHubAppConfig(): GitHubAppConfig {
     endpointOrigin: runtimeEnv.GITHUB_APP_ENDPOINT_ORIGIN,
     vercelEnv: runtimeEnv.VERCEL_ENV,
   });
+  const required = parseRequiredGitHubAppConfig(runtimeEnv);
 
   return {
-    apiVersion: runtimeEnv.GITHUB_API_VERSION,
-    appId: runtimeEnv.GITHUB_APP_ID,
-    appSlug: runtimeEnv.GITHUB_APP_SLUG,
-    clientId: runtimeEnv.GITHUB_APP_CLIENT_ID,
-    clientSecret: runtimeEnv.GITHUB_APP_CLIENT_SECRET,
+    apiVersion: required.apiVersion,
+    appId: required.appId,
+    appSlug: required.appSlug,
+    clientId: required.clientId,
+    clientSecret: required.clientSecret,
     endpoints,
-    privateKey: normalizeGitHubPrivateKey(runtimeEnv.GITHUB_APP_PRIVATE_KEY),
+    privateKey: normalizeGitHubPrivateKey(required.privateKey),
   };
 }
 
-function parseRequiredGitHubAppConfig(configEnv: GitHubAppConfigEnv) {
-  return {
+function parseRequiredGitHubAppConfig(
+  configEnv: GitHubAppConfigEnv
+): RequiredGitHubAppConfigValues {
+  const required = {
     apiVersion: configEnv.GITHUB_API_VERSION ?? "2022-11-28",
     appId: configEnv.GITHUB_APP_ID,
     appSlug: configEnv.GITHUB_APP_SLUG,
     clientId: configEnv.GITHUB_APP_CLIENT_ID,
     clientSecret: configEnv.GITHUB_APP_CLIENT_SECRET,
     privateKey: configEnv.GITHUB_APP_PRIVATE_KEY,
+  };
+  const { appId, appSlug, clientId, clientSecret, privateKey } = required;
+
+  if (!(appId && appSlug && clientId && clientSecret && privateKey)) {
+    throw new Error("GitHub App environment is incomplete.");
+  }
+
+  return {
+    apiVersion: required.apiVersion,
+    appId,
+    appSlug,
+    clientId,
+    clientSecret,
+    privateKey,
   };
 }

--- a/api/app/src/services/github/config.ts
+++ b/api/app/src/services/github/config.ts
@@ -24,7 +24,7 @@ export const DEFAULT_GITHUB_APP_ENDPOINTS: GitHubAppEndpoints = {
   webBaseUrl: "https://github.com",
 };
 
-interface GitHubConfigEnv {
+interface GitHubAppConfigEnv {
   GITHUB_API_VERSION?: string;
   GITHUB_APP_CLIENT_ID?: string;
   GITHUB_APP_CLIENT_SECRET?: string;
@@ -105,31 +105,16 @@ export function resolveGitHubAppEndpoints(
   return resolveOriginUrls(endpointOrigin);
 }
 
-export function getGitHubAppConfig(
-  input: { env?: GitHubConfigEnv } = {}
+export function parseGitHubAppConfig(
+  configEnv: GitHubAppConfigEnv
 ): GitHubAppConfig {
-  const explicitEnv = input.env;
-  const configEnv = explicitEnv ?? runtimeEnv;
-  const endpointsInput: Parameters<typeof resolveGitHubAppEndpoints>[0] = {};
-  if (explicitEnv) {
-    endpointsInput.endpointOrigin = explicitEnv.GITHUB_APP_ENDPOINT_ORIGIN;
-    endpointsInput.legacyInstallUrlOverride =
-      explicitEnv.GITHUB_INSTALL_URL_OVERRIDE;
-    endpointsInput.vercelEnv = explicitEnv.VERCEL_ENV ?? "development";
-  } else {
-    endpointsInput.endpointOrigin = configEnv.GITHUB_APP_ENDPOINT_ORIGIN;
-    endpointsInput.vercelEnv = configEnv.VERCEL_ENV;
-  }
-  const endpoints = resolveGitHubAppEndpoints(endpointsInput);
+  const endpoints = resolveGitHubAppEndpoints({
+    endpointOrigin: configEnv.GITHUB_APP_ENDPOINT_ORIGIN,
+    legacyInstallUrlOverride: configEnv.GITHUB_INSTALL_URL_OVERRIDE,
+    vercelEnv: configEnv.VERCEL_ENV ?? "development",
+  });
 
-  const required = {
-    apiVersion: configEnv.GITHUB_API_VERSION ?? "2022-11-28",
-    appId: configEnv.GITHUB_APP_ID,
-    appSlug: configEnv.GITHUB_APP_SLUG,
-    clientId: configEnv.GITHUB_APP_CLIENT_ID,
-    clientSecret: configEnv.GITHUB_APP_CLIENT_SECRET,
-    privateKey: configEnv.GITHUB_APP_PRIVATE_KEY,
-  };
+  const required = parseRequiredGitHubAppConfig(configEnv);
 
   if (
     !(
@@ -151,5 +136,33 @@ export function getGitHubAppConfig(
     clientSecret: required.clientSecret,
     endpoints,
     privateKey: normalizeGitHubPrivateKey(required.privateKey),
+  };
+}
+
+export function getGitHubAppConfig(): GitHubAppConfig {
+  const endpoints = resolveGitHubAppEndpoints({
+    endpointOrigin: runtimeEnv.GITHUB_APP_ENDPOINT_ORIGIN,
+    vercelEnv: runtimeEnv.VERCEL_ENV,
+  });
+
+  return {
+    apiVersion: runtimeEnv.GITHUB_API_VERSION,
+    appId: runtimeEnv.GITHUB_APP_ID,
+    appSlug: runtimeEnv.GITHUB_APP_SLUG,
+    clientId: runtimeEnv.GITHUB_APP_CLIENT_ID,
+    clientSecret: runtimeEnv.GITHUB_APP_CLIENT_SECRET,
+    endpoints,
+    privateKey: normalizeGitHubPrivateKey(runtimeEnv.GITHUB_APP_PRIVATE_KEY),
+  };
+}
+
+function parseRequiredGitHubAppConfig(configEnv: GitHubAppConfigEnv) {
+  return {
+    apiVersion: configEnv.GITHUB_API_VERSION ?? "2022-11-28",
+    appId: configEnv.GITHUB_APP_ID,
+    appSlug: configEnv.GITHUB_APP_SLUG,
+    clientId: configEnv.GITHUB_APP_CLIENT_ID,
+    clientSecret: configEnv.GITHUB_APP_CLIENT_SECRET,
+    privateKey: configEnv.GITHUB_APP_PRIVATE_KEY,
   };
 }


### PR DESCRIPTION
## Summary
- Require the GitHub App credential env set for all api/app runtime environments.
- Split GitHub runtime config from explicit parsed config so getGitHubAppConfig() trusts validated env.
- Update config/env tests for the always-present GitHub App env contract.

## Test Plan
- pnpm exec ultracite check api/app/src/services/github/config.ts api/app/src/__tests__/github-config.test.ts api/app/src/env.ts api/app/src/__tests__/env.test.ts
- pnpm --filter @api/app test -- src/__tests__/github-config.test.ts src/__tests__/env.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced required GitHub App environment variables, preventing misconfiguration at startup and providing clearer error messages when settings are missing.

* **Tests**
  * Added parameterized tests to validate environment variable validation and configuration parsing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->