### PR TITLE
Fix hosted MCP proxy middleware boundary

### DIFF
--- a/apps/app/src/__tests__/proxy.test.ts
+++ b/apps/app/src/__tests__/proxy.test.ts
@@ -548,6 +548,15 @@ describe("proxy pending-session route handling", () => {
     expect(authMock).not.toHaveBeenCalled();
     expect(runMicrofrontendsMiddlewareMock).not.toHaveBeenCalled();
   });
+
+  it("leaves the internal MCP proxy route to service auth", async () => {
+    const { response } = await invoke("/api/internal/mcp/proxy/find");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(authMock).not.toHaveBeenCalled();
+    expect(runMicrofrontendsMiddlewareMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("proxy bound org product route gate", () => {

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -89,6 +89,7 @@ const isPublicRoute = createRouteMatcher([...PUBLIC_ROUTE_PATTERNS]);
 const isApiRouteMatcher = createRouteMatcher([
   "/api/connectors/x/mcp(.*)",
   "/api/inngest(.*)",
+  "/api/internal/mcp/proxy(.*)",
   "/api/internal/mcp/signals(.*)",
   "/api/v1/(.*)",
 ]);
@@ -96,6 +97,7 @@ const isApiRouteMatcher = createRouteMatcher([
 const APP_OWNED_API_PREFIXES = [
   "/api/connectors/x/mcp",
   "/api/inngest",
+  "/api/internal/mcp/proxy",
   "/api/internal/mcp/signals",
   "/api/v1",
 ];


### PR DESCRIPTION
## Summary
- Allow `/api/internal/mcp/proxy` routes to bypass Clerk/browser routing and use route-level service auth.
- Add regression coverage matching the existing internal MCP signal route boundary.

## Verification
- RED: without the proxy allowlist, `pnpm --filter @lightfast/app test -- src/__tests__/proxy.test.ts -t 'internal MCP proxy route'` fails with `expected 307 to be 200`.
- GREEN: `pnpm --filter @lightfast/app test -- src/__tests__/proxy.test.ts -t 'internal MCP proxy route'` passes: 128 files, 656 tests.
- `pnpm --filter @lightfast/app typecheck`

## Production smoke context
A real AgentMail signup/onboarding reached a smoke team. OAuth DCR, authorize, and token exchange succeeded, and the live MCP server listed `proxy_find` and `proxy_call`. The `proxy_find` call then failed because app middleware redirected `/api/internal/mcp/proxy/find` instead of letting the internal service-auth route handle it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification for API route authentication handling, confirming service-level authentication is properly applied.

* **Internal Updates**
  * Updated API route classification in the proxy middleware to include additional internal API paths for improved request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->