### PR TITLE
Render decision callers by username

### DIFF
--- a/api/app/src/__tests__/connectors-flow.test.ts
+++ b/api/app/src/__tests__/connectors-flow.test.ts
@@ -1428,6 +1428,7 @@ describe("X connector flow", () => {
     );
     expect(listXBridgeMcpToolsMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        allowedEndpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
         endpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
         mcpToken: expect.stringMatching(/^lfmcp_v1\./),
       })
@@ -1582,6 +1583,8 @@ describe("X connector flow", () => {
 
     expect(listXBridgeMcpToolsMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        allowedEndpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
+        endpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
         mcpToken: expect.stringMatching(/^lfmcp_v1\./),
       })
     );

--- a/api/app/src/__tests__/connectors-runtime.test.ts
+++ b/api/app/src/__tests__/connectors-runtime.test.ts
@@ -18,7 +18,10 @@ const envMock = {
   CONNECTOR_MCP_AUTH_SECRET: "mcp_auth_secret_12345678901234567890",
   ENCRYPTION_KEY:
     "0000000000000000000000000000000000000000000000000000000000000000",
+  NEXT_PUBLIC_APP_URL: "https://app.lightfast.localhost",
   VERCEL_ENV: "test",
+  X_CLIENT_ID: "x_client_test",
+  X_CLIENT_SECRET: "x_secret_test",
 };
 
 vi.mock("@db/app/client", () => ({ db: {} }));
