### PR TITLE
feat: gate developer connections behind Vercel flag

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -17,6 +17,10 @@
       "types": "./src/env.ts",
       "default": "./src/env.ts"
     },
+    "./feature-flags": {
+      "types": "./src/feature-flags.ts",
+      "default": "./src/feature-flags.ts"
+    },
     "./services/github": {
       "types": "./src/services/github/index.ts",
       "default": "./src/services/github/index.ts"
@@ -92,6 +96,8 @@
     "@vendor/observability": "workspace:*",
     "@vendor/unkey": "workspace:*",
     "@vendor/upstash": "workspace:*",
+    "@vendor/vercel-flags": "workspace:*",
+    "@vercel/flags-core": "^1.1.0",
     "@vercel/related-projects": "catalog:",
     "drizzle-orm": "catalog:",
     "inngest": "catalog:",

--- a/api/app/src/__tests__/developer-connections-router.test.ts
+++ b/api/app/src/__tests__/developer-connections-router.test.ts
@@ -8,6 +8,7 @@ const connectDeveloperConnectionMock = vi.fn();
 const completeSentryDeveloperConnectionAuthMock = vi.fn();
 const setDeveloperConnectionSandboxEnabledMock = vi.fn();
 const disconnectDeveloperConnectionMock = vi.fn();
+const isDeveloperConnectionsEnabledMock = vi.fn();
 const startSentryDeveloperConnectionAuthMock = vi.fn();
 
 vi.mock("@db/app/client", () => ({ db: {} }));
@@ -32,6 +33,10 @@ vi.mock("../services/developer-connections", () => ({
   setDeveloperConnectionSandboxEnabled:
     setDeveloperConnectionSandboxEnabledMock,
   startSentryDeveloperConnectionAuth: startSentryDeveloperConnectionAuthMock,
+}));
+
+vi.mock("../feature-flags", () => ({
+  isDeveloperConnectionsEnabled: isDeveloperConnectionsEnabledMock,
 }));
 
 const { createCallerFactory, createTRPCRouter } = await import("../trpc");
@@ -75,6 +80,7 @@ function caller(access = adminAccess()) {
 describe("developerConnectionsRouter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isDeveloperConnectionsEnabledMock.mockResolvedValue(true);
     listDeveloperConnectionsForOrgMock.mockResolvedValue([
       { provider: "sentry", canManage: false, connection: null },
     ]);
@@ -102,6 +108,16 @@ describe("developerConnectionsRouter", () => {
     await expect(
       caller(nonAdminAccess()).developerConnections.list()
     ).resolves.toEqual([expect.objectContaining({ provider: "sentry" })]);
+  });
+
+  it("hides developer connections procedures when the feature flag is disabled", async () => {
+    isDeveloperConnectionsEnabledMock.mockResolvedValue(false);
+
+    await expect(caller().developerConnections.list()).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+
+    expect(listDeveloperConnectionsForOrgMock).not.toHaveBeenCalled();
   });
 
   it("does not expose public lease materialization on the workspace router", () => {

--- a/api/app/src/__tests__/developer-connections-service.test.ts
+++ b/api/app/src/__tests__/developer-connections-service.test.ts
@@ -12,6 +12,7 @@ const replaceCurrentDeveloperConnectionMock = vi.fn();
 const setCurrentDeveloperConnectionSandboxEnabledMock = vi.fn();
 const revokeCurrentDeveloperConnectionMock = vi.fn();
 const issueDeveloperConnectionLeaseMock = vi.fn();
+const isDeveloperAuthBoxConfiguredMock = vi.fn(() => true);
 const sentryAuthBoxStartMock = vi.fn();
 const sentryAuthBoxCompleteMock = vi.fn();
 
@@ -43,6 +44,7 @@ vi.mock("@db/app", () => ({
 }));
 
 vi.mock("../services/developer-connections/auth-box", () => ({
+  isDeveloperAuthBoxConfigured: isDeveloperAuthBoxConfiguredMock,
   sentryAuthBoxClient: {
     start: sentryAuthBoxStartMock,
     complete: sentryAuthBoxCompleteMock,
@@ -89,6 +91,7 @@ function ctx(input: { isAdmin?: boolean } = {}) {
 describe("developer connection services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isDeveloperAuthBoxConfiguredMock.mockReturnValue(true);
     listCurrentDeveloperConnectionsMock.mockResolvedValue([]);
     listDeveloperConnectionLeasesForSandboxRunMock.mockResolvedValue([]);
     replaceCurrentDeveloperConnectionMock.mockImplementation(
@@ -156,9 +159,23 @@ describe("developer connection services", () => {
     await expect(listDeveloperConnectionsForOrg(ctx())).resolves.toEqual([
       expect.objectContaining({ provider: "pscale", canManage: true }),
       expect.objectContaining({ provider: "upstash", canManage: true }),
-      expect.objectContaining({ provider: "sentry", canManage: true }),
+      expect.objectContaining({
+        provider: "sentry",
+        canManage: true,
+        sentryBrowserOAuthAvailable: true,
+      }),
       expect.objectContaining({ provider: "clerk", canManage: true }),
     ]);
+  });
+
+  it("marks Sentry browser OAuth unavailable when the auth box is not configured", async () => {
+    isDeveloperAuthBoxConfiguredMock.mockReturnValue(false);
+
+    const rows = await listDeveloperConnectionsForOrg(ctx());
+
+    expect(rows.find((row) => row.provider === "sentry")).toEqual(
+      expect.objectContaining({ sentryBrowserOAuthAvailable: false })
+    );
   });
 
   it("encrypts manual PlanetScale credentials and stores a current org connection", async () => {

--- a/api/app/src/feature-flags.ts
+++ b/api/app/src/feature-flags.ts
@@ -1,0 +1,73 @@
+import { flagsEnv } from "@vendor/vercel-flags/env";
+import { createClient } from "@vercel/flags-core";
+
+interface BooleanFlagDefinition {
+  defaultValue: boolean;
+  key: string;
+}
+
+export const featureFlags = {
+  developerConnections: {
+    defaultValue: false,
+    key: "developer-connections",
+  },
+} as const satisfies Record<string, BooleanFlagDefinition>;
+
+export const DEVELOPER_CONNECTIONS_FLAG_KEY =
+  featureFlags.developerConnections.key;
+
+type FlagsClient = ReturnType<typeof createClient>;
+
+const clientOptions = {
+  stream: { initTimeoutMs: 2000 },
+  polling: { intervalMs: 30_000, initTimeoutMs: 5000 },
+};
+
+let client: FlagsClient | null = null;
+let initPromise: Promise<void> | null = null;
+
+function getFlagsClient(): FlagsClient | null {
+  if (client) {
+    return client;
+  }
+  const sdkKey = flagsEnv.FLAGS;
+  if (!sdkKey) {
+    return null;
+  }
+  client = createClient(sdkKey, clientOptions);
+  return client;
+}
+
+async function ensureInitialized() {
+  const flagsClient = getFlagsClient();
+  if (!flagsClient) {
+    return null;
+  }
+  if (!initPromise) {
+    const result = flagsClient.initialize();
+    initPromise = result instanceof Promise ? result : Promise.resolve();
+  }
+  try {
+    await initPromise;
+  } catch {
+    initPromise = null;
+    return null;
+  }
+  return flagsClient;
+}
+
+async function evaluateBooleanFlag(definition: BooleanFlagDefinition) {
+  const flagsClient = await ensureInitialized();
+  if (!flagsClient) {
+    return definition.defaultValue;
+  }
+  const result = await flagsClient.evaluate<boolean>(
+    definition.key,
+    definition.defaultValue
+  );
+  return result.value ?? definition.defaultValue;
+}
+
+export function isDeveloperConnectionsEnabled() {
+  return evaluateBooleanFlag(featureFlags.developerConnections);
+}

--- a/api/app/src/router/(pending-not-allowed)/developer-connections.ts
+++ b/api/app/src/router/(pending-not-allowed)/developer-connections.ts
@@ -5,6 +5,8 @@ import {
   developerConnectionSetSandboxEnabledInputSchema,
   developerConnectionStartAuthInputSchema,
 } from "@repo/developer-connection-contract";
+import { TRPCError } from "@trpc/server";
+import { isDeveloperConnectionsEnabled } from "../../feature-flags";
 import {
   completeSentryDeveloperConnectionAuth,
   connectDeveloperConnection,
@@ -19,29 +21,54 @@ import {
   createTRPCRouter,
 } from "../../trpc";
 
+function developerConnectionsNotFoundError() {
+  return new TRPCError({
+    code: "NOT_FOUND",
+    message: "Developer connections not found",
+  });
+}
+
+const developerConnectionsProcedure = boundOrgProcedure.use(
+  async ({ next }) => {
+    if (!(await isDeveloperConnectionsEnabled())) {
+      throw developerConnectionsNotFoundError();
+    }
+    return next();
+  }
+);
+
+const developerConnectionsAdminProcedure = boundOrgAdminProcedure.use(
+  async ({ next }) => {
+    if (!(await isDeveloperConnectionsEnabled())) {
+      throw developerConnectionsNotFoundError();
+    }
+    return next();
+  }
+);
+
 export const developerConnectionsRouter = createTRPCRouter({
-  list: boundOrgProcedure.query(async ({ ctx }) =>
+  list: developerConnectionsProcedure.query(async ({ ctx }) =>
     listDeveloperConnectionsForOrg(ctx)
   ),
-  connect: boundOrgAdminProcedure
+  connect: developerConnectionsAdminProcedure
     .input(developerConnectionConnectInputSchema)
     .mutation(async ({ ctx, input }) => connectDeveloperConnection(ctx, input)),
-  startSentryAuth: boundOrgAdminProcedure
+  startSentryAuth: developerConnectionsAdminProcedure
     .input(developerConnectionStartAuthInputSchema)
     .mutation(async ({ ctx, input }) =>
       startSentryDeveloperConnectionAuth(ctx, input)
     ),
-  completeSentryAuth: boundOrgAdminProcedure
+  completeSentryAuth: developerConnectionsAdminProcedure
     .input(developerConnectionCompleteAuthInputSchema)
     .mutation(async ({ ctx, input }) =>
       completeSentryDeveloperConnectionAuth(ctx, input)
     ),
-  setSandboxEnabled: boundOrgAdminProcedure
+  setSandboxEnabled: developerConnectionsAdminProcedure
     .input(developerConnectionSetSandboxEnabledInputSchema)
     .mutation(async ({ ctx, input }) =>
       setDeveloperConnectionSandboxEnabled(ctx, input)
     ),
-  disconnect: boundOrgAdminProcedure
+  disconnect: developerConnectionsAdminProcedure
     .input(developerConnectionProviderInputSchema)
     .mutation(async ({ ctx, input }) =>
       disconnectDeveloperConnection(ctx, input)

--- a/api/app/src/services/developer-connections/auth-box.ts
+++ b/api/app/src/services/developer-connections/auth-box.ts
@@ -29,16 +29,22 @@ export interface SentryAuthBoxClient {
   }): Promise<SentryAuthBoxStartResult>;
 }
 
+export function isDeveloperAuthBoxConfigured() {
+  return Boolean(env.DEVELOPER_AUTH_BOX_ORIGIN && env.DEVELOPER_AUTH_BOX_TOKEN);
+}
+
 function authBoxConfig() {
-  if (!(env.DEVELOPER_AUTH_BOX_ORIGIN && env.DEVELOPER_AUTH_BOX_TOKEN)) {
+  const origin = env.DEVELOPER_AUTH_BOX_ORIGIN;
+  const token = env.DEVELOPER_AUTH_BOX_TOKEN;
+  if (!(origin && token)) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message: "Developer auth box is not configured.",
     });
   }
   return {
-    origin: env.DEVELOPER_AUTH_BOX_ORIGIN.replace(/\/$/, ""),
-    token: env.DEVELOPER_AUTH_BOX_TOKEN,
+    origin: origin.replace(/\/$/, ""),
+    token,
   };
 }
 

--- a/api/app/src/services/developer-connections/catalog.ts
+++ b/api/app/src/services/developer-connections/catalog.ts
@@ -5,6 +5,7 @@ import {
   type DeveloperConnectionProvider,
 } from "@repo/developer-connection-contract";
 import type { AuthContext } from "../../trpc";
+import { isDeveloperAuthBoxConfigured } from "./auth-box";
 
 interface DeveloperConnectionServiceContext {
   auth: AuthContext;
@@ -33,6 +34,7 @@ export interface DeveloperConnectionCatalogRow {
   description: string;
   displayName: string;
   provider: DeveloperConnectionProvider;
+  sentryBrowserOAuthAvailable: boolean;
 }
 
 export function canManageDeveloperConnections(
@@ -92,5 +94,7 @@ export async function listDeveloperConnectionsForOrg(
     canManage,
     connectAvailability: availabilityFor(canManage),
     connection: shapeConnection(byProvider.get(catalogItem.provider)),
+    sentryBrowserOAuthAvailable:
+      catalogItem.provider === "sentry" && isDeveloperAuthBoxConfigured(),
   }));
 }

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/developer-connections-page.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/developer-connections-page.test.tsx
@@ -22,6 +22,7 @@ interface DeveloperConnectionRow {
   description: string;
   displayName: string;
   provider: "pscale" | "upstash" | "sentry" | "clerk";
+  sentryBrowserOAuthAvailable: boolean;
 }
 
 const completeSentryAuthMutateMock = vi.fn();
@@ -36,6 +37,10 @@ const listQueryOptions = {
   queryKey: ["org", "workspace", "developerConnections", "list"],
 };
 const listQueryOptionsMock = vi.fn(() => listQueryOptions);
+const isDeveloperConnectionsEnabledMock = vi.fn();
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
 const setSandboxEnabledMutateMock = vi.fn();
 const startSentryAuthMutateMock = vi.fn();
 const useMutationMock = vi.fn();
@@ -71,6 +76,14 @@ vi.mock("~/trpc/server", () => ({
       },
     },
   },
+}));
+
+vi.mock("@api/app/feature-flags", () => ({
+  isDeveloperConnectionsEnabled: isDeveloperConnectionsEnabledMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
 }));
 
 vi.mock("~/trpc/react", () => ({
@@ -277,6 +290,7 @@ function baseRow(
     description: "Inspect Sentry issues and manage release artifacts.",
     displayName: "Sentry",
     provider: "sentry",
+    sentryBrowserOAuthAvailable: false,
     ...overrides,
   };
 }
@@ -298,8 +312,8 @@ function connectedSentry(
   });
 }
 
-function availableSentry() {
-  return baseRow();
+function availableSentry(overrides: Partial<DeveloperConnectionRow> = {}) {
+  return baseRow({ sentryBrowserOAuthAvailable: true, ...overrides });
 }
 
 function availablePscale() {
@@ -324,6 +338,8 @@ beforeEach(() => {
     delete capturedMutationOptions[key];
   }
   fetchQueryMock.mockResolvedValue([]);
+  isDeveloperConnectionsEnabledMock.mockResolvedValue(true);
+  notFoundMock.mockClear();
   useSuspenseQueryMock.mockReturnValue({ data: [] });
   useMutationMock.mockImplementation(
     (options: {
@@ -352,6 +368,19 @@ beforeEach(() => {
 });
 
 describe("DeveloperConnectionsPage", () => {
+  it("renders not found when the developer connections flag is disabled", async () => {
+    isDeveloperConnectionsEnabledMock.mockResolvedValue(false);
+
+    await expect(
+      DeveloperConnectionsPage({
+        searchParams: Promise.resolve({}),
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFoundMock).toHaveBeenCalledOnce();
+    expect(fetchQueryMock).not.toHaveBeenCalled();
+  });
+
   it("fetches developer connections before rendering hydrated client UI", async () => {
     fetchQueryMock.mockResolvedValue([connectedSentry()]);
     useSuspenseQueryMock.mockReturnValue({ data: [connectedSentry()] });
@@ -442,6 +471,15 @@ describe("DeveloperConnectionsPage", () => {
       provider: "sentry",
       attemptId: "auth_attempt_1",
     });
+  });
+
+  it("hides Sentry browser OAuth when the auth box is unavailable", () => {
+    renderClient([availableSentry({ sentryBrowserOAuthAvailable: false })]);
+
+    fireEvent.click(screen.getByRole("button", { name: /^connect$/i }));
+
+    expect(screen.queryByRole("button", { name: /browser oauth/i })).toBeNull();
+    expect(screen.getByLabelText(/sentry token/i)).toBeVisible();
   });
 
   it("disables management controls for non-admin members", () => {

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/workspace-layout.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/workspace-layout.test.tsx
@@ -6,6 +6,7 @@ const sidebarProviderSpy = vi.fn();
 const appSidebarSpy = vi.fn();
 const authenticatedTopbarSpy = vi.fn();
 const commandMenuSpy = vi.fn();
+const isDeveloperConnectionsEnabledMock = vi.fn();
 
 vi.mock("@repo/ui/components/ui/sidebar", () => ({
   SidebarProvider: (props: { children: ReactNode }) => {
@@ -19,10 +20,14 @@ vi.mock("@repo/ui/components/ui/sidebar", () => ({
 }));
 
 vi.mock("~/components/app-sidebar", () => ({
-  AppSidebar: () => {
-    appSidebarSpy();
+  AppSidebar: (props: { developerConnectionsEnabled?: boolean }) => {
+    appSidebarSpy(props);
     return <div data-testid="app-sidebar" />;
   },
+}));
+
+vi.mock("@api/app/feature-flags", () => ({
+  isDeveloperConnectionsEnabled: () => isDeveloperConnectionsEnabledMock(),
 }));
 
 vi.mock("~/components/authenticated-topbar", () => ({
@@ -51,15 +56,27 @@ beforeEach(() => {
   appSidebarSpy.mockClear();
   authenticatedTopbarSpy.mockClear();
   commandMenuSpy.mockClear();
+  isDeveloperConnectionsEnabledMock.mockReset();
+  isDeveloperConnectionsEnabledMock.mockResolvedValue(false);
 });
 
+async function renderWorkspaceLayout({
+  actions,
+  children,
+}: {
+  actions: ReactNode;
+  children: ReactNode;
+}) {
+  const element = await WorkspaceLayout({ actions, children });
+  render(element);
+}
+
 describe("WorkspaceLayout", () => {
-  it("wraps content with sidebar chrome and authenticated topbar", () => {
-    render(
-      <WorkspaceLayout actions={null}>
-        <div>workspace content</div>
-      </WorkspaceLayout>
-    );
+  it("wraps content with sidebar chrome and authenticated topbar", async () => {
+    await renderWorkspaceLayout({
+      actions: null,
+      children: <div>workspace content</div>,
+    });
 
     expect(sidebarProviderSpy).toHaveBeenCalledTimes(1);
     expect(appSidebarSpy).toHaveBeenCalledTimes(1);
@@ -67,37 +84,48 @@ describe("WorkspaceLayout", () => {
     expect(commandMenuSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("passes the sidebar trigger into the topbar left slot", () => {
-    render(
-      <WorkspaceLayout actions={null}>
-        <div>workspace content</div>
-      </WorkspaceLayout>
-    );
+  it("passes the sidebar trigger into the topbar left slot", async () => {
+    await renderWorkspaceLayout({
+      actions: null,
+      children: <div>workspace content</div>,
+    });
 
     const topbarProps = authenticatedTopbarSpy.mock.calls[0]?.[0];
     expect(topbarProps?.left).toBeTruthy();
   });
 
-  it("forwards the actions slot into the topbar", () => {
-    render(
-      <WorkspaceLayout actions={<div>view switcher</div>}>
-        <div>workspace content</div>
-      </WorkspaceLayout>
-    );
+  it("forwards the actions slot into the topbar", async () => {
+    await renderWorkspaceLayout({
+      actions: <div>view switcher</div>,
+      children: <div>workspace content</div>,
+    });
 
     const topbarProps = authenticatedTopbarSpy.mock.calls[0]?.[0];
     expect(topbarProps?.actions).toBeTruthy();
   });
 
-  it("renders children inside the command menu", () => {
-    render(
-      <WorkspaceLayout actions={null}>
-        <div>workspace content</div>
-      </WorkspaceLayout>
-    );
+  it("renders children inside the command menu", async () => {
+    await renderWorkspaceLayout({
+      actions: null,
+      children: <div>workspace content</div>,
+    });
 
     const commandMenuProps = commandMenuSpy.mock.calls[0]?.[0];
     expect(commandMenuProps?.children).toBeTruthy();
     expect(commandMenuProps).toBeTruthy();
+  });
+
+  it("passes the developer connections flag state to the sidebar", async () => {
+    isDeveloperConnectionsEnabledMock.mockResolvedValue(true);
+
+    await renderWorkspaceLayout({
+      actions: null,
+      children: <div>workspace content</div>,
+    });
+
+    expect(isDeveloperConnectionsEnabledMock).toHaveBeenCalledOnce();
+    expect(appSidebarSpy).toHaveBeenCalledWith({
+      developerConnectionsEnabled: true,
+    });
   });
 });

--- a/apps/app/src/__tests__/components/app-sidebar.test.tsx
+++ b/apps/app/src/__tests__/components/app-sidebar.test.tsx
@@ -160,6 +160,14 @@ vi.mock("@repo/ui/components/ui/popover", () => ({
 
 const { AppSidebar } = await import("~/components/app-sidebar");
 
+function renderSidebar(input: { developerConnectionsEnabled?: boolean } = {}) {
+  render(
+    <AppSidebar
+      developerConnectionsEnabled={input.developerConnectionsEnabled ?? false}
+    />
+  );
+}
+
 beforeEach(() => {
   pathname = "/acme/signals";
   isMobile = false;
@@ -184,7 +192,7 @@ beforeEach(() => {
 
 describe("AppSidebar", () => {
   it("renders workspace links separately from manage links", () => {
-    render(<AppSidebar />);
+    renderSidebar();
 
     expect(screen.getByRole("link", { name: /signals/i })).toHaveAttribute(
       "href",
@@ -211,8 +219,8 @@ describe("AppSidebar", () => {
       "/acme/connectors"
     );
     expect(
-      screen.getByRole("link", { name: /developer connections/i })
-    ).toHaveAttribute("href", "/acme/developer-connections");
+      screen.queryByRole("link", { name: /developer connections/i })
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("region", { name: "Workspace" })
     ).toBeInTheDocument();
@@ -221,7 +229,7 @@ describe("AppSidebar", () => {
 
   it("marks connectors active by route section", () => {
     pathname = "/acme/connectors";
-    render(<AppSidebar />);
+    renderSidebar();
 
     const connectorsLink = screen.getByRole("link", { name: /connectors/i });
     expect(connectorsLink.closest("[data-active]")).toHaveAttribute(
@@ -232,7 +240,7 @@ describe("AppSidebar", () => {
 
   it("marks developer connections active by route section", () => {
     pathname = "/acme/developer-connections";
-    render(<AppSidebar />);
+    renderSidebar({ developerConnectionsEnabled: true });
 
     const link = screen.getByRole("link", {
       name: /developer connections/i,
@@ -243,8 +251,16 @@ describe("AppSidebar", () => {
     );
   });
 
+  it("shows developer connections when the feature flag is enabled", () => {
+    renderSidebar({ developerConnectionsEnabled: true });
+
+    expect(
+      screen.getByRole("link", { name: /developer connections/i })
+    ).toHaveAttribute("href", "/acme/developer-connections");
+  });
+
   it("exposes workspace and manage navigation landmarks", () => {
-    render(<AppSidebar />);
+    renderSidebar();
 
     expect(
       screen.getByRole("navigation", { name: "Workspace" })
@@ -255,7 +271,7 @@ describe("AppSidebar", () => {
   });
 
   it("renders the workspace navigation links in order", () => {
-    render(<AppSidebar />);
+    renderSidebar();
 
     const workspaceLinks = screen
       .getByRole("region", { name: "Workspace" })
@@ -269,7 +285,7 @@ describe("AppSidebar", () => {
 
   it("marks the active nav link with aria-current", () => {
     pathname = "/acme/people";
-    render(<AppSidebar />);
+    renderSidebar();
 
     expect(screen.getByRole("link", { current: "page" })).toHaveAccessibleName(
       "People"
@@ -277,7 +293,7 @@ describe("AppSidebar", () => {
   });
 
   it("renders existing chats in a sidebar container below settings", () => {
-    render(<AppSidebar />);
+    renderSidebar();
 
     const manageLinks = screen
       .getByRole("region", { name: "Manage" })
@@ -307,7 +323,7 @@ describe("AppSidebar", () => {
   });
 
   it("renders a new chat button in the header", () => {
-    render(<AppSidebar />);
+    renderSidebar();
 
     expect(screen.getByRole("link", { name: "New chat" })).toHaveAttribute(
       "href",
@@ -317,7 +333,7 @@ describe("AppSidebar", () => {
 
   it("hides the chats group when there are no conversations", () => {
     conversationsData = { items: [], nextCursor: null };
-    render(<AppSidebar />);
+    renderSidebar();
 
     expect(
       screen.queryByRole("region", { name: "Chats" })
@@ -326,7 +342,7 @@ describe("AppSidebar", () => {
 
   it("marks the active existing chat in the chat history", () => {
     pathname = "/acme/chat/conv_recent";
-    render(<AppSidebar />);
+    renderSidebar();
 
     expect(
       screen
@@ -337,7 +353,7 @@ describe("AppSidebar", () => {
 
   it("does not mark settings active for similar path prefixes", () => {
     pathname = "/acme/settings-archive";
-    render(<AppSidebar />);
+    renderSidebar();
 
     const settingsLink = screen.getByRole("link", { name: /settings/i });
     expect(settingsLink.closest("[data-active]")).toHaveAttribute(
@@ -349,7 +365,7 @@ describe("AppSidebar", () => {
 
   it("closes the mobile sidebar when navigating", () => {
     isMobile = true;
-    render(<AppSidebar />);
+    renderSidebar();
 
     fireEvent.click(screen.getByRole("link", { name: /signals/i }));
 
@@ -358,7 +374,7 @@ describe("AppSidebar", () => {
 
   it("shows a mobile close control", () => {
     isMobile = true;
-    render(<AppSidebar />);
+    renderSidebar();
 
     fireEvent.click(screen.getByRole("button", { name: /close sidebar/i }));
 
@@ -367,7 +383,7 @@ describe("AppSidebar", () => {
 
   it("marks people active by route section", () => {
     pathname = "/acme/people";
-    render(<AppSidebar />);
+    renderSidebar();
 
     const peopleLink = screen.getByRole("link", { name: /people/i });
     expect(peopleLink.closest("[data-active]")).toHaveAttribute(

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/developer-connections/_components/developer-connections-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/developer-connections/_components/developer-connections-client.tsx
@@ -536,52 +536,54 @@ function DeveloperConnectionConnectDialog({
 
           {row.provider === "sentry" ? (
             <>
-              <div className="rounded-[9px] border border-border p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="font-medium text-sm">Browser OAuth</p>
-                    <p className="mt-1 text-muted-foreground text-xs">
-                      Preferred Sentry auth path for admin setup.
-                    </p>
-                  </div>
-                  <Button
-                    disabled={!providerAccountName}
-                    onClick={() => onStartSentryAuth(providerAccountName)}
-                    size="sm"
-                    type="button"
-                    variant="outline"
-                  >
-                    <ArrowUpRight className="mr-1.5 size-3.5" />
-                    Browser OAuth
-                  </Button>
-                </div>
-                {sentryAuthAttempt ? (
-                  <div className="mt-3 rounded-[8px] bg-muted p-3">
-                    <p className="text-muted-foreground text-xs">User code</p>
-                    <p className="mt-1 font-mono text-foreground text-sm">
-                      {sentryAuthAttempt.userCode}
-                    </p>
-                    <a
-                      className="mt-2 inline-flex text-primary text-xs underline"
-                      href={sentryAuthAttempt.verificationUri}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      Open Sentry authorization
-                    </a>
+              {row.sentryBrowserOAuthAvailable ? (
+                <div className="rounded-[9px] border border-border p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-sm">Browser OAuth</p>
+                      <p className="mt-1 text-muted-foreground text-xs">
+                        Preferred Sentry auth path for admin setup.
+                      </p>
+                    </div>
                     <Button
-                      className="mt-3"
-                      onClick={() =>
-                        onCompleteSentryAuth(sentryAuthAttempt.attemptId)
-                      }
+                      disabled={!providerAccountName}
+                      onClick={() => onStartSentryAuth(providerAccountName)}
                       size="sm"
                       type="button"
+                      variant="outline"
                     >
-                      Complete connection
+                      <ArrowUpRight className="mr-1.5 size-3.5" />
+                      Browser OAuth
                     </Button>
                   </div>
-                ) : null}
-              </div>
+                  {sentryAuthAttempt ? (
+                    <div className="mt-3 rounded-[8px] bg-muted p-3">
+                      <p className="text-muted-foreground text-xs">User code</p>
+                      <p className="mt-1 font-mono text-foreground text-sm">
+                        {sentryAuthAttempt.userCode}
+                      </p>
+                      <a
+                        className="mt-2 inline-flex text-primary text-xs underline"
+                        href={sentryAuthAttempt.verificationUri}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Open Sentry authorization
+                      </a>
+                      <Button
+                        className="mt-3"
+                        onClick={() =>
+                          onCompleteSentryAuth(sentryAuthAttempt.attemptId)
+                        }
+                        size="sm"
+                        type="button"
+                      >
+                        Complete connection
+                      </Button>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
               <TextField
                 id="sentry-token"
                 label="Sentry token"

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/developer-connections/page.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/developer-connections/page.tsx
@@ -1,3 +1,5 @@
+import { isDeveloperConnectionsEnabled } from "@api/app/feature-flags";
+import { notFound } from "next/navigation";
 import { getQueryClient, HydrateClient, trpc } from "~/trpc/server";
 import { DeveloperConnectionsClient } from "./_components/developer-connections-client";
 
@@ -15,6 +17,10 @@ export default async function DeveloperConnectionsPage({
     error?: string | string[];
   }>;
 }) {
+  if (!(await isDeveloperConnectionsEnabled())) {
+    notFound();
+  }
+
   const params = await searchParams;
 
   await getQueryClient().fetchQuery(

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/layout.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/layout.tsx
@@ -1,3 +1,4 @@
+import { isDeveloperConnectionsEnabled } from "@api/app/feature-flags";
 import {
   SidebarInset,
   SidebarProvider,
@@ -9,16 +10,18 @@ import { AppSidebar } from "~/components/app-sidebar";
 import { AuthenticatedTopbar } from "~/components/authenticated-topbar";
 import { WorkspaceCommandMenu } from "~/components/workspace-command-menu";
 
-export default function WorkspaceLayout({
+export default async function WorkspaceLayout({
   actions,
   children,
 }: {
   actions: React.ReactNode;
   children: React.ReactNode;
 }) {
+  const developerConnectionsEnabled = await isDeveloperConnectionsEnabled();
+
   return (
     <SidebarProvider className="!h-full !min-h-0 overflow-hidden bg-background">
-      <AppSidebar />
+      <AppSidebar developerConnectionsEnabled={developerConnectionsEnabled} />
       <SidebarInset className="min-h-0 overflow-hidden">
         <AuthenticatedTopbar
           actions={actions}

--- a/apps/app/src/components/app-sidebar.tsx
+++ b/apps/app/src/components/app-sidebar.tsx
@@ -57,8 +57,11 @@ interface NavItem {
   title: string;
 }
 
-function getOrgStandaloneItems(orgSlug: string): NavItem[] {
-  return [
+function getOrgStandaloneItems(
+  orgSlug: string,
+  developerConnectionsEnabled: boolean
+): NavItem[] {
+  const items: NavItem[] = [
     {
       title: "Automations",
       href: `/${orgSlug}/automations`,
@@ -68,11 +71,6 @@ function getOrgStandaloneItems(orgSlug: string): NavItem[] {
       title: "Connectors",
       href: `/${orgSlug}/connectors`,
       icon: Blocks,
-    },
-    {
-      title: "Developer Connections",
-      href: `/${orgSlug}/developer-connections`,
-      icon: KeyRound,
     },
     {
       title: "Skills",
@@ -86,6 +84,16 @@ function getOrgStandaloneItems(orgSlug: string): NavItem[] {
       icon: ListChecks,
     },
   ];
+
+  if (developerConnectionsEnabled) {
+    items.splice(2, 0, {
+      title: "Developer Connections",
+      href: `/${orgSlug}/developer-connections`,
+      icon: KeyRound,
+    });
+  }
+
+  return items;
 }
 
 function getOrgWorkspaceItems(orgSlug: string): NavItem[] {
@@ -254,7 +262,11 @@ function getConversationSidebarTitle(
   return title || "Untitled chat";
 }
 
-export function AppSidebar() {
+export function AppSidebar({
+  developerConnectionsEnabled = false,
+}: {
+  developerConnectionsEnabled?: boolean;
+}) {
   const pathname = usePathname();
   const { isMobile, setOpenMobile } = useSidebar();
 
@@ -311,7 +323,10 @@ export function AppSidebar() {
               <SidebarGroupContent>
                 <SidebarMenu>
                   <NavItems
-                    items={getOrgStandaloneItems(orgSlug)}
+                    items={getOrgStandaloneItems(
+                      orgSlug,
+                      developerConnectionsEnabled
+                    )}
                     pathname={pathname}
                   />
                 </SidebarMenu>

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -23,6 +23,7 @@
         "SENTRY_AUTH_TOKEN",
         "SENTRY_ORG",
         "SENTRY_PROJECT",
+        "FLAGS",
         "BRAINTRUST_API_KEY",
         "CLERK_SECRET_KEY",
         "CLERK_CLI_OAUTH_CLIENT_ID",
@@ -68,6 +69,7 @@
     "dev:next": {
       "persistent": true,
       "passThroughEnv": [
+        "FLAGS",
         "MFE_DISABLE_LOCAL_PROXY_REWRITE",
         "TURBO_TASK_HAS_MFE_PROXY"
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,12 @@ importers:
       '@vendor/upstash':
         specifier: workspace:*
         version: link:../../vendor/upstash
+      '@vendor/vercel-flags':
+        specifier: workspace:*
+        version: link:../../vendor/vercel-flags
+      '@vercel/flags-core':
+        specifier: ^1.1.0
+        version: 1.1.0(flags@4.0.3(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@vercel/related-projects':
         specifier: 'catalog:'
         version: 1.1.0


### PR DESCRIPTION
## Summary

- Adds an app-owned `developer-connections` Vercel flag registry/evaluator that defaults off when `FLAGS` is missing or unresolved.
- Gates Developer Connections across the sidebar, page route, and tRPC router so prod can keep the feature dark while infra work continues.
- Hides Sentry browser OAuth when the external auth box is not configured, and keeps manual token fallback behavior intact.
- Wires `FLAGS` through the app Turbo env while leaving `@vendor/vercel-flags` unchanged in this PR.

## Rollout Notes

- Create/confirm the boolean Vercel flag key: `developer-connections`.
- Keep the flag off in production until external auth/Sentry infrastructure is ready.
- The deferred Sentry emulator investigation lives in #807.

## Test Plan

- `pnpm check`
- `pnpm --dir vendor/vercel-flags typecheck`
- `pnpm --dir api/app typecheck`
- `pnpm --dir apps/app typecheck`
- `pnpm --dir api/app exec vitest run src/__tests__/developer-connections-router.test.ts src/__tests__/developer-connections-service.test.ts`
- `pnpm --dir apps/app exec vitest run "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/developer-connections-page.test.tsx" "src/__tests__/app/(app)/(pending-not-allowed)/[slug]/workspace-layout.test.tsx" src/__tests__/components/app-sidebar.test.tsx`
- `LINEAR_CLIENT_ID=local-linear-client-id LINEAR_CLIENT_SECRET=local-linear-client-secret pnpm build:app`

Note: after rebasing onto current `main`, a plain local `pnpm build:app` reaches page-data collection and then fails on this checkout if `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET` are absent. The prefixed build command above uses temporary local dummy values and does not write provider credentials to env files.
