### PR TITLE
Fix chat submitted button state

### DIFF
--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.test.tsx
@@ -47,9 +47,42 @@ describe("ChatComposer", () => {
       });
     });
     expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
-    expect(
-      screen.getByRole("button", { name: "Stop generating" })
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+
+    resolveSubmit?.();
+  });
+
+  it("clears the prompt immediately when submitted with Enter", async () => {
+    function Harness() {
+      const [text, setText] = useState("Summarize my workspace");
+
+      return (
+        <ChatComposer
+          compact={false}
+          error={undefined}
+          onSubmit={onSubmit}
+          onTextChange={setText}
+          status="ready"
+          stop={stop}
+          text={text}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Ask Lightfield"), {
+      key: "Enter",
+    });
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        files: [],
+        text: "Summarize my workspace",
+      });
+    });
+    expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
 
     resolveSubmit?.();
   });

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
@@ -41,17 +41,19 @@ export const ChatComposer = memo(function ChatComposer({
 
   const effectiveStatus: ChatStatus =
     status === "ready" && isSubmitPending ? "submitted" : status;
-  const isGenerating =
+  const isBusy =
     effectiveStatus === "submitted" || effectiveStatus === "streaming";
+  const isStreaming = effectiveStatus === "streaming";
+  const submitStatus: ChatStatus =
+    effectiveStatus === "submitted" ? "ready" : effectiveStatus;
   const submitDisabled =
-    effectiveStatus === "submitted" ||
-    (!isGenerating && text.trim().length === 0);
+    effectiveStatus === "submitted" || (!isBusy && text.trim().length === 0);
 
   // Keep the textarea editable while a response streams so the next message
   // can be drafted. The button acts as Stop during generation, and Enter is
   // ignored until the stream finishes to avoid sending mid-response.
   const handleSubmit = (message: PromptInputMessage) => {
-    if (isGenerating) {
+    if (isBusy) {
       return;
     }
 
@@ -75,13 +77,13 @@ export const ChatComposer = memo(function ChatComposer({
 
   const submit = (
     <PromptInputSubmit
-      aria-label={isGenerating ? "Stop generating" : "Send message"}
+      aria-label={isStreaming ? "Stop generating" : "Send message"}
       className={cn("size-8 rounded-full", compact && "mr-2 mb-2 shrink-0")}
       disabled={submitDisabled}
       onStop={stop}
-      status={effectiveStatus}
+      status={submitStatus}
     >
-      {effectiveStatus === "ready" ? <ArrowUp className="size-4" /> : undefined}
+      {submitStatus === "ready" ? <ArrowUp className="size-4" /> : undefined}
     </PromptInputSubmit>
   );
 


### PR DESCRIPTION
## Summary
- Keep the chat composer control as a disabled send button during submitted/pending submit state.
- Only switch the control to Stop while the assistant response is streaming.
- Add Enter-key coverage for immediate prompt clearing.

## Test Plan
- pnpm check
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @lightfast/app test