### PR TITLE
Fix hosted MCP proxy app boundary

### DIFF
--- a/apps/app/src/__tests__/app/api/internal/mcp-proxy-route.test.ts
+++ b/apps/app/src/__tests__/app/api/internal/mcp-proxy-route.test.ts
@@ -1,0 +1,269 @@
+import { signServiceJWT } from "@api/app/service-jwt";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assertHostedMcpOrgAccessMock = vi.fn();
+const callProviderRoutineMock = vi.fn();
+const findProviderRoutinesMock = vi.fn();
+
+vi.mock("@api/app/mcp-oauth/resource-access", () => ({
+  assertHostedMcpOrgAccess: assertHostedMcpOrgAccessMock,
+}));
+
+vi.mock("@repo/provider-routines", () => ({
+  callProviderRoutine: callProviderRoutineMock,
+  findProviderRoutines: findProviderRoutinesMock,
+}));
+
+vi.mock("@db/app/client", () => ({
+  db: { kind: "mock-db" },
+}));
+
+vi.mock("~/env", () => ({
+  env: {
+    SERVICE_JWT_SECRET: "test-service-jwt-secret-at-least-32-chars",
+  },
+}));
+
+const jwtSecret = "test-service-jwt-secret-at-least-32-chars";
+
+async function token(
+  input: {
+    audience?: "lightfast-app" | "lightfast-platform";
+    caller?: "app" | "mcp";
+  } = {}
+) {
+  return await signServiceJWT({
+    audience: input.audience ?? "lightfast-app",
+    caller: input.caller ?? "mcp",
+    jwtSecret,
+  });
+}
+
+function proxyCommand(input: { input: unknown }) {
+  return {
+    actor: {
+      clientId: "mcp_client_test",
+      grantId: "mcp_grant_test",
+      kind: "mcp",
+      orgId: "org_test",
+      userId: "user_test",
+    },
+    input: input.input,
+    scopes: {
+      providerRoutineRead: true,
+      providerRoutineWrite: false,
+    },
+  };
+}
+
+function request(
+  pathname: string,
+  body: unknown,
+  bearerToken?: string
+): Request {
+  return new Request(`https://lightfast.ai${pathname}`, {
+    body: JSON.stringify(body),
+    headers: {
+      ...(bearerToken ? { authorization: `Bearer ${bearerToken}` } : {}),
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+}
+
+describe("internal MCP proxy route", () => {
+  beforeEach(() => {
+    assertHostedMcpOrgAccessMock.mockReset();
+    assertHostedMcpOrgAccessMock.mockResolvedValue(undefined);
+    callProviderRoutineMock.mockReset();
+    findProviderRoutinesMock.mockReset();
+  });
+
+  it("rejects missing service bearer tokens", async () => {
+    const { POST } = await import(
+      "~/app/(internal)/api/internal/mcp/proxy/find/route"
+    );
+
+    const res = await POST(
+      request("/api/internal/mcp/proxy/find", proxyCommand({ input: {} }))
+    );
+
+    expect(res.status).toBe(401);
+    expect(findProviderRoutinesMock).not.toHaveBeenCalled();
+  });
+
+  it("finds provider routines after checking app-side organization access", async () => {
+    findProviderRoutinesMock.mockResolvedValueOnce({
+      routines: [
+        {
+          classification: "read",
+          provider: "linear",
+          providerToolName: "list_issues",
+          routineId: "linear__list_issues",
+          title: "List Issues",
+        },
+      ],
+    });
+    const { POST } = await import(
+      "~/app/(internal)/api/internal/mcp/proxy/find/route"
+    );
+
+    const res = await POST(
+      request(
+        "/api/internal/mcp/proxy/find",
+        proxyCommand({ input: { query: "issues" } }),
+        await token()
+      )
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      routines: [
+        {
+          classification: "read",
+          provider: "linear",
+          providerToolName: "list_issues",
+          routineId: "linear__list_issues",
+          title: "List Issues",
+        },
+      ],
+    });
+    expect(assertHostedMcpOrgAccessMock).toHaveBeenCalledWith(
+      { kind: "mock-db" },
+      {
+        orgId: "org_test",
+        userId: "user_test",
+      }
+    );
+    expect(findProviderRoutinesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { orgId: "org_test", userId: "user_test" },
+        db: { kind: "mock-db" },
+        scopes: {
+          providerRoutineRead: true,
+          providerRoutineWrite: false,
+        },
+        source: {
+          clientId: "mcp_client_test",
+          ref: "mcp_grant_test",
+          surface: "hosted_mcp",
+        },
+      }),
+      { query: "issues" }
+    );
+  });
+
+  it("calls provider routines through the app boundary", async () => {
+    callProviderRoutineMock.mockResolvedValueOnce({
+      provider: "linear",
+      providerRoutineCallId: "provider_routine_call_123",
+      providerToolName: "list_issues",
+      result: { content: [{ text: "ok" }] },
+      routineId: "linear__list_issues",
+      status: "succeeded",
+    });
+    const { POST } = await import(
+      "~/app/(internal)/api/internal/mcp/proxy/call/route"
+    );
+
+    const res = await POST(
+      request(
+        "/api/internal/mcp/proxy/call",
+        proxyCommand({
+          input: {
+            input: { query: "ABC" },
+            routineId: "linear__list_issues",
+          },
+        }),
+        await token()
+      )
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      provider: "linear",
+      providerRoutineCallId: "provider_routine_call_123",
+      providerToolName: "list_issues",
+      result: { content: [{ text: "ok" }] },
+      routineId: "linear__list_issues",
+      status: "succeeded",
+    });
+    expect(callProviderRoutineMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { orgId: "org_test", userId: "user_test" },
+        source: {
+          clientId: "mcp_client_test",
+          ref: "mcp_grant_test",
+          surface: "hosted_mcp",
+        },
+      }),
+      {
+        input: { query: "ABC" },
+        routineId: "linear__list_issues",
+      }
+    );
+  });
+
+  it("preserves provider routine failures for hosted MCP", async () => {
+    callProviderRoutineMock.mockRejectedValueOnce(
+      Object.assign(new Error("Provider routine requires additional scope."), {
+        code: "PROVIDER_ROUTINE_INSUFFICIENT_SCOPE",
+        routineId: "linear__create_issue",
+      })
+    );
+    const { POST } = await import(
+      "~/app/(internal)/api/internal/mcp/proxy/call/route"
+    );
+
+    const res = await POST(
+      request(
+        "/api/internal/mcp/proxy/call",
+        proxyCommand({
+          input: {
+            input: { title: "Bug" },
+            routineId: "linear__create_issue",
+          },
+        }),
+        await token()
+      )
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "PROVIDER_ROUTINE_INSUFFICIENT_SCOPE",
+      message: "Provider routine requires additional scope.",
+      routineId: "linear__create_issue",
+    });
+  });
+
+  it("rejects app-side organization access failures before proxy execution", async () => {
+    assertHostedMcpOrgAccessMock.mockRejectedValueOnce(
+      Object.assign(new Error("MCP organization is not connected."), {
+        status: 403,
+      })
+    );
+    const { POST } = await import(
+      "~/app/(internal)/api/internal/mcp/proxy/call/route"
+    );
+
+    const res = await POST(
+      request(
+        "/api/internal/mcp/proxy/call",
+        proxyCommand({
+          input: {
+            input: { query: "ABC" },
+            routineId: "linear__list_issues",
+          },
+        }),
+        await token()
+      )
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "org_access_denied",
+      message: "MCP organization is not connected.",
+    });
+    expect(callProviderRoutineMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(internal)/api/internal/mcp/proxy/_server.ts
+++ b/apps/app/src/app/(internal)/api/internal/mcp/proxy/_server.ts
@@ -1,0 +1,200 @@
+import { assertHostedMcpOrgAccess } from "@api/app/mcp-oauth/resource-access";
+import { db } from "@db/app/client";
+import {
+  type McpProviderRoutineCallCommandInput,
+  type McpProviderRoutineFindCommandInput,
+  mcpProviderRoutineCallCommandInputSchema,
+  mcpProviderRoutineFindCommandInputSchema,
+  providerRoutineCallSuccessSchema,
+  providerRoutineFindOutputSchema,
+} from "@repo/provider-routine-contract";
+import {
+  callProviderRoutine,
+  findProviderRoutines,
+} from "@repo/provider-routines";
+
+import { jsonError, verifyMcpServiceRequest } from "../signals/service-auth";
+
+const noopProviderRoutineLog = {
+  error: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+};
+
+export async function handleMcpProxyFindRequest(
+  request: Request
+): Promise<Response> {
+  const authError = await verifyMcpServiceRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const body = await request.json().catch(() => undefined);
+  const parsed = mcpProviderRoutineFindCommandInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(
+      "invalid_request",
+      "MCP provider routine find request is invalid.",
+      400
+    );
+  }
+
+  try {
+    await assertHostedMcpOrgAccess(db, {
+      orgId: parsed.data.actor.orgId,
+      userId: parsed.data.actor.userId,
+    });
+    const result = await findProviderRoutines(
+      providerRoutineContext(parsed.data),
+      parsed.data.input
+    );
+    return Response.json(providerRoutineFindOutputSchema.parse(result), {
+      status: 200,
+    });
+  } catch (error) {
+    return errorResponse(error, "Failed to find provider routines.");
+  }
+}
+
+export async function handleMcpProxyCallRequest(
+  request: Request
+): Promise<Response> {
+  const authError = await verifyMcpServiceRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const body = await request.json().catch(() => undefined);
+  const parsed = mcpProviderRoutineCallCommandInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(
+      "invalid_request",
+      "MCP provider routine call request is invalid.",
+      400
+    );
+  }
+
+  try {
+    await assertHostedMcpOrgAccess(db, {
+      orgId: parsed.data.actor.orgId,
+      userId: parsed.data.actor.userId,
+    });
+    const result = await callProviderRoutine(
+      providerRoutineContext(parsed.data),
+      parsed.data.input
+    );
+    return Response.json(providerRoutineCallSuccessSchema.parse(result), {
+      status: 200,
+    });
+  } catch (error) {
+    return errorResponse(error, "Failed to call provider routine.");
+  }
+}
+
+function providerRoutineContext(
+  command:
+    | McpProviderRoutineCallCommandInput
+    | McpProviderRoutineFindCommandInput
+) {
+  return {
+    actor: {
+      orgId: command.actor.orgId,
+      userId: command.actor.userId,
+    },
+    db,
+    log: noopProviderRoutineLog,
+    now: () => new Date(),
+    scopes: command.scopes,
+    source: {
+      clientId: command.actor.clientId,
+      ref: command.actor.grantId,
+      surface: "hosted_mcp" as const,
+    },
+  };
+}
+
+function errorResponse(error: unknown, fallbackMessage: string): Response {
+  if (isOrgAccessError(error)) {
+    return jsonError(
+      "org_access_denied",
+      error instanceof Error
+        ? error.message
+        : "MCP organization access denied.",
+      403
+    );
+  }
+
+  const providerRoutineError = providerRoutineErrorResponse(error);
+  if (providerRoutineError) {
+    return providerRoutineError;
+  }
+
+  return jsonError("internal_error", fallbackMessage, 500);
+}
+
+function isOrgAccessError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "status" in error &&
+    (error as { status: unknown }).status === 403
+  );
+}
+
+function providerRoutineErrorResponse(error: unknown): Response | null {
+  if (!isProviderRoutineErrorLike(error)) {
+    return null;
+  }
+
+  const body = {
+    error: error.code,
+    message: providerRoutineErrorMessage(error),
+    ...(typeof error.providerRoutineCallId === "string"
+      ? { providerRoutineCallId: error.providerRoutineCallId }
+      : {}),
+    ...(typeof error.routineId === "string"
+      ? { routineId: error.routineId }
+      : {}),
+  };
+  return Response.json(body, {
+    status: statusFromProviderRoutineError(error.code),
+  });
+}
+
+function isProviderRoutineErrorLike(error: unknown): error is Error & {
+  code: string;
+  providerRoutineCallId?: unknown;
+  publicMessage?: unknown;
+  routineId?: unknown;
+} {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    error.code.startsWith("PROVIDER_ROUTINE_")
+  );
+}
+
+function providerRoutineErrorMessage(error: {
+  message: string;
+  publicMessage?: unknown;
+}) {
+  return typeof error.publicMessage === "string"
+    ? error.publicMessage
+    : error.message;
+}
+
+function statusFromProviderRoutineError(code: string): number {
+  switch (code) {
+    case "PROVIDER_ROUTINE_INSUFFICIENT_SCOPE":
+      return 403;
+    case "PROVIDER_ROUTINE_INVALID_INPUT":
+      return 400;
+    case "PROVIDER_ROUTINE_CONNECTION_REQUIRED":
+    case "PROVIDER_ROUTINE_NOT_ENABLED":
+    case "PROVIDER_ROUTINE_NOT_FOUND":
+      return 404;
+    default:
+      return 502;
+  }
+}

