### PR TITLE
Loosen system health schedules

### DIFF
--- a/api/app/src/__tests__/system-health-workflow.test.ts
+++ b/api/app/src/__tests__/system-health-workflow.test.ts
@@ -49,7 +49,7 @@ describe("systemHealth", () => {
         id: "system-health",
         retries: 0,
         timeouts: { finish: "30s", start: "30s" },
-        triggers: { cron: "* * * * *" },
+        triggers: { cron: "*/30 * * * *" },
       },
       expect.any(Function)
     );

--- a/api/app/src/inngest/workflow/system-health.ts
+++ b/api/app/src/inngest/workflow/system-health.ts
@@ -5,7 +5,7 @@ export const systemHealth = inngest.createFunction(
   {
     id: "system-health",
     retries: 0,
-    triggers: { cron: "* * * * *" },
+    triggers: { cron: "*/30 * * * *" },
     timeouts: {
       finish: "30s",
       start: "30s",

--- a/api/platform/src/__tests__/system-health-workflow.test.ts
+++ b/api/platform/src/__tests__/system-health-workflow.test.ts
@@ -50,7 +50,7 @@ describe("systemHealth", () => {
         idempotency: "event.id",
         retries: 2,
         timeouts: { finish: "30s", start: "30s" },
-        triggers: { cron: "* * * * *" },
+        triggers: { cron: "*/30 * * * *" },
       },
       expect.any(Function)
     );

--- a/api/platform/src/inngest/workflow/system-health.ts
+++ b/api/platform/src/inngest/workflow/system-health.ts
@@ -6,7 +6,7 @@ export const systemHealth = inngest.createFunction(
     id: "system-health",
     idempotency: "event.id",
     retries: 2,
-    triggers: { cron: "* * * * *" },
+    triggers: { cron: "*/30 * * * *" },
     timeouts: {
       finish: "30s",
       start: "30s",


### PR DESCRIPTION
## Summary
- Change app system-health Inngest cron from every minute to every 30 minutes.
- Change platform system-health Inngest cron from every minute to every 30 minutes.
- Update workflow tests to assert the 30-minute schedule.

## Test Plan
- pnpm --filter @api/app test src/__tests__/system-health-workflow.test.ts
- pnpm --filter @api/platform test src/__tests__/system-health-workflow.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted system health monitoring frequency from every minute to every 30 minutes, optimizing resource usage while maintaining health tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->