### PR TITLE
Add source control settings loading state

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/loading.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/source-control/loading.tsx
@@ -1,0 +1,13 @@
+import { Loader2 } from "lucide-react";
+
+export default function SourceControlLoading() {
+  return (
+    <div
+      aria-label="Loading source control"
+      className="flex min-h-40 items-center justify-center"
+      role="status"
+    >
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a route-level loading state for the source control settings page.
- Match the existing settings subpage spinner pattern.

## Test Plan
- `pnpm --filter @lightfast/app typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading indicator to the source control settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->