--- a/apps/app/src/app/(internal)/api/internal/mcp/proxy/call/route.ts
+++ b/apps/app/src/app/(internal)/api/internal/mcp/proxy/call/route.ts
@@ -1,0 +1,7 @@
+import { handleMcpProxyCallRequest } from "../_server";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleMcpProxyCallRequest(request);
+}

--- a/apps/app/src/app/(internal)/api/internal/mcp/proxy/find/route.ts
+++ b/apps/app/src/app/(internal)/api/internal/mcp/proxy/find/route.ts
@@ -1,0 +1,7 @@
+import { handleMcpProxyFindRequest } from "../_server";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleMcpProxyFindRequest(request);
+}

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -25,7 +25,6 @@
     "@repo/api-contract": "workspace:*",
     "@repo/mcp-tools": "workspace:*",
     "@repo/provider-routine-contract": "workspace:*",
-    "@repo/provider-routines": "workspace:*",
     "@sentry/tanstackstart-react": "catalog:",
     "@t3-oss/env-core": "catalog:",
     "@tanstack/react-router": "catalog:",

--- a/apps/mcp/src/__tests__/app-proxy-intake.test.ts
+++ b/apps/mcp/src/__tests__/app-proxy-intake.test.ts
@@ -1,0 +1,178 @@
+import { jwtVerify } from "@vendor/jose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const jwtSecret = "test-service-jwt-secret-at-least-32-chars";
+
+async function importAdapter() {
+  vi.stubEnv("MCP_AUTH_ISSUER", "https://lightfast.ai");
+  vi.stubEnv("MCP_RESOURCE_URL", "https://mcp.lightfast.ai/mcp");
+  vi.stubEnv("SERVICE_JWT_SECRET", jwtSecret);
+  return await import("../tools/app-proxy-intake");
+}
+
+const proxyContext = {
+  actor: {
+    orgId: "org_test",
+    userId: "user_test",
+  },
+  db: {} as never,
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  now: () => new Date("2026-06-01T00:00:00.000Z"),
+  scopes: {
+    providerRoutineRead: true,
+    providerRoutineWrite: false,
+  },
+  source: {
+    clientId: "mcp_client_test",
+    ref: "mcp_grant_test",
+    surface: "hosted_mcp",
+  },
+} as const;
+
+describe("app proxy intake adapter", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("posts MCP proxy find commands to the app with service auth", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        routines: [
+          {
+            classification: "read",
+            provider: "linear",
+            providerToolName: "list_issues",
+            routineId: "linear__list_issues",
+            title: "List Issues",
+          },
+        ],
+      })
+    );
+    const { findProviderRoutinesViaApp } = await importAdapter();
+
+    await expect(
+      findProviderRoutinesViaApp(
+        proxyContext,
+        { query: "issues" },
+        { fetch: fetchMock }
+      )
+    ).resolves.toEqual({
+      routines: [
+        {
+          classification: "read",
+          provider: "linear",
+          providerToolName: "list_issues",
+          routineId: "linear__list_issues",
+          title: "List Issues",
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://lightfast.ai/api/internal/mcp/proxy/find",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const authorization = (init.headers as Record<string, string>)
+      .authorization;
+    const bearer = authorization!.replace(/^Bearer\s+/, "");
+    const { payload } = await jwtVerify(
+      bearer,
+      new TextEncoder().encode(jwtSecret),
+      { audience: "lightfast-app" }
+    );
+    expect(payload).toMatchObject({
+      iss: "mcp",
+      token_use: "service_access",
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      actor: {
+        clientId: "mcp_client_test",
+        grantId: "mcp_grant_test",
+        kind: "mcp",
+        orgId: "org_test",
+        userId: "user_test",
+      },
+      input: {
+        query: "issues",
+      },
+      scopes: {
+        providerRoutineRead: true,
+        providerRoutineWrite: false,
+      },
+    });
+  });
+
+  it("posts MCP proxy call commands to the app", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        provider: "linear",
+        providerRoutineCallId: "provider_routine_call_123",
+        providerToolName: "list_issues",
+        result: { content: [{ text: "ok" }] },
+        routineId: "linear__list_issues",
+        status: "succeeded",
+      })
+    );
+    const { callProviderRoutineViaApp } = await importAdapter();
+
+    await expect(
+      callProviderRoutineViaApp(
+        proxyContext,
+        {
+          input: { query: "ABC" },
+          routineId: "linear__list_issues",
+        },
+        { fetch: fetchMock }
+      )
+    ).resolves.toEqual({
+      provider: "linear",
+      providerRoutineCallId: "provider_routine_call_123",
+      providerToolName: "list_issues",
+      result: { content: [{ text: "ok" }] },
+      routineId: "linear__list_issues",
+      status: "succeeded",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://lightfast.ai/api/internal/mcp/proxy/call",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+
+  it("preserves app-side provider routine failures", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json(
+        {
+          error: "PROVIDER_ROUTINE_INSUFFICIENT_SCOPE",
+          message: "Provider routine requires additional scope.",
+        },
+        { status: 403 }
+      )
+    );
+    const { callProviderRoutineViaApp } = await importAdapter();
+
+    await expect(
+      callProviderRoutineViaApp(
+        proxyContext,
+        {
+          input: { title: "Bug" },
+          routineId: "linear__create_issue",
+        },
+        { fetch: fetchMock }
+      )
+    ).rejects.toMatchObject({
+      code: "PROVIDER_ROUTINE_INSUFFICIENT_SCOPE",
+      status: 403,
+    });
+  });
+});

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -91,6 +91,7 @@ describe("hosted MCP tools", () => {
     vi.doUnmock("@api/app/signals/service");
     vi.doUnmock("@db/app");
     vi.doUnmock("@repo/provider-routines");
+    vi.doUnmock("../tools/app-proxy-intake");
     vi.doUnmock("../tools/app-signal-intake");
   });
 
