### PR TITLE
Use AI Elements stick-to-bottom chat scroll

### DIFF
--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx
@@ -52,26 +52,6 @@ vi.mock("@vendor/ai", () => ({
   tool: vi.fn((definition: unknown) => definition),
 }));
 
-vi.mock("@tanstack/react-virtual", () => ({
-  useVirtualizer: ({
-    count,
-    getItemKey,
-  }: {
-    count: number;
-    getItemKey: (index: number) => string | number;
-  }) => ({
-    getTotalSize: () => count * 120,
-    getVirtualItems: () =>
-      Array.from({ length: count }, (_, index) => ({
-        index,
-        key: getItemKey(index),
-        start: index * 120,
-        size: 120,
-      })),
-    measureElement: () => undefined,
-  }),
-}));
-
 vi.mock("@ai-sdk/react", () => ({
   useChat: (
     options: { id?: string; messages?: WorkspaceAssistantMessageFixture[] } = {}

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/workspace-assistant-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/workspace-assistant-client.tsx
@@ -19,6 +19,7 @@ import {
   type UIMessage,
 } from "@vendor/ai";
 import { useParams } from "next/navigation";
+import type { CSSProperties } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { isResumableStreamEnabled } from "~/app/(chat)/api/chat/resumable-stream-config";
 import { useTRPC } from "~/trpc/react";
@@ -27,6 +28,11 @@ import { ChatMessage } from "./chat-message";
 
 type WorkspaceAssistantConversationResult =
   AppRouterOutputs["org"]["workspace"]["assistant"]["getConversation"];
+
+const messageRowRenderingHints = {
+  containIntrinsicSize: "0 160px",
+  contentVisibility: "auto",
+} satisfies CSSProperties;
 
 interface WorkspaceAssistantClientProps {
   // Stable conversation identity, generated up-front by the route. Feeding this
@@ -161,11 +167,13 @@ export function WorkspaceAssistantClient({
         <>
           <div className="relative min-h-0 flex-1">
             <Conversation className="h-full">
-              <ConversationContent
-                getItemKey={(message) => message.id}
-                items={messages}
-                renderItem={(message, index) => (
-                  <div className="mx-auto w-full max-w-3xl px-5 pt-8 md:px-10">
+              <ConversationContent className="gap-0 p-0 pb-8">
+                {messages.map((message, index) => (
+                  <div
+                    className="mx-auto w-full max-w-3xl px-5 pt-8 md:px-10"
+                    key={message.id}
+                    style={messageRowRenderingHints}
+                  >
                     <ChatMessage
                       isStreaming={
                         status === "streaming" && index === messages.length - 1
@@ -173,8 +181,8 @@ export function WorkspaceAssistantClient({
                       message={message}
                     />
                   </div>
-                )}
-              />
+                ))}
+              </ConversationContent>
               <ConversationScrollButton />
             </Conversation>
           </div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -81,7 +81,6 @@
     "@shikijs/langs": "catalog:",
     "@shikijs/themes": "catalog:",
     "@tanstack/react-table": "catalog:",
-    "@tanstack/react-virtual": "catalog:",
     "@tanstack/table-core": "catalog:",
     "@vendor/ai": "workspace:*",
     "@vendor/forms": "workspace:*",
@@ -109,6 +108,7 @@
     "streamdown": "catalog:",
     "tailwind-merge": "catalog:",
     "tw-animate-css": "catalog:",
+    "use-stick-to-bottom": "catalog:",
     "vaul": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/ui/src/components/ai-elements/conversation.test.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.test.tsx
@@ -1,105 +1,114 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
 } from "./conversation";
 
-vi.mock("@tanstack/react-virtual", () => ({
-  useVirtualizer: ({
-    count,
-    getItemKey,
-  }: {
-    count: number;
-    getItemKey: (index: number) => string | number;
-  }) => {
-    const windowSize = Math.min(count, 5);
-    return {
-      getTotalSize: () => count * 80,
-      getVirtualItems: () =>
-        Array.from({ length: windowSize }, (_, index) => ({
-          index,
-          key: getItemKey(index),
-          start: index * 80,
-          size: 80,
-        })),
-      measureElement: () => undefined,
-    };
+const stickToBottomMock = vi.hoisted(() => ({
+  scrollToBottom: vi.fn(),
+  state: {
+    isAtBottom: true,
   },
 }));
 
-function setGeometry(
-  el: HTMLElement,
-  geo: { scrollTop: number; scrollHeight: number; clientHeight: number }
-) {
-  Object.defineProperty(el, "scrollHeight", {
-    configurable: true,
-    value: geo.scrollHeight,
-  });
-  Object.defineProperty(el, "clientHeight", {
-    configurable: true,
-    value: geo.clientHeight,
-  });
-  el.scrollTop = geo.scrollTop;
-}
+vi.mock("use-stick-to-bottom", async () => {
+  const React = await import("react");
+
+  type StickToBottomProps = React.ComponentProps<"div"> & {
+    initial?: string;
+    resize?: string;
+  };
+
+  const StickToBottom = ({
+    children,
+    className,
+    initial,
+    resize,
+    ...props
+  }: StickToBottomProps) => (
+    <div
+      className={className}
+      data-initial={initial}
+      data-resize={resize}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+
+  StickToBottom.Content = ({
+    children,
+    className,
+    ...props
+  }: React.ComponentProps<"div">) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  );
+
+  return {
+    StickToBottom,
+    useStickToBottomContext: () => ({
+      isAtBottom: stickToBottomMock.state.isAtBottom,
+      scrollToBottom: stickToBottomMock.scrollToBottom,
+    }),
+  };
+});
+
+beforeEach(() => {
+  stickToBottomMock.state.isAtBottom = true;
+  stickToBottomMock.scrollToBottom.mockClear();
+});
 
 describe("Conversation scroll button", () => {
-  it("hides at bottom and shows after scrolling up", () => {
-    const { container } = render(
+  it("hides at bottom and scrolls to the latest message when shown", () => {
+    const { rerender } = render(
       <Conversation>
-        <ConversationContent
-          getItemKey={(item) => item}
-          items={["messages"]}
-          renderItem={(item) => <div style={{ height: 2000 }}>{item}</div>}
-        />
+        <ConversationContent>
+          <div style={{ height: 2000 }}>messages</div>
+        </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
     );
 
-    const scroller = container.querySelector(
-      "[data-slot=conversation-scroller]"
-    ) as HTMLElement;
-    expect(scroller).not.toBeNull();
-
-    // At bottom: scrollTop + clientHeight === scrollHeight → button hidden.
-    setGeometry(scroller, {
-      scrollTop: 1500,
-      scrollHeight: 2000,
-      clientHeight: 500,
-    });
-    fireEvent.scroll(scroller);
     expect(
       screen.queryByRole("button", { name: "Scroll to latest message" })
     ).toBeNull();
 
-    // Scrolled up: gap > threshold → button shows.
-    setGeometry(scroller, {
-      scrollTop: 0,
-      scrollHeight: 2000,
-      clientHeight: 500,
-    });
-    fireEvent.scroll(scroller);
-    expect(
-      screen.queryByRole("button", { name: "Scroll to latest message" })
-    ).not.toBeNull();
+    stickToBottomMock.state.isAtBottom = false;
+    rerender(
+      <Conversation>
+        <ConversationContent>
+          <div style={{ height: 2000 }}>messages</div>
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Scroll to latest message" })
+    );
+
+    expect(stickToBottomMock.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("ConversationContent virtualization", () => {
-  it("renders only the windowed items", () => {
+describe("ConversationContent", () => {
+  it("renders every child so native scrolling can stay attached to the message DOM", () => {
     const items = Array.from({ length: 50 }, (_, i) => `Message ${i + 1}`);
     render(
       <Conversation>
-        <ConversationContent
-          getItemKey={(item) => item}
-          items={items}
-          renderItem={(item) => <div>{item}</div>}
-        />
+        <ConversationContent>
+          {items.map((item) => (
+            <div key={item}>{item}</div>
+          ))}
+        </ConversationContent>
       </Conversation>
     );
 
     expect(screen.queryByText("Message 1")).not.toBeNull();
-    expect(screen.queryByText("Message 40")).toBeNull();
+    expect(screen.queryByText("Message 40")).not.toBeNull();
   });
 });

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -2,148 +2,44 @@
 
 import { Button } from "@repo/ui/components/ui/button";
 import { cn } from "@repo/ui/lib/utils";
-import { useVirtualizer } from "@tanstack/react-virtual";
 import type { UIMessage } from "@vendor/ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
-import type { ComponentProps, ReactNode, RefObject } from "react";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useRef,
-  useState,
-} from "react";
+import type { ComponentProps } from "react";
+import { useCallback } from "react";
+import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
-const STICK_TO_BOTTOM_THRESHOLD_PX = 70;
-
-interface ConversationScrollState {
-  isAtBottom: boolean;
-  scrollRef: RefObject<HTMLDivElement | null>;
-  scrollToBottom: () => void;
-}
-
-const ConversationScrollContext = createContext<ConversationScrollState | null>(
-  null
-);
-
-function useConversationScroll(): ConversationScrollState {
-  const ctx = useContext(ConversationScrollContext);
-  if (!ctx) {
-    throw new Error(
-      "Conversation components must be used within <Conversation>"
-    );
-  }
-  return ctx;
-}
-
-export type ConversationProps = ComponentProps<"div"> & {
+export type ConversationProps = ComponentProps<typeof StickToBottom> & {
   "aria-label"?: string;
 };
 
 export const Conversation = ({
   "aria-label": ariaLabel,
   className,
-  children,
   ...props
-}: ConversationProps) => {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const [isAtBottom, setIsAtBottom] = useState(true);
+}: ConversationProps) => (
+  <StickToBottom
+    aria-label={ariaLabel ?? "Conversation"}
+    className={cn("relative flex-1 overflow-y-hidden", className)}
+    initial="smooth"
+    resize="smooth"
+    role="log"
+    {...props}
+  />
+);
 
-  const recompute = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) {
-      return;
-    }
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    setIsAtBottom(distance <= STICK_TO_BOTTOM_THRESHOLD_PX);
-  }, []);
+export type ConversationContentProps = ComponentProps<
+  typeof StickToBottom.Content
+>;
 
-  const scrollToBottom = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) {
-      return;
-    }
-    el.scrollTo({ top: el.scrollHeight });
-  }, []);
-
-  return (
-    <ConversationScrollContext.Provider
-      value={{ scrollRef, isAtBottom, scrollToBottom }}
-    >
-      <div
-        aria-label={ariaLabel ?? "Conversation"}
-        className={cn("relative flex-1 overflow-hidden", className)}
-        role="log"
-        {...props}
-      >
-        <div
-          className="h-full overflow-y-auto"
-          data-slot="conversation-scroller"
-          onScroll={recompute}
-          ref={scrollRef}
-        >
-          {children}
-        </div>
-      </div>
-    </ConversationScrollContext.Provider>
-  );
-};
-
-const DEFAULT_ESTIMATE_SIZE = 120;
-
-export type ConversationContentProps<T> = Omit<
-  ComponentProps<"div">,
-  "children"
-> & {
-  items: T[];
-  renderItem: (item: T, index: number) => ReactNode;
-  getItemKey: (item: T, index: number) => string;
-  estimateSize?: number;
-};
-
-export const ConversationContent = <T,>({
+export const ConversationContent = ({
   className,
-  items,
-  renderItem,
-  getItemKey,
-  estimateSize = DEFAULT_ESTIMATE_SIZE,
   ...props
-}: ConversationContentProps<T>) => {
-  const { scrollRef } = useConversationScroll();
-
-  const virtualizer = useVirtualizer({
-    count: items.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => estimateSize,
-    getItemKey: (index) => getItemKey(items[index] as T, index),
-    // Native end-anchoring keeps the view pinned to the bottom while the last
-    // row grows during streaming (virtual-core 3.16 options, surfaced through
-    // react-virtual 3.13's VirtualizerOptions import).
-    anchorTo: "end",
-    followOnAppend: "smooth",
-    scrollEndThreshold: STICK_TO_BOTTOM_THRESHOLD_PX,
-  });
-
-  return (
-    <div
-      className={cn("relative w-full", className)}
-      style={{ height: `${virtualizer.getTotalSize()}px` }}
-      {...props}
-    >
-      {virtualizer.getVirtualItems().map((virtualItem) => (
-        <div
-          className="absolute top-0 left-0 w-full"
-          data-index={virtualItem.index}
-          key={virtualItem.key}
-          ref={virtualizer.measureElement}
-          style={{ transform: `translateY(${virtualItem.start}px)` }}
-        >
-          {renderItem(items[virtualItem.index] as T, virtualItem.index)}
-        </div>
-      ))}
-    </div>
-  );
-};
+}: ConversationContentProps) => (
+  <StickToBottom.Content
+    className={cn("flex flex-col gap-8 p-4", className)}
+    {...props}
+  />
+);
 
 export type ConversationEmptyStateProps = ComponentProps<"div"> & {
   title?: string;
@@ -187,7 +83,11 @@ export const ConversationScrollButton = ({
   className,
   ...props
 }: ConversationScrollButtonProps) => {
-  const { isAtBottom, scrollToBottom } = useConversationScroll();
+  const { isAtBottom, scrollToBottom } = useStickToBottomContext();
+
+  const handleScrollToBottom = useCallback(() => {
+    scrollToBottom();
+  }, [scrollToBottom]);
 
   if (isAtBottom) {
     return null;
@@ -200,7 +100,7 @@ export const ConversationScrollButton = ({
         "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full dark:bg-background dark:hover:bg-muted",
         className
       )}
-      onClick={scrollToBottom}
+      onClick={handleScrollToBottom}
       size="icon"
       type="button"
       variant="outline"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ catalogs:
     typescript:
       specifier: ^5.9.2
       version: 5.9.3
+    use-stick-to-bottom:
+      specifier: 1.1.3
+      version: 1.1.3
     vaul:
       specifier: ^1.1.2
       version: 1.1.2
@@ -2480,9 +2483,6 @@ importers:
       '@tanstack/react-table':
         specifier: 'catalog:'
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-virtual':
-        specifier: 'catalog:'
-        version: 3.13.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/table-core':
         specifier: 'catalog:'
         version: 8.21.3
@@ -2564,6 +2564,9 @@ importers:
       tw-animate-css:
         specifier: 'catalog:'
         version: 1.4.0
+      use-stick-to-bottom:
+        specifier: 'catalog:'
+        version: 1.1.3(react@19.2.6)
       vaul:
         specifier: 'catalog:'
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -14586,6 +14589,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-stick-to-bottom@1.1.3:
+    resolution: {integrity: sha512-GgRLdeGhxBxpcbrBbEIEoOKUQ9d46/eaSII+wyv1r9Du+NbCn1W/OE+VddefvRP4+5w/1kATN/6g2/BAC/yowQ==}
+    peerDependencies:
+      react: ^19.2.6
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -27733,6 +27741,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.15
+
+  use-stick-to-bottom@1.1.3(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:


### PR DESCRIPTION
## Summary
- Replace chat conversation virtualization with AI Elements stick-to-bottom scrolling.
- Render workspace chat messages as keyed DOM rows with browser rendering hints for long threads.
- Update tests and package dependencies for the new conversation behavior.

## Test Plan
- pnpm exec vitest run 'src/components/ai-elements/conversation.test.tsx'
- pnpm exec vitest run 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx'
- pnpm --filter @repo/ui typecheck
- pnpm --filter @lightfast/app typecheck