### PR TITLE
Fix typed setup redirect route

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from "@repo/app-setup-contract";
 import { parseError } from "@vendor/observability/error/next";
 import { log } from "@vendor/observability/log/next";
+import type { Route } from "next";
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { OrgPageErrorBoundary } from "~/components/errors/org-page-error-boundary";
@@ -80,7 +81,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     pathname: requestPathname,
   });
   if (setupRedirectPath) {
-    redirect(setupRedirectPath);
+    redirect(setupRedirectPath as Route);
   }
 
   return (


### PR DESCRIPTION
## Summary
- Cast the DB-derived setup redirect path to a typed Next `Route` before calling `redirect()`.
- Fixes the Vercel app build failure introduced after PR #805 merged.

## Test Plan
- [x] `pnpm --filter @lightfast/app exec vitest run 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/layout.test.tsx'`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm check`
- [ ] Vercel app preview build