### PR TITLE
fix: isolate local infra env overrides

### DIFF
--- a/.agents/skills/lightfast-local-infra/SKILL.md
+++ b/.agents/skills/lightfast-local-infra/SKILL.md
@@ -10,11 +10,11 @@ Local DB/Redis provisioning for this repo. Replaces the old `pnpm db:up`,
 
 ## Boundaries
 
-- No repo runtime scripts, root package scripts, or replacement CLI.
+- No provisioning runtime scripts, root package scripts, or replacement CLI.
 - No interactive `pscale auth login` in the agent shell — ask the human.
 - No provider deletes. `drop` is intentionally deferred.
-- Only write the managed keys listed in `references/env-files.md`. Leave
-  legacy/non-managed keys alone unless the human explicitly prunes.
+- Only write the managed keys listed in `references/env-files.md` to local
+  override files. Do not write DB/Redis credentials to Vercel-pulled env files.
 
 ## First Probes
 

--- a/.agents/skills/lightfast-local-infra/lib/write-env.mjs
+++ b/.agents/skills/lightfast-local-infra/lib/write-env.mjs
@@ -5,8 +5,8 @@
 //
 // Usage:
 //   FOO=bar BAZ=qux node lib/write-env.mjs \
-//     --file apps/app/.vercel/.env.development.local \
-//     --file apps/platform/.vercel/.env.development.local \
+//     --file apps/app/.env.overrides.local \
+//     --file apps/platform/.env.overrides.local \
 //     --set FOO --set BAZ
 //
 // Each --set NAME pulls process.env[NAME] and writes NAME=<value>.

--- a/.agents/skills/lightfast-local-infra/references/env-files.md
+++ b/.agents/skills/lightfast-local-infra/references/env-files.md
@@ -1,19 +1,31 @@
 # Env Files
 
-The setup skill writes durable local runtime credentials to ignored Vercel env
-files. It preserves unrelated lines and replaces only the managed keys.
+The setup skill writes durable local runtime credentials to ignored local
+override env files. Vercel-pulled env files remain owned by `vercel pull` and
+must not store generated local DB/Redis credentials.
 
 ## Target Files
 
 ```text
-apps/app/.vercel/.env.development.local
-apps/platform/.vercel/.env.development.local
+apps/app/.env.overrides.local
+apps/platform/.env.overrides.local
 ```
 
-`@db/app` reads the app env file through:
+`@db/app` reads the app env files through:
 
 ```bash
-dotenv -e ../../apps/app/.vercel/.env.development.local --
+dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --
+```
+
+`dotenv-cli` keeps the first value it sees, so local override files must be
+loaded before `.vercel/.env.development.local`.
+
+Package scripts expose both forms:
+
+```text
+with-env:local   local override file, then Vercel-pulled env file
+with-env:vercel  Vercel-pulled env file only
+with-env         same local override chain as with-env:local
 ```
 
 ## Managed Keys
@@ -35,8 +47,8 @@ KV_REST_API_URL
 KV_REST_API_TOKEN
 ```
 
-Only the keys above are managed. Leave any other keys in the file alone
-unless the human explicitly asks to prune local secrets.
+Only the keys above are managed. Leave any other keys in the override file
+alone unless the human explicitly asks to prune local secrets.
 
 ## Safe Write Helper
 
@@ -49,8 +61,8 @@ For database credentials (after `references/planetscale.md`):
 DATABASE_HOST="$database_host" \
 DATABASE_USERNAME="$database_username" \
 DATABASE_PASSWORD="$database_password" \
-node .claude/skills/lightfast-local-infra/lib/write-env.mjs \
-  --file apps/app/.vercel/.env.development.local \
+node .agents/skills/lightfast-local-infra/lib/write-env.mjs \
+  --file apps/app/.env.overrides.local \
   --set DATABASE_HOST --set DATABASE_USERNAME --set DATABASE_PASSWORD
 ```
 
@@ -59,9 +71,9 @@ For Redis credentials (after `references/upstash.md`):
 ```bash
 KV_REST_API_URL="$kv_rest_api_url" \
 KV_REST_API_TOKEN="$kv_rest_api_token" \
-node .claude/skills/lightfast-local-infra/lib/write-env.mjs \
-  --file apps/app/.vercel/.env.development.local \
-  --file apps/platform/.vercel/.env.development.local \
+node .agents/skills/lightfast-local-infra/lib/write-env.mjs \
+  --file apps/app/.env.overrides.local \
+  --file apps/platform/.env.overrides.local \
   --set KV_REST_API_URL --set KV_REST_API_TOKEN
 ```
 
