### PR TITLE
Broaden tRPC Sentry capture

### DIFF
--- a/apps/app/src/__tests__/sentry-config.test.ts
+++ b/apps/app/src/__tests__/sentry-config.test.ts
@@ -1,0 +1,88 @@
+import { TRPCClientError } from "@trpc/client";
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it, vi } from "vitest";
+
+const sentryMocks = vi.hoisted(() => ({
+  addIntegration: vi.fn(),
+  captureRouterTransitionStart: vi.fn(),
+  consoleLoggingIntegration: vi.fn(() => ({ name: "console-logging" })),
+  extraErrorDataIntegration: vi.fn(() => ({ name: "extra-error-data" })),
+  feedbackIntegration: vi.fn(() => ({ name: "feedback" })),
+  httpClientIntegration: vi.fn(() => ({ name: "http-client" })),
+  init: vi.fn(),
+  replayIntegration: vi.fn(() => ({ name: "replay" })),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  addIntegration: sentryMocks.addIntegration,
+  captureRouterTransitionStart: sentryMocks.captureRouterTransitionStart,
+  consoleLoggingIntegration: sentryMocks.consoleLoggingIntegration,
+  extraErrorDataIntegration: sentryMocks.extraErrorDataIntegration,
+  feedbackIntegration: sentryMocks.feedbackIntegration,
+  httpClientIntegration: sentryMocks.httpClientIntegration,
+  init: sentryMocks.init,
+  replayIntegration: sentryMocks.replayIntegration,
+}));
+
+vi.mock("@vendor/braintrust/otel", () => ({
+  registerBraintrustOTel: vi.fn(),
+}));
+
+vi.mock("@vendor/inngest", () => ({
+  NonRetriableError: class NonRetriableError extends Error {},
+}));
+
+vi.mock("~/env", () => ({
+  env: {
+    NEXT_PUBLIC_SENTRY_DSN: "https://public@example.com/1",
+    NEXT_PUBLIC_VERCEL_ENV: "production",
+    SENTRY_DSN: "https://server@example.com/1",
+  },
+}));
+
+describe("Sentry config", () => {
+  it("keeps low-status tRPC server errors during wide capture mode", async () => {
+    vi.resetModules();
+    sentryMocks.init.mockClear();
+
+    await import("../sentry.server.config");
+
+    const options = sentryMocks.init.mock.calls[0]?.[0];
+    const event = { event_id: "server_event" };
+    const error = new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Unsupported connector provider: x",
+    });
+
+    expect(options?.beforeSend?.(event, { originalException: error })).toBe(
+      event
+    );
+  });
+
+  it("keeps low-status tRPC client errors during wide capture mode", async () => {
+    vi.resetModules();
+    sentryMocks.init.mockClear();
+
+    await import("../instrumentation-client");
+
+    const options = sentryMocks.init.mock.calls[0]?.[0];
+    const event = { event_id: "client_event" };
+    const error = new TRPCClientError("Unsupported connector provider: x", {
+      result: {
+        error: {
+          code: -32_600,
+          data: {
+            code: "BAD_REQUEST",
+            httpStatus: 400,
+            path: "org.workspace.connectors.setAgentEnabled",
+          },
+          message: "Unsupported connector provider: x",
+        },
+      },
+    });
+
+    expect(options?.beforeSend?.(event, { originalException: error })).toBe(
+      event
+    );
+  });
+});

--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -5,7 +5,6 @@ import {
   httpClientIntegration,
   init as initSentry,
 } from "@sentry/nextjs";
-import { TRPCClientError } from "@trpc/client";
 
 import { env } from "~/env";
 
