### PR TITLE
Render decision callers by username

### DIFF
--- a/api/app/src/__tests__/decisions-router.test.ts
+++ b/api/app/src/__tests__/decisions-router.test.ts
@@ -3,10 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 
 const listProviderRoutineCallsMock = vi.fn();
+const getUserListMock = vi.fn();
 
 vi.mock("@db/app/client", () => ({ db: {} }));
 vi.mock("@db/app", () => ({
   listProviderRoutineCalls: listProviderRoutineCallsMock,
+}));
+vi.mock("@vendor/clerk/server", () => ({
+  clerkClient: async () => ({
+    users: { getUserList: getUserListMock },
+  }),
 }));
 vi.mock("@vendor/clerk/env", () => ({
   clerkEnvBase: { CLERK_SECRET_KEY: "sk_test_fake-secret-key-for-tests" },
@@ -75,16 +81,21 @@ describe("decisionsRouter", () => {
   beforeEach(() => {
     listProviderRoutineCallsMock.mockReset();
     listProviderRoutineCallsMock.mockResolvedValue(page);
+    getUserListMock.mockReset();
+    getUserListMock.mockResolvedValue({ data: [] });
   });
 
-  it("forwards cursor, limit, and search and returns the page unchanged", async () => {
+  it("forwards cursor, limit, and search and returns the enriched page", async () => {
     await expect(
       caller().decisions.list({
         cursor: { createdAt: new Date("2026-06-02T03:20:11.419Z"), id: 1 },
         limit: 25,
         search: "create_issue",
       })
-    ).resolves.toEqual(page);
+    ).resolves.toEqual({
+      items: [{ ...decision, calledByUsername: null }],
+      nextCursor: null,
+    });
 
     expect(listProviderRoutineCallsMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -97,6 +108,7 @@ describe("decisionsRouter", () => {
         statuses: undefined,
       }
     );
+    expect(getUserListMock).not.toHaveBeenCalled();
   });
 
   it("forwards provider and status filters", async () => {
@@ -116,6 +128,30 @@ describe("decisionsRouter", () => {
         statuses: ["failed", "succeeded"],
       }
     );
+  });
+
+  it("adds Clerk usernames for user callers", async () => {
+    const userDecision = {
+      ...decision,
+      calledByKind: "user",
+      calledById: "user_ada",
+      calledByUserId: "user_ada",
+      sourceSurface: "chat",
+    } satisfies ProviderRoutineCall;
+    listProviderRoutineCallsMock.mockResolvedValue({
+      items: [userDecision],
+      nextCursor: null,
+    });
+    getUserListMock.mockResolvedValue({
+      data: [{ id: "user_ada", username: "ada-dev" }],
+    });
+
+    await expect(caller().decisions.list({})).resolves.toEqual({
+      items: [{ ...userDecision, calledByUsername: "ada-dev" }],
+      nextCursor: null,
+    });
+
+    expect(getUserListMock).toHaveBeenCalledWith({ userId: ["user_ada"] });
   });
 
   it("coerces empty filter arrays and blank search to undefined", async () => {

--- a/api/app/src/router/(pending-not-allowed)/decisions.ts
+++ b/api/app/src/router/(pending-not-allowed)/decisions.ts
@@ -1,5 +1,8 @@
 import { listProviderRoutineCalls, type ProviderRoutineCall } from "@db/app";
 import type { TRPCRouterRecord } from "@trpc/server";
+import { clerkClient } from "@vendor/clerk/server";
+import { parseError } from "@vendor/observability/error/next";
+import { log } from "@vendor/observability/log/next";
 import { z } from "zod";
 
 import { boundOrgProcedure } from "../../trpc";
@@ -35,15 +38,73 @@ const listDecisionsInput = z.object({
     .optional(),
 });
 
+type DecisionListPage = Awaited<ReturnType<typeof listProviderRoutineCalls>>;
+type DecisionRow = DecisionListPage["items"][number];
+
+function getCallerUserId(decision: DecisionRow): string | null {
+  if (decision.calledByKind !== "user") {
+    return null;
+  }
+  return decision.calledByUserId ?? decision.calledById;
+}
+
+async function resolveClerkUsernames(userIds: string[]) {
+  if (userIds.length === 0) {
+    return new Map<string, string>();
+  }
+
+  try {
+    const clerk = await clerkClient();
+    const users = await clerk.users.getUserList({ userId: userIds });
+    return new Map(
+      users.data.flatMap((user) =>
+        user.username ? [[user.id, user.username] as const] : []
+      )
+    );
+  } catch (error: unknown) {
+    log.warn("[decisions] caller username enrichment failed", {
+      error: parseError(error),
+      userIds,
+    });
+    return new Map<string, string>();
+  }
+}
+
+async function withCallerUsernames(page: DecisionListPage): Promise<
+  Omit<DecisionListPage, "items"> & {
+    items: Array<ProviderRoutineCall & { calledByUsername: string | null }>;
+  }
+> {
+  const userIds = [
+    ...new Set(page.items.map(getCallerUserId).filter((id) => id !== null)),
+  ];
+  const usernamesById = await resolveClerkUsernames(userIds);
+
+  return {
+    ...page,
+    items: page.items.map((decision) => {
+      const userId = getCallerUserId(decision);
+      return {
+        ...decision,
+        calledByUsername: userId ? (usernamesById.get(userId) ?? null) : null,
+      };
+    }),
+  };
+}
+
 export const decisionsRouter = {
-  list: boundOrgProcedure.input(listDecisionsInput).query(({ ctx, input }) =>
-    listProviderRoutineCalls(ctx.db, {
-      clerkOrgId: ctx.auth.identity.orgId,
-      cursor: input.cursor,
-      limit: input.limit,
-      providers: input.providers?.length ? input.providers : undefined,
-      search: input.search,
-      statuses: input.statuses?.length ? input.statuses : undefined,
-    })
-  ),
+  list: boundOrgProcedure
+    .input(listDecisionsInput)
+    .query(async ({ ctx, input }) => {
+      const page = await listProviderRoutineCalls(ctx.db, {
+        clerkOrgId: ctx.auth.identity.orgId,
+        cursor: input.cursor,
+        limit: input.limit,
+        providers: input.providers?.length ? input.providers : undefined,
+        search: input.search,
+        statuses: input.statuses?.length ? input.statuses : undefined,
+      });
+
+      return withCallerUsernames(page);
+    }),
 } satisfies TRPCRouterRecord;

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-model.test.ts
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-model.test.ts
@@ -45,11 +45,23 @@ describe("formatCaller", () => {
       "Automation run_1"
     );
     expect(
-      formatCaller(makeRow({ calledByKind: "user", calledByUserId: "user_42" }))
-    ).toBe("User user_42");
+      formatCaller(
+        makeRow({
+          calledByKind: "user",
+          calledByUserId: "user_42",
+          calledByUsername: "ada-dev",
+        })
+      )
+    ).toBe("ada-dev");
     expect(formatCaller(makeRow({ calledByKind: "system" }))).toBe(
       "System run_1"
     );
+  });
+
+  it("falls back to the stable user id when Clerk username enrichment is unavailable", () => {
+    expect(
+      formatCaller(makeRow({ calledByKind: "user", calledByUserId: "user_42" }))
+    ).toBe("user_42");
   });
 });
 

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/decisions/_components/decisions-model.ts
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/decisions/_components/decisions-model.ts
@@ -81,7 +81,11 @@ export function formatCaller(decision: DecisionRow): string {
     return `Automation ${decision.calledById}`;
   }
   if (decision.calledByKind === "user") {
-    return `User ${decision.calledByUserId ?? decision.calledById}`;
+    return (
+      decision.calledByUsername ??
+      decision.calledByUserId ??
+      decision.calledById
+    );
   }
   return `System ${decision.calledById}`;
 }


### PR DESCRIPTION
## Summary
- Enrich decisions list rows with Clerk usernames for user callers.
- Render user callers as the username alone, with the stable user id as fallback.
- Add router/model coverage for username enrichment and fallback behavior.

## Test Plan
- pnpm --filter @api/app test src/__tests__/decisions-router.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app test 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-model.test.ts' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/decisions-client.test.tsx'
- pnpm --filter @lightfast/app typecheck

## Notes
- pnpm check previously reported unrelated existing issues in apps/app/src/app/(chat)/api/chat/route.ts and db/app/src/index.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decision lists now display caller usernames for improved readability instead of user IDs.
  * System gracefully falls back to user IDs when username lookup is unavailable.

* **Tests**
  * Added test coverage for caller username enrichment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->