@@ -70,7 +82,7 @@ node .claude/skills/lightfast-local-infra/lib/write-env.mjs \
 Print key names only:
 
 ```bash
-for file in apps/app/.vercel/.env.development.local apps/platform/.vercel/.env.development.local; do
+for file in apps/app/.env.overrides.local apps/platform/.env.overrides.local; do
   echo "$file"
   awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/{print $1}' "$file" | sort
 done
@@ -80,10 +92,10 @@ Expected managed keys:
 
 ```bash
 for key in DATABASE_HOST DATABASE_USERNAME DATABASE_PASSWORD KV_REST_API_URL KV_REST_API_TOKEN; do
-  grep -q "^$key=" apps/app/.vercel/.env.development.local
+  grep -q "^$key=" apps/app/.env.overrides.local
 done
 
 for key in KV_REST_API_URL KV_REST_API_TOKEN; do
-  grep -q "^$key=" apps/platform/.vercel/.env.development.local
+  grep -q "^$key=" apps/platform/.env.overrides.local
 done
 ```

--- a/.agents/skills/lightfast-local-infra/references/planetscale.md
+++ b/.agents/skills/lightfast-local-infra/references/planetscale.md
@@ -1,7 +1,7 @@
 # PlanetScale Up
 
 `db up` creates or reuses a PlanetScale branch for this checkout and writes a
-fresh branch password to the app env file.
+fresh branch password to the app local override env file.
 
 ## Inputs
 
@@ -20,7 +20,7 @@ app env files.
 ## Compute Identity
 
 ```bash
-eval "$(node .claude/skills/lightfast-local-infra/lib/compute-identity.mjs)"
+eval "$(node .agents/skills/lightfast-local-infra/lib/compute-identity.mjs)"
 ```
 
 This sets `database_name`, `base_branch`, `pscale_branch`, and
@@ -55,8 +55,8 @@ fi
 
 ## Mint Password
 
-PlanetScale shows the plain-text password only once. Write it to the env file
-immediately.
+PlanetScale shows the plain-text password only once. Write it to the local
+override env file immediately.
 
 ```bash
 pscale password create "$database_name" "$pscale_branch" "$pscale_credential_name" --role admin --format json > /tmp/lightfast-pscale-password.json