@@ -21,16 +20,7 @@ initSentry({
   tracesSampleRate: env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 0.2 : 1.0,
   debug: false,
   enableLogs: true,
-  beforeSend(event, hint) {
-    // Drop tRPC client errors (4xx) — server owns tRPC error observability.
-    const err = hint?.originalException;
-    if (
-      err instanceof TRPCClientError &&
-      err.data?.httpStatus != null &&
-      err.data.httpStatus < 500
-    ) {
-      return null;
-    }
+  beforeSend(event) {
     return event;
   },
   beforeBreadcrumb(breadcrumb) {

--- a/apps/app/src/sentry.server.config.ts
+++ b/apps/app/src/sentry.server.config.ts
@@ -1,7 +1,5 @@
 import { LIGHTFAST_AGENT_RUNTIME_BRAINTRUST_PARENT } from "@repo/ai/telemetry";
 import * as Sentry from "@sentry/nextjs";
-import { TRPCError } from "@trpc/server";
-import { getHTTPStatusCodeFromError } from "@trpc/server/http";
 import { registerBraintrustOTel } from "@vendor/braintrust/otel";
 import { NonRetriableError } from "@vendor/inngest";
 
@@ -13,9 +11,6 @@ const beforeSend: NonNullable<
   Parameters<typeof Sentry.init>[0]["beforeSend"]
 > = (event, hint) => {
   const err = hint?.originalException;
-  if (err instanceof TRPCError && getHTTPStatusCodeFromError(err) < 500) {
-    return null;
-  }
   if (err instanceof NonRetriableError) {
     return null;
   }

--- a/vendor/observability/src/trpc.test.ts
+++ b/vendor/observability/src/trpc.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const captureExceptionMock = vi.fn();
 const logErrorMock = vi.fn();
 const logInfoMock = vi.fn();
+const scopeSetContextMock = vi.fn();
 
 vi.mock("server-only", () => ({}));
 
@@ -23,7 +24,7 @@ vi.mock("@sentry/core", () => ({
     }) => Promise<unknown>
   ) =>
     callback({
-      setContext: vi.fn(),
+      setContext: scopeSetContextMock,
       setExtra: vi.fn(),
       setTag: vi.fn(),
     }),
@@ -53,6 +54,7 @@ describe("createObservabilityMiddleware", () => {
     captureExceptionMock.mockClear();
     logErrorMock.mockClear();
     logInfoMock.mockClear();
+    scopeSetContextMock.mockClear();
   });
 
   it("omits the cause message from server error logs", async () => {
@@ -98,5 +100,75 @@ describe("createObservabilityMiddleware", () => {
     expect(captureExceptionMock.mock.invocationCallOrder[0]).toBeLessThan(
       logErrorMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
     );
+  });
+
+  it("captures client tRPC errors for short-term visibility", async () => {
+    const error = new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Unsupported connector provider: x",
+    });
+    const middleware = createObservabilityMiddleware({
+      extractAuth: () => ({ orgId: "org_1", userId: "user_1" }),
+      isDev: false,
+    });
+
+    await middleware({
+      ctx: {},
+      getRawInput: async () => ({ provider: "x" }),
+      next: async () => ({ error, ok: false }),
+      path: "org.workspace.connectors.setAgentEnabled",
+      type: "mutation",
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        extra: expect.objectContaining({
+          httpStatus: 400,
+          requestId: "request_1",
+        }),
+        tags: expect.objectContaining({
+          "trpc.error_code": "BAD_REQUEST",
+          "trpc.http_status": "400",
+          "trpc.path": "org.workspace.connectors.setAgentEnabled",
+          "trpc.type": "mutation",
+        }),
+      })
+    );
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "[trpc] client error",
+      expect.objectContaining({
+        errorCode: "BAD_REQUEST",
+        errorMessage: "Unsupported connector provider: x",
+        path: "org.workspace.connectors.setAgentEnabled",
+      })
+    );
+  });
+
+  it("does not attach raw tRPC input to the Sentry scope", async () => {
+    const error = new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid input",
+    });
+    const middleware = createObservabilityMiddleware({
+      extractAuth: () => ({}),
+      isDev: false,
+    });
+
+    await middleware({
+      ctx: {},
+      getRawInput: async () => ({
+        nested: { token: "secret" },
+        provider: "x",
+      }),
+      next: async () => ({ error, ok: false }),
+      path: "org.workspace.connectors.setAgentEnabled",
+      type: "mutation",
+    });
+
+    expect(scopeSetContextMock).toHaveBeenCalledWith("trpc", {
+      procedure_path: "org.workspace.connectors.setAgentEnabled",
+      procedure_type: "mutation",
+    });
   });
 });