@@ -553,5 +554,68 @@ describe("hosted MCP tools", () => {
       },
       id: signalId,
     });
+  });
+
+  it("does not load app OAuth or provider routine defaults for proxy calls", async () => {
+    const callProviderRoutine = vi.fn().mockResolvedValue({
+      provider: "linear",
+      providerRoutineCallId,
+      providerToolName: "list_issues",
+      result: { content: [{ text: "ok" }] },
+      routineId: "linear__list_issues",
+      status: "succeeded",
+    });
+    const findProviderRoutines = vi.fn();
+    const recordMcpAuditEvent = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock("@db/app", () => ({
+      db,
+      getVisibleSignalByPublicId: vi.fn(),
+      recordMcpAuditEvent,
+    }));
+    vi.doMock("@api/app/mcp-oauth", () => {
+      throw new Error("mcp-oauth should not load for proxy calls");
+    });
+    vi.doMock("@api/app/signals/service", () => {
+      throw new Error("signal service should not load for proxy calls");
+    });
+    vi.doMock("../tools/app-signal-intake", () => {
+      throw new Error("app signal intake should not load for proxy calls");
+    });
+    vi.doMock("../tools/app-proxy-intake", () => ({
+      callProviderRoutineViaApp: callProviderRoutine,
+      findProviderRoutinesViaApp: findProviderRoutines,
+    }));
+    vi.doMock("@repo/provider-routines", () => {
+      throw new Error("provider routines should not load for proxy calls");
+    });
+
+    await expect(
+      executeHostedMcpTool({
+        context: context({ scopes: ["mcp:provider_routines:read"] }),
+        contractPath: "proxy.call",
+        rawInput: {
+          input: { query: "ABC" },
+          routineId: "linear__list_issues",
+        },
+      })
+    ).resolves.toMatchObject({
+      providerRoutineCallId,
+      status: "succeeded",
+    });
+
+    expect(callProviderRoutine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { orgId: "org_test", userId: "user_test" },
+        scopes: {
+          providerRoutineRead: true,
+          providerRoutineWrite: false,
+        },
+      }),
+      {
+        input: { query: "ABC" },
+        routineId: "linear__list_issues",
+      }
+    );
   });
 });

