### PR TITLE
Fix X connector agent enablement

### DIFF
--- a/api/app/src/__tests__/connectors-flow.test.ts
+++ b/api/app/src/__tests__/connectors-flow.test.ts
@@ -167,6 +167,7 @@ const {
 const {
   disconnectConnector,
   refreshConnectorTools,
+  setConnectorAgentEnabled,
   setConnectorAutomationEnabled,
   startConnectorOAuth,
 } = await import("../services/connectors");
@@ -1666,6 +1667,7 @@ describe("X connector flow", () => {
     listXBridgeMcpToolsMock.mockResolvedValue([{ name: "getUsersMe" }]);
     updateConnectorToolManifestAndAutomationStateMock.mockResolvedValue(true);
     setConnectorAutomationEnabledDbMock.mockResolvedValue(true);
+    setConnectorAgentEnabledDbMock.mockResolvedValue(true);
 
     await expect(
       startConnectorOAuth(ctx(), { provider: "x" })
@@ -1677,9 +1679,21 @@ describe("X connector flow", () => {
       setConnectorAutomationEnabled(ctx(), { enabled: true, provider: "x" })
     ).resolves.toEqual({ enabled: true });
     await expect(
+      setConnectorAgentEnabled(ctx(), { enabled: true, provider: "x" })
+    ).resolves.toEqual({ enabled: true });
+    await expect(
       disconnectConnector(ctx(), { provider: "x" })
     ).resolves.toEqual({
       disconnected: true,
     });
+
+    expect(setConnectorAgentEnabledDbMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_acme",
+        enabled: true,
+        provider: "x",
+      }
+    );
   });
 });

--- a/api/app/src/services/connectors/index.ts
+++ b/api/app/src/services/connectors/index.ts
@@ -19,6 +19,7 @@ import {
 import {
   disconnectXConnector,
   refreshXConnectorTools,
+  setXConnectorAgentEnabled,
   setXConnectorAutomationEnabled,
   startXConnectorOAuth,
 } from "./x-flow";
@@ -52,6 +53,7 @@ export {
   completeXConnectorOAuth,
   disconnectXConnector,
   refreshXConnectorTools,
+  setXConnectorAgentEnabled,
   setXConnectorAutomationEnabled,
   startXConnectorOAuth,
 } from "./x-flow";
@@ -114,6 +116,8 @@ export async function setConnectorAgentEnabled(
   switch (input.provider) {
     case "linear":
       return await setLinearConnectorAgentEnabled(ctx, input);
+    case "x":
+      return await setXConnectorAgentEnabled(ctx, input);
     default:
       return unsupportedProvider(input.provider);
   }

--- a/api/app/src/services/connectors/x-flow.ts
+++ b/api/app/src/services/connectors/x-flow.ts
@@ -6,6 +6,7 @@ import {
   markCurrentOrgConnectorConnectionRevoked,
   type OrgConnectorConnection,
   recordConnectorToolRefreshError,
+  setConnectorAgentEnabled as setConnectorAgentEnabledInDb,
   setConnectorAutomationEnabled as setConnectorAutomationEnabledInDb,
   updateConnectorToolManifestAndAutomationState,
   updateObservedConnectorTokens,
@@ -736,6 +737,25 @@ export async function setXConnectorAutomationEnabled(
 ) {
   const identity = activeIdentity(ctx);
   const updated = await setConnectorAutomationEnabledInDb(ctx.db, {
+    clerkOrgId: identity.orgId,
+    enabled: input.enabled,
+    provider: "x",
+  });
+  if (!updated) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "X connector is not connected.",
+    });
+  }
+  return { enabled: input.enabled };
+}
+
+export async function setXConnectorAgentEnabled(
+  ctx: ConnectorServiceContext,
+  input: { enabled: boolean }
+) {
+  const identity = activeIdentity(ctx);
+  const updated = await setConnectorAgentEnabledInDb(ctx.db, {
     clerkOrgId: identity.orgId,
     enabled: input.enabled,
     provider: "x",


### PR DESCRIPTION
## Summary
- Route X connector agent enablement through the generic connector service dispatcher.
- Add an X-specific agent enablement helper that updates the current org connector row.
- Cover the X generic connector operations path with a regression assertion.

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/connectors-flow.test.ts
- pnpm --filter @api/app typecheck

Replaces #827, which was opened from a dirty detached worktree history and included unrelated commits.