### PR TITLE
Optimize app Turbo build graph

### DIFF
--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -4,7 +4,7 @@
   "tags": ["app"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["transit"],
       "env": [
         "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
         "NEXT_PUBLIC_SENTRY_DSN",
@@ -43,7 +43,15 @@
         "SERVICE_JWT_SECRET",
         "PORT"
       ],
-      "inputs": ["$TURBO_DEFAULT$", ".env.overrides.local", ".vercel/.env*"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/**/__tests__/**",
+        "!src/**/*.test.*",
+        "!src/**/*.spec.*",
+        "!vitest.config.ts",
+        ".env.overrides.local",
+        ".vercel/.env*"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/**/__tests__/**",
+        "!src/**/*.test.*",
+        "!src/**/*.spec.*",
+        "!vitest.config.ts"
+      ],
       "outputs": [
         ".cache/tsbuildinfo.json",
         "dist/**",
@@ -58,7 +65,14 @@
       "outputs": []
     },
     "transit": {
-      "dependsOn": ["^transit"]
+      "dependsOn": ["^transit"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/**/__tests__/**",
+        "!src/**/*.test.*",
+        "!src/**/*.spec.*",
+        "!vitest.config.ts"
+      ]
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- add a Turborepo transit task so app builds retain dependency-source cache invalidation without running upstream build commands
- switch @lightfast/app build from ^build to the transit node
- exclude test/spec inputs from build hashes

## Verification
- pnpm turbo run build -F @lightfast/app --dry=json
- Vercel preview deployment succeeded: https://lightfast-a4w55icqi-lightfast.vercel.app
- Vercel inspector: https://vercel.com/lightfast/lightfast-app/6QWcrVp79sxXYw5aC7nAHMBndzxe

Vercel preview timings:
- pnpm install: 13.6s
- Next compile: 51s
- Sentry post-compile: 15.3s
- TypeScript: 24.2s
- Turbo build total: 1m38.765s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved build efficiency and cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->