### PR TITLE
Add skills route loading boundary

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/loading.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/skills/loading.tsx
@@ -1,0 +1,3 @@
+export default function SkillsRouteLoading() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add a route-level `loading.tsx` for the skills page.
- Return `null` so the App Router loading boundary renders no additional UI.

## Test Plan
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added route loading configuration for the skills section (no visible UI changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->