### PR TITLE
Require X connector during org setup

### DIFF
--- a/api/app/src/__tests__/connectors-router.test.ts
+++ b/api/app/src/__tests__/connectors-router.test.ts
@@ -49,6 +49,11 @@ const activeIdentity = {
   userId: "user_current",
 } satisfies AuthIdentity;
 
+const xSetupIdentity = {
+  ...activeIdentity,
+  orgGate: { bindingStatus: "unbound", nextSetupRequirement: "x_connector" },
+} satisfies AuthIdentity;
+
 function adminAccess() {
   return {
     has: ({ role }: { role?: string }) => role === "org:admin",
@@ -65,9 +70,12 @@ function nonAdminAccess() {
   };
 }
 
-function caller(access = adminAccess()) {
+function caller(
+  access = adminAccess(),
+  identity: AuthIdentity = activeIdentity
+) {
   return createCaller({
-    auth: { access, identity: activeIdentity },
+    auth: { access, identity },
     db: {} as Database,
     headers: new Headers(),
   });
@@ -229,6 +237,26 @@ describe("connectorsRouter", () => {
       { enabled: true, provider: "x" }
     );
     expect(disconnectConnectorMock).toHaveBeenCalledWith(expect.anything(), {
+      provider: "x",
+    });
+  });
+
+  it("allows X setup to list connectors and start X OAuth before the org is bound", async () => {
+    await expect(
+      caller(adminAccess(), xSetupIdentity).connectors.list()
+    ).resolves.toEqual([expect.objectContaining({ provider: "linear" })]);
+
+    await expect(
+      caller(adminAccess(), xSetupIdentity).connectors.startConnect({
+        provider: "x",
+      })
+    ).resolves.toEqual({
+      authorizationUrl: "https://linear.test/oauth/authorize",
+      mode: "connect",
+    });
+
+    expect(listConnectorsForOrgMock).toHaveBeenCalled();
+    expect(startConnectorOAuthMock).toHaveBeenCalledWith(expect.anything(), {
       provider: "x",
     });
   });

--- a/api/app/src/__tests__/github-setup-router.test.ts
+++ b/api/app/src/__tests__/github-setup-router.test.ts
@@ -5,6 +5,7 @@ import type { AuthIdentity } from "../auth/identity";
 const clerkGetOrganizationMembershipListMock = vi.fn();
 const completeWatchedSourceControlRepositorySetupMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 const mirrorOrgSetupGateMock = vi.fn();
 const nanoidMock = vi.fn();
 const redisSetMock = vi.fn();
@@ -21,6 +22,7 @@ vi.mock("@db/app", () => ({
   completeWatchedSourceControlRepositorySetup:
     completeWatchedSourceControlRepositorySetupMock,
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
   upsertWatchedSourceControlRepository:
     upsertWatchedSourceControlRepositoryMock,
 }));
@@ -144,6 +146,7 @@ describe("githubSetupRouter", () => {
     clerkGetOrganizationMembershipListMock.mockReset();
     completeWatchedSourceControlRepositorySetupMock.mockReset();
     getActiveOrgBindingMock.mockReset();
+    getCurrentOrgConnectorConnectionMock.mockReset();
     mirrorOrgSetupGateMock.mockReset();
     nanoidMock.mockReset();
     redisGetdelMock.mockReset();
@@ -158,6 +161,9 @@ describe("githubSetupRouter", () => {
       .mockReturnValueOnce("attempt_123456789012345678901234")
       .mockReturnValueOnce("nonce_1234567890123456789012345");
     getActiveOrgBindingMock.mockResolvedValue(undefined);
+    getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+      status: "active",
+    });
     completeWatchedSourceControlRepositorySetupMock.mockResolvedValue({});
     upsertWatchedSourceControlRepositoryMock.mockResolvedValue({});
     createGitHubAppJwtMock.mockResolvedValue("app.jwt");

--- a/api/app/src/__tests__/native-auth-router.test.ts
+++ b/api/app/src/__tests__/native-auth-router.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const clerkGetUserMock = vi.fn();
 const clerkGetOrganizationMembershipListMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 const issueNativeAuthAttemptMock = vi.fn();
 const consumeNativeAuthAttemptMock = vi.fn();
 
@@ -11,6 +12,7 @@ vi.mock("@db/app/client", () => ({ db: {} }));
 
 vi.mock("@db/app", () => ({
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
 }));
 
 vi.mock("@vendor/clerk/env", () => ({
@@ -92,6 +94,10 @@ describe("nativeAuthRouter", () => {
     issueNativeAuthAttemptMock.mockReset();
     consumeNativeAuthAttemptMock.mockReset();
     getActiveOrgBindingMock.mockReset();
+    getCurrentOrgConnectorConnectionMock.mockReset();
+    getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+      status: "active",
+    });
     getActiveOrgBindingMock.mockImplementation(
       async (_db: Database, orgId: string) =>
         orgId === "org_1"

--- a/api/app/src/__tests__/native-oauth-identity.test.ts
+++ b/api/app/src/__tests__/native-oauth-identity.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const authMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 const clerkGetOrganizationMembershipListMock = vi.fn();
 
 vi.mock("@db/app", () => ({
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
 }));
 
 vi.mock("@vendor/clerk/env", () => ({
@@ -36,7 +38,11 @@ describe("native OAuth identity resolution", () => {
   beforeEach(() => {
     authMock.mockReset();
     getActiveOrgBindingMock.mockReset();
+    getCurrentOrgConnectorConnectionMock.mockReset();
     clerkGetOrganizationMembershipListMock.mockReset();
+    getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+      status: "active",
+    });
     getActiveOrgBindingMock.mockResolvedValue({
       metadata: {
         lightfastRepository: {

--- a/api/app/src/__tests__/org-setup-gate.test.ts
+++ b/api/app/src/__tests__/org-setup-gate.test.ts
@@ -2,9 +2,11 @@ import type { Database } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 
 vi.mock("@db/app", () => ({
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
 }));
 
 const { resolveOrgSetupGate } = await import("../auth/org-setup-gate");
@@ -31,9 +33,42 @@ function activeGitHubBinding(
   };
 }
 
+function activeXConnection(overrides: Record<string, unknown> = {}) {
+  return {
+    accessTokenExpiresAt: new Date("2026-06-04T02:00:00.000Z"),
+    clerkOrgId: "org_acme",
+    connectedAt: new Date("2026-06-04T00:00:00.000Z"),
+    connectedByUserId: "user_admin",
+    createdAt: new Date("2026-06-04T00:00:00.000Z"),
+    encryptedAccessToken: "encrypted_access",
+    encryptedRefreshToken: "encrypted_refresh",
+    enabledForAgents: false,
+    enabledForAutomations: true,
+    id: 9,
+    lastToolRefreshAt: new Date("2026-06-04T00:01:00.000Z"),
+    lastToolRefreshErrorAt: null,
+    lastToolRefreshErrorCode: null,
+    mcpEndpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
+    metadata: {},
+    provider: "x",
+    providerActorId: "x_user_1",
+    providerActorName: "@lightfast",
+    providerWorkspaceId: null,
+    providerWorkspaceName: "X",
+    refreshTokenExpiresAt: null,
+    revokedAt: null,
+    scopes: ["tweet.read", "users.read", "offline.access"],
+    status: "active",
+    toolManifest: [],
+    updatedAt: new Date("2026-06-04T00:01:00.000Z"),
+    ...overrides,
+  };
+}
+
 describe("resolveOrgSetupGate", () => {
   beforeEach(() => {
     getActiveOrgBindingMock.mockReset();
+    getCurrentOrgConnectorConnectionMock.mockReset();
   });
 
   it("requires the GitHub org first when no active binding exists", async () => {
@@ -58,7 +93,7 @@ describe("resolveOrgSetupGate", () => {
     });
   });
 
-  it("is bound when the active binding has a matching .lightfast proof", async () => {
+  it("requires the X connector after the .lightfast repository is verified", async () => {
     getActiveOrgBindingMock.mockResolvedValue(
       activeGitHubBinding({
         lightfastRepository: {
@@ -70,6 +105,57 @@ describe("resolveOrgSetupGate", () => {
         },
       })
     );
+    getCurrentOrgConnectorConnectionMock.mockResolvedValue(undefined);
+
+    await expect(
+      resolveOrgSetupGate({ db: {} as Database, clerkOrgId: "org_acme" })
+    ).resolves.toEqual({
+      bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
+    });
+    expect(getCurrentOrgConnectorConnectionMock).toHaveBeenCalledWith(
+      {},
+      { clerkOrgId: "org_acme", provider: "x" }
+    );
+  });
+
+  it("requires the X connector when the current X connection is not active", async () => {
+    getActiveOrgBindingMock.mockResolvedValue(
+      activeGitHubBinding({
+        lightfastRepository: {
+          fullName: "acme/.lightfast",
+          id: "987",
+          installationId: "1001",
+          name: ".lightfast",
+          verifiedAt: "2026-05-30T10:00:00.000Z",
+        },
+      })
+    );
+    getCurrentOrgConnectorConnectionMock.mockResolvedValue(
+      activeXConnection({ status: "error" })
+    );
+
+    await expect(
+      resolveOrgSetupGate({ db: {} as Database, clerkOrgId: "org_acme" })
+    ).resolves.toEqual({
+      bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
+    });
+  });
+
+  it("is bound when GitHub, .lightfast, and X connector requirements are satisfied", async () => {
+    getActiveOrgBindingMock.mockResolvedValue(
+      activeGitHubBinding({
+        lightfastRepository: {
+          fullName: "acme/.lightfast",
+          id: "987",
+          installationId: "1001",
+          name: ".lightfast",
+          verifiedAt: "2026-05-30T10:00:00.000Z",
+        },
+      })
+    );
+    getCurrentOrgConnectorConnectionMock.mockResolvedValue(activeXConnection());
 
     await expect(
       resolveOrgSetupGate({ db: {} as Database, clerkOrgId: "org_acme" })

--- a/api/app/src/__tests__/organization-router.test.ts
+++ b/api/app/src/__tests__/organization-router.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 const authMock = vi.fn();
 const createOrganizationMock = vi.fn();
 const getOrganizationMock = vi.fn();
@@ -32,6 +33,7 @@ vi.mock("@db/app", () => ({
   deletePreClerkNamespaceReservation: deletePreClerkNamespaceReservationMock,
   finalizeNamespaceOperation: finalizeNamespaceOperationMock,
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
   markNamespaceOperationClerkApplied: markNamespaceOperationClerkAppliedMock,
   reserveNamespaceForOperation: reserveNamespaceForOperationMock,
   startNamespaceOperation: startNamespaceOperationMock,
@@ -144,6 +146,7 @@ beforeEach(() => {
   getOrganizationMock.mockReset();
   getOrganizationMembershipListMock.mockReset();
   getActiveOrgBindingMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockReset();
   updateOrganizationMock.mockReset();
   startNamespaceOperationMock.mockReset();
   reserveNamespaceForOperationMock.mockReset();
@@ -169,6 +172,7 @@ beforeEach(() => {
     operation({ clerkOrgId: "org_acme", status: "finalized" })
   );
   isClerkConflictErrorMock.mockReturnValue(false);
+  getCurrentOrgConnectorConnectionMock.mockResolvedValue({ status: "active" });
 });
 
 describe("organization.listUserOrganizations", () => {

--- a/api/app/src/__tests__/resolve.test.ts
+++ b/api/app/src/__tests__/resolve.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const authMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 
 vi.mock("@db/app", () => ({
   getActiveOrgBinding: (...args: unknown[]) => getActiveOrgBindingMock(...args),
+  getCurrentOrgConnectorConnection: (...args: unknown[]) =>
+    getCurrentOrgConnectorConnectionMock(...args),
 }));
 
 vi.mock("@vendor/clerk/env", () => ({
@@ -37,6 +40,8 @@ const db = {} as Database;
 beforeEach(() => {
   authMock.mockReset();
   getActiveOrgBindingMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockResolvedValue({ status: "active" });
 });
 
 function resolve(headers = new Headers()) {

--- a/api/app/src/__tests__/signal-orpc.test.ts
+++ b/api/app/src/__tests__/signal-orpc.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const verifyMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 const createSignalForActorMock = vi.fn();
 const getVisibleSignalByPublicIdMock = vi.fn();
 
@@ -15,6 +16,7 @@ vi.mock("@vendor/unkey/server", () => ({
 vi.mock("@db/app/client", () => ({ db: { kind: "mock-db" } }));
 vi.mock("@db/app", () => ({
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
   getVisibleSignalByPublicId: getVisibleSignalByPublicIdMock,
 }));
 
@@ -51,10 +53,14 @@ function context() {
 beforeEach(() => {
   verifyMock.mockReset();
   getActiveOrgBindingMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockReset();
   createSignalForActorMock.mockReset();
   getVisibleSignalByPublicIdMock.mockReset();
 
   verifyMock.mockResolvedValue(verifyResult());
+  getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+    status: "active",
+  });
   getActiveOrgBindingMock.mockResolvedValue({
     metadata: {
       lightfastRepository: {

--- a/api/app/src/__tests__/skills-index-workflows.test.ts
+++ b/api/app/src/__tests__/skills-index-workflows.test.ts
@@ -5,6 +5,7 @@ const completeWatchedSourceControlRepositorySetupMock = vi.fn();
 const createGitHubAppJwtMock = vi.fn();
 const createGitHubInstallationTokenMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 const getGitHubRepositoryMock = vi.fn();
 const mirrorOrgSetupGateMock = vi.fn();
 const markDeliveryMock = vi.fn();
@@ -91,6 +92,7 @@ vi.mock("@db/app", () => ({
   completeWatchedSourceControlRepositorySetup:
     completeWatchedSourceControlRepositorySetupMock,
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
   markSourceControlWebhookDeliveryStatus: markDeliveryMock,
   upsertWatchedSourceControlRepository:
     upsertWatchedSourceControlRepositoryMock,
@@ -262,6 +264,7 @@ beforeEach(() => {
   createGitHubAppJwtMock.mockReset();
   createGitHubInstallationTokenMock.mockReset();
   getActiveOrgBindingMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockReset();
   getGitHubRepositoryMock.mockReset();
   mirrorOrgSetupGateMock.mockReset();
   markDeliveryMock.mockReset();
@@ -290,6 +293,9 @@ beforeEach(() => {
     provider: "github",
     providerAccountLogin: "acme",
     providerInstallationId: "1001",
+  });
+  getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+    status: "active",
   });
   getGitHubRepositoryMock.mockResolvedValue({
     fullName: "acme/.lightfast",

--- a/api/app/src/auth/org-setup-gate.ts
+++ b/api/app/src/auth/org-setup-gate.ts
@@ -1,5 +1,10 @@
 import type { Database } from "@db/app";
-import { getActiveOrgBinding, type OrgSourceControlBinding } from "@db/app";
+import {
+  getActiveOrgBinding,
+  getCurrentOrgConnectorConnection,
+  type OrgConnectorConnection,
+  type OrgSourceControlBinding,
+} from "@db/app";
 import {
   type GitHubLightfastRepositoryProof,
   githubLightfastRepositoryProofSchema,
@@ -64,7 +69,8 @@ export function hasMatchingGitHubLightfastRepositoryProof(
 }
 
 export function deriveOrgSetupGate(
-  binding: OrgSourceControlBinding | undefined
+  binding: OrgSourceControlBinding | undefined,
+  xConnection?: OrgConnectorConnection
 ): OrgSetupGate {
   if (!(binding && hasGitHubOrgRequirement(binding))) {
     return {
@@ -80,6 +86,13 @@ export function deriveOrgSetupGate(
     };
   }
 
+  if (xConnection?.status !== "active") {
+    return {
+      bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
+    };
+  }
+
   return {
     bindingStatus: "bound",
     nextSetupRequirement: null,
@@ -91,5 +104,13 @@ export async function resolveOrgSetupGate(input: {
   clerkOrgId: string;
 }): Promise<OrgSetupGate> {
   const binding = await getActiveOrgBinding(input.db, input.clerkOrgId);
-  return deriveOrgSetupGate(binding);
+  if (!(binding && hasMatchingGitHubLightfastRepositoryProof(binding))) {
+    return deriveOrgSetupGate(binding);
+  }
+
+  const xConnection = await getCurrentOrgConnectorConnection(input.db, {
+    clerkOrgId: input.clerkOrgId,
+    provider: "x",
+  });
+  return deriveOrgSetupGate(binding, xConnection);
 }

--- a/api/app/src/orpc/__tests__/auth.test.ts
+++ b/api/app/src/orpc/__tests__/auth.test.ts
@@ -3,9 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const verifyMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 
 vi.mock("@db/app/client", () => ({ db: {} }));
-vi.mock("@db/app", () => ({ getActiveOrgBinding: getActiveOrgBindingMock }));
+vi.mock("@db/app", () => ({
+  getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
+}));
 
 vi.mock("@vendor/unkey/server", () => ({
   getUnkeyClient: () => ({
@@ -54,6 +58,10 @@ async function invokeAuth(headers: Headers) {
 beforeEach(() => {
   verifyMock.mockReset();
   getActiveOrgBindingMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+    status: "active",
+  });
   getActiveOrgBindingMock.mockResolvedValue({
     metadata: {
       lightfastRepository: {

--- a/api/app/src/orpc/__tests__/system-health.test.ts
+++ b/api/app/src/orpc/__tests__/system-health.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const verifyMock = vi.fn();
 const getActiveOrgBindingMock = vi.fn();
+const getCurrentOrgConnectorConnectionMock = vi.fn();
 
 vi.mock("@vendor/unkey/server", () => ({
   getUnkeyClient: () => ({
@@ -14,6 +15,7 @@ vi.mock("@db/app/client", () => ({ db: {} }));
 vi.mock("@db/app", () => ({
   createSignal: vi.fn(),
   getActiveOrgBinding: getActiveOrgBindingMock,
+  getCurrentOrgConnectorConnection: getCurrentOrgConnectorConnectionMock,
   getSignalByPublicId: vi.fn(),
   markSignalFailed: vi.fn(),
 }));
@@ -25,6 +27,10 @@ const validKey = `lf_${"a".repeat(40)}`;
 beforeEach(() => {
   verifyMock.mockReset();
   getActiveOrgBindingMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockReset();
+  getCurrentOrgConnectorConnectionMock.mockResolvedValue({
+    status: "active",
+  });
   getActiveOrgBindingMock.mockResolvedValue({
     metadata: {
       lightfastRepository: {

--- a/api/app/src/router/(pending-not-allowed)/connectors.ts
+++ b/api/app/src/router/(pending-not-allowed)/connectors.ts
@@ -15,13 +15,14 @@ import {
 } from "../../services/connectors";
 import {
   boundOrgAdminProcedure,
-  boundOrgProcedure,
   createTRPCRouter,
+  orgAdminProcedure,
+  setupProcedure,
 } from "../../trpc";
 
 export const connectorsRouter = createTRPCRouter({
-  list: boundOrgProcedure.query(async ({ ctx }) => listConnectorsForOrg(ctx)),
-  startConnect: boundOrgAdminProcedure
+  list: setupProcedure.query(async ({ ctx }) => listConnectorsForOrg(ctx)),
+  startConnect: orgAdminProcedure
     .input(connectorStartConnectInputSchema)
     .mutation(async ({ ctx, input }) => startConnectorOAuth(ctx, input)),
   refreshTools: boundOrgAdminProcedure

--- a/api/app/src/services/github/setup/lightfast-repository.ts
+++ b/api/app/src/services/github/setup/lightfast-repository.ts
@@ -2,6 +2,7 @@ import type { Database } from "@db/app";
 import {
   completeWatchedSourceControlRepositorySetup,
   getActiveOrgBinding,
+  getCurrentOrgConnectorConnection,
   upsertWatchedSourceControlRepository,
 } from "@db/app";
 import {
@@ -124,6 +125,18 @@ async function enqueueInitialIdentityRefresh(input: {
   }
 }
 
+async function deriveSetupGateWithConnector(input: {
+  binding: NonNullable<Awaited<ReturnType<typeof getActiveOrgBinding>>>;
+  clerkOrgId: string;
+  db: Database;
+}) {
+  const xConnection = await getCurrentOrgConnectorConnection(input.db, {
+    clerkOrgId: input.clerkOrgId,
+    provider: "x",
+  });
+  return deriveOrgSetupGate(input.binding, xConnection);
+}
+
 export async function verifyGitHubLightfastRepositorySetup(input: {
   clerkOrgId: string;
   db: Database;
@@ -147,7 +160,11 @@ export async function verifyGitHubLightfastRepositorySetup(input: {
     await enqueueInitialIdentityRefresh({
       sourceControlRepositoryId: watchedRepository.id,
     });
-    const gate = deriveOrgSetupGate(binding);
+    const gate = await deriveSetupGateWithConnector({
+      binding,
+      clerkOrgId: input.clerkOrgId,
+      db: input.db,
+    });
     await mirrorOrgSetupGate({
       clerkOrgId: input.clerkOrgId,
       gate,
@@ -242,9 +259,13 @@ export async function verifyGitHubLightfastRepositorySetup(input: {
     sourceControlRepositoryId: watchedRepository.id,
   });
 
-  const gate = deriveOrgSetupGate({
-    ...binding,
-    metadata,
+  const gate = await deriveSetupGateWithConnector({
+    binding: {
+      ...binding,
+      metadata,
+    },
+    clerkOrgId: input.clerkOrgId,
+    db: input.db,
   });
   await mirrorOrgSetupGate({
     clerkOrgId: input.clerkOrgId,

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/layout.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/layout.test.tsx
@@ -15,6 +15,9 @@ let headerPathname = "/acme";
 const notFoundMock = vi.fn(() => {
   throw new Error("NEXT_NOT_FOUND");
 });
+const redirectMock = vi.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`);
+});
 
 vi.mock("@db/app/client", () => ({ db: {} }));
 
@@ -77,6 +80,7 @@ vi.mock("~/components/shell-data-boundary", () => ({
 
 vi.mock("next/navigation", () => ({
   notFound: notFoundMock,
+  redirect: redirectMock,
 }));
 
 vi.mock("next/headers", () => ({
@@ -175,9 +179,36 @@ describe("[slug]/layout — membership/slug access gate", () => {
     expect(notFoundMock).toHaveBeenCalledOnce();
   });
 
-  it("returns a UI-less membership boundary with shell data when org access is allowed", async () => {
+  it("redirects product routes using the DB-derived setup requirement", async () => {
     fetchQueryMock.mockResolvedValue({
       bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
+      org: {
+        id: "org_123",
+        imageUrl: "",
+        name: "Acme",
+        slug: "acme",
+      },
+      role: "org:member",
+    });
+
+    await expect(invoke("acme")).rejects.toThrow(
+      "NEXT_REDIRECT:/acme/tasks/connectors/x"
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith("/acme/tasks/connectors/x");
+    expect(getActiveNamespaceByHandleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "acme"
+    );
+    expect(getBySlugQueryOptionsMock).toHaveBeenCalledWith({ slug: "acme" });
+  });
+
+  it("allows the active setup route for an unbound org", async () => {
+    headerPathname = "/acme/tasks/connectors/x";
+    fetchQueryMock.mockResolvedValue({
+      bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
       org: {
         id: "org_123",
         imageUrl: "",
@@ -194,15 +225,31 @@ describe("[slug]/layout — membership/slug access gate", () => {
     expect(screen.getByTestId("shell-data-boundary")).toHaveTextContent(
       "Workspace"
     );
-    expect(
-      screen.queryByTestId("authenticated-topbar")
-    ).not.toBeInTheDocument();
-    expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
-    expect(getActiveNamespaceByHandleMock).toHaveBeenCalledWith(
-      expect.anything(),
-      "acme"
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("allows settings routes for an unbound org", async () => {
+    headerPathname = "/acme/settings";
+    fetchQueryMock.mockResolvedValue({
+      bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
+      org: {
+        id: "org_123",
+        imageUrl: "",
+        name: "Acme",
+        slug: "acme",
+      },
+      role: "org:member",
+    });
+
+    const element = await invoke("acme");
+
+    render(element);
+
+    expect(screen.getByTestId("shell-data-boundary")).toHaveTextContent(
+      "Workspace"
     );
-    expect(getBySlugQueryOptionsMock).toHaveBeenCalledWith({ slug: "acme" });
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 
   it("renders a user namespace root without trying org membership access", async () => {

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/bind/github/complete-page.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/bind/github/complete-page.test.tsx
@@ -107,6 +107,22 @@ describe("GitHubBindCompleteClient", () => {
     });
   });
 
+  it("routes to the X connector task when that is the next setup requirement", async () => {
+    mutateAsyncMock.mockResolvedValue({
+      bindingStatus: "unbound",
+      nextSetupRequirement: "x_connector",
+    });
+    reloadMock.mockResolvedValue(undefined);
+
+    render(<GitHubBindCompleteClient orgSlug="acme" />);
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledTimes(1);
+      expect(reloadMock).toHaveBeenCalledTimes(1);
+      expect(replaceMock).toHaveBeenCalledWith("/acme/tasks/connectors/x");
+    });
+  });
+
   it("waits for the Clerk session to load before syncing and redirecting", async () => {
     sessionState = { isLoaded: false, session: null };
     mutateAsyncMock.mockResolvedValue({ bindingStatus: "bound" });

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/page.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/page.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redirectMock = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+const fetchQueryMock = vi.fn();
+const getBySlugQueryOptionsMock = vi.fn((input: { slug: string }) => ({
+  queryKey: [["viewer", "organization", "getBySlug"], input],
+}));
+const connectorsListQueryOptionsMock = vi.fn(() => ({
+  queryKey: [["org", "workspace", "connectors", "list"]],
+}));
+const xSetupClientMock = vi.fn(({ orgSlug }: { orgSlug: string }) => (
+  <div data-testid="x-setup-client">{orgSlug}</div>
+));
+
+vi.mock("~/trpc/server", () => ({
+  getQueryClient: () => ({ fetchQuery: fetchQueryMock }),
+  HydrateClient: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  trpc: {
+    org: {
+      workspace: {
+        connectors: {
+          list: { queryOptions: connectorsListQueryOptionsMock },
+        },
+      },
+    },
+    viewer: {
+      organization: {
+        getBySlug: { queryOptions: getBySlugQueryOptionsMock },
+      },
+    },
+  },
+}));
+
+vi.mock(
+  "~/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/_components/x-connector-setup-client",
+  () => ({ XConnectorSetupClient: xSetupClientMock })
+);
+
+const { default: XConnectorSetupPage } = await import(
+  "~/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/page"
+);
+
+function invoke(slug = "acme") {
+  return XConnectorSetupPage({
+    params: Promise.resolve({ slug }),
+  });
+}
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  fetchQueryMock.mockReset();
+  getBySlugQueryOptionsMock.mockClear();
+  connectorsListQueryOptionsMock.mockClear();
+  xSetupClientMock.mockClear();
+});
+
+describe("tasks/connectors/x/page", () => {
+  it("redirects to the earlier setup requirement when X is not next", async () => {
+    fetchQueryMock.mockResolvedValueOnce({
+      bindingStatus: "unbound",
+      nextSetupRequirement: "github_lightfast_repo",
+    });
+
+    await expect(invoke("acme")).rejects.toThrow(
+      "NEXT_REDIRECT:/acme/tasks/github/lightfast-repo"
+    );
+  });
+
+  it("redirects fully bound orgs through X completion for session refresh", async () => {
+    fetchQueryMock.mockResolvedValueOnce({
+      bindingStatus: "bound",
+      nextSetupRequirement: null,
+    });
+
+    await expect(invoke("acme")).rejects.toThrow(
+      "NEXT_REDIRECT:/acme/tasks/connectors/x/complete"
+    );
+  });
+
+  it("prefetches connectors and renders the X setup client when X is required", async () => {
+    fetchQueryMock
+      .mockResolvedValueOnce({
+        bindingStatus: "unbound",
+        nextSetupRequirement: "x_connector",
+      })
+      .mockResolvedValueOnce([]);
+
+    const element = await invoke("acme");
+    render(element);
+
+    expect(screen.getByTestId("x-setup-client")).toHaveTextContent("acme");
+    expect(getBySlugQueryOptionsMock).toHaveBeenCalledWith({ slug: "acme" });
+    expect(connectorsListQueryOptionsMock).toHaveBeenCalled();
+    expect(xSetupClientMock).toHaveBeenCalledWith(
+      { orgSlug: "acme" },
+      undefined
+    );
+  });
+});

--- a/apps/app/src/__tests__/proxy.test.ts
+++ b/apps/app/src/__tests__/proxy.test.ts
@@ -160,6 +160,9 @@ function matchesPattern(pattern: string, pathname: string) {
   if (pattern === "/:slug/tasks/github/lightfast-repo(.*)") {
     return /^\/[^/]+\/tasks\/github\/lightfast-repo(?:\/.*)?$/.test(pathname);
   }
+  if (pattern === "/:slug/tasks/connectors/x(.*)") {
+    return /^\/[^/]+\/tasks\/connectors\/x(?:\/.*)?$/.test(pathname);
+  }
   if (pattern.endsWith("(.*)")) {
     const prefix = pattern.slice(0, -4);
     return pathname === prefix.slice(0, -1) || pathname.startsWith(prefix);
@@ -260,6 +263,7 @@ describe("proxy Nemo composition", () => {
           "/:slug/settings(.*)",
           "/:slug/tasks/bind(.*)",
           "/:slug/tasks/github/lightfast-repo(.*)",
+          "/:slug/tasks/connectors/x(.*)",
         ],
       },
     });
@@ -575,6 +579,26 @@ describe("proxy bound org product route gate", () => {
     );
   });
 
+  it("redirects orgs missing the X connector from the workspace root to the X connector task", async () => {
+    authMock.mockResolvedValue({
+      orgId: "org_123",
+      orgSlug: "acme",
+      sessionClaims: {
+        lf_binding_status: "unbound",
+        lf_next_setup_requirement: "x_connector",
+      },
+      sessionStatus: "active",
+      userId: "user_123",
+    });
+
+    const { response } = await invoke("/acme");
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://app.lightfast.localhost/acme/tasks/connectors/x"
+    );
+  });
+
   it("passes bound orgs through on the workspace root", async () => {
     const { response } = await invoke("/acme");
 
@@ -662,6 +686,24 @@ describe("proxy bound org product route gate", () => {
     });
 
     const { response } = await invoke("/acme/tasks/github/lightfast-repo");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("does not gate the X connector setup route", async () => {
+    authMock.mockResolvedValue({
+      orgId: "org_123",
+      orgSlug: "acme",
+      sessionClaims: {
+        lf_binding_status: "unbound",
+        lf_next_setup_requirement: "x_connector",
+      },
+      sessionStatus: "active",
+      userId: "user_123",
+    });
+
+    const { response } = await invoke("/acme/tasks/connectors/x");
 
     expect(response.status).toBe(200);
     expect(response.headers.get("location")).toBeNull();

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.tsx
@@ -1,14 +1,24 @@
 import { getActiveNamespaceByHandle } from "@db/app";
 import { db } from "@db/app/client";
+import {
+  type OrgSetupGate,
+  pathForSetupRequirement,
+} from "@repo/app-setup-contract";
 import { parseError } from "@vendor/observability/error/next";
 import { log } from "@vendor/observability/log/next";
 import { headers } from "next/headers";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { OrgPageErrorBoundary } from "~/components/errors/org-page-error-boundary";
 import { ShellDataBoundary } from "~/components/shell-data-boundary";
 import { getQueryClient, trpc } from "~/trpc/server";
 
 const LIGHTFAST_PATHNAME_HEADER = "x-lightfast-pathname";
+const ORG_SETUP_EXEMPT_PATH_SUFFIXES = [
+  "/settings",
+  "/tasks/bind",
+  "/tasks/github/lightfast-repo",
+  "/tasks/connectors/x",
+] as const;
 
 interface OrgLayoutProps {
   children: React.ReactNode;
@@ -48,8 +58,9 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     );
   }
 
+  let orgAccess: OrgSetupGate;
   try {
-    await getQueryClient().fetchQuery(
+    orgAccess = await getQueryClient().fetchQuery(
       trpc.viewer.organization.getBySlug.queryOptions({
         slug: orgSlug,
       })
@@ -60,6 +71,16 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
       slug: orgSlug,
     });
     notFound();
+  }
+
+  const requestPathname = await getRequestPathname(orgSlug);
+  const setupRedirectPath = getSetupRedirectPath({
+    gate: orgAccess,
+    orgSlug,
+    pathname: requestPathname,
+  });
+  if (setupRedirectPath) {
+    redirect(setupRedirectPath);
   }
 
   return (
@@ -88,6 +109,32 @@ async function getRequestPathname(handle: string) {
 
 function isNamespaceRootPath(pathname: string, handle: string) {
   return pathname === `/${handle}` || pathname === `/${handle}/`;
+}
+
+function isSetupExemptOrgPath(pathname: string, orgSlug: string) {
+  const orgRoot = `/${orgSlug}`;
+  return ORG_SETUP_EXEMPT_PATH_SUFFIXES.some((suffix) => {
+    const path = `${orgRoot}${suffix}`;
+    return pathname === path || pathname.startsWith(`${path}/`);
+  });
+}
+
+function getSetupRedirectPath(input: {
+  gate: OrgSetupGate;
+  orgSlug: string;
+  pathname: string;
+}) {
+  if (
+    input.gate.bindingStatus === "bound" ||
+    isSetupExemptOrgPath(input.pathname, input.orgSlug)
+  ) {
+    return null;
+  }
+
+  return pathForSetupRequirement({
+    orgSlug: input.orgSlug,
+    requirement: input.gate.nextSetupRequirement,
+  });
 }
 
 function UserNamespaceRoot({ handle }: { handle: string }) {

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/_components/x-connector-setup-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/_components/x-connector-setup-client.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { ArrowUpRight, Loader2 } from "lucide-react";
+import { useTRPC } from "~/trpc/react";
+import { ConnectorIcon } from "../../../../(workspace)/connectors/_components/connector-icons";
+import {
+  type ConnectorCatalogRow,
+  connectionStatus,
+} from "../../../../(workspace)/connectors/_components/connectors-model";
+
+interface XConnectorSetupClientProps {
+  orgSlug: string;
+}
+
+function missingConfigMessage(row: ConnectorCatalogRow) {
+  if (
+    row.connectAvailability.status === "unavailable" &&
+    row.connectAvailability.reason === "missing_config"
+  ) {
+    return row.connectAvailability.missing?.join(", ") ?? "X OAuth";
+  }
+  return null;
+}
+
+function unavailableMessage(row: ConnectorCatalogRow) {
+  if (row.connectAvailability.status === "available") {
+    return null;
+  }
+
+  switch (row.connectAvailability.reason) {
+    case "missing_config":
+      return `X OAuth credentials are not configured: ${missingConfigMessage(row)}.`;
+    case "permission_required":
+      return "Admin access required to connect X.";
+    default:
+      return "X is not available yet.";
+  }
+}
+
+export function XConnectorSetupClient({ orgSlug }: XConnectorSetupClientProps) {
+  const trpc = useTRPC();
+  const listQueryOptions = trpc.org.workspace.connectors.list.queryOptions();
+  const { data: connectors } = useSuspenseQuery({
+    ...listQueryOptions,
+    staleTime: 30_000,
+  });
+  const xConnector = connectors.find((row) => row.provider === "x");
+
+  const startConnectMutation = useMutation(
+    trpc.org.workspace.connectors.startConnect.mutationOptions({
+      meta: { errorTitle: "Failed to connect X" },
+      onSuccess: (result) => {
+        window.location.href = result.authorizationUrl;
+      },
+    })
+  );
+
+  if (!xConnector) {
+    return (
+      <main className="flex min-h-full flex-1 items-center justify-center px-4 pb-32">
+        <section className="w-full max-w-md space-y-3">
+          <h1 className="font-medium font-pp text-2xl text-foreground">
+            Connect X
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            X is not available in this workspace.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const status = xConnector.connection
+    ? connectionStatus(xConnector.connection)
+    : null;
+  const disabled =
+    startConnectMutation.isPending ||
+    xConnector.connectAvailability.status !== "available";
+  const unavailable = unavailableMessage(xConnector);
+  const actionLabel = xConnector.connection ? "Reconnect X" : "Connect X";
+
+  return (
+    <main className="flex min-h-full flex-1 items-center justify-center px-4 pb-32">
+      <section className="w-full max-w-md space-y-5">
+        <div className="w-fit rounded-sm bg-card p-3">
+          <ConnectorIcon provider="x" />
+        </div>
+
+        <div className="space-y-3">
+          <h1 className="font-medium font-pp text-2xl text-foreground">
+            Connect X
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Lightfast needs an X connector before workspace features unlock for{" "}
+            {orgSlug}.
+          </p>
+        </div>
+
+        {xConnector.connection ? (
+          <div className="rounded-lg border border-border bg-muted/30 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-medium text-foreground text-sm">
+                  {xConnector.connection.providerActorName ?? "X account"}
+                </p>
+                <p className="mt-1 text-muted-foreground text-xs">
+                  Current connector status
+                </p>
+              </div>
+              {status ? (
+                <span className="inline-flex shrink-0 items-center gap-1.5 text-foreground text-sm">
+                  <span
+                    className={`size-1.5 rounded-full ${status.dotClass}`}
+                  />
+                  {status.label}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        {unavailable ? (
+          <div
+            className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-destructive text-sm"
+            role="alert"
+          >
+            {unavailable}
+          </div>
+        ) : null}
+
+        <Button
+          className="w-full"
+          disabled={disabled}
+          onClick={() => startConnectMutation.mutate({ provider: "x" })}
+        >
+          {startConnectMutation.isPending ? (
+            <>
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              Connecting...
+            </>
+          ) : (
+            <>
+              {actionLabel}
+              <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
+            </>
+          )}
+        </Button>
+      </section>
+    </main>
+  );
+}

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/complete/_components/x-connector-setup-complete-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/complete/_components/x-connector-setup-complete-client.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { pathForSetupRequirement } from "@repo/app-setup-contract";
+import { Button } from "@repo/ui/components/ui/button";
+import { useMutation } from "@tanstack/react-query";
+import { useSession } from "@vendor/clerk";
+import { Loader2 } from "lucide-react";
+import type { Route } from "next";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTRPC } from "~/trpc/react";
+
+interface XConnectorSetupCompleteClientProps {
+  orgSlug: string;
+}
+
+export function XConnectorSetupCompleteClient({
+  orgSlug,
+}: XConnectorSetupCompleteClientProps) {
+  const trpc = useTRPC();
+  const router = useRouter();
+  const { isLoaded: isSessionLoaded, session } = useSession();
+  const [failed, setFailed] = useState(false);
+  const hasStartedRef = useRef(false);
+
+  const syncMutation = useMutation(
+    trpc.org.setup.github.syncBindingClaim.mutationOptions({
+      meta: { errorTitle: "Failed to finish X connection" },
+    })
+  );
+  const { mutateAsync } = syncMutation;
+
+  const finish = useCallback(async () => {
+    setFailed(false);
+
+    if (!session) {
+      setFailed(true);
+      return;
+    }
+
+    try {
+      const result = await mutateAsync();
+      if (result.bindingStatus !== "bound" && !result.nextSetupRequirement) {
+        setFailed(true);
+        return;
+      }
+
+      await session.reload();
+      if (result.nextSetupRequirement) {
+        router.replace(
+          pathForSetupRequirement({
+            orgSlug,
+            requirement: result.nextSetupRequirement,
+          }) as Route
+        );
+        return;
+      }
+      router.replace(`/${orgSlug}` as Route);
+    } catch {
+      setFailed(true);
+    }
+  }, [mutateAsync, orgSlug, router, session]);
+
+  useEffect(() => {
+    if (!isSessionLoaded || hasStartedRef.current) {
+      return;
+    }
+
+    if (!session) {
+      setFailed(true);
+      return;
+    }
+
+    hasStartedRef.current = true;
+    void finish();
+  }, [finish, isSessionLoaded, session]);
+
+  return (
+    <div className="flex min-h-full flex-1 items-center justify-center px-4 pb-32">
+      <div className="w-full max-w-md space-y-4">
+        <h1 className="font-medium font-pp text-2xl text-foreground">
+          Finishing X connection...
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Lightfast is updating your team session.
+        </p>
+        {failed ? (
+          <Button className="w-full" onClick={() => void finish()}>
+            Retry
+          </Button>
+        ) : (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Syncing X connector
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/complete/page.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/complete/page.tsx
@@ -1,0 +1,13 @@
+import { XConnectorSetupCompleteClient } from "./_components/x-connector-setup-complete-client";
+
+interface XConnectorSetupCompletePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function XConnectorSetupCompletePage({
+  params,
+}: XConnectorSetupCompletePageProps) {
+  const { slug } = await params;
+
+  return <XConnectorSetupCompleteClient orgSlug={slug} />;
+}

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/page.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/page.tsx
@@ -1,0 +1,45 @@
+import { pathForSetupRequirement } from "@repo/app-setup-contract";
+import type { Route } from "next";
+import { redirect } from "next/navigation";
+import { getQueryClient, HydrateClient, trpc } from "~/trpc/server";
+import { XConnectorSetupClient } from "./_components/x-connector-setup-client";
+
+interface XConnectorSetupPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function XConnectorSetupPage({
+  params,
+}: XConnectorSetupPageProps) {
+  const { slug } = await params;
+  const queryClient = getQueryClient();
+  const gate = await queryClient.fetchQuery(
+    trpc.viewer.organization.getBySlug.queryOptions({ slug })
+  );
+
+  if (gate.bindingStatus === "bound") {
+    redirect(`/${slug}/tasks/connectors/x/complete` as Route);
+  }
+
+  if (
+    gate.nextSetupRequirement &&
+    gate.nextSetupRequirement !== "x_connector"
+  ) {
+    redirect(
+      pathForSetupRequirement({
+        orgSlug: slug,
+        requirement: gate.nextSetupRequirement,
+      }) as Route
+    );
+  }
+
+  await queryClient.fetchQuery(
+    trpc.org.workspace.connectors.list.queryOptions()
+  );
+
+  return (
+    <HydrateClient>
+      <XConnectorSetupClient orgSlug={slug} />
+    </HydrateClient>
+  );
+}

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -137,6 +137,11 @@ const ORG_ROUTE_POLICIES = [
     pattern: "/:slug/tasks/github/lightfast-repo(.*)",
     setupExempt: true,
   },
+  {
+    clerkSync: true,
+    pattern: "/:slug/tasks/connectors/x(.*)",
+    setupExempt: true,
+  },
 ] as const;
 
 const ORG_PRODUCT_ROUTE_PATTERNS = ["/:slug", "/:slug/(.*)"] as const;

--- a/packages/app-setup-contract/src/__tests__/app-setup-contract.test.ts
+++ b/packages/app-setup-contract/src/__tests__/app-setup-contract.test.ts
@@ -11,10 +11,11 @@ import {
 } from "../index";
 
 describe("@repo/app-setup-contract", () => {
-  it("defines the two setup requirements in order", () => {
+  it("defines the setup requirements in order", () => {
     expect(ORG_SETUP_REQUIREMENTS).toEqual([
       "github_org",
       "github_lightfast_repo",
+      "x_connector",
     ]);
   });
 
@@ -26,6 +27,9 @@ describe("@repo/app-setup-contract", () => {
     expect(repairIdForSetupRequirement("github_org")).toBe("setup-github-org");
     expect(repairIdForSetupRequirement("github_lightfast_repo")).toBe(
       "setup-github-lightfast-repo"
+    );
+    expect(repairIdForSetupRequirement("x_connector")).toBe(
+      "setup-x-connector"
     );
   });
 
@@ -42,6 +46,12 @@ describe("@repo/app-setup-contract", () => {
         requirement: "github_lightfast_repo",
       })
     ).toBe("/acme/tasks/github/lightfast-repo");
+    expect(
+      pathForSetupRequirement({
+        orgSlug: "acme",
+        requirement: "x_connector",
+      })
+    ).toBe("/acme/tasks/connectors/x");
   });
 
   it("models setup gate states without impossible nullable combinations", () => {

--- a/packages/app-setup-contract/src/index.ts
+++ b/packages/app-setup-contract/src/index.ts
@@ -5,6 +5,7 @@ export const LIGHTFAST_REPOSITORY_NAME = ".lightfast" as const;
 export const ORG_SETUP_REQUIREMENTS = [
   "github_org",
   "github_lightfast_repo",
+  "x_connector",
 ] as const;
 
 export type OrgSetupRequirement = (typeof ORG_SETUP_REQUIREMENTS)[number];
@@ -26,7 +27,8 @@ export type OrgSetupGate = z.infer<typeof orgSetupGateSchema>;
 
 export type OrgSetupRepairId =
   | "setup-github-org"
-  | "setup-github-lightfast-repo";
+  | "setup-github-lightfast-repo"
+  | "setup-x-connector";
 
 export function repairIdForSetupRequirement(
   requirement: OrgSetupRequirement
@@ -36,6 +38,8 @@ export function repairIdForSetupRequirement(
       return "setup-github-org";
     case "github_lightfast_repo":
       return "setup-github-lightfast-repo";
+    case "x_connector":
+      return "setup-x-connector";
     default: {
       const exhaustive: never = requirement;
       return exhaustive;
@@ -52,6 +56,8 @@ export function pathForSetupRequirement(input: {
       return `/${input.orgSlug}/tasks/bind`;
     case "github_lightfast_repo":
       return `/${input.orgSlug}/tasks/github/lightfast-repo`;
+    case "x_connector":
+      return `/${input.orgSlug}/tasks/connectors/x`;
     default: {
       const exhaustive: never = input.requirement;
       return exhaustive;


### PR DESCRIPTION
## Summary
- Add `x_connector` as a required org setup step after GitHub org binding and `.lightfast` repository verification.
- Gate org setup on an active current X connector connection and allow the connector list/start flow during setup.
- Add setup-only X connector pages, completion redirect handling, proxy exemptions, and focused coverage.

## Test Plan
- [x] `pnpm check`
- [x] `pnpm --filter @repo/app-setup-contract exec vitest run src/__tests__/app-setup-contract.test.ts`
- [x] `pnpm --filter @api/app test`
- [x] `pnpm --filter @lightfast/app exec vitest run 'src/__tests__/proxy.test.ts' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/connectors/x/page.test.tsx' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/tasks/bind/github/complete-page.test.tsx'`
- [x] `pnpm --filter @repo/app-setup-contract typecheck`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`