### PR TITLE
Smooth workspace assistant streaming

### DIFF
--- a/apps/app/src/__tests__/app/api/chat/route.test.ts
+++ b/apps/app/src/__tests__/app/api/chat/route.test.ts
@@ -22,6 +22,7 @@ const markWorkspaceAssistantMessageFailedMock = vi.fn();
 const setWorkspaceAssistantConversationActiveStreamMock = vi.fn();
 const resolveAuthContextFromClerkMock = vi.fn();
 const safeValidateUIMessagesMock = vi.fn();
+const smoothStreamMock = vi.fn();
 const stepCountIsMock = vi.fn();
 const toUIMessageStreamResponseMock = vi.fn();
 const toolMock = vi.fn();
@@ -70,6 +71,7 @@ vi.mock("@vendor/ai", () => ({
   convertToModelMessages: convertToModelMessagesMock,
   gateway: gatewayMock,
   safeValidateUIMessages: safeValidateUIMessagesMock,
+  smoothStream: smoothStreamMock,
   stepCountIs: stepCountIsMock,
   streamText: streamTextMock,
   tool: toolMock,
@@ -127,6 +129,7 @@ beforeEach(() => {
   setWorkspaceAssistantConversationActiveStreamMock.mockReset();
   resolveAuthContextFromClerkMock.mockReset();
   safeValidateUIMessagesMock.mockReset();
+  smoothStreamMock.mockReset();
   stepCountIsMock.mockReset();
   toUIMessageStreamResponseMock.mockReset();
   toolMock.mockReset();
@@ -195,6 +198,7 @@ beforeEach(() => {
     status: "succeeded",
   });
   findProviderRoutinesMock.mockResolvedValue({ routines: [] });
+  smoothStreamMock.mockReturnValue("smooth-stream-transform");
   stepCountIsMock.mockImplementation((count) => ({
     count,
     kind: "step-count",
@@ -394,6 +398,10 @@ describe("chat route", () => {
       },
     ]);
     expect(gatewayMock).toHaveBeenCalledWith("anthropic/claude-sonnet-4.6");
+    expect(smoothStreamMock).toHaveBeenCalledWith({
+      chunking: "word",
+      delayInMs: 20,
+    });
     expect(streamTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         experimental_telemetry: expect.objectContaining({
@@ -402,6 +410,7 @@ describe("chat route", () => {
           recordInputs: false,
           recordOutputs: false,
         }),
+        experimental_transform: "smooth-stream-transform",
         messages: modelMessages,
         model: "gateway:anthropic/claude-sonnet-4.6",
         providerOptions: {

--- a/apps/app/src/app/(chat)/api/chat/route.ts
+++ b/apps/app/src/app/(chat)/api/chat/route.ts
@@ -45,6 +45,7 @@ import {
   convertToModelMessages,
   gateway,
   safeValidateUIMessages,
+  smoothStream,
   stepCountIs,
   streamText,
   tool,
@@ -57,6 +58,10 @@ import { isResumableStreamEnabled } from "~/app/(chat)/api/chat/resumable-stream
 const WORKSPACE_ASSISTANT_MODEL = "anthropic/claude-sonnet-4.6";
 const WORKSPACE_ASSISTANT_FALLBACK_MODELS = ["openai/gpt-5.4"] as const;
 const WORKSPACE_ASSISTANT_MAX_TOOL_STEPS = 5;
+const WORKSPACE_ASSISTANT_STREAM_SMOOTHING = {
+  chunking: "word",
+  delayInMs: 20,
+} as const;
 
 const chatRequestSchema = z
   .object({
@@ -256,6 +261,7 @@ export async function POST(req: Request) {
       recordInputs: false,
       recordOutputs: false,
     },
+    experimental_transform: smoothStream(WORKSPACE_ASSISTANT_STREAM_SMOOTHING),
     messages: modelMessages,
     model: gateway(WORKSPACE_ASSISTANT_MODEL),
     onError: async ({ error }) => {

--- a/vendor/ai/src/index.ts
+++ b/vendor/ai/src/index.ts
@@ -22,6 +22,7 @@ export {
   Output,
   RetryError,
   safeValidateUIMessages,
+  smoothStream,
   stepCountIs,
   streamText,
   tool,


### PR DESCRIPTION
## Summary
- Add AI SDK stream smoothing to the workspace assistant API stream.
- Re-export `smoothStream` through `@vendor/ai`.
- Cover the route wiring with a regression assertion.

## Test Plan
- `pnpm --filter @vendor/ai typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @lightfast/app test`