### PR TITLE
Fix chat submit loading state

### DIFF
--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/chat/workspace-assistant-client.test.tsx
@@ -177,11 +177,18 @@ vi.mock("@repo/ui/components/ai-elements/prompt-input", () => ({
   PromptInputSubmit: ({
     "aria-label": ariaLabel,
     disabled,
+    status,
   }: {
     "aria-label"?: string;
     disabled?: boolean;
+    status?: string;
   }) => (
-    <button aria-label={ariaLabel} disabled={disabled} type="submit">
+    <button
+      aria-label={ariaLabel}
+      data-status={status}
+      disabled={disabled}
+      type="submit"
+    >
       Send
     </button>
   ),
@@ -409,6 +416,10 @@ describe("WorkspaceAssistantClient", () => {
     });
     expect(sendMessageMock).not.toHaveBeenCalled();
     expect(refreshMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Summarize my active opportunities")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Send message" })
+    ).toHaveAttribute("data-status", "submitted");
 
     resolveCreate?.({
       publicId: "conv_new",

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.test.tsx
@@ -48,6 +48,7 @@ describe("ChatComposer", () => {
     });
     expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(screen.getByRole("status", { name: "Loading" })).toBeVisible();
 
     resolveSubmit?.();
   });
@@ -83,6 +84,7 @@ describe("ChatComposer", () => {
     });
     expect(screen.getByPlaceholderText("Ask Lightfield")).toHaveValue("");
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(screen.getByRole("status", { name: "Loading" })).toBeVisible();
 
     resolveSubmit?.();
   });

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/chat-composer.tsx
@@ -44,8 +44,6 @@ export const ChatComposer = memo(function ChatComposer({
   const isBusy =
     effectiveStatus === "submitted" || effectiveStatus === "streaming";
   const isStreaming = effectiveStatus === "streaming";
-  const submitStatus: ChatStatus =
-    effectiveStatus === "submitted" ? "ready" : effectiveStatus;
   const submitDisabled =
     effectiveStatus === "submitted" || (!isBusy && text.trim().length === 0);
 
@@ -81,9 +79,9 @@ export const ChatComposer = memo(function ChatComposer({
       className={cn("size-8 rounded-full", compact && "mr-2 mb-2 shrink-0")}
       disabled={submitDisabled}
       onStop={stop}
-      status={submitStatus}
+      status={effectiveStatus}
     >
-      {submitStatus === "ready" ? <ArrowUp className="size-4" /> : undefined}
+      {effectiveStatus === "ready" ? <ArrowUp className="size-4" /> : undefined}
     </PromptInputSubmit>
   );
 

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/workspace-assistant-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/_components/workspace-assistant-client.tsx
@@ -64,6 +64,8 @@ export function WorkspaceAssistantClient({
   );
   const [text, setText] = useState("");
   const [creationError, setCreationError] = useState<Error | undefined>();
+  const [optimisticFirstMessage, setOptimisticFirstMessage] =
+    useState<UIMessage | null>(null);
   // Existing conversations are already persisted; new chats create lazily on the
   // first message. We never recreate, so a ref (not state) is enough.
   const conversationCreatedRef = useRef(Boolean(initialConversation));
@@ -96,11 +98,18 @@ export function WorkspaceAssistantClient({
     transport,
   });
 
-  const hasMessages = messages.length > 0;
+  const displayMessages =
+    optimisticFirstMessage && messages.length === 0
+      ? [optimisticFirstMessage]
+      : messages;
+  const hasMessages = displayMessages.length > 0;
   const displayError = creationError ?? error;
-  const composerStatus: ChatStatus = createConversation.isPending
-    ? "submitted"
-    : status;
+  const isPreparingFirstMessage =
+    Boolean(optimisticFirstMessage) && status === "ready";
+  const composerStatus: ChatStatus =
+    createConversation.isPending || isPreparingFirstMessage
+      ? "submitted"
+      : status;
 
   const handleSubmit = useCallback(
     async (message: PromptInputMessage) => {
@@ -114,6 +123,7 @@ export function WorkspaceAssistantClient({
 
       if (!conversationCreatedRef.current) {
         setCreationError(undefined);
+        setOptimisticFirstMessage(createOptimisticUserMessage(nextText));
         replaceBrowserChatUrl(params.slug, conversationId);
         try {
           await createConversation.mutateAsync({
@@ -124,6 +134,7 @@ export function WorkspaceAssistantClient({
           void queryClient.invalidateQueries(listConversationsQueryFilter);
         } catch (error) {
           replaceBrowserChatUrl(params.slug);
+          setOptimisticFirstMessage(null);
           setCreationError(
             error instanceof Error
               ? error
@@ -133,15 +144,19 @@ export function WorkspaceAssistantClient({
         }
       }
 
-      await sendMessage(
-        { text: nextText },
-        {
-          body: {
-            idempotencyKey: createWorkspaceAssistantIdempotencyKey(),
-            conversationId,
-          },
-        }
-      );
+      try {
+        await sendMessage(
+          { text: nextText },
+          {
+            body: {
+              idempotencyKey: createWorkspaceAssistantIdempotencyKey(),
+              conversationId,
+            },
+          }
+        );
+      } finally {
+        setOptimisticFirstMessage(null);
+      }
       setText("");
       if (!initialConversation) {
         router.refresh();
@@ -179,7 +194,7 @@ export function WorkspaceAssistantClient({
           <div className="relative min-h-0 flex-1">
             <Conversation className="h-full">
               <ConversationContent className="gap-0 p-0 pb-8">
-                {messages.map((message, index) => (
+                {displayMessages.map((message, index) => (
                   <div
                     className="mx-auto w-full max-w-3xl px-5 pt-8 md:px-10"
                     key={message.id}
@@ -187,7 +202,8 @@ export function WorkspaceAssistantClient({
                   >
                     <ChatMessage
                       isStreaming={
-                        status === "streaming" && index === messages.length - 1
+                        status === "streaming" &&
+                        index === displayMessages.length - 1
                       }
                       message={message}
                     />
@@ -212,6 +228,14 @@ export function WorkspaceAssistantClient({
 
 function createWorkspaceAssistantIdempotencyKey() {
   return `idem_${createUuid()}`;
+}
+
+function createOptimisticUserMessage(text: string): UIMessage {
+  return {
+    id: `optimistic_${createUuid()}`,
+    parts: [{ text, type: "text" }],
+    role: "user",
+  };
 }
 
 function createUuid() {


### PR DESCRIPTION
## Summary
- render the first user message optimistically while a new chat conversation is being created
- pass the submitted chat status through to the prompt submit control so the loading affordance remains visible
- cover the immediate first-message transition and submitted loading state in tests

## Verification
- `pnpm check`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @lightfast/app test -- chat-composer.test.tsx workspace-assistant-client.test.tsx`