--- a/vendor/observability/src/trpc.ts
+++ b/vendor/observability/src/trpc.ts
@@ -47,7 +47,7 @@ function errorLogFields(error: TRPCError): Record<string, unknown> {
  * Create a tRPC observability middleware that consolidates:
  * - Sentry isolation scope + span creation (replaces trpcMiddleware)
  * - Error classification via HTTP status derivation (no constants needed)
- * - Selective Sentry capture (server errors only, with tags)
+ * - Sentry capture for all tRPC errors, with tags for later filtering
  * - Structured logging with trace ID correlation
  */
 export function createObservabilityMiddleware<TCtx>(
@@ -58,13 +58,12 @@ export function createObservabilityMiddleware<TCtx>(
     path,
     ctx,
     type,
-    getRawInput,
   }: {
     next: () => Promise<TResult>;
     path: string;
     ctx: TCtx;
     type: string;
-    getRawInput: () => Promise<unknown>;
+    getRawInput?: () => Promise<unknown>;
   }): Promise<TResult> => {
     if (opts.isDev) {
       const waitMs = Math.floor(Math.random() * 400) + 100;
@@ -79,15 +78,6 @@ export function createObservabilityMiddleware<TCtx>(
         procedure_path: path,
         procedure_type: type,
       };
-
-      try {
-        const rawInput = await getRawInput();
-        if (rawInput !== undefined) {
-          trpcContext.input = rawInput;
-        }
-      } catch {
-        // getRawInput can throw if input parsing failed — safe to ignore
-      }
 
       scope.setContext("trpc", trpcContext);
 
@@ -130,27 +120,26 @@ export function createObservabilityMiddleware<TCtx>(
             log.info("[trpc] ok", meta);
           } else if (result.error) {
             const httpStatus = getHTTPStatusCodeFromError(result.error);
+            const reportedError =
+              result.error.code === "INTERNAL_SERVER_ERROR" &&
+              result.error.cause instanceof Error
+                ? result.error.cause
+                : result.error;
 
+            Sentry.captureException(reportedError, {
+              extra: {
+                durationMs,
+                httpStatus,
+                requestId,
+              },
+              tags: {
+                "trpc.error_code": result.error.code,
+                "trpc.http_status": String(httpStatus),
+                "trpc.path": path,
+                "trpc.type": type,
+              },
+            });
             if (httpStatus >= 500) {
-              // Send the original error for better Sentry grouping and titles.
-              // TRPCError wraps raw Errors with a generic message; the cause has the real info.
-              const reportedError =
-                result.error.code === "INTERNAL_SERVER_ERROR" &&
-                result.error.cause instanceof Error
-                  ? result.error.cause
-                  : result.error;
-
-              Sentry.captureException(reportedError, {
-                extra: {
-                  durationMs,
-                  requestId,
-                },
-                tags: {
-                  "trpc.error_code": result.error.code,
-                  "trpc.path": path,
-                  "trpc.type": type,
-                },
-              });
               log.error("[trpc] server error", meta);
             } else {
               log.info("[trpc] client error", meta);


### PR DESCRIPTION
## Summary
- Capture all tRPC errors in Sentry with status/path/type/code tags so low-status operational bugs are visible during debugging.
- Stop attaching raw tRPC input to Sentry scope to avoid leaking request payloads while capture is broad.
- Remove app-level low-status tRPC `beforeSend` drops for this wide-capture period while keeping `NonRetriableError` suppression.

## Test Plan
- [x] `pnpm --filter @vendor/observability test -- src/trpc.test.ts`
- [x] `pnpm --filter @vendor/observability typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/sentry-config.test.ts`
- [x] `git diff --check --cached`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Sentry configuration, including validation of error handling and capture behavior across server and client implementations

* **Bug Fixes**
  * Improved error observability by capturing all tRPC errors instead of filtering based on response status, enabling better issue detection and tracking
  * Enhanced error context with additional metadata for improved diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->