### PR TITLE
Remove integrations route ownership

### DIFF
--- a/apps/app/microfrontends.json
+++ b/apps/app/microfrontends.json
@@ -63,8 +63,6 @@
           "group": "marketing",
           "paths": [
             "/opengraph-image-:hash",
-            "/integrations",
-            "/integrations/:path*",
             "/api/health",
             "/api/search",
             "/images/:path*",

--- a/apps/app/src/__tests__/microfrontends-config.test.ts
+++ b/apps/app/src/__tests__/microfrontends-config.test.ts
@@ -87,6 +87,8 @@ describe("microfrontends config", () => {
       ])
     );
     expect(oldWwwPaths.has("/pitch-deck")).toBe(false);
+    expect(oldWwwPaths.has("/integrations")).toBe(false);
+    expect(oldWwwPaths.has("/integrations/:path*")).toBe(false);
 
     for (const route of startPaths) {
       expect(oldWwwPaths.has(route)).toBe(false);


### PR DESCRIPTION
## Summary
- Remove stale `/integrations` and `/integrations/:path*` ownership from `apps/app/microfrontends.json`.
- Add negative assertions so the old www MFE table no longer claims integrations routes.

## Stack
- Depends on #812, which depends on #811.

## Test Plan
- `pnpm --filter @lightfast/app exec vitest run src/__tests__/microfrontends-config.test.ts`
- `pnpm --filter @lightfast/app typecheck`