### PR TITLE
Fix settings when Clerk org domains are disabled

### DIFF
--- a/api/app/src/__tests__/clerk-errors.test.ts
+++ b/api/app/src/__tests__/clerk-errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isClerkConflictError,
+  isClerkOrganizationDomainsNotEnabled,
   isClerkResourceNotFound,
 } from "../auth/clerk-errors";
 
@@ -46,5 +47,17 @@ describe("Clerk error helpers", () => {
         clerkError(422, "form_param_format_invalid", "slug is taken")
       )
     ).toBe(false);
+  });
+
+  it("recognizes Clerk organization-domain feature responses", () => {
+    expect(
+      isClerkOrganizationDomainsNotEnabled(
+        clerkError(
+          403,
+          "organization_domains_not_enabled",
+          "organization domains not enabled"
+        )
+      )
+    ).toBe(true);
   });
 });

--- a/api/app/src/__tests__/organization-router.test.ts
+++ b/api/app/src/__tests__/organization-router.test.ts
@@ -1,4 +1,5 @@
 import type { Database } from "@db/app";
+import { ClerkAPIResponseError } from "@vendor/clerk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthIdentity } from "../auth/identity";
@@ -66,7 +67,8 @@ vi.mock("@vendor/clerk/server", () => ({
     }),
 }));
 