@@ -109,6 +112,7 @@ function connection(
 
 describe("loadConnectorRuntimeTools", () => {
   beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = envMock.NEXT_PUBLIC_APP_URL;
     listCurrentOrgConnectorConnectionsMock.mockReset();
     getCurrentOrgConnectorConnectionMock.mockReset();
     markCurrentOrgConnectorConnectionErrorMock.mockReset();
@@ -526,6 +530,7 @@ describe("loadConnectorRuntimeTools", () => {
     expect(result).toEqual({ content: [{ text: "x ok" }] });
     expect(getFreshLinearConnectorAccessTokenMock).not.toHaveBeenCalled();
     expect(callXBridgeMcpToolMock).toHaveBeenCalledWith({
+      allowedEndpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
       endpoint: "https://app.lightfast.localhost/api/connectors/x/mcp",
       input: { username: "lightfast" },
       mcpToken: expect.stringMatching(/^lfmcp_v1\./),

--- a/api/app/src/__tests__/decisions-router.test.ts
+++ b/api/app/src/__tests__/decisions-router.test.ts
@@ -3,10 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 
 const listProviderRoutineCallsMock = vi.fn();
+const getUserListMock = vi.fn();
 
 vi.mock("@db/app/client", () => ({ db: {} }));
 vi.mock("@db/app", () => ({
   listProviderRoutineCalls: listProviderRoutineCallsMock,
+}));
+vi.mock("@vendor/clerk/server", () => ({
+  clerkClient: async () => ({
+    users: { getUserList: getUserListMock },
+  }),
 }));
 vi.mock("@vendor/clerk/env", () => ({
   clerkEnvBase: { CLERK_SECRET_KEY: "sk_test_fake-secret-key-for-tests" },
@@ -75,16 +81,21 @@ describe("decisionsRouter", () => {
   beforeEach(() => {
     listProviderRoutineCallsMock.mockReset();
     listProviderRoutineCallsMock.mockResolvedValue(page);
+    getUserListMock.mockReset();
+    getUserListMock.mockResolvedValue({ data: [] });
   });
 
-  it("forwards cursor, limit, and search and returns the page unchanged", async () => {
+  it("forwards cursor, limit, and search and returns the enriched page", async () => {
     await expect(
       caller().decisions.list({
         cursor: { createdAt: new Date("2026-06-02T03:20:11.419Z"), id: 1 },
         limit: 25,
         search: "create_issue",
       })
-    ).resolves.toEqual(page);
+    ).resolves.toEqual({
+      items: [{ ...decision, calledByUsername: null }],
+      nextCursor: null,
+    });
 
     expect(listProviderRoutineCallsMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -97,6 +108,7 @@ describe("decisionsRouter", () => {
         statuses: undefined,
       }
     );
+    expect(getUserListMock).not.toHaveBeenCalled();
   });
 
   it("forwards provider and status filters", async () => {
@@ -116,6 +128,30 @@ describe("decisionsRouter", () => {
         statuses: ["failed", "succeeded"],
       }
     );
+  });
+
+  it("adds Clerk usernames for user callers", async () => {
+    const userDecision = {
+      ...decision,
+      calledByKind: "user",
+      calledById: "user_ada",
+      calledByUserId: "user_ada",
+      sourceSurface: "chat",
+    } satisfies ProviderRoutineCall;
+    listProviderRoutineCallsMock.mockResolvedValue({
+      items: [userDecision],
+      nextCursor: null,
+    });
+    getUserListMock.mockResolvedValue({
+      data: [{ id: "user_ada", username: "ada-dev" }],
+    });
+
+    await expect(caller().decisions.list({})).resolves.toEqual({
+      items: [{ ...userDecision, calledByUsername: "ada-dev" }],
+      nextCursor: null,
+    });
+
+    expect(getUserListMock).toHaveBeenCalledWith({ userId: ["user_ada"] });
   });
 
   it("coerces empty filter arrays and blank search to undefined", async () => {

--- a/api/app/src/router/(pending-not-allowed)/decisions.ts
+++ b/api/app/src/router/(pending-not-allowed)/decisions.ts
@@ -1,5 +1,8 @@
 import { listProviderRoutineCalls, type ProviderRoutineCall } from "@db/app";
 import type { TRPCRouterRecord } from "@trpc/server";
+import { clerkClient } from "@vendor/clerk/server";
+import { parseError } from "@vendor/observability/error/next";
+import { log } from "@vendor/observability/log/next";
 import { z } from "zod";
 
 import { boundOrgProcedure } from "../../trpc";
@@ -35,15 +38,73 @@ const listDecisionsInput = z.object({
     .optional(),
 });
 
+type DecisionListPage = Awaited<ReturnType<typeof listProviderRoutineCalls>>;
+type DecisionRow = DecisionListPage["items"][number];
+
+function getCallerUserId(decision: DecisionRow): string | null {
+  if (decision.calledByKind !== "user") {
+    return null;
+  }
+  return decision.calledByUserId ?? decision.calledById;
+}
+
+async function resolveClerkUsernames(userIds: string[]) {
+  if (userIds.length === 0) {
+    return new Map<string, string>();
+  }
+
+  try {
+    const clerk = await clerkClient();
+    const users = await clerk.users.getUserList({ userId: userIds });
+    return new Map(
+      users.data.flatMap((user) =>
+        user.username ? [[user.id, user.username] as const] : []
+      )
+    );
+  } catch (error: unknown) {
+    log.warn("[decisions] caller username enrichment failed", {
+      error: parseError(error),
+      userIds,
+    });
+    return new Map<string, string>();
+  }
+}
+
+async function withCallerUsernames(page: DecisionListPage): Promise<
+  Omit<DecisionListPage, "items"> & {
+    items: Array<ProviderRoutineCall & { calledByUsername: string | null }>;
+  }
+> {
+  const userIds = [
+    ...new Set(page.items.map(getCallerUserId).filter((id) => id !== null)),
+  ];
+  const usernamesById = await resolveClerkUsernames(userIds);
+
+  return {
+    ...page,
+    items: page.items.map((decision) => {
+      const userId = getCallerUserId(decision);
+      return {
+        ...decision,
+        calledByUsername: userId ? (usernamesById.get(userId) ?? null) : null,
+      };
+    }),
+  };
+}
+
 export const decisionsRouter = {
-  list: boundOrgProcedure.input(listDecisionsInput).query(({ ctx, input }) =>
-    listProviderRoutineCalls(ctx.db, {
-      clerkOrgId: ctx.auth.identity.orgId,
-      cursor: input.cursor,
-      limit: input.limit,
-      providers: input.providers?.length ? input.providers : undefined,
-      search: input.search,
-      statuses: input.statuses?.length ? input.statuses : undefined,
-    })
-  ),
+  list: boundOrgProcedure
+    .input(listDecisionsInput)
+    .query(async ({ ctx, input }) => {
+      const page = await listProviderRoutineCalls(ctx.db, {
+        clerkOrgId: ctx.auth.identity.orgId,
+        cursor: input.cursor,
+        limit: input.limit,
+        providers: input.providers?.length ? input.providers : undefined,
+        search: input.search,
+        statuses: input.statuses?.length ? input.statuses : undefined,
+      });
+
+      return withCallerUsernames(page);
+    }),
 } satisfies TRPCRouterRecord;

--- a/api/app/src/services/connectors/runtime.ts
+++ b/api/app/src/services/connectors/runtime.ts
@@ -19,6 +19,7 @@ import { callLinearMcpTool, LinearAppNodeError } from "@repo/linear-app-node";
 import { callXBridgeMcpTool, XAppNodeError } from "@repo/x-app-node";
 import { log } from "@vendor/observability/log/next";
 
+import { requireXConnectorConfig } from "./config";
 import { getFreshLinearConnectorAccessToken } from "./linear-flow";
 import { issueConnectorMcpToken } from "./mcp-auth";
 
@@ -344,7 +345,9 @@ async function callXRuntimeTool(
       logContext
     );
   }
+  const config = requireXConnectorConfig();
   return await callXBridgeMcpTool({
+    allowedEndpoint: config.endpoints.mcpEndpoint,
     endpoint: connection.mcpEndpoint,
     input: normalizeMcpToolInput(input),
     mcpToken,

--- a/api/app/src/services/connectors/x-flow.ts
+++ b/api/app/src/services/connectors/x-flow.ts
@@ -546,6 +546,7 @@ async function finalizeXConnection(input: {
 
   try {
     await discoverXConnectorTools({
+      allowedEndpoint: config.endpoints.mcpEndpoint,
       clerkOrgId: input.attempt.clerkOrgId,
       connection: persisted,
       db: appDb,
@@ -643,6 +644,7 @@ export async function refreshXConnectorTools(ctx: ConnectorServiceContext) {
 
   try {
     const toolManifest = await discoverXConnectorTools({
+      allowedEndpoint: config.endpoints.mcpEndpoint,
       clerkOrgId: identity.orgId,
       connection,
       db: ctx.db,
@@ -667,6 +669,7 @@ export async function refreshXConnectorTools(ctx: ConnectorServiceContext) {
 }
 
 async function discoverXConnectorTools(input: {
+  allowedEndpoint: string;
   clerkOrgId: string;
   connection: OrgConnectorConnection;
   db: Database;
@@ -679,6 +682,7 @@ async function discoverXConnectorTools(input: {
     purpose: "list",
   });
   const toolManifest = await listXBridgeMcpTools({
+    allowedEndpoint: input.allowedEndpoint,
     endpoint: input.endpoint,
     mcpToken,
   });

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx
@@ -337,7 +337,7 @@ describe("WorkspaceAssistantClient", () => {
     expect(submit).toBeEnabled();
   });
 
-  it("creates an addressable conversation before sending the first prompt", async () => {
+  it("updates the URL and sends the first prompt to the generated conversation id", async () => {
     render(<WorkspaceAssistantClient conversationId="conv_new" />);
 
     fireEvent.change(screen.getByPlaceholderText("Ask Lightfield"), {
@@ -345,18 +345,13 @@ describe("WorkspaceAssistantClient", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
 
-    await waitFor(() => {
-      expect(mutateAsyncMock).toHaveBeenCalledWith({
-        publicId: "conv_new",
-        title: "Summarize my active opportunities",
-      });
-    });
     expect(historyReplaceStateMock).toHaveBeenCalledWith(
       null,
       "",
       "/acme/chat/conv_new"
     );
     expect(replaceMock).not.toHaveBeenCalled();
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
     expect(sendMessageMock).toHaveBeenCalledWith(
       { text: "Summarize my active opportunities" },
       {
@@ -368,16 +363,7 @@ describe("WorkspaceAssistantClient", () => {
     );
   });
 
-  it("updates the URL immediately before waiting for the first conversation create", async () => {
-    let resolveCreate:
-      | ((conversation: { publicId: string; title: string }) => void)
-      | undefined;
-    mutateAsyncMock.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveCreate = resolve;
-        })
-    );
+  it("sends and clears the first prompt immediately", async () => {
     render(<WorkspaceAssistantClient conversationId="conv_new" />);
 
     fireEvent.change(screen.getByPlaceholderText("Ask Lightfield"), {
@@ -390,28 +376,66 @@ describe("WorkspaceAssistantClient", () => {
       "",
       "/acme/chat/conv_new"
     );
-    expect(mutateAsyncMock).toHaveBeenCalledWith({
-      publicId: "conv_new",
-      title: "Summarize my active opportunities",
-    });
-    expect(sendMessageMock).not.toHaveBeenCalled();
-
-    resolveCreate?.({
-      publicId: "conv_new",
-      title: "Summarize my active opportunities",
-    });
-
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      { text: "Summarize my active opportunities" },
+      {
+        body: {
+          idempotencyKey: expect.stringMatching(/^idem_/),
+          conversationId: "conv_new",
+        },
+      }
+    );
     await waitFor(() => {
-      expect(sendMessageMock).toHaveBeenCalledWith(
-        { text: "Summarize my active opportunities" },
-        {
-          body: {
-            idempotencyKey: expect.stringMatching(/^idem_/),
-            conversationId: "conv_new",
-          },
-        }
-      );
+      expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
     });
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+  });
+
+  it("clears a follow-up prompt immediately while the send is in flight", async () => {
+    let resolveSend: (() => void) | undefined;
+    sendMessageMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+    render(
+      <WorkspaceAssistantClient
+        conversationId="conv_existing"
+        initialConversation={{
+          messages: [
+            makeWorkspaceAssistantMessage({
+              parts: [{ text: "Earlier prompt", type: "text" }],
+              publicId: "msg_user",
+              role: "user",
+            }),
+          ],
+          conversation: makeWorkspaceAssistantConversation(),
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Ask Lightfield"), {
+      target: { value: "What should I do next?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      { text: "What should I do next?" },
+      {
+        body: {
+          idempotencyKey: expect.stringMatching(/^idem_/),
+          conversationId: "conv_existing",
+        },
+      }
+    );
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
+    });
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+
+    resolveSend?.();
   });
 
   it("does not let hidden attachment state block a text prompt", async () => {
@@ -451,6 +475,16 @@ describe("WorkspaceAssistantClient", () => {
     expect(
       screen.getByRole("button", { name: "Stop generating" })
     ).toBeEnabled();
+  });
+
+  it("disables the submit control while a prompt is submitted", () => {
+    chatStatus = "submitted";
+
+    render(<WorkspaceAssistantClient conversationId="conv_new" />);
+
+    expect(
+      screen.getByRole("button", { name: "Stop generating" })
+    ).toBeDisabled();
   });
 
   it("renders persisted chat messages and sends follow-ups to the existing conversation", async () => {

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-model.test.ts
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-model.test.ts
@@ -45,11 +45,23 @@ describe("formatCaller", () => {
       "Automation run_1"
     );
     expect(
-      formatCaller(makeRow({ calledByKind: "user", calledByUserId: "user_42" }))
-    ).toBe("User user_42");
+      formatCaller(
+        makeRow({
+          calledByKind: "user",
+          calledByUserId: "user_42",
+          calledByUsername: "ada-dev",
+        })
+      )
+    ).toBe("ada-dev");
     expect(formatCaller(makeRow({ calledByKind: "system" }))).toBe(
       "System run_1"
     );
+  });
+
+  it("falls back to the stable user id when Clerk username enrichment is unavailable", () => {
+    expect(
+      formatCaller(makeRow({ calledByKind: "user", calledByUserId: "user_42" }))
+    ).toBe("user_42");
   });
 });
 

--- a/apps/app/src/__tests__/app/api/chat/route.test.ts
+++ b/apps/app/src/__tests__/app/api/chat/route.test.ts
@@ -11,6 +11,7 @@ const findProviderRoutinesMock = vi.fn();
 const gatewayMock = vi.fn();
 const getWorkspaceAssistantConversationByPublicIdMock = vi.fn();
 const getVerifiedLightfastSkillSourceRepositoryIdMock = vi.fn();
+const isDuplicateKeyErrorMock = vi.fn();
 const listWorkspaceAssistantMessagesMock = vi.fn();
 const logErrorMock = vi.fn();
 const logInfoMock = vi.fn();
@@ -50,6 +51,7 @@ vi.mock("@db/app", () => ({
     createWorkspaceAssistantConversationMock,
   getWorkspaceAssistantConversationByPublicId:
     getWorkspaceAssistantConversationByPublicIdMock,
+  isDuplicateKeyError: isDuplicateKeyErrorMock,
   listWorkspaceAssistantMessages: listWorkspaceAssistantMessagesMock,
   markWorkspaceAssistantGenerationCompleted:
     markWorkspaceAssistantGenerationCompletedMock,
@@ -116,6 +118,7 @@ beforeEach(() => {
   gatewayMock.mockReset();
   getWorkspaceAssistantConversationByPublicIdMock.mockReset();
   getVerifiedLightfastSkillSourceRepositoryIdMock.mockReset();
+  isDuplicateKeyErrorMock.mockReset();
   listWorkspaceAssistantMessagesMock.mockReset();
   logErrorMock.mockReset();
   logInfoMock.mockReset();
@@ -150,6 +153,7 @@ beforeEach(() => {
   getWorkspaceAssistantConversationByPublicIdMock.mockResolvedValue(
     makeConversation()
   );
+  isDuplicateKeyErrorMock.mockReturnValue(false);
   listWorkspaceAssistantMessagesMock.mockResolvedValue([]);
   appendWorkspaceAssistantMessageMock
     .mockResolvedValueOnce(
@@ -233,6 +237,25 @@ describe("chat route", () => {
     );
 
     expect(response.status).toBe(400);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed supplied conversation ids", async () => {
+    const response = await POST(
+      createJsonRequest({
+        messages: [
+          {
+            id: "client-message-1",
+            parts: [{ text: "Start a new workspace plan", type: "text" }],
+            role: "user",
+          },
+        ],
+        conversationId: "not-a-conversation-id",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(createWorkspaceAssistantConversationMock).not.toHaveBeenCalled();
     expect(streamTextMock).not.toHaveBeenCalled();
   });
 
@@ -734,6 +757,64 @@ describe("chat route", () => {
     expect(response).toBe(streamResponse);
   });
 
+  it("creates a missing supplied conversation id from the submitted prompt", async () => {
+    const uiMessages = [
+      {
+        id: "client-message-1",
+        parts: [{ text: "Start a new workspace plan", type: "text" }],
+        role: "user",
+      },
+    ];
+    const createdConversation = makeConversation({
+      publicId: "conv_client_generated",
+      title: "Start a new workspace plan",
+    });
+    const streamResponse = new Response("stream");
+
+    getWorkspaceAssistantConversationByPublicIdMock.mockResolvedValueOnce(
+      undefined
+    );
+    createWorkspaceAssistantConversationMock.mockResolvedValueOnce(
+      createdConversation
+    );
+    listWorkspaceAssistantMessagesMock.mockResolvedValue([]);
+    convertToModelMessagesMock.mockResolvedValue([
+      { content: "Start a new workspace plan", role: "user" },
+    ]);
+    gatewayMock.mockReturnValue("gateway:anthropic/claude-sonnet-4.6");
+    streamTextMock.mockReturnValue({
+      toUIMessageStreamResponse: toUIMessageStreamResponseMock,
+    });
+    toUIMessageStreamResponseMock.mockReturnValue(streamResponse);
+
+    const response = await POST(
+      createJsonRequest({
+        idempotencyKey: "idem_user_1",
+        messages: uiMessages,
+        conversationId: "conv_client_generated",
+      })
+    );
+
+    expect(createWorkspaceAssistantConversationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_123",
+        createdByUserId: "user_123",
+        publicId: "conv_client_generated",
+        title: "Start a new workspace plan",
+      }
+    );
+    expect(listWorkspaceAssistantMessagesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        conversation: expect.objectContaining({
+          publicId: "conv_client_generated",
+        }),
+      })
+    );
+    expect(response).toBe(streamResponse);
+  });
+
   it("does not persist messages when canonical message validation fails", async () => {
     listWorkspaceAssistantMessagesMock.mockResolvedValueOnce([
       makeMessage({
@@ -780,9 +861,17 @@ describe("chat route", () => {
   });
 
   it("does not continue a same-org workspace assistant conversation owned by a different user", async () => {
+    const duplicatePublicIdError = Object.assign(
+      new Error("Duplicate entry for key"),
+      { code: "ER_DUP_ENTRY" }
+    );
     getWorkspaceAssistantConversationByPublicIdMock.mockResolvedValueOnce(
       undefined
     );
+    createWorkspaceAssistantConversationMock.mockRejectedValueOnce(
+      duplicatePublicIdError
+    );
+    isDuplicateKeyErrorMock.mockReturnValueOnce(true);
 
     const response = await POST(
       createJsonRequest({
@@ -806,6 +895,18 @@ describe("chat route", () => {
       createdByUserId: "user_123",
       publicId: "conv_other_user",
     });
+    expect(createWorkspaceAssistantConversationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_123",
+        createdByUserId: "user_123",
+        publicId: "conv_other_user",
+        title: "Continue this",
+      }
+    );
+    expect(isDuplicateKeyErrorMock).toHaveBeenCalledWith(
+      duplicatePublicIdError
+    );
     expect(appendWorkspaceAssistantMessageMock).not.toHaveBeenCalled();
     expect(streamTextMock).not.toHaveBeenCalled();
   });
@@ -819,7 +920,7 @@ function createJsonRequest(body: unknown) {
   });
 }
 
-function makeConversation() {
+function makeConversation(overrides: Record<string, unknown> = {}) {
   return {
     clerkOrgId: "org_123",
     createdAt: new Date("2026-06-02T00:00:00.000Z"),
@@ -833,6 +934,7 @@ function makeConversation() {
     status: "active",
     title: "Summarize my active opportunities",
     updatedAt: new Date("2026-06-02T00:00:00.000Z"),
+    ...overrides,
   };
 }
 

--- a/apps/app/src/__tests__/app/api/chat/route.test.ts
+++ b/apps/app/src/__tests__/app/api/chat/route.test.ts
@@ -23,6 +23,7 @@ const markWorkspaceAssistantMessageFailedMock = vi.fn();
 const setWorkspaceAssistantConversationActiveStreamMock = vi.fn();
 const resolveAuthContextFromClerkMock = vi.fn();
 const safeValidateUIMessagesMock = vi.fn();
+const smoothStreamMock = vi.fn();
 const stepCountIsMock = vi.fn();
 const toUIMessageStreamResponseMock = vi.fn();
 const toolMock = vi.fn();
@@ -72,6 +73,7 @@ vi.mock("@vendor/ai", () => ({
   convertToModelMessages: convertToModelMessagesMock,
   gateway: gatewayMock,
   safeValidateUIMessages: safeValidateUIMessagesMock,
+  smoothStream: smoothStreamMock,
   stepCountIs: stepCountIsMock,
   streamText: streamTextMock,
   tool: toolMock,
@@ -130,6 +132,7 @@ beforeEach(() => {
   setWorkspaceAssistantConversationActiveStreamMock.mockReset();
   resolveAuthContextFromClerkMock.mockReset();
   safeValidateUIMessagesMock.mockReset();
+  smoothStreamMock.mockReset();
   stepCountIsMock.mockReset();
   toUIMessageStreamResponseMock.mockReset();
   toolMock.mockReset();
@@ -199,6 +202,7 @@ beforeEach(() => {
     status: "succeeded",
   });
   findProviderRoutinesMock.mockResolvedValue({ routines: [] });
+  smoothStreamMock.mockReturnValue("smooth-stream-transform");
   stepCountIsMock.mockImplementation((count) => ({
     count,
     kind: "step-count",
@@ -417,6 +421,10 @@ describe("chat route", () => {
       },
     ]);
     expect(gatewayMock).toHaveBeenCalledWith("anthropic/claude-sonnet-4.6");
+    expect(smoothStreamMock).toHaveBeenCalledWith({
+      chunking: "word",
+      delayInMs: 20,
+    });
     expect(streamTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         experimental_telemetry: expect.objectContaining({
@@ -425,6 +433,7 @@ describe("chat route", () => {
           recordInputs: false,
           recordOutputs: false,
         }),
+        experimental_transform: "smooth-stream-transform",
         messages: modelMessages,
         model: "gateway:anthropic/claude-sonnet-4.6",
         providerOptions: {

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
@@ -32,7 +32,8 @@ export const ChatComposer = memo(function ChatComposer({
   text: string;
 }) {
   const isGenerating = status === "submitted" || status === "streaming";
-  const submitDisabled = !isGenerating && text.trim().length === 0;
+  const submitDisabled =
+    status === "submitted" || (!isGenerating && text.trim().length === 0);
 
   // Keep the textarea editable while a response streams so the next message
   // can be drafted. The button acts as Stop during generation, and Enter is
@@ -41,7 +42,9 @@ export const ChatComposer = memo(function ChatComposer({
     if (isGenerating) {
       return;
     }
-    return onSubmit(message);
+
+    const submittedText = message.text.trim() ? message.text : text;
+    return onSubmit({ ...message, text: submittedText });
   };
 
   const submit = (

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/workspace-assistant-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/workspace-assistant-client.tsx
@@ -12,7 +12,6 @@ import {
   ConversationScrollButton,
 } from "@repo/ui/components/ai-elements/conversation";
 import type { PromptInputMessage } from "@repo/ui/components/ai-elements/prompt-input";
-import { useMutation } from "@tanstack/react-query";
 import {
   type ChatStatus,
   DefaultChatTransport,
@@ -21,7 +20,6 @@ import {
 import { useParams } from "next/navigation";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { isResumableStreamEnabled } from "~/app/(chat)/api/chat/resumable-stream-config";
-import { useTRPC } from "~/trpc/react";
 import { ChatComposer } from "./chat-composer";
 import { ChatMessage } from "./chat-message";
 
@@ -42,19 +40,15 @@ export function WorkspaceAssistantClient({
   initialConversation,
 }: WorkspaceAssistantClientProps) {
   const params = useParams<{ slug: string }>();
-  const trpc = useTRPC();
-  const createConversation = useMutation(
-    trpc.org.workspace.assistant.createConversation.mutationOptions()
-  );
   const initialMessages = useMemo(
     () => initialConversation?.messages.map(toUIMessage) ?? [],
     [initialConversation]
   );
   const [text, setText] = useState("");
-  const [creationError, setCreationError] = useState<Error | undefined>();
   // Existing conversations are already persisted; new chats create lazily on the
-  // first message. We never recreate, so a ref (not state) is enough.
-  const conversationCreatedRef = useRef(Boolean(initialConversation));
+  // first message through /api/chat. We only need to reflect the generated id
+  // in the URL once.
+  const conversationAddressedRef = useRef(Boolean(initialConversation));
 
   const transport = useMemo(
     () =>
@@ -85,10 +79,7 @@ export function WorkspaceAssistantClient({
   });
 
   const hasMessages = messages.length > 0;
-  const displayError = creationError ?? error;
-  const composerStatus: ChatStatus = createConversation.isPending
-    ? "submitted"
-    : status;
+  const composerStatus: ChatStatus = status;
 
   const handleSubmit = useCallback(
     async (message: PromptInputMessage) => {
@@ -99,28 +90,13 @@ export function WorkspaceAssistantClient({
       }
 
       clearError();
+      setText("");
 
-      if (!conversationCreatedRef.current) {
-        setCreationError(undefined);
-        // Reflect the conversation in the URL right away — without a navigation,
-        // so the stable Chat instance (and its live stream) stays mounted. The id
-        // is known up-front, so this is safe to do before the create resolves.
+      if (!conversationAddressedRef.current) {
+        // Reflect the conversation in the URL right away without a navigation,
+        // so the stable Chat instance (and its live stream) stays mounted.
         replaceBrowserChatUrl(params.slug, conversationId);
-        try {
-          await createConversation.mutateAsync({
-            publicId: conversationId,
-            title: nextText,
-          });
-          conversationCreatedRef.current = true;
-        } catch (error) {
-          replaceBrowserChatUrl(params.slug);
-          setCreationError(
-            error instanceof Error
-              ? error
-              : new Error("Unable to create conversation.")
-          );
-          return;
-        }
+        conversationAddressedRef.current = true;
       }
 
       await sendMessage(
@@ -132,21 +108,14 @@ export function WorkspaceAssistantClient({
           },
         }
       );
-      setText("");
     },
-    [
-      params.slug,
-      conversationId,
-      createConversation.mutateAsync,
-      sendMessage,
-      clearError,
-    ]
+    [params.slug, conversationId, sendMessage, clearError]
   );
 
   const renderComposer = (compact: boolean) => (
     <ChatComposer
       compact={compact}
-      error={displayError}
+      error={error}
       onSubmit={handleSubmit}
       onTextChange={setText}
       status={composerStatus}

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/decisions/_components/decisions-model.ts
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/decisions/_components/decisions-model.ts
@@ -81,7 +81,11 @@ export function formatCaller(decision: DecisionRow): string {
     return `Automation ${decision.calledById}`;
   }
   if (decision.calledByKind === "user") {
-    return `User ${decision.calledByUserId ?? decision.calledById}`;
+    return (
+      decision.calledByUsername ??
+      decision.calledByUserId ??
+      decision.calledById
+    );
   }
   return `System ${decision.calledById}`;
 }

--- a/apps/app/src/app/(chat)/api/chat/route.ts
+++ b/apps/app/src/app/(chat)/api/chat/route.ts
@@ -11,6 +11,7 @@ import {
   createWorkspaceAssistantMessageId,
   createWorkspaceAssistantStreamId,
   getWorkspaceAssistantConversationByPublicId,
+  isDuplicateKeyError,
   listWorkspaceAssistantMessages,
   markWorkspaceAssistantGenerationCompleted,
   markWorkspaceAssistantGenerationFailed,
@@ -68,7 +69,13 @@ const chatRequestSchema = z
       .regex(/^[A-Za-z0-9:_.-]+$/)
       .optional(),
     messages: z.array(z.unknown()),
-    conversationId: z.string().trim().min(1).optional(),
+    conversationId: z
+      .string()
+      .trim()
+      .min(1)
+      .max(80)
+      .regex(/^conv_[A-Za-z0-9_-]+$/)
+      .optional(),
   })
   .passthrough();
 
@@ -593,11 +600,28 @@ async function resolveConversation(input: {
   conversationId?: string;
 }): Promise<WorkspaceAssistantConversation | undefined> {
   if (input.conversationId) {
-    return getWorkspaceAssistantConversationByPublicId(db, {
+    const existing = await getWorkspaceAssistantConversationByPublicId(db, {
       clerkOrgId: input.orgId,
       createdByUserId: input.createdByUserId,
       publicId: input.conversationId,
     });
+    if (existing) {
+      return existing;
+    }
+
+    try {
+      return await createWorkspaceAssistantConversation(db, {
+        clerkOrgId: input.orgId,
+        createdByUserId: input.createdByUserId,
+        publicId: input.conversationId,
+        title: firstTextPart(input.submittedMessage),
+      });
+    } catch (error) {
+      if (isDuplicateKeyError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   return createWorkspaceAssistantConversation(db, {

--- a/apps/app/src/app/(chat)/api/chat/route.ts
+++ b/apps/app/src/app/(chat)/api/chat/route.ts
@@ -46,6 +46,7 @@ import {
   convertToModelMessages,
   gateway,
   safeValidateUIMessages,
+  smoothStream,
   stepCountIs,
   streamText,
   tool,
@@ -58,6 +59,10 @@ import { isResumableStreamEnabled } from "~/app/(chat)/api/chat/resumable-stream
 const WORKSPACE_ASSISTANT_MODEL = "anthropic/claude-sonnet-4.6";
 const WORKSPACE_ASSISTANT_FALLBACK_MODELS = ["openai/gpt-5.4"] as const;
 const WORKSPACE_ASSISTANT_MAX_TOOL_STEPS = 5;
+const WORKSPACE_ASSISTANT_STREAM_SMOOTHING = {
+  chunking: "word",
+  delayInMs: 20,
+} as const;
 
 const chatRequestSchema = z
   .object({
@@ -263,6 +268,7 @@ export async function POST(req: Request) {
       recordInputs: false,
       recordOutputs: false,
     },
+    experimental_transform: smoothStream(WORKSPACE_ASSISTANT_STREAM_SMOOTHING),
     messages: modelMessages,
     model: gateway(WORKSPACE_ASSISTANT_MODEL),
     onError: async ({ error }) => {

--- a/db/app/src/index.ts
+++ b/db/app/src/index.ts
@@ -391,6 +391,7 @@ export {
   UserSourceControlAccountConflictError,
   updateObservedUserSourceControlAccountTokens,
 } from "./utils/user-source-control-account";
+export { isDuplicateKeyError } from "./utils/drizzle-results";
 export {
   type AppendWorkspaceAssistantMessageInput,
   appendWorkspaceAssistantMessage,

--- a/packages/x-app-node/src/__tests__/mcp.test.ts
+++ b/packages/x-app-node/src/__tests__/mcp.test.ts
@@ -101,6 +101,37 @@ describe("X bridge MCP client helpers", () => {
     ]);
   });
 
+  it("allows the configured first-party MCP endpoint in production", async () => {
+    await expect(
+      listXBridgeMcpTools({
+        allowedEndpoint: "https://lightfast.ai/api/connectors/x/mcp",
+        endpoint: "https://lightfast.ai/api/connectors/x/mcp",
+        mcpToken: "lfmcp_v1.test.payload.signature",
+        nodeEnv: "production",
+      })
+    ).resolves.toEqual([
+      {
+        description: "Look up an X user by username",
+        inputSchema: {
+          properties: { username: { type: "string" } },
+          required: ["username"],
+          type: "object",
+        },
+        name: "getUsersByUsername",
+      },
+    ]);
+  });
+
+  it("rejects unconfigured MCP endpoints in production", async () => {
+    await expect(
+      listXBridgeMcpTools({
+        endpoint: "https://other.example/api/connectors/x/mcp",
+        mcpToken: "lfmcp_v1.test.payload.signature",
+        nodeEnv: "production",
+      })
+    ).rejects.toMatchObject({ code: "X_CUSTOM_ENDPOINT_FORBIDDEN" });
+  });
+
   it("calls tools with a Lightfast MCP bearer token", async () => {
     await expect(
       callXBridgeMcpTool({
@@ -125,5 +156,18 @@ describe("X bridge MCP client helpers", () => {
       },
       url: "https://app.test/api/connectors/x/mcp",
     });
+  });
+
+  it("calls tools against the configured first-party MCP endpoint in production", async () => {
+    await expect(
+      callXBridgeMcpTool({
+        allowedEndpoint: "https://lightfast.ai/api/connectors/x/mcp",
+        endpoint: "https://lightfast.ai/api/connectors/x/mcp",
+        input: { username: "lightfast" },
+        mcpToken: "lfmcp_v1.test.payload.signature",
+        name: "getUsersByUsername",
+        nodeEnv: "production",
+      })
+    ).resolves.toEqual({ content: [{ text: "done", type: "text" }] });
   });
 });

--- a/packages/x-app-node/src/mcp.ts
+++ b/packages/x-app-node/src/mcp.ts
@@ -15,13 +15,14 @@ const DEFAULT_X_MCP_TIMEOUT_MS = 10_000;
 const DEFAULT_X_MCP_CLOSE_TIMEOUT_MS = 1000;
 
 export async function listXBridgeMcpTools(input: {
+  allowedEndpoint?: string;
   endpoint: string;
   mcpToken: string;
   nodeEnv?: string;
   timeoutMs?: number;
 }): Promise<FullConnectorToolManifest> {
   assertXEndpointAllowed({
-    defaultValue: DEFAULT_X_ENDPOINTS.mcpEndpoint,
+    defaultValue: input.allowedEndpoint ?? DEFAULT_X_ENDPOINTS.mcpEndpoint,
     nodeEnv: input.nodeEnv,
     value: input.endpoint,
   });
@@ -66,6 +67,7 @@ export async function listXBridgeMcpTools(input: {
 }
 
 export async function callXBridgeMcpTool(input: {
+  allowedEndpoint?: string;
   endpoint: string;
   input?: Record<string, unknown>;
   mcpToken: string;
@@ -74,7 +76,7 @@ export async function callXBridgeMcpTool(input: {
   timeoutMs?: number;
 }): Promise<unknown> {
   assertXEndpointAllowed({
-    defaultValue: DEFAULT_X_ENDPOINTS.mcpEndpoint,
+    defaultValue: input.allowedEndpoint ?? DEFAULT_X_ENDPOINTS.mcpEndpoint,
     nodeEnv: input.nodeEnv,
     value: input.endpoint,
   });

--- a/vendor/ai/src/index.ts
+++ b/vendor/ai/src/index.ts
@@ -22,6 +22,7 @@ export {
   Output,
   RetryError,
   safeValidateUIMessages,
+  smoothStream,
   stepCountIs,
   streamText,
   tool,


### PR DESCRIPTION
## Summary
- Enrich decisions list rows with Clerk usernames for user callers.
- Render user callers as the username alone, with the stable user id as fallback.
- Add router/model coverage for username enrichment and fallback behavior.

## Test Plan
- pnpm --filter @api/app test src/__tests__/decisions-router.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app test 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-model.test.ts' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-client.test.tsx'
- pnpm --filter @lightfast/app typecheck

## Notes
- pnpm check still reports unrelated existing issues in apps/app/src/app/(chat)/api/chat/route.ts and db/app/src/index.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decision history now displays caller usernames when available for improved context identification.

* **Improvements**
  * Optimized chat message streaming for smoother delivery.
  * Refined conversation initialization and browser URL handling.
  * Enhanced error recovery in chat flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->