### PR TITLE
Fix Linear OAuth response type

### DIFF
--- a/packages/linear-app-node/src/__tests__/oauth.test.ts
+++ b/packages/linear-app-node/src/__tests__/oauth.test.ts
@@ -24,6 +24,7 @@ describe("buildLinearOAuthAuthorizeUrl", () => {
       "https://linear.test/oauth/authorize"
     );
     expect(url.searchParams.get("actor")).toBe("app");
+    expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("scope")).toBe("read,write");
     expect(url.searchParams.get("state")).toBe("state_123");
     expect(url.searchParams.get("code_challenge")).toBe("challenge_123");

--- a/packages/linear-app-node/src/oauth.ts
+++ b/packages/linear-app-node/src/oauth.ts
@@ -74,6 +74,7 @@ export function buildLinearOAuthAuthorizeUrl(input: {
 
   const url = new URL(oauthAuthorizeUrl);
   url.searchParams.set("actor", "app");
+  url.searchParams.set("response_type", "code");
   url.searchParams.set("client_id", input.clientId);
   url.searchParams.set("redirect_uri", input.callbackUrl);
   url.searchParams.set("scope", "read,write");


### PR DESCRIPTION
## Summary
- Add the required `response_type=code` authorize parameter to the Linear OAuth URL builder.
- Cover the parameter in the Linear OAuth authorize URL unit test.

## Test Plan
- `pnpm --filter @repo/linear-app-node test`
- `pnpm --filter @repo/linear-app-node typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth authorization flow by adding the required response type parameter to ensure proper OAuth 2.0 standard compliance.

* **Tests**
  * Added test assertion to verify OAuth authorization URLs include the correct required parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->