--- a/apps/mcp/src/tools/app-proxy-intake.ts
+++ b/apps/mcp/src/tools/app-proxy-intake.ts
@@ -1,0 +1,204 @@
+import { signServiceJWT } from "@api/app/service-jwt";
+import {
+  type McpProviderRoutineCallCommandInput,
+  type McpProviderRoutineFindCommandInput,
+  mcpProviderRoutineCallCommandInputSchema,
+  mcpProviderRoutineFindCommandInputSchema,
+  type ProviderRoutineCallInput,
+  type ProviderRoutineCallSuccess,
+  type ProviderRoutineFindInput,
+  type ProviderRoutineFindOutput,
+  providerRoutineCallSuccessSchema,
+  providerRoutineFindOutputSchema,
+} from "@repo/provider-routine-contract";
+
+import { env } from "../env";
+
+type Fetch = typeof fetch;
+
+interface ProviderRoutineProxyContext {
+  actor: {
+    orgId: string;
+    userId: string;
+  };
+  scopes: {
+    providerRoutineRead: boolean;
+    providerRoutineWrite: boolean;
+  };
+  source: {
+    clientId?: string | null;
+    ref?: string | null;
+    surface: string;
+  };
+}
+
+export class AppProxyIntakeError extends Error {
+  readonly code: string;
+  readonly providerRoutineCallId?: string;
+  readonly routineId?: string;
+  readonly status: number;
+
+  constructor(
+    message: string,
+    options: ErrorOptions & {
+      code?: string;
+      providerRoutineCallId?: string;
+      routineId?: string;
+      status?: number;
+    } = {}
+  ) {
+    super(message, options);
+    this.code = options.code ?? "app_proxy_intake_failed";
+    this.name = "AppProxyIntakeError";
+    this.providerRoutineCallId = options.providerRoutineCallId;
+    this.routineId = options.routineId;
+    this.status = options.status ?? 502;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return await response.json().catch(() => undefined);
+}
+
+function appProxyUrl(pathname: string): string {
+  return new URL(pathname, env.MCP_AUTH_ISSUER).toString();
+}
+
+function commandActorFromContext(
+  context: ProviderRoutineProxyContext
+): McpProviderRoutineFindCommandInput["actor"] {
+  return {
+    clientId: context.source.clientId ?? "",
+    grantId: context.source.ref ?? "",
+    kind: "mcp",
+    orgId: context.actor.orgId,
+    userId: context.actor.userId,
+  };
+}
+
+function messageFromBody(body: unknown): string {
+  if (
+    body &&
+    typeof body === "object" &&
+    "message" in body &&
+    typeof (body as { message: unknown }).message === "string"
+  ) {
+    return (body as { message: string }).message;
+  }
+  return "App proxy command failed.";
+}
+
+function stringField(body: unknown, field: string): string | undefined {
+  if (
+    body &&
+    typeof body === "object" &&
+    field in body &&
+    typeof (body as Record<string, unknown>)[field] === "string"
+  ) {
+    return (body as Record<string, string>)[field];
+  }
+  return;
+}
+
+function errorCodeFromBody(responseStatus: number, body: unknown): string {
+  const code = stringField(body, "error");
+  if (code) {
+    return code;
+  }
+  if (responseStatus === 401 || responseStatus === 403) {
+    return "org_access_denied";
+  }
+  return "app_proxy_intake_failed";
+}
+
+function mappedErrorStatus(responseStatus: number): number {
+  if ([400, 401, 403, 404].includes(responseStatus)) {
+    return responseStatus;
+  }
+  return 502;
+}
+
+async function postAppProxyCommand(input: {
+  body: unknown;
+  fetch?: Fetch;
+  pathname: string;
+}): Promise<unknown> {
+  const serviceToken = await signServiceJWT({
+    audience: "lightfast-app",
+    caller: "mcp",
+    jwtSecret: env.SERVICE_JWT_SECRET,
+  });
+  const requestFetch = input.fetch ?? fetch;
+  const response = await requestFetch(appProxyUrl(input.pathname), {
+    body: JSON.stringify(input.body),
+    headers: {
+      authorization: `Bearer ${serviceToken}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  const responseBody = await readJson(response);
+
+  if (!response.ok) {
+    throw new AppProxyIntakeError(messageFromBody(responseBody), {
+      code: errorCodeFromBody(response.status, responseBody),
+      providerRoutineCallId: stringField(responseBody, "providerRoutineCallId"),
+      routineId: stringField(responseBody, "routineId"),
+      status: mappedErrorStatus(response.status),
+    });
+  }
+
+  return responseBody;
+}
+
+export async function findProviderRoutinesViaApp(
+  context: ProviderRoutineProxyContext,
+  input: ProviderRoutineFindInput,
+  dependencies: { fetch?: Fetch } = {}
+): Promise<ProviderRoutineFindOutput> {
+  const body: McpProviderRoutineFindCommandInput =
+    mcpProviderRoutineFindCommandInputSchema.parse({
+      actor: commandActorFromContext(context),
+      input,
+      scopes: context.scopes,
+    });
+  const responseBody = await postAppProxyCommand({
+    body,
+    fetch: dependencies.fetch,
+    pathname: "/api/internal/mcp/proxy/find",
+  });
+
+  try {
+    return providerRoutineFindOutputSchema.parse(responseBody);
+  } catch (error) {
+    throw new AppProxyIntakeError("App proxy find response was invalid.", {
+      cause: error,
+    });
+  }
+}
+
+export async function callProviderRoutineViaApp(
+  context: ProviderRoutineProxyContext,
+  input: ProviderRoutineCallInput,
+  dependencies: { fetch?: Fetch } = {}
+): Promise<ProviderRoutineCallSuccess> {
+  const body: McpProviderRoutineCallCommandInput =
+    mcpProviderRoutineCallCommandInputSchema.parse({
+      actor: commandActorFromContext(context),
+      input,
+      scopes: context.scopes,
+    });
+  const responseBody = await postAppProxyCommand({
+    body,
+    fetch: dependencies.fetch,
+    pathname: "/api/internal/mcp/proxy/call",
+  });
+
+  try {
+    return providerRoutineCallSuccessSchema.parse(responseBody);
+  } catch (error) {
+    throw new AppProxyIntakeError("App proxy call response was invalid.", {
+      cause: error,
+    });
+  }
+}

--- a/apps/mcp/src/tools/execute.ts
+++ b/apps/mcp/src/tools/execute.ts
@@ -149,11 +149,6 @@ type FindProviderRoutinesService = (
   input: ProviderRoutineFindInput
 ) => Promise<ProviderRoutineFindOutput>;
 
-interface ProviderRoutineServiceModule {
-  callProviderRoutine: CallProviderRoutineService;
-  findProviderRoutines: FindProviderRoutinesService;
-}
-
 export interface ExecuteHostedMcpToolInput {
   context: HostedMcpContext;
   contractPath: string;
@@ -497,6 +492,18 @@ function normalizeToolError(error: unknown): HostedMcpToolError {
     return error;
   }
 
+  if (isProviderRoutineErrorLike(error)) {
+    const mapped = mapProviderRoutineError(error);
+    return new HostedMcpToolError(
+      mapped.code,
+      error instanceof Error ? error.message : mapped.message,
+      mapped.status,
+      mapped.outcome,
+      { cause: error },
+      error.providerRoutineCallId
+    );
+  }
+
   if (
     error &&
     typeof error === "object" &&
@@ -533,18 +540,6 @@ function normalizeToolError(error: unknown): HostedMcpToolError {
       400,
       "denied",
       { cause: error }
-    );
-  }
-
-  if (isProviderRoutineErrorLike(error)) {
-    const mapped = mapProviderRoutineError(error);
-    return new HostedMcpToolError(
-      mapped.code,
-      error instanceof Error ? error.message : mapped.message,
-      mapped.status,
-      mapped.outcome,
-      { cause: error },
-      error.providerRoutineCallId
     );
   }
 
@@ -606,18 +601,13 @@ async function defaultDependencies(
   }
 
   if (contractPath === "proxy.find" || contractPath === "proxy.call") {
-    const [mcpOauth, providerRoutines] = await Promise.all([
-      import("@api/app/mcp-oauth"),
-      import(
-        "@repo/provider-routines"
-      ) as Promise<ProviderRoutineServiceModule>,
-    ]);
+    const appProxyIntake = await import("./app-proxy-intake");
     return {
       ...base,
-      assertOrgAccess: mcpOauth.assertHostedMcpOrgAccess,
-      callProviderRoutine: providerRoutines.callProviderRoutine,
+      assertOrgAccess: appOrgAccessHandledDownstream,
+      callProviderRoutine: appProxyIntake.callProviderRoutineViaApp,
       createSignalForActor: unavailableCreateSignalForActor,
-      findProviderRoutines: providerRoutines.findProviderRoutines,
+      findProviderRoutines: appProxyIntake.findProviderRoutinesViaApp,
       getVisibleSignalByPublicId: dbApp.getVisibleSignalByPublicId,
     };
   }
@@ -637,6 +627,10 @@ async function unavailableAssertOrgAccess(): Promise<void> {
 }
 
 async function signalOrgAccessHandledDownstream(): Promise<void> {
+  return;
+}
+
+async function appOrgAccessHandledDownstream(): Promise<void> {
   return;
 }
 

--- a/packages/provider-routine-contract/src/__tests__/provider-routine-contract.test.ts
+++ b/packages/provider-routine-contract/src/__tests__/provider-routine-contract.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  mcpProviderRoutineCallCommandInputSchema,
+  mcpProviderRoutineFindCommandInputSchema,
   parseProviderRoutineId,
   providerRoutineCallInputSchema,
   providerRoutineFindInputSchema,
@@ -70,6 +72,62 @@ describe("proxy schemas", () => {
       providerRoutineCallInputSchema.parse({
         input: ["not", "an", "object"],
         routineId: "linear__create_issue",
+      })
+    ).toThrow();
+  });
+
+  it("parses MCP provider routine proxy commands with actor and scope context", () => {
+    expect(
+      mcpProviderRoutineFindCommandInputSchema.parse({
+        actor: {
+          clientId: "mcp_client_test",
+          grantId: "mcp_grant_test",
+          kind: "mcp",
+          orgId: "org_test",
+          userId: "user_test",
+        },
+        input: {
+          query: "issues",
+        },
+        scopes: {
+          providerRoutineRead: true,
+          providerRoutineWrite: false,
+        },
+      })
+    ).toEqual({
+      actor: {
+        clientId: "mcp_client_test",
+        grantId: "mcp_grant_test",
+        kind: "mcp",
+        orgId: "org_test",
+        userId: "user_test",
+      },
+      input: {
+        query: "issues",
+      },
+      scopes: {
+        providerRoutineRead: true,
+        providerRoutineWrite: false,
+      },
+    });
+
+    expect(() =>
+      mcpProviderRoutineCallCommandInputSchema.parse({
+        actor: {
+          clientId: "mcp_client_test",
+          grantId: "mcp_grant_test",
+          kind: "mcp",
+          orgId: "org_test",
+          userId: "user_test",
+        },
+        input: {
+          input: ["not", "an", "object"],
+          routineId: "linear__create_issue",
+        },
+        scopes: {
+          providerRoutineRead: true,
+          providerRoutineWrite: false,
+        },
       })
     ).toThrow();
   });

--- a/packages/provider-routine-contract/src/index.ts
+++ b/packages/provider-routine-contract/src/index.ts
@@ -131,6 +131,51 @@ export type ProviderRoutineCallInput = z.infer<
   typeof providerRoutineCallInputSchema
 >;
 
+export const mcpProviderRoutineActorSchema = z
+  .object({
+    clientId: z.string().min(1),
+    grantId: z.string().min(1),
+    kind: z.literal("mcp"),
+    orgId: z.string().min(1),
+    userId: z.string().min(1),
+  })
+  .strict();
+export type McpProviderRoutineActor = z.infer<
+  typeof mcpProviderRoutineActorSchema
+>;
+
+export const providerRoutineScopeContextSchema = z
+  .object({
+    providerRoutineRead: z.boolean(),
+    providerRoutineWrite: z.boolean(),
+  })
+  .strict();
+export type ProviderRoutineScopeContext = z.infer<
+  typeof providerRoutineScopeContextSchema
+>;
+
+export const mcpProviderRoutineFindCommandInputSchema = z
+  .object({
+    actor: mcpProviderRoutineActorSchema,
+    input: providerRoutineFindInputSchema,
+    scopes: providerRoutineScopeContextSchema,
+  })
+  .strict();
+export type McpProviderRoutineFindCommandInput = z.infer<
+  typeof mcpProviderRoutineFindCommandInputSchema
+>;
+
+export const mcpProviderRoutineCallCommandInputSchema = z
+  .object({
+    actor: mcpProviderRoutineActorSchema,
+    input: providerRoutineCallInputSchema,
+    scopes: providerRoutineScopeContextSchema,
+  })
+  .strict();
+export type McpProviderRoutineCallCommandInput = z.infer<
+  typeof mcpProviderRoutineCallCommandInputSchema
+>;
+
 export const providerRoutineCallStatusSchema = z.enum(["succeeded", "failed"]);
 export type ProviderRoutineCallStatus = z.infer<
   typeof providerRoutineCallStatusSchema

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1066,9 +1066,6 @@ importers:
       '@repo/provider-routine-contract':
         specifier: workspace:*
         version: link:../../packages/provider-routine-contract
-      '@repo/provider-routines':
-        specifier: workspace:*
-        version: link:../../packages/provider-routines
       '@sentry/tanstackstart-react':
         specifier: 'catalog:'
         version: 10.56.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(react@19.2.6)


### PR DESCRIPTION
## Summary
- Route hosted MCP proxy_find/proxy_call through app-owned internal routes with service JWT auth.
- Add shared MCP provider routine command schemas and preserve provider routine errors across the app hop.
- Add regression coverage proving apps/mcp no longer loads app OAuth or provider routine defaults for proxy calls.

## Test Plan
- pnpm check
- pnpm --filter @repo/provider-routine-contract test -- src/__tests__/provider-routine-contract.test.ts
- pnpm --filter @repo/provider-routine-contract typecheck
- pnpm --filter @lightfast/mcp test -- src/__tests__/app-proxy-intake.test.ts src/__tests__/tools.test.ts src/__tests__/audit.test.ts
- pnpm --filter @lightfast/mcp typecheck
- pnpm --filter @lightfast/app exec vitest run src/__tests__/app/api/internal/mcp-proxy-route.test.ts
- pnpm --filter @lightfast/app typecheck