-vi.mock("../auth/clerk-errors", () => ({
+vi.mock("../auth/clerk-errors", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth/clerk-errors")>()),
   isClerkConflictError: isClerkConflictErrorMock,
 }));
 
@@ -162,6 +164,22 @@ function organizationDomain(overrides: Record<string, unknown> = {}) {
     verification: { status: "verified" },
     ...overrides,
   };
+}
+
+function clerkOrganizationDomainsNotEnabledError() {
+  return new ClerkAPIResponseError("Forbidden", {
+    clerkTraceId: "trace_org_domains_disabled",
+    data: [
+      {
+        code: "organization_domains_not_enabled",
+        long_message:
+          "This instance does not have domains enabled for organizations.",
+        message: "organization domains not enabled",
+      },
+    ],
+    retryAfter: undefined,
+    status: 403,
+  });
 }
 
 function organizationMembership(overrides: Record<string, unknown> = {}) {
@@ -581,19 +599,52 @@ describe("organization domains", () => {
 
     await expect(
       caller().org.settings.organization.listDomains({ slug: "acme" })
-    ).resolves.toEqual([
-      {
-        enrollmentMode: "automatic_invitation",
-        id: "orgdmn_lightfast",
-        name: "lightfast.ai",
-        verificationStatus: "verified",
-      },
-    ]);
+    ).resolves.toEqual({
+      domains: [
+        {
+          enrollmentMode: "automatic_invitation",
+          id: "orgdmn_lightfast",
+          name: "lightfast.ai",
+          verificationStatus: "verified",
+        },
+      ],
+      enabled: true,
+    });
 
     expect(getOrganizationDomainListMock).toHaveBeenCalledWith({
       limit: 100,
       organizationId: "org_acme",
     });
+  });
+
+  it("returns an empty list when Clerk organization domains are unavailable", async () => {
+    getOrganizationDomainListMock.mockRejectedValue(
+      clerkOrganizationDomainsNotEnabledError()
+    );
+
+    await expect(
+      caller().org.settings.organization.listDomains({ slug: "acme" })
+    ).resolves.toEqual({ domains: [], enabled: false });
+  });
+
+  it("rejects domain updates when Clerk organization domains are unavailable", async () => {
+    getOrganizationDomainListMock.mockRejectedValue(
+      clerkOrganizationDomainsNotEnabledError()
+    );
+
+    await expect(
+      caller(
+        activeIdentity(),
+        adminAccess()
+      ).org.settings.organization.updateDomains({
+        domains: ["acme.com"],
+        slug: "acme",
+      })
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(createOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(deleteOrganizationDomainMock).not.toHaveBeenCalled();
+    expect(updateOrganizationDomainMock).not.toHaveBeenCalled();
   });
 
   it("reconciles auto-join domains for the requested admin organization slug", async () => {

--- a/api/app/src/auth/clerk-errors.ts
+++ b/api/app/src/auth/clerk-errors.ts
@@ -1,6 +1,8 @@
 import { isClerkAPIResponseError } from "@vendor/clerk";
 
 const CLERK_RESOURCE_NOT_FOUND = "resource_not_found";
+const CLERK_ORGANIZATION_DOMAINS_NOT_ENABLED =
+  "organization_domains_not_enabled";
 const CLERK_CONFLICT_CODES = new Set([
   "duplicate_record",
   "form_identifier_exists",
@@ -31,4 +33,12 @@ export function isClerkResourceNotFound(error: unknown): boolean {
 
 export function isClerkConflictError(error: unknown): boolean {
   return hasClerkErrorCode(error, CLERK_CONFLICT_CODES);
+}
+
+export function isClerkOrganizationDomainsNotEnabled(error: unknown): boolean {
+  return (
+    isClerkAPIResponseError(error) &&
+    error.status === 403 &&
+    hasClerkErrorCode(error, [CLERK_ORGANIZATION_DOMAINS_NOT_ENABLED])
+  );
 }

--- a/api/app/src/router/(pending-allowed)/organization.ts
+++ b/api/app/src/router/(pending-allowed)/organization.ts
@@ -14,7 +14,10 @@ import { parseError } from "@vendor/observability/error/next";
 import { log } from "@vendor/observability/log/next";
 import { z } from "zod";
 
-import { isClerkConflictError } from "../../auth/clerk-errors";
+import {
+  isClerkConflictError,
+  isClerkOrganizationDomainsNotEnabled,
+} from "../../auth/clerk-errors";
 import { listUserOrganizationMemberships } from "../../auth/clerk-org-membership";
 import {
   getOrgAccessBySlug,
@@ -117,6 +120,35 @@ async function listOrganizationDomains(
     organizationId,
   });
   return result.data;
+}
+
+function organizationDomainsUnavailableError(error: unknown) {
+  return new TRPCError({
+    code: "PRECONDITION_FAILED",
+    message: "Organization domains are not enabled for this Clerk instance.",
+    cause: error,
+  });
+}
+
+async function listOrganizationDomainsWithAvailability(
+  clerk: ClerkClient,
+  organizationId: string
+) {
+  try {
+    return {
+      domains: await listOrganizationDomains(clerk, organizationId),
+      enabled: true,
+    };
+  } catch (error) {
+    if (isClerkOrganizationDomainsNotEnabled(error)) {
+      log.warn("[organization] domains unavailable", {
+        organizationId,
+        error: parseError(error),
+      });
+      return { domains: [], enabled: false };
+    }
+    throw error;
+  }
 }
 
 async function getOrganizationAccessBySlugOrThrow(input: {
@@ -376,9 +408,15 @@ export const orgSettingsOrganizationRouter = {
         userId: ctx.auth.identity.userId,
       });
       const clerk = await clerkClient();
-      const domains = await listOrganizationDomains(clerk, access.org.id);
+      const domainResult = await listOrganizationDomainsWithAvailability(
+        clerk,
+        access.org.id
+      );
 
-      return sortDomainResponses(domains.map(domainResponse));
+      return {
+        domains: sortDomainResponses(domainResult.domains.map(domainResponse)),
+        enabled: domainResult.enabled,
+      };
     }),
 
   updateDomains: orgAdminProcedure
@@ -398,59 +436,66 @@ export const orgSettingsOrganizationRouter = {
       }
 
       const clerk = await clerkClient();
-      const existingDomains = await listOrganizationDomains(
-        clerk,
-        access.org.id
-      );
-      const nextDomainNames = new Set(input.domains);
-      const existingByName = new Map(
-        existingDomains.map((domain) => [domain.name.toLowerCase(), domain])
-      );
-      const domainsToDelete = existingDomains.filter(
-        (domain) => !nextDomainNames.has(domain.name.toLowerCase())
-      );
+      try {
+        const existingDomains = await listOrganizationDomains(
+          clerk,
+          access.org.id
+        );
+        const nextDomainNames = new Set(input.domains);
+        const existingByName = new Map(
+          existingDomains.map((domain) => [domain.name.toLowerCase(), domain])
+        );
+        const domainsToDelete = existingDomains.filter(
+          (domain) => !nextDomainNames.has(domain.name.toLowerCase())
+        );
 
-      await Promise.all(
-        input.domains.map((name) => {
-          const existingDomain = existingByName.get(name);
-          if (!existingDomain) {
-            return clerk.organizations.createOrganizationDomain({
-              enrollmentMode: AUTO_JOIN_DOMAIN_ENROLLMENT_MODE,
-              name,
-              organizationId: access.org.id,
-              verified: true,
-            });
-          }
+        await Promise.all(
+          input.domains.map((name) => {
+            const existingDomain = existingByName.get(name);
+            if (!existingDomain) {
+              return clerk.organizations.createOrganizationDomain({
+                enrollmentMode: AUTO_JOIN_DOMAIN_ENROLLMENT_MODE,
+                name,
+                organizationId: access.org.id,
+                verified: true,
+              });
+            }
 
-          if (
-            domainEnrollmentMode(existingDomain) !==
-              AUTO_JOIN_DOMAIN_ENROLLMENT_MODE ||
-            domainVerificationStatus(existingDomain) !== "verified"
-          ) {
-            return clerk.organizations.updateOrganizationDomain({
-              domainId: existingDomain.id,
-              enrollmentMode: AUTO_JOIN_DOMAIN_ENROLLMENT_MODE,
-              organizationId: access.org.id,
-              verified: true,
-            });
-          }
+            if (
+              domainEnrollmentMode(existingDomain) !==
+                AUTO_JOIN_DOMAIN_ENROLLMENT_MODE ||
+              domainVerificationStatus(existingDomain) !== "verified"
+            ) {
+              return clerk.organizations.updateOrganizationDomain({
+                domainId: existingDomain.id,
+                enrollmentMode: AUTO_JOIN_DOMAIN_ENROLLMENT_MODE,
+                organizationId: access.org.id,
+                verified: true,
+              });
+            }
 
-          return Promise.resolve(existingDomain);
-        })
-      );
-
-      await Promise.all(
-        domainsToDelete.map((domain) =>
-          clerk.organizations.deleteOrganizationDomain({
-            domainId: domain.id,
-            organizationId: access.org.id,
+            return Promise.resolve(existingDomain);
           })
-        )
-      );
+        );
 
-      const domains = await listOrganizationDomains(clerk, access.org.id);
+        await Promise.all(
+          domainsToDelete.map((domain) =>
+            clerk.organizations.deleteOrganizationDomain({
+              domainId: domain.id,
+              organizationId: access.org.id,
+            })
+          )
+        );
 
-      return sortDomainResponses(domains.map(domainResponse));
+        const domains = await listOrganizationDomains(clerk, access.org.id);
+
+        return sortDomainResponses(domains.map(domainResponse));
+      } catch (error) {
+        if (isClerkOrganizationDomainsNotEnabled(error)) {
+          throw organizationDomainsUnavailableError(error);
+        }
+        throw error;
+      }
     }),
 
   /**

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const updateDomainsMutateMock = vi.fn();
 const useAuthMock = vi.fn();
+let domainsEnabled = true;
 const domainsQueryOptions = {
   queryKey: ["org", "settings", "organization", "listDomains", "acme"],
 };
@@ -57,10 +58,15 @@ vi.mock("@tanstack/react-query", () => ({
   useSuspenseQuery: vi.fn((options: { queryKey: string[] }) => {
     if (options.queryKey === domainsQueryOptions.queryKey) {
       return {
-        data: [
-          { id: "orgdmn_1", name: "jeevanpillay.com" },
-          { id: "orgdmn_2", name: "lightfast.ai" },
-        ],
+        data: {
+          domains: domainsEnabled
+            ? [
+                { id: "orgdmn_1", name: "jeevanpillay.com" },
+                { id: "orgdmn_2", name: "lightfast.ai" },
+              ]
+            : [],
+          enabled: domainsEnabled,
+        },
       };
     }
     return {
@@ -93,6 +99,7 @@ beforeEach(() => {
   updateDomainsMutateMock.mockClear();
   updateDomainsMutationOptionsMock.mockClear();
   updateNameMutationOptionsMock.mockClear();
+  domainsEnabled = true;
   useAuthMock.mockReset();
   useAuthMock.mockReturnValue({
     has: ({ role }: { role?: string }) => role === "org:admin",
@@ -125,6 +132,16 @@ describe("TeamGeneralSettingsClient", () => {
     expect(listDomainsQueryOptionsMock).toHaveBeenCalledWith({
       slug: "acme",
     });
+  });
+
+  it("hides the Domains controls when Clerk domains are unavailable", () => {
+    domainsEnabled = false;
+
+    render(<TeamGeneralSettingsClient slug="acme" />);
+
+    expect(screen.getByRole("heading", { name: "Profile" })).toBeVisible();
+    expect(screen.queryByText("Domains")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Add domain")).not.toBeInTheDocument();
   });
 
   it("disables the Domains controls for non-admin members", () => {

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx
@@ -63,7 +63,7 @@ export function TeamGeneralSettingsClient({
     [organizations, slug]
   );
   const currentDomainNames = useMemo(
-    () => organizationDomains.map((domain) => domain.name),
+    () => organizationDomains.domains.map((domain) => domain.name),
     [organizationDomains]
   );
   const [draftDomains, setDraftDomains] = useState(currentDomainNames);
@@ -274,51 +274,53 @@ export function TeamGeneralSettingsClient({
         </Form>
       </SettingsGroup>
 
-      <SettingsGroup title="Domains">
-        <div className="space-y-3 py-4">
-          <p className="text-muted-foreground text-sm leading-relaxed">
-            People with matching email domains will automatically join this
-            team.
-          </p>
-          <div className="flex min-h-12 w-full flex-wrap items-center gap-2 rounded-[9px] border border-input bg-card px-2.5 py-2 shadow-none transition-[color,box-shadow,background-color] focus-within:bg-background focus-within:shadow-[inset_0_0_0_1px_var(--ring)]">
-            {draftDomains.map((domain) => (
-              <span
-                className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-md bg-muted px-2.5 text-foreground text-sm"
-                key={domain}
-              >
-                <span className="truncate">{domain}</span>
-                <button
-                  aria-label={`Remove ${domain}`}
-                  className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
-                  disabled={isDomainEditorDisabled}
-                  onClick={() => removeDomain(domain)}
-                  type="button"
+      {organizationDomains.enabled ? (
+        <SettingsGroup title="Domains">
+          <div className="space-y-3 py-4">
+            <p className="text-muted-foreground text-sm leading-relaxed">
+              People with matching email domains will automatically join this
+              team.
+            </p>
+            <div className="flex min-h-12 w-full flex-wrap items-center gap-2 rounded-[9px] border border-input bg-card px-2.5 py-2 shadow-none transition-[color,box-shadow,background-color] focus-within:bg-background focus-within:shadow-[inset_0_0_0_1px_var(--ring)]">
+              {draftDomains.map((domain) => (
+                <span
+                  className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-md bg-muted px-2.5 text-foreground text-sm"
+                  key={domain}
                 >
-                  <X className="size-3.5" />
-                </button>
-              </span>
-            ))}
-            <input
-              aria-label="Add domain"
-              className="h-7 min-w-36 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
-              disabled={isDomainEditorDisabled}
-              onBlur={addDomainInput}
-              onChange={(event) => setDomainInput(event.target.value)}
-              onKeyDown={handleDomainKeyDown}
-              onPaste={handleDomainPaste}
-              placeholder={draftDomains.length === 0 ? "lightfast.ai" : ""}
-              type="text"
-              value={domainInput}
-            />
-            {isUpdatingDomains ? (
-              <Loader2
-                aria-label="Saving domains"
-                className="size-3.5 animate-spin text-muted-foreground"
+                  <span className="truncate">{domain}</span>
+                  <button
+                    aria-label={`Remove ${domain}`}
+                    className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+                    disabled={isDomainEditorDisabled}
+                    onClick={() => removeDomain(domain)}
+                    type="button"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                </span>
+              ))}
+              <input
+                aria-label="Add domain"
+                className="h-7 min-w-36 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
+                disabled={isDomainEditorDisabled}
+                onBlur={addDomainInput}
+                onChange={(event) => setDomainInput(event.target.value)}
+                onKeyDown={handleDomainKeyDown}
+                onPaste={handleDomainPaste}
+                placeholder={draftDomains.length === 0 ? "lightfast.ai" : ""}
+                type="text"
+                value={domainInput}
               />
-            ) : null}
+              {isUpdatingDomains ? (
+                <Loader2
+                  aria-label="Saving domains"
+                  className="size-3.5 animate-spin text-muted-foreground"
+                />
+              ) : null}
+            </div>
           </div>
-        </div>
-      </SettingsGroup>
+        </SettingsGroup>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Handle Clerk `organization_domains_not_enabled` responses from the settings domain list query so `/[slug]/settings` can still render in production.
- Return Clerk org-domain feature availability to the settings client and hide the Domains editor when the production instance cannot support it.
- Keep domain writes fail-closed with `PRECONDITION_FAILED` when the Clerk instance cannot support organization domains.
- Add regression coverage for the Clerk error helper, read/write domain behavior, and hidden Domains UI state.

## Production Context
- Sentry issues `LIGHTFAST-APP-2A`, `LIGHTFAST-APP-2B`, and `LIGHTFAST-APP-2C` point at `org.settings.organization.listDomains` on `GET /[slug]/settings`.
- Clerk prod config has `organization_settings.domains_enabled: false`; `clerk enable orgs --instance prod --domains --dry-run` fails with `unsupported_subscription_plan_features` for `org:domains`, so code must tolerate the unsupported prod plan.

## Test Plan
- [x] `pnpm exec biome check api/app/src/auth/clerk-errors.ts 'api/app/src/router/(pending-allowed)/organization.ts' api/app/src/__tests__/clerk-errors.test.ts api/app/src/__tests__/organization-router.test.ts 'apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/(manage)/settings/_components/team-general-settings-client.tsx' 'apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx'`
- [x] `cd api/app && pnpm exec vitest run src/__tests__/clerk-errors.test.ts src/__tests__/organization-router.test.ts`
- [x] `cd apps/app && pnpm exec vitest run 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-general-page.test.tsx' 'src/__tests__/app/(app)/(pending-not-allowed)/[slug]/settings-team-general-client.test.tsx'`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `git diff --check`