@@ -68,14 +68,14 @@ database_password=$(node -e 'const d=require("/tmp/lightfast-pscale-password.jso
 test -n "$database_host" && test -n "$database_username" && test -n "$database_password"
 ```
 
-Then write the app env file with `references/env-files.md`.
+Then write the app local override env file with `references/env-files.md`.
 
 ## Baseline Inherited Schema
 
 A branch created from `main` may inherit app tables without matching rows in
 `__drizzle_migrations`. In that state, the migration runner tries to replay
-`0000` against existing tables. Detect the state after the env file contains the
-fresh branch credentials:
+`0000` against existing tables. Detect the state after the local override env
+file contains the fresh branch credentials:
 
 ```bash
 schema_state=$(

--- a/.agents/skills/lightfast-local-infra/references/upstash.md
+++ b/.agents/skills/lightfast-local-infra/references/upstash.md
@@ -1,7 +1,7 @@
 # Upstash Redis Up
 
 `redis up` creates or reuses one Upstash Redis database for this checkout and
-writes REST credentials to the app and platform env files.
+writes REST credentials to the app and platform local override env files.
 
 ## Inputs
 
@@ -19,7 +19,7 @@ runtime code for this V1 setup.
 
 ```bash
 redis_region=${redis_region:-ap-southeast-2}
-eval "$(node .claude/skills/lightfast-local-infra/lib/compute-identity.mjs)"
+eval "$(node .agents/skills/lightfast-local-infra/lib/compute-identity.mjs)"
 ```
 
 This sets `redis_name` (and pscale fields that are unused here).
@@ -40,12 +40,12 @@ output instead of guessing.
 ```bash
 upstash redis list --json > /tmp/lightfast-upstash-list.json
 
-eval "$(node .claude/skills/lightfast-local-infra/lib/upstash-extract.mjs \
+eval "$(node .agents/skills/lightfast-local-infra/lib/upstash-extract.mjs \
   --mode id --file /tmp/lightfast-upstash-list.json --name "$redis_name")"
 
 if [ -z "$redis_id" ]; then
   upstash redis create --name "$redis_name" --region "$redis_region" --json > /tmp/lightfast-upstash-create.json
-  eval "$(node .claude/skills/lightfast-local-infra/lib/upstash-extract.mjs \
+  eval "$(node .agents/skills/lightfast-local-infra/lib/upstash-extract.mjs \
     --mode id --file /tmp/lightfast-upstash-create.json)"
 fi
 
@@ -57,13 +57,14 @@ Fetch details:
 ```bash
 upstash redis get --id "$redis_id" --json > /tmp/lightfast-upstash-db.json
 
-eval "$(node .claude/skills/lightfast-local-infra/lib/upstash-extract.mjs \
+eval "$(node .agents/skills/lightfast-local-infra/lib/upstash-extract.mjs \
   --mode rest --file /tmp/lightfast-upstash-db.json)"
 
 test -n "$kv_rest_api_url" && test -n "$kv_rest_api_token"
 ```
 
-Then write app and platform env files with `references/env-files.md`.
+Then write app and platform local override env files with
+`references/env-files.md`.
 
 ## Verify
 

--- a/.agents/skills/planetscale-drizzle/SKILL.md
+++ b/.agents/skills/planetscale-drizzle/SKILL.md
@@ -23,7 +23,7 @@ database: load `lightfast-db`. Canonical commands: `db/CLAUDE.md`.
 | drizzle-kit | `dialect: "mysql"` (via `createDrizzleConfig` in `@vendor/db`) — **not** `"planetscale"`, which isn't a valid value. `tablesFilter: ["lightfast_*"]`. |
 | No `RETURNING` | MySQL has none. Use `.$returningId()` (returns `{ id }` only). Need other columns? Pre-compute client-side (e.g. `nanoid()` in a `$defaultFn`) or follow with a `SELECT`. Example: `db/app/src/utils/org-binding.ts`. |
 | Migrations | `pnpm db:generate` runs offline from `db/app/`; local dev applies schema with `pnpm db:push` to the worktree branch; CI runs `pnpm db:migrate` against persistent `staging`, then deploys `staging` → `main`. **Never hand-write or edit `.sql`.** |
-| Local dev | Per-worktree PlanetScale branch provisioned by `lightfast-local-infra` (`db up`). Runtime credentials live in `apps/app/.vercel/.env.development.local`. |
+| Local dev | Per-worktree PlanetScale branch provisioned by `lightfast-local-infra` (`db up`). Runtime credentials live in `apps/app/.env.overrides.local`. |
 | Foreign keys | Vitess FK support is limited; the repo avoids `references()`. Prefer application-level referential integrity. |
 
 ## Official PlanetScale docs — fetch when relevant

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ logs
 
 # local env files
 .env
+.env.overrides.local
 .env*.local
 .env.development.local
 .env.test.local

--- a/api/app/package.json
+++ b/api/app/package.json
@@ -56,7 +56,9 @@
     "seed:people": "pnpm with-env tsx scripts/seed-people-signals.ts",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit",
-    "with-env": "dotenv -e ../../apps/app/.vercel/.env.development.local --"
+    "with-env": "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+    "with-env:local": "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+    "with-env:vercel": "dotenv -e ../../apps/app/.vercel/.env.development.local --"
   },
   "dependencies": {
     "@db/app": "workspace:*",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -14,7 +14,9 @@
     "mfe:proxy": "portless run --name lightfast sh -c 'pnpm exec microfrontends proxy ./microfrontends.json --port \"$PORT\" --local-apps lightfast-app lightfast-www --local-app-url lightfast-app=$(portless get app.lightfast) --local-app-url lightfast-www=$(portless get www.lightfast)'",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "with-env": "dotenv -e ./.vercel/.env.development.local --",
+    "with-env": "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+    "with-env:local": "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+    "with-env:vercel": "dotenv -e ./.vercel/.env.development.local --",
     "with-related-projects": "env -S \"$(pnpm --silent --filter @repo/github-emulator env:sh -- --callback-url \"$(portless get lightfast)/api/github/setup\" --public-origin \"$(portless get github.lightfast)\")\n$(pnpm --silent --filter @repo/linear-emulator env:sh -- --public-origin \"$(portless get linear.lightfast)\")\n$(pnpm --silent --filter @repo/x-emulator env:sh -- --callback-url \"$(portless get lightfast)/api/connectors/x/mcp\" --public-origin \"$(portless get x.lightfast)\")\" INNGEST_SERVE_ORIGIN=$(portless get lightfast) NEXT_PUBLIC_APP_URL=$(portless get lightfast) NEXT_PUBLIC_WWW_URL=$(portless get www.lightfast) NEXT_PUBLIC_PLATFORM_URL=$(portless get platform.lightfast) INNGEST_DEV=$(portless get inngest.lightfast) QSTASH_URL=$(portless get qstash.lightfast)"
   },
   "dependencies": {

--- a/apps/app/src/__tests__/local-env-overrides.test.ts
+++ b/apps/app/src/__tests__/local-env-overrides.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(resolve(repoRoot, path), "utf8")) as T;
+}
+
+describe("local env overrides", () => {
+  it("loads local infra overrides before Vercel-pulled app env files", () => {
+    const expectedScripts = new Map([
+      [
+        "apps/app/package.json",
+        {
+          "with-env":
+            "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+          "with-env:local":
+            "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+          "with-env:vercel": "dotenv -e ./.vercel/.env.development.local --",
+        },
+      ],
+      [
+        "apps/platform/package.json",
+        {
+          "with-env":
+            "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+          "with-env:local":
+            "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+          "with-env:vercel": "dotenv -e ./.vercel/.env.development.local --",
+        },
+      ],
+      [
+        "apps/mcp/package.json",
+        {
+          "with-env":
+            "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
+          "with-env:local":
+            "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
+          "with-env:vercel":
+            "dotenv -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
+        },
+      ],
+      [
+        "api/app/package.json",
+        {
+          "with-env":
+            "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+          "with-env:local":
+            "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+          "with-env:vercel":
+            "dotenv -e ../../apps/app/.vercel/.env.development.local --",
+        },
+      ],
+      [
+        "db/app/package.json",
+        {
+          "with-env":
+            "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+          "with-env:local":
+            "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+          "with-env:vercel":
+            "dotenv -e ../../apps/app/.vercel/.env.development.local --",
+        },
+      ],
+    ]);
+
+    for (const [path, expectedScriptsByName] of expectedScripts) {
+      const packageJson = readJson<{ scripts: Record<string, string> }>(path);
+      for (const [scriptName, expected] of Object.entries(
+        expectedScriptsByName
+      )) {
+        expect(packageJson.scripts[scriptName], `${path} ${scriptName}`).toBe(
+          expected
+        );
+      }
+    }
+  });
+
+  it("tracks local override files in package build inputs", () => {
+    const appTurbo = readJson<{ tasks: { build: { inputs: string[] } } }>(
+      "apps/app/turbo.json"
+    );
+    const platformTurbo = readJson<{ tasks: { build: { inputs: string[] } } }>(
+      "apps/platform/turbo.json"
+    );
+    const mcpTurbo = readJson<{ tasks: { build: { inputs: string[] } } }>(
+      "apps/mcp/turbo.json"
+    );
+
+    expect(appTurbo.tasks.build.inputs).toContain(".env.overrides.local");
+    expect(platformTurbo.tasks.build.inputs).toContain(".env.overrides.local");
+    expect(mcpTurbo.tasks.build.inputs).toContain(
+      "../app/.env.overrides.local"
+    );
+  });
+});

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -43,7 +43,7 @@
         "SERVICE_JWT_SECRET",
         "PORT"
       ],
-      "inputs": ["$TURBO_DEFAULT$", ".vercel/.env*"],
+      "inputs": ["$TURBO_DEFAULT$", ".env.overrides.local", ".vercel/.env*"],
       "outputs": [
         ".next/**",
         "!.next/cache/**",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -11,7 +11,9 @@
     "dev:next": "portless run pnpm with-related-projects pnpm with-env next dev --turbo",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "with-env": "dotenv -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
+    "with-env": "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
+    "with-env:local": "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
+    "with-env:vercel": "dotenv -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
     "with-related-projects": "NEXT_PUBLIC_APP_URL=$(portless get lightfast) MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast) INNGEST_DEV=$(portless get inngest.lightfast) QSTASH_URL=$(portless get qstash.lightfast)"
   },
   "dependencies": {

--- a/apps/mcp/turbo.json
+++ b/apps/mcp/turbo.json
@@ -24,7 +24,12 @@
         "SERVICE_JWT_SECRET",
         "PORT"
       ],
-      "inputs": ["$TURBO_DEFAULT$", ".vercel/.env*"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../app/.env.overrides.local",
+        "../app/.vercel/.env*",
+        ".vercel/.env*"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -12,7 +12,9 @@
     "start": "pnpm with-env next start -p 4112",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "with-env": "dotenv -e ./.vercel/.env.development.local --",
+    "with-env": "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+    "with-env:local": "dotenv -e ./.env.overrides.local -e ./.vercel/.env.development.local --",
+    "with-env:vercel": "dotenv -e ./.vercel/.env.development.local --",
     "with-related-projects": "INNGEST_SERVE_ORIGIN=$(portless get platform.lightfast) NEXT_PUBLIC_APP_URL=$(portless get lightfast) NEXT_PUBLIC_WWW_URL=$(portless get www.lightfast) NEXT_PUBLIC_PLATFORM_URL=$(portless get platform.lightfast) INNGEST_DEV=$(portless get inngest.lightfast) QSTASH_URL=$(portless get qstash.lightfast)"
   },
   "dependencies": {

--- a/apps/platform/turbo.json
+++ b/apps/platform/turbo.json
@@ -24,7 +24,7 @@
         "KV_REST_API_TOKEN",
         "PORT"
       ],
-      "inputs": ["$TURBO_DEFAULT$", ".vercel/.env*"],
+      "inputs": ["$TURBO_DEFAULT$", ".env.overrides.local", ".vercel/.env*"],
       "outputs": [
         ".next/**",
         "!.next/cache/**",

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -26,7 +26,7 @@ pnpm db:studio  # Open Drizzle Studio through Portless
 Local PlanetScale branch/password setup is skill-driven. Load
 `.agents/skills/lightfast-local-infra` and use its `db up` runbook to create or
 reuse a branch and write `DATABASE_HOST`, `DATABASE_USERNAME`, and
-`DATABASE_PASSWORD` to `apps/app/.vercel/.env.development.local`.
+`DATABASE_PASSWORD` to `apps/app/.env.overrides.local`.
 
 ## Branch Model & Deploy Pipeline
 

--- a/db/app/package.json
+++ b/db/app/package.json
@@ -38,7 +38,9 @@
     "db:studio": "portless run --name db.lightfast sh -c 'pnpm with-env drizzle-kit studio --config=./src/drizzle.config.ts --host \"$HOST\" --port \"$PORT\"'",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit",
-    "with-env": "dotenv -e ../../apps/app/.vercel/.env.development.local --"
+    "with-env": "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+    "with-env:local": "dotenv -e ../../apps/app/.env.overrides.local -e ../../apps/app/.vercel/.env.development.local --",
+    "with-env:vercel": "dotenv -e ../../apps/app/.vercel/.env.development.local --"
   },
   "dependencies": {
     "@repo/ai": "workspace:*",


### PR DESCRIPTION
## Summary
- Move local DB/Redis credentials out of Vercel-pulled env files into ignored .env.overrides.local files.
- Add explicit with-env:local and with-env:vercel wrappers while preserving with-env for local override loading.
- Update local infra runbooks and add a regression test for env load order and Turbo inputs.

## Test Plan
- pnpm --filter @lightfast/app test src/__tests__/local-env-overrides.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm check .gitignore apps/app/src/__tests__/local-env-overrides.test.ts apps/app/package.json apps/platform/package.json apps/mcp/package.json api/app/package.json db/app/package.json apps/app/turbo.json apps/platform/turbo.json apps/mcp/turbo.json .agents/skills/lightfast-local-infra/SKILL.md .agents/skills/lightfast-local-infra/references/env-files.md .agents/skills/lightfast-local-infra/references/planetscale.md .agents/skills/lightfast-local-infra/references/upstash.md .agents/skills/lightfast-local-infra/lib/write-env.mjs .agents/skills/planetscale-drizzle/SKILL.md db/CLAUDE.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added convenience scripts for environment configuration management across development workspaces, enabling flexible switching between local and cloud-hosted environments.
  * Enhanced build configuration to track local environment override files as input dependencies, ensuring builds invalidate when local configurations change.

* **Tests**
  * Added test suite to verify local environment override precedence and build input tracking across multiple workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->