### PR TITLE
Add organization auto-join domains

### DIFF
--- a/api/app/src/__tests__/organization-router.test.ts
+++ b/api/app/src/__tests__/organization-router.test.ts
@@ -7,8 +7,12 @@ const getActiveOrgBindingMock = vi.fn();
 const getCurrentOrgConnectorConnectionMock = vi.fn();
 const authMock = vi.fn();
 const createOrganizationMock = vi.fn();
+const createOrganizationDomainMock = vi.fn();
+const deleteOrganizationDomainMock = vi.fn();
 const getOrganizationMock = vi.fn();
+const getOrganizationDomainListMock = vi.fn();
 const getOrganizationMembershipListMock = vi.fn();
+const updateOrganizationDomainMock = vi.fn();
 const updateOrganizationMock = vi.fn();
 const startNamespaceOperationMock = vi.fn();
 const reserveNamespaceForOperationMock = vi.fn();
@@ -49,7 +53,11 @@ vi.mock("@vendor/clerk/server", () => ({
     Promise.resolve({
       organizations: {
         createOrganization: createOrganizationMock,
+        createOrganizationDomain: createOrganizationDomainMock,
+        deleteOrganizationDomain: deleteOrganizationDomainMock,
         getOrganization: getOrganizationMock,
+        getOrganizationDomainList: getOrganizationDomainListMock,
+        updateOrganizationDomain: updateOrganizationDomainMock,
         updateOrganization: updateOrganizationMock,
       },
       users: {
@@ -129,6 +137,35 @@ function operation(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function organizationDomain(overrides: Record<string, unknown> = {}) {
+  return {
+    affiliationEmailAddress: null,
+    createdAt: 1_765_000_000_000,
+    enrollmentMode: "automatic_invitation",
+    id: "orgdmn_acme",
+    name: "acme.com",
+    organizationId: "org_acme",
+    totalPendingInvitations: 0,
+    totalPendingSuggestions: 0,
+    updatedAt: 1_765_000_000_000,
+    verification: { status: "verified" },
+    ...overrides,
+  };
+}
+
+function organizationMembership(overrides: Record<string, unknown> = {}) {
+  return {
+    organization: {
+      id: "org_acme",
+      imageUrl: "https://img.test/acme.png",
+      name: "Acme Inc",
+      slug: "acme",
+    },
+    role: "org:admin",
+    ...overrides,
+  };
+}
+
 function caller(
   identity = pendingIdentity,
   access?: ReturnType<typeof adminAccess> | ReturnType<typeof nonAdminAccess>
@@ -143,10 +180,14 @@ function caller(
 beforeEach(() => {
   authMock.mockReset();
   createOrganizationMock.mockReset();
+  createOrganizationDomainMock.mockReset();
+  deleteOrganizationDomainMock.mockReset();
   getOrganizationMock.mockReset();
+  getOrganizationDomainListMock.mockReset();
   getOrganizationMembershipListMock.mockReset();
   getActiveOrgBindingMock.mockReset();
   getCurrentOrgConnectorConnectionMock.mockReset();
+  updateOrganizationDomainMock.mockReset();
   updateOrganizationMock.mockReset();
   startNamespaceOperationMock.mockReset();
   reserveNamespaceForOperationMock.mockReset();
@@ -160,7 +201,19 @@ beforeEach(() => {
     orgId: "org_acme",
     userId: "user_test",
   });
+  getOrganizationMembershipListMock.mockResolvedValue({
+    data: [organizationMembership()],
+    totalCount: 1,
+  });
   createOrganizationMock.mockResolvedValue({ id: "org_acme", slug: "acme" });
+  createOrganizationDomainMock.mockResolvedValue(
+    organizationDomain({ id: "orgdmn_new", name: "new.com" })
+  );
+  deleteOrganizationDomainMock.mockResolvedValue({});
+  getOrganizationDomainListMock.mockResolvedValue({ data: [] });
+  updateOrganizationDomainMock.mockResolvedValue(
+    organizationDomain({ id: "orgdmn_lightfast", name: "lightfast.ai" })
+  );
   startNamespaceOperationMock.mockResolvedValue(operation());
   reserveNamespaceForOperationMock.mockResolvedValue(
     operation({ status: "namespace_reserved" })
@@ -498,5 +551,143 @@ describe("organization.updateName", () => {
       ).org.settings.organization.updateName({ slug: "acme", name: "acme-inc" })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(updateOrganizationMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("organization domains", () => {
+  it("lists domains for the requested organization slug", async () => {
+    getOrganizationDomainListMock.mockResolvedValue({
+      data: [
+        organizationDomain({
+          enrollmentMode: undefined,
+          enrollment_mode: "automatic_invitation",
+          id: "orgdmn_lightfast",
+          name: "Lightfast.AI",
+          verification: { status: "verified" },
+        }),
+      ],
+    });
+
+    await expect(
+      caller().org.settings.organization.listDomains({ slug: "acme" })
+    ).resolves.toEqual([
+      {
+        enrollmentMode: "automatic_invitation",
+        id: "orgdmn_lightfast",
+        name: "lightfast.ai",
+        verificationStatus: "verified",
+      },
+    ]);
+
+    expect(getOrganizationDomainListMock).toHaveBeenCalledWith({
+      limit: 100,
+      organizationId: "org_acme",
+    });
+  });
+
+  it("reconciles auto-join domains for the requested admin organization slug", async () => {
+    getOrganizationDomainListMock
+      .mockResolvedValueOnce({
+        data: [
+          organizationDomain({
+            id: "orgdmn_acme",
+            name: "acme.com",
+          }),
+          organizationDomain({
+            enrollmentMode: undefined,
+            enrollment_mode: "manual_invitation",
+            id: "orgdmn_lightfast",
+            name: "lightfast.ai",
+          }),
+          organizationDomain({
+            id: "orgdmn_old",
+            name: "old.com",
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          organizationDomain({
+            id: "orgdmn_acme",
+            name: "acme.com",
+          }),
+          organizationDomain({
+            id: "orgdmn_lightfast",
+            name: "lightfast.ai",
+          }),
+          organizationDomain({
+            id: "orgdmn_new",
+            name: "new.com",
+          }),
+        ],
+      });
+
+    await expect(
+      caller().org.settings.organization.updateDomains({
+        domains: [" Lightfast.AI ", "new.com", "acme.com", "lightfast.ai"],
+        slug: "acme",
+      })
+    ).resolves.toEqual([
+      {
+        enrollmentMode: "automatic_invitation",
+        id: "orgdmn_acme",
+        name: "acme.com",
+        verificationStatus: "verified",
+      },
+      {
+        enrollmentMode: "automatic_invitation",
+        id: "orgdmn_lightfast",
+        name: "lightfast.ai",
+        verificationStatus: "verified",
+      },
+      {
+        enrollmentMode: "automatic_invitation",
+        id: "orgdmn_new",
+        name: "new.com",
+        verificationStatus: "verified",
+      },
+    ]);
+
+    expect(updateOrganizationDomainMock).toHaveBeenCalledWith({
+      domainId: "orgdmn_lightfast",
+      enrollmentMode: "automatic_invitation",
+      organizationId: "org_acme",
+      verified: true,
+    });
+    expect(createOrganizationDomainMock).toHaveBeenCalledWith({
+      enrollmentMode: "automatic_invitation",
+      name: "new.com",
+      organizationId: "org_acme",
+      verified: true,
+    });
+    const createCallOrder =
+      createOrganizationDomainMock.mock.invocationCallOrder[0];
+    const deleteCallOrder =
+      deleteOrganizationDomainMock.mock.invocationCallOrder[0];
+    expect(createCallOrder).toBeDefined();
+    expect(deleteCallOrder).toBeDefined();
+    expect(createCallOrder!).toBeLessThan(deleteCallOrder!);
+    expect(deleteOrganizationDomainMock).toHaveBeenCalledWith({
+      domainId: "orgdmn_old",
+      organizationId: "org_acme",
+    });
+  });
+
+  it("rejects domain updates without the admin role", async () => {
+    getOrganizationMembershipListMock.mockResolvedValueOnce({
+      data: [organizationMembership({ role: "org:member" })],
+      totalCount: 1,
+    });
+
+    await expect(
+      caller().org.settings.organization.updateDomains({
+        domains: ["acme.com"],
+        slug: "acme",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(createOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(deleteOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(updateOrganizationDomainMock).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/organization-router.test.ts
+++ b/api/app/src/__tests__/organization-router.test.ts
@@ -106,6 +106,17 @@ const unauthenticatedIdentity: AuthIdentity = {
   type: "unauthenticated",
 };
 
+function activeIdentity(
+  overrides: { orgId?: string; userId?: string } = {}
+): AuthIdentity {
+  return {
+    type: "active",
+    userId: overrides.userId ?? "user_test",
+    orgId: overrides.orgId ?? "org_acme",
+    orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+  };
+}
+
 function adminAccess(overrides: { orgId?: string; userId?: string } = {}) {
   return {
     kind: "clerk-session" as const,
@@ -623,7 +634,10 @@ describe("organization domains", () => {
       });
 
     await expect(
-      caller().org.settings.organization.updateDomains({
+      caller(
+        activeIdentity(),
+        adminAccess()
+      ).org.settings.organization.updateDomains({
         domains: [" Lightfast.AI ", "new.com", "acme.com", "lightfast.ai"],
         slug: "acme",
       })
@@ -673,14 +687,42 @@ describe("organization domains", () => {
     });
   });
 
-  it("rejects domain updates without the admin role", async () => {
-    getOrganizationMembershipListMock.mockResolvedValueOnce({
-      data: [organizationMembership({ role: "org:member" })],
-      totalCount: 1,
-    });
-
+  it("rejects domain updates when the caller has no active organization", async () => {
     await expect(
       caller().org.settings.organization.updateDomains({
+        domains: ["acme.com"],
+        slug: "acme",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(getOrganizationDomainListMock).not.toHaveBeenCalled();
+    expect(createOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(deleteOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(updateOrganizationDomainMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects domain updates when the active organization differs from the requested slug", async () => {
+    await expect(
+      caller(
+        activeIdentity({ orgId: "org_other" }),
+        adminAccess({ orgId: "org_other" })
+      ).org.settings.organization.updateDomains({
+        domains: ["acme.com"],
+        slug: "acme",
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(createOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(deleteOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(updateOrganizationDomainMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects domain updates without the admin role", async () => {
+    await expect(
+      caller(
+        activeIdentity(),
+        nonAdminAccess()
+      ).org.settings.organization.updateDomains({
         domains: ["acme.com"],
         slug: "acme",
       })

--- a/api/app/src/router/(pending-allowed)/organization.ts
+++ b/api/app/src/router/(pending-allowed)/organization.ts
@@ -381,7 +381,7 @@ export const orgSettingsOrganizationRouter = {
       return sortDomainResponses(domains.map(domainResponse));
     }),
 
-  updateDomains: viewerProcedure
+  updateDomains: orgAdminProcedure
     .input(organizationDomainsUpdateInputSchema)
     .mutation(async ({ ctx, input }) => {
       const access = await getOrganizationAccessBySlugOrThrow({
@@ -390,7 +390,7 @@ export const orgSettingsOrganizationRouter = {
         userId: ctx.auth.identity.userId,
       });
 
-      if (access.role !== "org:admin") {
+      if (access.org.id !== ctx.auth.identity.orgId) {
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "Only administrators can perform this action",

--- a/api/app/src/router/(pending-allowed)/organization.ts
+++ b/api/app/src/router/(pending-allowed)/organization.ts
@@ -23,6 +23,125 @@ import {
 } from "../../auth/organization-access";
 import { orgAdminProcedure, viewerProcedure } from "../../trpc";
 
+const AUTO_JOIN_DOMAIN_ENROLLMENT_MODE = "automatic_invitation" as const;
+const MAX_ORGANIZATION_DOMAINS = 10;
+const DOMAIN_PATTERN =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+type ClerkClient = Awaited<ReturnType<typeof clerkClient>>;
+type ClerkOrganizationDomain = Awaited<
+  ReturnType<ClerkClient["organizations"]["getOrganizationDomainList"]>
+>["data"][number];
+
+function normalizeOrganizationDomainName(value: string) {
+  const trimmed = value.trim().toLowerCase();
+  const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+
+  let hostname = "";
+  try {
+    hostname = new URL(withProtocol).hostname;
+  } catch {
+    hostname = trimmed.split(/[/?#]/, 1)[0] ?? "";
+  }
+
+  return hostname
+    .replace(/^\.+|\.+$/g, "")
+    .replace(/^www\./, "")
+    .replace(/\.$/, "");
+}
+
+const organizationDomainSchema = z.string().transform((value, ctx) => {
+  const normalized = normalizeOrganizationDomainName(value);
+  if (!DOMAIN_PATTERN.test(normalized)) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Enter a valid domain, like lightfast.ai",
+    });
+    return z.NEVER;
+  }
+  return normalized;
+});
+
+const organizationDomainsInputSchema = z.object({
+  domains: z
+    .array(organizationDomainSchema)
+    .max(50)
+    .transform((domains) => [...new Set(domains)])
+    .pipe(z.array(z.string()).max(MAX_ORGANIZATION_DOMAINS)),
+});
+const organizationDomainsBySlugInputSchema = z.object({
+  slug: clerkOrgSlugSchema,
+});
+const organizationDomainsUpdateInputSchema =
+  organizationDomainsInputSchema.extend({
+    slug: clerkOrgSlugSchema,
+  });
+
+function domainVerificationStatus(domain: ClerkOrganizationDomain) {
+  return domain.verification?.status ?? "unverified";
+}
+
+function domainEnrollmentMode(domain: ClerkOrganizationDomain) {
+  return (
+    domain.enrollmentMode ??
+    (domain as { enrollment_mode?: ClerkOrganizationDomain["enrollmentMode"] })
+      .enrollment_mode
+  );
+}
+
+function domainResponse(domain: ClerkOrganizationDomain) {
+  return {
+    enrollmentMode: domainEnrollmentMode(domain),
+    id: domain.id,
+    name: domain.name.toLowerCase(),
+    verificationStatus: domainVerificationStatus(domain),
+  };
+}
+
+function sortDomainResponses(
+  domains: ReturnType<typeof domainResponse>[]
+): ReturnType<typeof domainResponse>[] {
+  return [...domains].sort((left, right) =>
+    left.name.localeCompare(right.name)
+  );
+}
+
+async function listOrganizationDomains(
+  clerk: ClerkClient,
+  organizationId: string
+) {
+  const result = await clerk.organizations.getOrganizationDomainList({
+    limit: 100,
+    organizationId,
+  });
+  return result.data;
+}
+
+async function getOrganizationAccessBySlugOrThrow(input: {
+  ctx: { db: Parameters<typeof getOrgAccessBySlug>[0]["db"] };
+  slug: string;
+  userId: string;
+}) {
+  try {
+    return await getOrgAccessBySlug({
+      db: input.ctx.db,
+      slug: input.slug,
+      userId: input.userId,
+    });
+  } catch (error) {
+    if (isOrgAccessError(error)) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Organization not found",
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
 function namespaceConflictToTRPCError(
   error: NamespaceConflictError,
   handle: string
@@ -248,6 +367,92 @@ export const organizationRouter = {
 } satisfies TRPCRouterRecord;
 
 export const orgSettingsOrganizationRouter = {
+  listDomains: viewerProcedure
+    .input(organizationDomainsBySlugInputSchema)
+    .query(async ({ ctx, input }) => {
+      const access = await getOrganizationAccessBySlugOrThrow({
+        ctx,
+        slug: input.slug,
+        userId: ctx.auth.identity.userId,
+      });
+      const clerk = await clerkClient();
+      const domains = await listOrganizationDomains(clerk, access.org.id);
+
+      return sortDomainResponses(domains.map(domainResponse));
+    }),
+
+  updateDomains: viewerProcedure
+    .input(organizationDomainsUpdateInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const access = await getOrganizationAccessBySlugOrThrow({
+        ctx,
+        slug: input.slug,
+        userId: ctx.auth.identity.userId,
+      });
+
+      if (access.role !== "org:admin") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only administrators can perform this action",
+        });
+      }
+
+      const clerk = await clerkClient();
+      const existingDomains = await listOrganizationDomains(
+        clerk,
+        access.org.id
+      );
+      const nextDomainNames = new Set(input.domains);
+      const existingByName = new Map(
+        existingDomains.map((domain) => [domain.name.toLowerCase(), domain])
+      );
+      const domainsToDelete = existingDomains.filter(
+        (domain) => !nextDomainNames.has(domain.name.toLowerCase())
+      );
+
+      await Promise.all(
+        input.domains.map((name) => {
+          const existingDomain = existingByName.get(name);
+          if (!existingDomain) {
+            return clerk.organizations.createOrganizationDomain({
+              enrollmentMode: AUTO_JOIN_DOMAIN_ENROLLMENT_MODE,
+              name,
+              organizationId: access.org.id,
+              verified: true,
+            });
+          }
+
+          if (
+            domainEnrollmentMode(existingDomain) !==
+              AUTO_JOIN_DOMAIN_ENROLLMENT_MODE ||
+            domainVerificationStatus(existingDomain) !== "verified"
+          ) {
+            return clerk.organizations.updateOrganizationDomain({
+              domainId: existingDomain.id,
+              enrollmentMode: AUTO_JOIN_DOMAIN_ENROLLMENT_MODE,
+              organizationId: access.org.id,
+              verified: true,
+            });
+          }
+
+          return Promise.resolve(existingDomain);
+        })
+      );
+
+      await Promise.all(
+        domainsToDelete.map((domain) =>
+          clerk.organizations.deleteOrganizationDomain({
+            domainId: domain.id,
+            organizationId: access.org.id,
+          })
+        )
+      );
+
+      const domains = await listOrganizationDomains(clerk, access.org.id);
+
+      return sortDomainResponses(domains.map(domainResponse));
+    }),
+
   /**
    * Update organization name
    * Used by team settings page to update the organization name/slug in Clerk

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-model.test.ts
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   normalizeTeamSlugInput,
+  parseTeamDomainInput,
   renameOrganizationSlug,
 } from "~/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-actions";
 
@@ -27,5 +28,15 @@ describe("team general settings model", () => {
       { id: "org_1", initials: "A", slug: "acme-next" },
       { id: "org_2", initials: "B", slug: "beta" },
     ]);
+  });
+
+  it("parses pasted domains into normalized unique names", () => {
+    expect(
+      parseTeamDomainInput(`
+        Lightfast.AI, https://Example.com/docs
+        acme.com
+        lightfast.ai
+      `)
+    ).toEqual(["lightfast.ai", "example.com", "acme.com"]);
   });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-page.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-page.test.tsx
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const identityGetQueryOptionsMock = vi.fn(() => ({
   queryKey: ["org", "settings", "identity", "get"],
 }));
+const listDomainsQueryOptionsMock = vi.fn((input: { slug: string }) => ({
+  input,
+  queryKey: ["org", "settings", "organization", "listDomains", input.slug],
+}));
 const listUserOrganizationsQueryOptionsMock = vi.fn(() => ({
   queryKey: ["viewer", "organization", "listUserOrganizations"],
 }));
@@ -21,6 +25,11 @@ vi.mock("~/trpc/server", () => ({
         identity: {
           get: {
             queryOptions: identityGetQueryOptionsMock,
+          },
+        },
+        organization: {
+          listDomains: {
+            queryOptions: listDomainsQueryOptionsMock,
           },
         },
       },
@@ -59,6 +68,7 @@ const { default: SettingsPage } = await import(
 
 beforeEach(() => {
   identityGetQueryOptionsMock.mockClear();
+  listDomainsQueryOptionsMock.mockClear();
   listUserOrganizationsQueryOptionsMock.mockClear();
   prefetchMock.mockClear();
 });
@@ -71,9 +81,16 @@ describe("general settings page", () => {
     render(element);
 
     expect(identityGetQueryOptionsMock).toHaveBeenCalledOnce();
+    expect(listDomainsQueryOptionsMock).toHaveBeenCalledWith({
+      slug: "acme",
+    });
     expect(listUserOrganizationsQueryOptionsMock).toHaveBeenCalledOnce();
     expect(prefetchMock).toHaveBeenCalledWith({
       queryKey: ["org", "settings", "identity", "get"],
+    });
+    expect(prefetchMock).toHaveBeenCalledWith({
+      input: { slug: "acme" },
+      queryKey: ["org", "settings", "organization", "listDomains", "acme"],
     });
     expect(prefetchMock).toHaveBeenCalledWith({
       queryKey: ["viewer", "organization", "listUserOrganizations"],

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
@@ -1,9 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const domainsQueryOptions = {
+  queryKey: ["org", "settings", "organization", "listDomains", "acme"],
+};
 const listUserOrganizationsQueryOptionsMock = vi.fn(() => ({
   queryKey: ["viewer", "organization", "listUserOrganizations"],
 }));
+const listDomainsQueryOptionsMock = vi.fn((input: { slug: string }) => ({
+  ...domainsQueryOptions,
+  input,
+}));
+const updateDomainsMutationOptionsMock = vi.fn((options: unknown) => options);
 const updateNameMutationOptionsMock = vi.fn((options: unknown) => options);
 
 vi.mock("~/trpc/react", () => ({
@@ -11,6 +19,12 @@ vi.mock("~/trpc/react", () => ({
     org: {
       settings: {
         organization: {
+          listDomains: {
+            queryOptions: listDomainsQueryOptionsMock,
+          },
+          updateDomains: {
+            mutationOptions: updateDomainsMutationOptionsMock,
+          },
           updateName: {
             mutationOptions: updateNameMutationOptionsMock,
           },
@@ -38,9 +52,19 @@ vi.mock("@tanstack/react-query", () => ({
     invalidateQueries: vi.fn(),
     setQueryData: vi.fn(),
   }),
-  useSuspenseQuery: vi.fn(() => ({
-    data: [{ initials: "AI", slug: "acme" }],
-  })),
+  useSuspenseQuery: vi.fn((options: { queryKey: string[] }) => {
+    if (options.queryKey === domainsQueryOptions.queryKey) {
+      return {
+        data: [
+          { id: "orgdmn_1", name: "jeevanpillay.com" },
+          { id: "orgdmn_2", name: "lightfast.ai" },
+        ],
+      };
+    }
+    return {
+      data: [{ initials: "AI", slug: "acme" }],
+    };
+  }),
 }));
 
 vi.mock("@vendor/clerk", () => ({
@@ -61,7 +85,9 @@ const { TeamGeneralSettingsClient } = await import(
 );
 
 beforeEach(() => {
+  listDomainsQueryOptionsMock.mockClear();
   listUserOrganizationsQueryOptionsMock.mockClear();
+  updateDomainsMutationOptionsMock.mockClear();
   updateNameMutationOptionsMock.mockClear();
 });
 
@@ -73,5 +99,22 @@ describe("TeamGeneralSettingsClient", () => {
     expect(screen.getByText("Avatar")).toBeVisible();
     expect(screen.getByText("Team name")).toBeVisible();
     expect(screen.getByLabelText("Team name")).toHaveValue("acme");
+  });
+
+  it("renders the Domains controls in General settings", () => {
+    render(<TeamGeneralSettingsClient slug="acme" />);
+
+    expect(screen.getByText("Domains")).toBeVisible();
+    expect(
+      screen.getByText(
+        "People with matching email domains will automatically join this team."
+      )
+    ).toBeVisible();
+    expect(screen.getByText("jeevanpillay.com")).toBeVisible();
+    expect(screen.getByText("lightfast.ai")).toBeVisible();
+    expect(screen.getByLabelText("Add domain")).toBeVisible();
+    expect(listDomainsQueryOptionsMock).toHaveBeenCalledWith({
+      slug: "acme",
+    });
   });
 });

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const updateDomainsMutateMock = vi.fn();
+const useAuthMock = vi.fn();
 const domainsQueryOptions = {
   queryKey: ["org", "settings", "organization", "listDomains", "acme"],
 };
@@ -44,7 +46,7 @@ vi.mock("~/trpc/react", () => ({
 vi.mock("@tanstack/react-query", () => ({
   useMutation: () => ({
     isPending: false,
-    mutate: vi.fn(),
+    mutate: updateDomainsMutateMock,
   }),
   useQueryClient: () => ({
     cancelQueries: vi.fn(),
@@ -68,6 +70,7 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 vi.mock("@vendor/clerk", () => ({
+  useAuth: useAuthMock,
   useOrganizationList: () => ({
     setActive: vi.fn(),
   }),
@@ -87,8 +90,14 @@ const { TeamGeneralSettingsClient } = await import(
 beforeEach(() => {
   listDomainsQueryOptionsMock.mockClear();
   listUserOrganizationsQueryOptionsMock.mockClear();
+  updateDomainsMutateMock.mockClear();
   updateDomainsMutationOptionsMock.mockClear();
   updateNameMutationOptionsMock.mockClear();
+  useAuthMock.mockReset();
+  useAuthMock.mockReturnValue({
+    has: ({ role }: { role?: string }) => role === "org:admin",
+    isLoaded: true,
+  });
 });
 
 describe("TeamGeneralSettingsClient", () => {
@@ -112,9 +121,28 @@ describe("TeamGeneralSettingsClient", () => {
     ).toBeVisible();
     expect(screen.getByText("jeevanpillay.com")).toBeVisible();
     expect(screen.getByText("lightfast.ai")).toBeVisible();
-    expect(screen.getByLabelText("Add domain")).toBeVisible();
+    expect(screen.getByLabelText("Add domain")).toBeEnabled();
     expect(listDomainsQueryOptionsMock).toHaveBeenCalledWith({
       slug: "acme",
     });
+  });
+
+  it("disables the Domains controls for non-admin members", () => {
+    useAuthMock.mockReturnValue({
+      has: () => false,
+      isLoaded: true,
+    });
+
+    render(<TeamGeneralSettingsClient slug="acme" />);
+
+    const addDomainInput = screen.getByLabelText("Add domain");
+    expect(addDomainInput).toBeDisabled();
+    expect(screen.getByLabelText("Remove jeevanpillay.com")).toBeDisabled();
+    expect(screen.getByLabelText("Remove lightfast.ai")).toBeDisabled();
+
+    fireEvent.change(addDomainInput, { target: { value: "new.com" } });
+    fireEvent.blur(addDomainInput);
+
+    expect(updateDomainsMutateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-actions.ts
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-actions.ts
@@ -5,11 +5,49 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useTRPC } from "~/trpc/react";
 
+const DOMAIN_PATTERN =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
 export function normalizeTeamSlugInput(value: string) {
   return value
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, "")
     .replace(/^-+|-+$/g, "");
+}
+
+export function normalizeTeamDomainInput(value: string) {
+  const trimmed = value.trim().toLowerCase();
+  const withoutEmailLocalPart = trimmed.includes("@")
+    ? (trimmed.split("@").at(-1) ?? "")
+    : trimmed;
+  const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(withoutEmailLocalPart)
+    ? withoutEmailLocalPart
+    : `https://${withoutEmailLocalPart}`;
+
+  let hostname = "";
+  try {
+    hostname = new URL(withProtocol).hostname;
+  } catch {
+    hostname = withoutEmailLocalPart.split(/[/?#]/, 1)[0] ?? "";
+  }
+
+  return hostname
+    .replace(/^\.+|\.+$/g, "")
+    .replace(/^www\./, "")
+    .replace(/\.$/, "");
+}
+
+export function parseTeamDomainInput(value: string) {
+  const domains = value
+    .split(/[\s,;]+/)
+    .map(normalizeTeamDomainInput)
+    .filter((domain) => DOMAIN_PATTERN.test(domain));
+
+  return [...new Set(domains)];
+}
+
+export function normalizeTeamDomainList(domains: string[]) {
+  return [...new Set(domains.flatMap(parseTeamDomainInput))];
 }
 
 export function renameOrganizationSlug<T extends { slug: string }>(
@@ -81,5 +119,48 @@ export function useTeamNameUpdate({
   return {
     isUpdating: updateNameMutation.isPending,
     updateTeamName,
+  };
+}
+
+export function useTeamDomainsUpdate({
+  onError,
+  onUpdated,
+  slug,
+}: {
+  onError?: () => void;
+  onUpdated?: (domains: { id: string; name: string }[]) => void;
+  slug: string;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const updateDomainsMutation = useMutation(
+    trpc.org.settings.organization.updateDomains.mutationOptions({
+      meta: { errorTitle: "Failed to update domains" },
+      onError: () => {
+        onError?.();
+      },
+      onSuccess: (domains) => {
+        toast.success("Domains updated!", {
+          description: "Matching email domains will auto-join this team.",
+        });
+        onUpdated?.(domains);
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries(
+          trpc.org.settings.organization.listDomains.queryFilter({ slug })
+        );
+      },
+    })
+  );
+
+  const updateTeamDomains = useCallback(
+    (domains: string[]) => updateDomainsMutation.mutate({ domains, slug }),
+    [slug, updateDomainsMutation.mutate]
+  );
+
+  return {
+    isUpdatingDomains: updateDomainsMutation.isPending,
+    updateTeamDomains,
   };
 }

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
@@ -17,18 +17,28 @@ import { Input } from "@repo/ui/components/ui/input";
 import { toast } from "@repo/ui/components/ui/sonner";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useOrganizationList } from "@vendor/clerk";
-import { Loader2 } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { SettingRow, SettingsGroup } from "~/components/settings-section";
 import { useTRPC } from "~/trpc/react";
 import {
+  normalizeTeamDomainList,
   normalizeTeamSlugInput,
+  parseTeamDomainInput,
+  useTeamDomainsUpdate,
   useTeamNameUpdate,
 } from "./team-general-settings-actions";
 
 interface TeamGeneralSettingsClientProps {
   slug: string;
+}
+
+function areDomainListsEqual(left: string[], right: string[]) {
+  return (
+    left.length === right.length &&
+    left.every((domain, index) => domain === right[index])
+  );
 }
 
 export function TeamGeneralSettingsClient({
@@ -42,10 +52,28 @@ export function TeamGeneralSettingsClient({
     ...trpc.viewer.organization.listUserOrganizations.queryOptions(),
     staleTime: 5 * 60 * 1000,
   });
+  const { data: organizationDomains } = useSuspenseQuery({
+    ...trpc.org.settings.organization.listDomains.queryOptions({ slug }),
+    staleTime: 5 * 60 * 1000,
+  });
   const currentOrg = useMemo(
     () => organizations.find((org) => org.slug === slug),
     [organizations, slug]
   );
+  const currentDomainNames = useMemo(
+    () => organizationDomains.map((domain) => domain.name),
+    [organizationDomains]
+  );
+  const [draftDomains, setDraftDomains] = useState(currentDomainNames);
+  const [domainInput, setDomainInput] = useState("");
+
+  useEffect(() => {
+    setDraftDomains((current) =>
+      areDomainListsEqual(current, currentDomainNames)
+        ? current
+        : currentDomainNames
+    );
+  }, [currentDomainNames]);
 
   const form = useFormCompat<TeamSettingsFormValues>({
     resolver: zodResolver(teamSettingsFormSchema),
@@ -77,6 +105,15 @@ export function TeamGeneralSettingsClient({
   const { isUpdating, updateTeamName } = useTeamNameUpdate({
     onUpdated: handleTeamUpdated,
   });
+  const { isUpdatingDomains, updateTeamDomains } = useTeamDomainsUpdate({
+    onError: () => {
+      setDraftDomains(currentDomainNames);
+    },
+    onUpdated: (domains) => {
+      setDraftDomains(domains.map((domain) => domain.name));
+    },
+    slug,
+  });
 
   const onSubmit = useCallback(
     async (values: TeamSettingsFormValues) => {
@@ -104,68 +141,177 @@ export function TeamGeneralSettingsClient({
     []
   );
 
-  return (
-    <SettingsGroup title="Profile">
-      <SettingRow label="Avatar">
-        <Avatar className="size-7">
-          <AvatarFallback className="bg-foreground text-background text-xs">
-            {currentOrg?.initials ?? "?"}
-          </AvatarFallback>
-        </Avatar>
-      </SettingRow>
+  const commitDomains = useCallback(
+    (domains: string[]) => {
+      const nextDomains = normalizeTeamDomainList(domains);
+      if (areDomainListsEqual(nextDomains, draftDomains)) {
+        return;
+      }
 
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
-          <FormField
-            control={form.control}
-            name="teamName"
-            render={({ field }) => (
-              <SettingRow
-                description="This is your team's visible name within Lightfast. Lowercase letters, numbers, and hyphens (3-39 characters)."
-                label="Team name"
-              >
-                <FormItem className="space-y-0">
-                  <div className="flex flex-col items-end gap-2">
-                    <div className="flex items-center gap-2">
-                      <FormControl>
-                        <Input
-                          {...field}
-                          aria-label="Team name"
-                          className="w-64"
-                          onChange={(event) =>
-                            handleTeamNameChange(field.onChange, event)
+      setDraftDomains(nextDomains);
+      updateTeamDomains(nextDomains);
+    },
+    [draftDomains, updateTeamDomains]
+  );
+
+  const addDomainInput = useCallback(() => {
+    const parsedDomains = parseTeamDomainInput(domainInput);
+    if (parsedDomains.length === 0) {
+      return;
+    }
+    commitDomains([...draftDomains, ...parsedDomains]);
+    setDomainInput("");
+  }, [commitDomains, domainInput, draftDomains]);
+
+  const handleDomainKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (
+        (event.key === "Enter" ||
+          event.key === "," ||
+          (event.key === "Tab" && domainInput.trim())) &&
+        domainInput.trim()
+      ) {
+        event.preventDefault();
+        addDomainInput();
+      }
+    },
+    [addDomainInput, domainInput]
+  );
+
+  const handleDomainPaste = useCallback(
+    (event: React.ClipboardEvent<HTMLInputElement>) => {
+      const pastedDomains = parseTeamDomainInput(
+        event.clipboardData.getData("text")
+      );
+      if (pastedDomains.length <= 1) {
+        return;
+      }
+
+      event.preventDefault();
+      commitDomains([...draftDomains, ...pastedDomains]);
+      setDomainInput("");
+    },
+    [commitDomains, draftDomains]
+  );
+
+  const removeDomain = useCallback(
+    (domainToRemove: string) => {
+      commitDomains(draftDomains.filter((domain) => domain !== domainToRemove));
+    },
+    [commitDomains, draftDomains]
+  );
+
+  return (
+    <div className="space-y-10">
+      <SettingsGroup title="Profile">
+        <SettingRow label="Avatar">
+          <Avatar className="size-7">
+            <AvatarFallback className="bg-foreground text-background text-xs">
+              {currentOrg?.initials ?? "?"}
+            </AvatarFallback>
+          </Avatar>
+        </SettingRow>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name="teamName"
+              render={({ field }) => (
+                <SettingRow
+                  description="This is your team's visible name within Lightfast. Lowercase letters, numbers, and hyphens (3-39 characters)."
+                  label="Team name"
+                >
+                  <FormItem className="space-y-0">
+                    <div className="flex flex-col items-end gap-2">
+                      <div className="flex items-center gap-2">
+                        <FormControl>
+                          <Input
+                            {...field}
+                            aria-label="Team name"
+                            className="w-64"
+                            onChange={(event) =>
+                              handleTeamNameChange(field.onChange, event)
+                            }
+                            placeholder="acme-inc"
+                            size="lf"
+                            type="text"
+                            variant="lf"
+                          />
+                        </FormControl>
+                        <Button
+                          disabled={
+                            !(hasChanges && form.formState.isValid) ||
+                            isUpdating
                           }
-                          placeholder="acme-inc"
                           size="lf"
-                          type="text"
-                          variant="lf"
-                        />
-                      </FormControl>
-                      <Button
-                        disabled={
-                          !(hasChanges && form.formState.isValid) || isUpdating
-                        }
-                        size="lf"
-                        type="submit"
-                      >
-                        {isUpdating ? (
-                          <>
-                            <Loader2 className="size-3.5 animate-spin" />
-                            Saving
-                          </>
-                        ) : (
-                          "Save"
-                        )}
-                      </Button>
+                          type="submit"
+                        >
+                          {isUpdating ? (
+                            <>
+                              <Loader2 className="size-3.5 animate-spin" />
+                              Saving
+                            </>
+                          ) : (
+                            "Save"
+                          )}
+                        </Button>
+                      </div>
+                      <FormMessage className="text-xs" />
                     </div>
-                    <FormMessage className="text-xs" />
-                  </div>
-                </FormItem>
-              </SettingRow>
-            )}
-          />
-        </form>
-      </Form>
-    </SettingsGroup>
+                  </FormItem>
+                </SettingRow>
+              )}
+            />
+          </form>
+        </Form>
+      </SettingsGroup>
+
+      <SettingsGroup title="Domains">
+        <div className="space-y-3 py-4">
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            People with matching email domains will automatically join this
+            team.
+          </p>
+          <div className="flex min-h-12 w-full flex-wrap items-center gap-2 rounded-[9px] border border-input bg-card px-2.5 py-2 shadow-none transition-[color,box-shadow,background-color] focus-within:bg-background focus-within:shadow-[inset_0_0_0_1px_var(--ring)]">
+            {draftDomains.map((domain) => (
+              <span
+                className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-md bg-muted px-2.5 text-foreground text-sm"
+                key={domain}
+              >
+                <span className="truncate">{domain}</span>
+                <button
+                  aria-label={`Remove ${domain}`}
+                  className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+                  disabled={isUpdatingDomains}
+                  onClick={() => removeDomain(domain)}
+                  type="button"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </span>
+            ))}
+            <input
+              aria-label="Add domain"
+              className="h-7 min-w-36 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
+              disabled={isUpdatingDomains}
+              onBlur={addDomainInput}
+              onChange={(event) => setDomainInput(event.target.value)}
+              onKeyDown={handleDomainKeyDown}
+              onPaste={handleDomainPaste}
+              placeholder={draftDomains.length === 0 ? "lightfast.ai" : ""}
+              type="text"
+              value={domainInput}
+            />
+            {isUpdatingDomains ? (
+              <Loader2
+                aria-label="Saving domains"
+                className="size-3.5 animate-spin text-muted-foreground"
+              />
+            ) : null}
+          </div>
+        </div>
+      </SettingsGroup>
+    </div>
   );
 }

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
@@ -16,7 +16,7 @@ import {
 import { Input } from "@repo/ui/components/ui/input";
 import { toast } from "@repo/ui/components/ui/sonner";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useOrganizationList } from "@vendor/clerk";
+import { useAuth, useOrganizationList } from "@vendor/clerk";
 import { Loader2, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -46,7 +46,9 @@ export function TeamGeneralSettingsClient({
 }: TeamGeneralSettingsClientProps) {
   const router = useRouter();
   const trpc = useTRPC();
+  const { has, isLoaded } = useAuth();
   const { setActive } = useOrganizationList();
+  const canManageDomains = isLoaded && !!has?.({ role: "org:admin" });
 
   const { data: organizations } = useSuspenseQuery({
     ...trpc.viewer.organization.listUserOrganizations.queryOptions(),
@@ -114,6 +116,7 @@ export function TeamGeneralSettingsClient({
     },
     slug,
   });
+  const isDomainEditorDisabled = isUpdatingDomains || !canManageDomains;
 
   const onSubmit = useCallback(
     async (values: TeamSettingsFormValues) => {
@@ -143,6 +146,10 @@ export function TeamGeneralSettingsClient({
 
   const commitDomains = useCallback(
     (domains: string[]) => {
+      if (!canManageDomains) {
+        return;
+      }
+
       const nextDomains = normalizeTeamDomainList(domains);
       if (areDomainListsEqual(nextDomains, draftDomains)) {
         return;
@@ -151,7 +158,7 @@ export function TeamGeneralSettingsClient({
       setDraftDomains(nextDomains);
       updateTeamDomains(nextDomains);
     },
-    [draftDomains, updateTeamDomains]
+    [canManageDomains, draftDomains, updateTeamDomains]
   );
 
   const addDomainInput = useCallback(() => {
@@ -283,7 +290,7 @@ export function TeamGeneralSettingsClient({
                 <button
                   aria-label={`Remove ${domain}`}
                   className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
-                  disabled={isUpdatingDomains}
+                  disabled={isDomainEditorDisabled}
                   onClick={() => removeDomain(domain)}
                   type="button"
                 >
@@ -294,7 +301,7 @@ export function TeamGeneralSettingsClient({
             <input
               aria-label="Add domain"
               className="h-7 min-w-36 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
-              disabled={isUpdatingDomains}
+              disabled={isDomainEditorDisabled}
               onBlur={addDomainInput}
               onChange={(event) => setDomainInput(event.target.value)}
               onKeyDown={handleDomainKeyDown}

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/page.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/page.tsx
@@ -18,6 +18,7 @@ export default async function SettingsPage({
   // organization list is also prefetched by the ancestor ShellDataBoundary;
   // repeating it here keeps this route self-documenting and is a no-op dedupe.
   prefetch(trpc.org.settings.identity.get.queryOptions());
+  prefetch(trpc.org.settings.organization.listDomains.queryOptions({ slug }));
   prefetch(trpc.viewer.organization.listUserOrganizations.queryOptions());
 
   return (


### PR DESCRIPTION
## Summary
- Add Clerk-backed organization domain list/update endpoints keyed by team slug.
- Add Domains controls to General settings with normalization, chip add/remove, optimistic updates, and rollback on failed saves.
- Store multiple domains per org as verified Clerk domains using automatic invitation enrollment, with safer upsert-before-delete reconciliation.

## Test Plan
- [x] `pnpm exec vitest run src/__tests__/organization-router.test.ts` from `api/app`
- [x] `pnpm exec vitest run 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-model.test.ts' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-page.test.tsx'` from `apps/app`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `git diff --check`
- [x] Local E2E with `lightfast-local-infra`: provisioned PlanetScale/Upstash for this worktree, completed org onboarding for `domainse2e`, added/removed `domainse2e494d.com` and `domainse2e494d.dev`, verified Clerk persisted both as `automatic_invitation` + `verified`, tested blocked-domain rollback, and confirmed final Clerk domain list is empty.

## Known Check Failures
- `pnpm check` still fails on pre-existing unrelated issues:
  - `apps/app/src/app/(chat)/api/chat/route.ts:627` (`return undefined`)
  - `db/app/src/index.ts:4` export/import ordering
