### PR TITLE
Fix chat prompt clearing on submit

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatComposer } from "./chat-composer";
+
+describe("ChatComposer", () => {
+  let resolveSubmit: (() => void) | undefined;
+  const onSubmit = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveSubmit = resolve;
+      })
+  );
+  const stop = vi.fn();
+
+  beforeEach(() => {
+    onSubmit.mockClear();
+    stop.mockClear();
+    resolveSubmit = undefined;
+  });
+
+  it("clears the prompt immediately while keeping the submit control disabled", async () => {
+    function Harness() {
+      const [text, setText] = useState("Summarize my workspace");
+
+      return (
+        <ChatComposer
+          compact={false}
+          error={undefined}
+          onSubmit={onSubmit}
+          onTextChange={setText}
+          status="ready"
+          stop={stop}
+          text={text}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        files: [],
+        text: "Summarize my workspace",
+      });
+    });
+    expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
+    expect(
+      screen.getByRole("button", { name: "Stop generating" })
+    ).toBeDisabled();
+
+    resolveSubmit?.();
+  });
+});

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
@@ -12,7 +12,7 @@ import {
 import { cn } from "@repo/ui/lib/utils";
 import type { ChatStatus } from "@vendor/ai";
 import { ArrowUp } from "lucide-react";
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 
 export const ChatComposer = memo(function ChatComposer({
   compact,
@@ -31,8 +31,21 @@ export const ChatComposer = memo(function ChatComposer({
   stop: () => void;
   text: string;
 }) {
-  const isGenerating = status === "submitted" || status === "streaming";
-  const submitDisabled = !isGenerating && text.trim().length === 0;
+  const [isSubmitPending, setIsSubmitPending] = useState(false);
+
+  useEffect(() => {
+    if (status !== "ready") {
+      setIsSubmitPending(false);
+    }
+  }, [status]);
+
+  const effectiveStatus: ChatStatus =
+    status === "ready" && isSubmitPending ? "submitted" : status;
+  const isGenerating =
+    effectiveStatus === "submitted" || effectiveStatus === "streaming";
+  const submitDisabled =
+    effectiveStatus === "submitted" ||
+    (!isGenerating && text.trim().length === 0);
 
   // Keep the textarea editable while a response streams so the next message
   // can be drafted. The button acts as Stop during generation, and Enter is
@@ -41,7 +54,23 @@ export const ChatComposer = memo(function ChatComposer({
     if (isGenerating) {
       return;
     }
-    return onSubmit(message);
+
+    const submittedText = message.text.trim() ? message.text : text;
+    if (!submittedText.trim()) {
+      return;
+    }
+
+    onTextChange("");
+    setIsSubmitPending(true);
+
+    try {
+      return onSubmit({ ...message, text: submittedText }).finally(() => {
+        setIsSubmitPending(false);
+      });
+    } catch (error) {
+      setIsSubmitPending(false);
+      throw error;
+    }
   };
 
   const submit = (
@@ -50,9 +79,9 @@ export const ChatComposer = memo(function ChatComposer({
       className={cn("size-8 rounded-full", compact && "mr-2 mb-2 shrink-0")}
       disabled={submitDisabled}
       onStop={stop}
-      status={status}
+      status={effectiveStatus}
     >
-      {status === "ready" ? <ArrowUp className="size-4" /> : undefined}
+      {effectiveStatus === "ready" ? <ArrowUp className="size-4" /> : undefined}
     </PromptInputSubmit>
   );
 


### PR DESCRIPTION
## Summary
- Clear the chat composer text immediately when a prompt is submitted.
- Keep the composer submit control in the submitted/disabled state while the send is in flight.
- Add a regression test for the in-flight submit UI state.

## Test Plan
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @lightfast/app test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test for ChatComposer that verifies submission behavior, input clearing, and button states while a send is in progress.

* **Bug Fixes**
  * Input now clears immediately when sending a message.
  * Submission flow prevents empty sends and reliably tracks in-flight state so send/stop button accurately reflects processing vs. generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->