### PR TITLE
Add signal entity link indexing workflow

### DIFF
--- a/ai/package.json
+++ b/ai/package.json
@@ -10,6 +10,10 @@
       "types": "./src/people-classifier/index.ts",
       "default": "./src/people-classifier/index.ts"
     },
+    "./signal-entity-linker": {
+      "types": "./src/signal-entity-linker/index.ts",
+      "default": "./src/signal-entity-linker/index.ts"
+    },
     "./signal-classifier": {
       "types": "./src/signal-classifier/index.ts",
       "default": "./src/signal-classifier/index.ts"

--- a/ai/src/__tests__/_internal/agent-graphs/signal-intake.test.ts
+++ b/ai/src/__tests__/_internal/agent-graphs/signal-intake.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { signalIntakeAgentGraph } from "../../../_internal/agent-graphs/signal-intake";
 
 describe("signalIntakeAgentGraph", () => {
-  it("defines the routed signal to people classifier topology", () => {
+  it("defines the routed signal intake topology", () => {
     expect(signalIntakeAgentGraph).toMatchObject({
       id: "signal-intake",
       routerId: "signals",
@@ -16,6 +16,12 @@ describe("signalIntakeAgentGraph", () => {
         peopleClassifier: {
           id: "people-classifier",
           role: "extractor",
+          upstreamNodeIds: ["signal-classifier"],
+        },
+        signalEntityLinker: {
+          id: "signal-entity-linker",
+          role: "extractor",
+          schemaVersion: "signal.entity-links.v1",
           upstreamNodeIds: ["signal-classifier"],
         },
       },

--- a/ai/src/__tests__/signal-entity-linker/classify.test.ts
+++ b/ai/src/__tests__/signal-entity-linker/classify.test.ts
@@ -1,0 +1,251 @@
+import type { SignalClassification } from "@repo/api-contract";
+import { MockLanguageModelV3 } from "@vendor/ai/test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildSignalEntityLinkingRequest,
+  classifySignalEntityLinks,
+  getSignalEntityLinkingFailure,
+  SIGNAL_ENTITY_LINKER_MODEL,
+  SIGNAL_ENTITY_LINKER_PROMPT_ID,
+  SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT,
+  SIGNAL_ENTITY_LINKER_WORKFLOW,
+  SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE,
+  type SignalEntityLinkCandidate,
+  type SignalEntityLinkingModelOutput,
+} from "../../signal-entity-linker";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+const signalId = "sig_123e4567-e89b-12d3-a456-426614174000";
+
+const signalClassification = {
+  schemaVersion: "signal.classification.v2",
+  disposition: "actionable",
+  title: "Follow up with Jordi",
+  summary: "The signal asks the team to follow up with Jordi Torras.",
+  kind: "engage",
+  nextAction: "Review Jordi's context and prepare a response.",
+  priority: "normal",
+  rationale: "The input names a person who may need follow-up.",
+  confidence: 0.9,
+  routing: {
+    visibility: {
+      scope: "team",
+      rationale: "The request is shared team context.",
+    },
+    review: { required: false, reason: null, rationale: null },
+    routes: {
+      people: {
+        shouldRun: true,
+        confidence: 0.86,
+        rationale: "The input includes a person reference.",
+      },
+    },
+  },
+} satisfies SignalClassification;
+
+const deterministicCandidates = [
+  {
+    targetType: "person",
+    localEntityKey: "person_1",
+    label: "jordi@example.com",
+    mentionKind: "email",
+    anchorText: "jordi@example.com",
+    anchorOccurrence: 1,
+    extractionMethod: "deterministic",
+    rationale: "Email address matched deterministic extractor.",
+    confidence: 1,
+  },
+] satisfies SignalEntityLinkCandidate[];
+
+const modelOwnedEntityLinks = {
+  candidates: [
+    {
+      targetType: "person",
+      localEntityKey: "person_2",
+      label: "Jordi Torras",
+      mentionKind: "name",
+      anchorText: "Jordi Torras",
+      anchorOccurrence: 1,
+      rationale: "The signal explicitly names Jordi Torras as a person.",
+      confidence: 0.82,
+    },
+  ],
+} satisfies SignalEntityLinkingModelOutput;
+
+const usage = {
+  inputTokens: {
+    total: 31,
+    noCache: 31,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 63, text: 63, reasoning: undefined },
+};
+
+function createClassifierModel(text: string) {
+  return new MockLanguageModelV3({
+    provider: "openai",
+    modelId: "gpt-5.4-nano",
+    doGenerate: async () => ({
+      content: [{ type: "text", text }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage,
+      warnings: [],
+    }),
+  });
+}
+
+beforeEach(() => {
+  logger.info.mockReset();
+  logger.warn.mockReset();
+});
+
+describe("classifySignalEntityLinks", () => {
+  it("builds a signal entity linking request with signal context", () => {
+    const input =
+      "Jordi Torras asked us to email jordi@example.com after the launch.";
+    const request = buildSignalEntityLinkingRequest({
+      classification: signalClassification,
+      clerkOrgId: "org_test",
+      deploymentEnvironment: "development",
+      deterministicCandidates,
+      input,
+      signalId,
+    });
+
+    expect(SIGNAL_ENTITY_LINKER_MODEL).toBe("openai/gpt-5.4-nano");
+    expect(SIGNAL_ENTITY_LINKER_WORKFLOW).toBe("index-signal-entities");
+    expect(SIGNAL_ENTITY_LINKER_PROMPT_ID).toBe("signal-entity-linker");
+    expect(request).toEqual(
+      expect.objectContaining({
+        classification: signalClassification,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "development",
+        deterministicCandidates,
+        inputLength: input.length,
+        model: SIGNAL_ENTITY_LINKER_MODEL,
+        signalId,
+        system: SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT,
+      })
+    );
+    expect(request.prompt).toContain(input);
+    expect(request.prompt).toContain(JSON.stringify(signalClassification));
+    expect(request.prompt).toContain(JSON.stringify(deterministicCandidates));
+  });
+
+  it("uses structured output and stamps schema version and extraction method", async () => {
+    const model = createClassifierModel(JSON.stringify(modelOwnedEntityLinks));
+    const request = {
+      ...buildSignalEntityLinkingRequest({
+        classification: signalClassification,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "production",
+        deterministicCandidates,
+        input: "Jordi Torras asked us to email jordi@example.com.",
+        signalId,
+      }),
+      model,
+    };
+
+    await expect(
+      classifySignalEntityLinks(request, { logger })
+    ).resolves.toEqual({
+      schemaVersion: "signal.entity-links.v1",
+      candidates: [
+        {
+          ...modelOwnedEntityLinks.candidates[0],
+          extractionMethod: "ai",
+        },
+      ],
+    });
+
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(model.doGenerateCalls[0]).toEqual(
+      expect.objectContaining({
+        maxOutputTokens: 768,
+        responseFormat: expect.objectContaining({ type: "json" }),
+      })
+    );
+  });
+
+  it("logs signal entity linker graph metadata on success", async () => {
+    const model = createClassifierModel(JSON.stringify(modelOwnedEntityLinks));
+    const input = "Jordi Torras asked us to email jordi@example.com.";
+    const request = {
+      ...buildSignalEntityLinkingRequest({
+        classification: signalClassification,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "production",
+        deterministicCandidates,
+        input,
+        signalId,
+      }),
+      model,
+    };
+
+    await classifySignalEntityLinks(request, { logger });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "[entity-links] classification completed",
+      expect.objectContaining({
+        agentGraphId: "signal-intake",
+        agentRunId: signalId,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "production",
+        feature: "entity-links",
+        inputLength: input.length,
+        nodeId: "signal-entity-linker",
+        nodeKind: "llm",
+        nodeRole: "extractor",
+        promptId: "signal-entity-linker",
+        routerId: "signals",
+        signalId,
+        upstreamNodeId: "signal-classifier",
+        workflow: "index-signal-entities",
+      })
+    );
+  });
+
+  it("maps invalid model output to a durable signal entity linking failure code", async () => {
+    const model = createClassifierModel(
+      JSON.stringify({ candidates: [{ targetType: "project" }] })
+    );
+    const request = {
+      ...buildSignalEntityLinkingRequest({
+        classification: signalClassification,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "preview",
+        deterministicCandidates,
+        input: "Jordi Torras asked us to email jordi@example.com.",
+        signalId,
+      }),
+      model,
+    };
+
+    const failure = await classifySignalEntityLinks(request, { logger }).catch(
+      (error) => getSignalEntityLinkingFailure(error)
+    );
+
+    expect(failure.errorCode).toBe(
+      SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE
+    );
+  });
+
+  it("instructs the model to link only explicit raw-input person references", () => {
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain(
+      "Name-only person references are allowed"
+    );
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain(
+      "Do not extract role-only"
+    );
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain(
+      "anchorText must be an exact substring"
+    );
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain("Do not browse");
+  });
+});

--- a/ai/src/__tests__/signal-entity-linker/extract.test.ts
+++ b/ai/src/__tests__/signal-entity-linker/extract.test.ts
@@ -87,20 +87,22 @@ describe("signal entity linker extraction", () => {
     });
 
     expect(candidates).toHaveLength(2);
-    expect(candidates.filter((candidate) => candidate.mentionKind === "email"))
-      .toEqual([
-        expect.objectContaining({
-          label: "jordi@doccy.com.au",
-          anchorText: "jordi@doccy.com.au",
-        }),
-      ]);
-    expect(candidates.filter((candidate) => candidate.mentionKind === "handle"))
-      .toEqual([
-        expect.objectContaining({
-          label: "@jordi",
-          anchorText: "@jordi",
-        }),
-      ]);
+    expect(
+      candidates.filter((candidate) => candidate.mentionKind === "email")
+    ).toEqual([
+      expect.objectContaining({
+        label: "jordi@doccy.com.au",
+        anchorText: "jordi@doccy.com.au",
+      }),
+    ]);
+    expect(
+      candidates.filter((candidate) => candidate.mentionKind === "handle")
+    ).toEqual([
+      expect.objectContaining({
+        label: "@jordi",
+        anchorText: "@jordi",
+      }),
+    ]);
   });
 
   it("caps deterministic candidates at ten by input position", () => {

--- a/ai/src/__tests__/signal-entity-linker/extract.test.ts
+++ b/ai/src/__tests__/signal-entity-linker/extract.test.ts
@@ -30,10 +30,10 @@ describe("signal entity linker extraction", () => {
   it("extracts recognized person profile URLs", () => {
     const candidates = extractDeterministicSignalEntityLinks({
       input:
-        "Review https://www.linkedin.com/in/JordiExample and https://x.com/archer.",
+        "Review https://www.linkedin.com/in/JordiExample, https://github.com/jordi, https://x.com/archer, and https://twitter.com/jordi.",
     });
 
-    expect(candidates).toHaveLength(2);
+    expect(candidates).toHaveLength(4);
     expect(candidates).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -45,11 +45,40 @@ describe("signal entity linker extraction", () => {
         expect.objectContaining({
           targetType: "person",
           localEntityKey: "person_2",
+          label: "https://github.com/jordi",
+          mentionKind: "profile_url",
+        }),
+        expect.objectContaining({
+          targetType: "person",
+          localEntityKey: "person_3",
           label: "https://x.com/archer",
+          mentionKind: "profile_url",
+        }),
+        expect.objectContaining({
+          targetType: "person",
+          localEntityKey: "person_4",
+          label: "https://twitter.com/jordi",
           mentionKind: "profile_url",
         }),
       ])
     );
+  });
+
+  it("strips trailing bracket and parenthesis punctuation from profile URLs", () => {
+    const candidates = extractDeterministicSignalEntityLinks({
+      input: "Review [https://github.com/jordi] and (https://x.com/archer).",
+    });
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        label: "https://github.com/jordi",
+        anchorText: "https://github.com/jordi",
+      }),
+      expect.objectContaining({
+        label: "https://x.com/archer",
+        anchorText: "https://x.com/archer",
+      }),
+    ]);
   });
 
   it("extracts provider-obvious handles without treating emails as handles", () => {
@@ -107,7 +136,7 @@ describe("signal entity linker extraction", () => {
     expect(
       extractDeterministicSignalEntityLinks({
         input:
-          "Skip https://github.com/org/repo, https://x.com/i/status/123, https://twitter.com/search, and https://example.com/@jordi.",
+          "Skip https://github.com/org/repo, https://x.com/i/status/123, https://x.com/explore, https://twitter.com/search, https://twitter.com/settings, and https://example.com/@jordi.",
       })
     ).toEqual([]);
   });
@@ -151,5 +180,44 @@ describe("signal entity linker extraction", () => {
         ],
       })
     ).toEqual([deterministicCandidates[0], jordiCandidate]);
+  });
+
+  it("caps merged candidates at ten", () => {
+    const deterministicInput = Array.from(
+      { length: 8 },
+      (_, index) => `person${index + 1}@doccy.com`
+    ).join(" ");
+    const aiInput = Array.from(
+      { length: 5 },
+      (_, index) => `Name${index + 1}`
+    ).join(" ");
+    const input = `${deterministicInput} ${aiInput}`;
+    const deterministicCandidates = extractDeterministicSignalEntityLinks({
+      input,
+    });
+    const aiCandidates: SignalEntityLinkCandidate[] = Array.from(
+      { length: 5 },
+      (_, index) => ({
+        targetType: "person",
+        localEntityKey: `person_${index + 9}`,
+        label: `Name${index + 1}`,
+        mentionKind: "name",
+        anchorText: `Name${index + 1}`,
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "The text names a person.",
+        confidence: 0.8,
+      })
+    );
+
+    const mergedCandidates = mergeSignalEntityLinkCandidates({
+      input,
+      deterministicCandidates,
+      aiCandidates,
+    });
+
+    expect(mergedCandidates).toHaveLength(10);
+    expect(mergedCandidates.slice(0, 8)).toEqual(deterministicCandidates);
+    expect(mergedCandidates.at(-1)).toEqual(aiCandidates[1]);
   });
 });

--- a/ai/src/__tests__/signal-entity-linker/extract.test.ts
+++ b/ai/src/__tests__/signal-entity-linker/extract.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { SignalEntityLinkCandidate } from "../../signal-entity-linker";
+import {
+  extractDeterministicSignalEntityLinks,
+  mergeSignalEntityLinkCandidates,
+} from "../../signal-entity-linker";
+
+describe("signal entity linker extraction", () => {
+  it("extracts deterministic email candidates", () => {
+    expect(
+      extractDeterministicSignalEntityLinks({
+        input: "Email Jordi at jordi@doccy.com.au.",
+      })
+    ).toEqual([
+      {
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "jordi@doccy.com.au",
+        mentionKind: "email",
+        anchorText: "jordi@doccy.com.au",
+        anchorOccurrence: 1,
+        extractionMethod: "deterministic",
+        rationale: "Email address matched deterministic extractor.",
+        confidence: 1,
+      },
+    ]);
+  });
+
+  it("extracts recognized person profile URLs", () => {
+    const candidates = extractDeterministicSignalEntityLinks({
+      input:
+        "Review https://www.linkedin.com/in/JordiExample and https://x.com/archer.",
+    });
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetType: "person",
+          localEntityKey: "person_1",
+          label: "https://www.linkedin.com/in/JordiExample",
+          mentionKind: "profile_url",
+        }),
+        expect.objectContaining({
+          targetType: "person",
+          localEntityKey: "person_2",
+          label: "https://x.com/archer",
+          mentionKind: "profile_url",
+        }),
+      ])
+    );
+  });
+
+  it("extracts provider-obvious handles without treating emails as handles", () => {
+    const candidates = extractDeterministicSignalEntityLinks({
+      input: "DM @jordi but do not split jordi@doccy.com.au.",
+    });
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates.filter((candidate) => candidate.mentionKind === "email"))
+      .toEqual([
+        expect.objectContaining({
+          label: "jordi@doccy.com.au",
+          anchorText: "jordi@doccy.com.au",
+        }),
+      ]);
+    expect(candidates.filter((candidate) => candidate.mentionKind === "handle"))
+      .toEqual([
+        expect.objectContaining({
+          label: "@jordi",
+          anchorText: "@jordi",
+        }),
+      ]);
+  });
+
+  it("keeps deterministic candidates first, filters invalid anchors, and dedupes", () => {
+    const input = "Email Jordi at jordi@doccy.com.au.";
+    const deterministicCandidates = extractDeterministicSignalEntityLinks({
+      input,
+    });
+    const jordiCandidate: SignalEntityLinkCandidate = {
+      targetType: "person",
+      localEntityKey: "person_2",
+      label: "Jordi",
+      mentionKind: "name",
+      anchorText: "Jordi",
+      anchorOccurrence: 1,
+      extractionMethod: "ai",
+      rationale: "The text names Jordi as a person.",
+      confidence: 0.8,
+    };
+    const ghostCandidate: SignalEntityLinkCandidate = {
+      targetType: "person",
+      localEntityKey: "person_3",
+      label: "Ghost",
+      mentionKind: "name",
+      anchorText: "Ghost",
+      anchorOccurrence: 1,
+      extractionMethod: "ai",
+      rationale: "The model inferred a person not anchored in the text.",
+      confidence: 0.8,
+    };
+
+    expect(
+      mergeSignalEntityLinkCandidates({
+        input,
+        deterministicCandidates,
+        aiCandidates: [
+          jordiCandidate,
+          ghostCandidate,
+          deterministicCandidates[0],
+        ],
+      })
+    ).toEqual([deterministicCandidates[0], jordiCandidate]);
+  });
+});

--- a/ai/src/__tests__/signal-entity-linker/extract.test.ts
+++ b/ai/src/__tests__/signal-entity-linker/extract.test.ts
@@ -74,6 +74,44 @@ describe("signal entity linker extraction", () => {
       ]);
   });
 
+  it("caps deterministic candidates at ten by input position", () => {
+    const input = Array.from(
+      { length: 12 },
+      (_, index) => `person${index + 1}@doccy.com`
+    ).join(" ");
+
+    const candidates = extractDeterministicSignalEntityLinks({ input });
+
+    expect(candidates).toHaveLength(10);
+    expect(candidates.map((candidate) => candidate.localEntityKey)).toEqual([
+      "person_1",
+      "person_2",
+      "person_3",
+      "person_4",
+      "person_5",
+      "person_6",
+      "person_7",
+      "person_8",
+      "person_9",
+      "person_10",
+    ]);
+    expect(candidates.at(-1)).toEqual(
+      expect.objectContaining({
+        label: "person10@doccy.com",
+        anchorText: "person10@doccy.com",
+      })
+    );
+  });
+
+  it("rejects repository, reserved social routes, and handles inside unsupported URLs", () => {
+    expect(
+      extractDeterministicSignalEntityLinks({
+        input:
+          "Skip https://github.com/org/repo, https://x.com/i/status/123, https://twitter.com/search, and https://example.com/@jordi.",
+      })
+    ).toEqual([]);
+  });
+
   it("keeps deterministic candidates first, filters invalid anchors, and dedupes", () => {
     const input = "Email Jordi at jordi@doccy.com.au.";
     const deterministicCandidates = extractDeterministicSignalEntityLinks({

--- a/ai/src/__tests__/signal-entity-linker/schema.test.ts
+++ b/ai/src/__tests__/signal-entity-linker/schema.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+  signalEntityLinkCandidateModelSchema,
+  signalEntityLinkCandidateSchema,
+  signalEntityLinkingModelSchema,
+  signalEntityLinkingSchema,
+} from "../../signal-entity-linker";
+
+describe("signal entity linker schemas", () => {
+  it("accepts an AI-extracted person name candidate", () => {
+    expect(
+      signalEntityLinkCandidateSchema.parse({
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "Jordi Torras",
+        mentionKind: "name",
+        anchorText: "Jordi Torras",
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "The text names Jordi as the person being discussed.",
+        confidence: 0.74,
+      })
+    ).toEqual({
+      targetType: "person",
+      localEntityKey: "person_1",
+      label: "Jordi Torras",
+      mentionKind: "name",
+      anchorText: "Jordi Torras",
+      anchorOccurrence: 1,
+      extractionMethod: "ai",
+      rationale: "The text names Jordi as the person being discussed.",
+      confidence: 0.74,
+    });
+  });
+
+  it("accepts deterministic email candidates and resolves the schema version", () => {
+    expect(
+      signalEntityLinkingSchema.parse({
+        schemaVersion: SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+        candidates: [
+          {
+            targetType: "person",
+            localEntityKey: "person_2",
+            label: "jordi@example.com",
+            mentionKind: "email",
+            anchorText: "jordi@example.com",
+            anchorOccurrence: 1,
+            extractionMethod: "deterministic",
+            rationale: "The email address identifies a person entity.",
+            confidence: 1,
+          },
+        ],
+      })
+    ).toEqual({
+      schemaVersion: "signal.entity-links.v1",
+      candidates: [
+        {
+          targetType: "person",
+          localEntityKey: "person_2",
+          label: "jordi@example.com",
+          mentionKind: "email",
+          anchorText: "jordi@example.com",
+          anchorOccurrence: 1,
+          extractionMethod: "deterministic",
+          rationale: "The email address identifies a person entity.",
+          confidence: 1,
+        },
+      ],
+    });
+  });
+
+  it("accepts model-facing candidates without extractionMethod or schemaVersion", () => {
+    expect(
+      signalEntityLinkCandidateModelSchema.parse({
+        targetType: "person",
+        localEntityKey: "person_3",
+        label: "@jordi",
+        mentionKind: "handle",
+        anchorText: "@jordi",
+        anchorOccurrence: 2,
+        rationale: "The handle appears near the person mention.",
+        confidence: 0.82,
+      })
+    ).toEqual({
+      targetType: "person",
+      localEntityKey: "person_3",
+      label: "@jordi",
+      mentionKind: "handle",
+      anchorText: "@jordi",
+      anchorOccurrence: 2,
+      rationale: "The handle appears near the person mention.",
+      confidence: 0.82,
+    });
+
+    expect(
+      signalEntityLinkingModelSchema.parse({
+        candidates: [
+          {
+            targetType: "person",
+            localEntityKey: "person_4",
+            label: "https://linkedin.com/in/jordi",
+            mentionKind: "profile_url",
+            anchorText: "https://linkedin.com/in/jordi",
+            anchorOccurrence: 1,
+            rationale: "The profile URL identifies a person.",
+            confidence: 0.88,
+          },
+        ],
+      })
+    ).toEqual({
+      candidates: [
+        {
+          targetType: "person",
+          localEntityKey: "person_4",
+          label: "https://linkedin.com/in/jordi",
+          mentionKind: "profile_url",
+          anchorText: "https://linkedin.com/in/jordi",
+          anchorOccurrence: 1,
+          rationale: "The profile URL identifies a person.",
+          confidence: 0.88,
+        },
+      ],
+    });
+  });
+
+  it("rejects unsupported target types and invalid local entity keys", () => {
+    const validCandidate = {
+      targetType: "person",
+      localEntityKey: "person_1",
+      label: "Jordi Torras",
+      mentionKind: "name",
+      anchorText: "Jordi Torras",
+      anchorOccurrence: 1,
+      extractionMethod: "ai",
+      rationale: "The text names Jordi as the person being discussed.",
+      confidence: 0.74,
+    };
+
+    expect(() =>
+      signalEntityLinkCandidateSchema.parse({
+        ...validCandidate,
+        targetType: "project",
+      })
+    ).toThrow();
+
+    expect(() =>
+      signalEntityLinkCandidateSchema.parse({
+        ...validCandidate,
+        localEntityKey: "jordi",
+      })
+    ).toThrow();
+  });
+});

--- a/ai/src/__tests__/telemetry/metadata.test.ts
+++ b/ai/src/__tests__/telemetry/metadata.test.ts
@@ -31,6 +31,16 @@ describe("agent graph metadata", () => {
           upstreamNodeIds: ["signal-classifier"],
           workflow: "classify-people",
         },
+        signalEntityLinker: {
+          feature: "entity-links",
+          id: "signal-entity-linker",
+          kind: "llm",
+          promptId: "signal-entity-linker",
+          role: "extractor",
+          schemaVersion: "signal.entity-links.v1",
+          upstreamNodeIds: ["signal-classifier"],
+          workflow: "index-signal-entities",
+        },
       },
     });
 
@@ -81,6 +91,31 @@ describe("agent graph metadata", () => {
       schemaVersion: "people.classification.v1",
       upstreamNodeId: "signal-classifier",
       workflow: "classify-people",
+    });
+
+    expect(
+      createAgentNodeMetadata(graph, graph.nodes.signalEntityLinker, {
+        agentRunId: "sig_123",
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "production",
+        inputLength: 42,
+      })
+    ).toEqual({
+      agentGraphId: "signal-intake",
+      agentGraphVersion: "v1",
+      agentRunId: "sig_123",
+      clerkOrgId: "org_test",
+      deploymentEnvironment: "production",
+      feature: "entity-links",
+      inputLength: 42,
+      nodeId: "signal-entity-linker",
+      nodeKind: "llm",
+      nodeRole: "extractor",
+      promptId: "signal-entity-linker",
+      routerId: "signals",
+      schemaVersion: "signal.entity-links.v1",
+      upstreamNodeId: "signal-classifier",
+      workflow: "index-signal-entities",
     });
   });
 });

--- a/ai/src/_internal/agent-graphs/signal-intake.ts
+++ b/ai/src/_internal/agent-graphs/signal-intake.ts
@@ -24,5 +24,15 @@ export const signalIntakeAgentGraph = defineAgentGraph({
       upstreamNodeIds: ["signal-classifier"],
       workflow: "classify-people",
     },
+    signalEntityLinker: {
+      feature: "entity-links",
+      id: "signal-entity-linker",
+      kind: "llm",
+      promptId: "signal-entity-linker",
+      role: "extractor",
+      schemaVersion: "signal.entity-links.v1",
+      upstreamNodeIds: ["signal-classifier"],
+      workflow: "index-signal-entities",
+    },
   },
 });

--- a/ai/src/signal-entity-linker/classify.ts
+++ b/ai/src/signal-entity-linker/classify.ts
@@ -1,0 +1,140 @@
+import "server-only";
+
+import { createAgentNodeMetadata } from "@repo/ai/telemetry";
+import type { SignalClassification } from "@repo/api-contract";
+import type { LanguageModel } from "@vendor/ai";
+
+import { signalIntakeAgentGraph } from "../_internal/agent-graphs/signal-intake";
+import {
+  type ObjectClassificationLogger,
+  runObjectClassification,
+} from "../_internal/object-classification/run-object-classification";
+import {
+  SIGNAL_ENTITY_LINKER_MAX_OUTPUT_TOKENS,
+  SIGNAL_ENTITY_LINKER_MODEL,
+  SIGNAL_ENTITY_LINKER_TELEMETRY_FUNCTION_ID,
+  SIGNAL_ENTITY_LINKER_TIMEOUT_MS,
+  SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+} from "./constants";
+import { getSignalEntityLinkingFailure } from "./errors";
+import { SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT } from "./prompt";
+import {
+  type SignalEntityLinkCandidate,
+  type SignalEntityLinking,
+  signalEntityLinkingModelSchema,
+} from "./schema";
+
+const noopLogger: ObjectClassificationLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+};
+
+const signalEntityLinkerNode =
+  signalIntakeAgentGraph.nodes.signalEntityLinker;
+
+export type DeploymentEnvironment = "development" | "preview" | "production";
+
+export interface SignalEntityLinkingRequest {
+  classification: SignalClassification | null;
+  clerkOrgId: string;
+  deploymentEnvironment: DeploymentEnvironment;
+  deterministicCandidates: SignalEntityLinkCandidate[];
+  inputLength: number;
+  model: LanguageModel;
+  prompt: string;
+  signalId: string;
+  system: string;
+}
+
+export interface BuildSignalEntityLinkingRequestInput {
+  classification: SignalClassification | null;
+  clerkOrgId: string;
+  deploymentEnvironment: DeploymentEnvironment;
+  deterministicCandidates: SignalEntityLinkCandidate[];
+  input: string;
+  signalId: string;
+}
+
+export interface ClassifySignalEntityLinksOptions {
+  logger?: ObjectClassificationLogger;
+}
+
+export function buildSignalEntityLinkingRequest({
+  classification,
+  clerkOrgId,
+  deploymentEnvironment,
+  deterministicCandidates,
+  input,
+  signalId,
+}: BuildSignalEntityLinkingRequestInput): SignalEntityLinkingRequest {
+  return {
+    classification,
+    clerkOrgId,
+    deploymentEnvironment,
+    deterministicCandidates,
+    inputLength: input.length,
+    model: SIGNAL_ENTITY_LINKER_MODEL,
+    prompt: [
+      "Extract explicit person entity links from this signal.",
+      "",
+      "Signal input:",
+      input,
+      "",
+      "Signal classification:",
+      JSON.stringify(classification),
+      "",
+      "Deterministic candidates:",
+      JSON.stringify(deterministicCandidates),
+    ].join("\n"),
+    signalId,
+    system: SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT,
+  };
+}
+
+export async function classifySignalEntityLinks(
+  {
+    clerkOrgId,
+    deploymentEnvironment,
+    inputLength,
+    model,
+    prompt,
+    signalId,
+    system,
+  }: SignalEntityLinkingRequest,
+  { logger = noopLogger }: ClassifySignalEntityLinksOptions = {}
+): Promise<SignalEntityLinking> {
+  const output = await runObjectClassification({
+    failureMessage: "[entity-links] classification failed",
+    getFailure: getSignalEntityLinkingFailure,
+    logger,
+    maxOutputTokens: SIGNAL_ENTITY_LINKER_MAX_OUTPUT_TOKENS,
+    metadata: {
+      ...createAgentNodeMetadata(
+        signalIntakeAgentGraph,
+        signalEntityLinkerNode,
+        {
+          agentRunId: signalId,
+          clerkOrgId,
+          deploymentEnvironment,
+          inputLength,
+        }
+      ),
+      signalId,
+    },
+    model,
+    prompt,
+    schema: signalEntityLinkingModelSchema,
+    successMessage: "[entity-links] classification completed",
+    system,
+    telemetryFunctionId: SIGNAL_ENTITY_LINKER_TELEMETRY_FUNCTION_ID,
+    timeoutMs: SIGNAL_ENTITY_LINKER_TIMEOUT_MS,
+  });
+
+  return {
+    schemaVersion: SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+    candidates: output.candidates.map((candidate) => ({
+      ...candidate,
+      extractionMethod: "ai" as const,
+    })),
+  };
+}

--- a/ai/src/signal-entity-linker/classify.ts
+++ b/ai/src/signal-entity-linker/classify.ts
@@ -29,8 +29,7 @@ const noopLogger: ObjectClassificationLogger = {
   warn: () => undefined,
 };
 
-const signalEntityLinkerNode =
-  signalIntakeAgentGraph.nodes.signalEntityLinker;
+const signalEntityLinkerNode = signalIntakeAgentGraph.nodes.signalEntityLinker;
 
 export type DeploymentEnvironment = "development" | "preview" | "production";
 

--- a/ai/src/signal-entity-linker/constants.ts
+++ b/ai/src/signal-entity-linker/constants.ts
@@ -1,0 +1,29 @@
+import { signalIntakeAgentGraph } from "../_internal/agent-graphs/signal-intake";
+
+const signalEntityLinkerNode = signalIntakeAgentGraph.nodes.signalEntityLinker;
+
+export const SIGNAL_ENTITY_LINKS_SCHEMA_VERSION =
+  signalEntityLinkerNode.schemaVersion;
+export const SIGNAL_ENTITY_LINKER_MAX_OUTPUT_TOKENS = 768;
+export const SIGNAL_ENTITY_LINKER_MODEL = "openai/gpt-5.4-nano";
+export const SIGNAL_ENTITY_LINKER_FEATURE = signalEntityLinkerNode.feature;
+export const SIGNAL_ENTITY_LINKER_PROMPT_ID = signalEntityLinkerNode.promptId;
+export const SIGNAL_ENTITY_LINKER_WORKFLOW = signalEntityLinkerNode.workflow;
+export const SIGNAL_ENTITY_LINKER_TELEMETRY_FUNCTION_ID =
+  "app.inngest.index-signal-entities";
+export const SIGNAL_ENTITY_LINKER_TIMEOUT_MS = 30_000;
+
+export const SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_FAILED";
+export const SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_PROVIDER_ERROR";
+export const SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_INVALID_OUTPUT";
+export const SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_TIMEOUT";
+
+export type SignalEntityLinkingFailureCode =
+  | typeof SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE
+  | typeof SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE
+  | typeof SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE
+  | typeof SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE;

--- a/ai/src/signal-entity-linker/errors.ts
+++ b/ai/src/signal-entity-linker/errors.ts
@@ -1,0 +1,93 @@
+import { APICallError, NoObjectGeneratedError, RetryError } from "@vendor/ai";
+
+import {
+  SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE,
+  SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE,
+  SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE,
+  SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE,
+  type SignalEntityLinkingFailureCode,
+} from "./constants";
+
+export interface SignalEntityLinkingFailure {
+  errorCode: SignalEntityLinkingFailureCode;
+  errorMessage: string;
+}
+
+export function getSignalEntityLinkingFailure(
+  error: unknown
+): SignalEntityLinkingFailure {
+  const message = getErrorMessage(error);
+
+  if (isTimeoutError(error)) {
+    return {
+      errorCode: SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE,
+      errorMessage: message,
+    };
+  }
+
+  if (isInvalidOutputError(error)) {
+    return {
+      errorCode: SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE,
+      errorMessage: message,
+    };
+  }
+
+  if (isProviderError(error)) {
+    return {
+      errorCode: SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE,
+      errorMessage: message,
+    };
+  }
+
+  return {
+    errorCode: SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE,
+    errorMessage: message,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isProviderError(error: unknown): boolean {
+  return (
+    APICallError.isInstance(error) ||
+    hasErrorName(error, "AI_APICallError") ||
+    hasErrorName(error, "GatewayError") ||
+    hasCauseMatching(error, isProviderError)
+  );
+}
+
+function isInvalidOutputError(error: unknown): boolean {
+  return (
+    NoObjectGeneratedError.isInstance(error) ||
+    hasErrorName(error, "AI_NoObjectGeneratedError") ||
+    hasCauseMatching(error, isInvalidOutputError)
+  );
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    hasErrorName(error, "AbortError") ||
+    hasErrorName(error, "TimeoutError") ||
+    (RetryError.isInstance(error) && error.reason === "abort") ||
+    hasCauseMatching(error, isTimeoutError)
+  );
+}
+
+function hasErrorName(error: unknown, name: string): boolean {
+  return (
+    error instanceof Error && (error.name === name || error.name.includes(name))
+  );
+}
+
+function hasCauseMatching(
+  error: unknown,
+  predicate: (error: unknown) => boolean
+): boolean {
+  if (!(error instanceof Error && "cause" in error)) {
+    return false;
+  }
+
+  return predicate(error.cause);
+}

--- a/ai/src/signal-entity-linker/extract.ts
+++ b/ai/src/signal-entity-linker/extract.ts
@@ -1,0 +1,288 @@
+import type {
+  SignalEntityLinkCandidate,
+  SignalEntityMentionKind,
+} from "./schema";
+
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const HANDLE_PATTERN = /(^|[^\w@.])@[A-Z0-9_]{1,30}\b/gi;
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')]+/gi;
+
+const MAX_SIGNAL_ENTITY_LINK_CANDIDATES = 10;
+const TRAILING_LABEL_PUNCTUATION_PATTERN = /[.,;:!?]+$/g;
+
+type DeterministicMentionKind = Extract<
+  SignalEntityMentionKind,
+  "email" | "handle" | "profile_url"
+>;
+
+interface DeterministicMatch {
+  mentionKind: DeterministicMentionKind;
+  label: string;
+  anchorText: string;
+  start: number;
+  end: number;
+  rationale: string;
+}
+
+interface TextRange {
+  start: number;
+  end: number;
+}
+
+export function extractDeterministicSignalEntityLinks(input: {
+  input: string;
+}): SignalEntityLinkCandidate[] {
+  const deterministicMatches = [
+    ...findEmailMatches(input.input),
+    ...findRecognizedProfileUrlMatches(input.input),
+  ];
+  const occupiedRanges = deterministicMatches.map(({ start, end }) => ({
+    start,
+    end,
+  }));
+
+  deterministicMatches.push(...findHandleMatches(input.input, occupiedRanges));
+
+  return deterministicMatches
+    .sort((left, right) => left.start - right.start)
+    .map((match, index) => ({
+      targetType: "person",
+      localEntityKey: `person_${index + 1}`,
+      label: match.label,
+      mentionKind: match.mentionKind,
+      anchorText: match.anchorText,
+      anchorOccurrence: getAnchorOccurrenceAt(
+        input.input,
+        match.anchorText,
+        match.start
+      ),
+      extractionMethod: "deterministic",
+      rationale: match.rationale,
+      confidence: 1,
+    }));
+}
+
+export function mergeSignalEntityLinkCandidates(input: {
+  aiCandidates: SignalEntityLinkCandidate[];
+  deterministicCandidates: SignalEntityLinkCandidate[];
+  input: string;
+}): SignalEntityLinkCandidate[] {
+  const mergedCandidates: SignalEntityLinkCandidate[] = [];
+  const seenCandidateKeys = new Set<string>();
+
+  for (const candidate of [
+    ...input.deterministicCandidates,
+    ...input.aiCandidates,
+  ]) {
+    if (
+      !hasAnchorOccurrence(
+        input.input,
+        candidate.anchorText,
+        candidate.anchorOccurrence
+      )
+    ) {
+      continue;
+    }
+
+    const candidateKey = [
+      candidate.targetType,
+      candidate.mentionKind,
+      candidate.anchorText,
+      candidate.anchorOccurrence,
+    ].join("\u001f");
+
+    if (seenCandidateKeys.has(candidateKey)) {
+      continue;
+    }
+
+    seenCandidateKeys.add(candidateKey);
+    mergedCandidates.push(candidate);
+
+    if (mergedCandidates.length >= MAX_SIGNAL_ENTITY_LINK_CANDIDATES) {
+      break;
+    }
+  }
+
+  return mergedCandidates;
+}
+
+function findEmailMatches(input: string): DeterministicMatch[] {
+  const matches: DeterministicMatch[] = [];
+
+  for (const match of input.matchAll(EMAIL_PATTERN)) {
+    const rawLabel = match[0];
+    const label = stripTrailingLabelPunctuation(rawLabel);
+    const start = match.index ?? 0;
+
+    matches.push({
+      mentionKind: "email",
+      label,
+      anchorText: label,
+      start,
+      end: start + label.length,
+      rationale: "Email address matched deterministic extractor.",
+    });
+  }
+
+  return matches;
+}
+
+function findRecognizedProfileUrlMatches(input: string): DeterministicMatch[] {
+  const matches: DeterministicMatch[] = [];
+
+  for (const match of input.matchAll(URL_PATTERN)) {
+    const rawLabel = match[0];
+    const label = stripTrailingLabelPunctuation(rawLabel);
+
+    if (!isRecognizedPersonProfileUrl(label)) {
+      continue;
+    }
+
+    const start = match.index ?? 0;
+
+    matches.push({
+      mentionKind: "profile_url",
+      label,
+      anchorText: label,
+      start,
+      end: start + label.length,
+      rationale: "Profile URL matched deterministic extractor.",
+    });
+  }
+
+  return matches;
+}
+
+function findHandleMatches(
+  input: string,
+  occupiedRanges: TextRange[]
+): DeterministicMatch[] {
+  const matches: DeterministicMatch[] = [];
+
+  for (const match of input.matchAll(HANDLE_PATTERN)) {
+    const rawMatch = match[0];
+    const prefix = match[1] ?? "";
+    const label = rawMatch.slice(prefix.length);
+    const start = (match.index ?? 0) + prefix.length;
+    const end = start + label.length;
+
+    if (isRangeInsideAnyRange({ start, end }, occupiedRanges)) {
+      continue;
+    }
+
+    matches.push({
+      mentionKind: "handle",
+      label,
+      anchorText: label,
+      start,
+      end,
+      rationale: "Handle matched deterministic extractor.",
+    });
+  }
+
+  return matches;
+}
+
+function stripTrailingLabelPunctuation(label: string): string {
+  return label.replace(TRAILING_LABEL_PUNCTUATION_PATTERN, "");
+}
+
+function isRecognizedPersonProfileUrl(label: string): boolean {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(label);
+  } catch {
+    return false;
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase().replace(/^www\./, "");
+  const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+
+  if (hostname === "linkedin.com") {
+    return (
+      pathSegments[0]?.toLowerCase() === "in" &&
+      typeof pathSegments[1] === "string" &&
+      pathSegments[1].length > 0
+    );
+  }
+
+  if (
+    hostname === "x.com" ||
+    hostname === "twitter.com" ||
+    hostname === "github.com"
+  ) {
+    return pathSegments.length > 0;
+  }
+
+  return false;
+}
+
+function isRangeInsideAnyRange(range: TextRange, ranges: TextRange[]): boolean {
+  return ranges.some(
+    (occupiedRange) =>
+      range.start >= occupiedRange.start && range.end <= occupiedRange.end
+  );
+}
+
+function getAnchorOccurrenceAt(
+  input: string,
+  anchorText: string,
+  startIndex: number
+): number {
+  let occurrence = 0;
+  let searchIndex = 0;
+
+  while (searchIndex <= startIndex) {
+    const foundIndex = input.indexOf(anchorText, searchIndex);
+
+    if (foundIndex === -1 || foundIndex > startIndex) {
+      break;
+    }
+
+    occurrence += 1;
+
+    if (foundIndex === startIndex) {
+      return occurrence;
+    }
+
+    searchIndex = foundIndex + anchorText.length;
+  }
+
+  return Math.max(occurrence, 1);
+}
+
+function hasAnchorOccurrence(
+  input: string,
+  anchorText: string,
+  anchorOccurrence: number
+): boolean {
+  if (
+    anchorText.length === 0 ||
+    !Number.isInteger(anchorOccurrence) ||
+    anchorOccurrence < 1
+  ) {
+    return false;
+  }
+
+  let occurrence = 0;
+  let searchIndex = 0;
+
+  while (searchIndex < input.length) {
+    const foundIndex = input.indexOf(anchorText, searchIndex);
+
+    if (foundIndex === -1) {
+      return false;
+    }
+
+    occurrence += 1;
+
+    if (occurrence === anchorOccurrence) {
+      return true;
+    }
+
+    searchIndex = foundIndex + anchorText.length;
+  }
+
+  return false;
+}

--- a/ai/src/signal-entity-linker/extract.ts
+++ b/ai/src/signal-entity-linker/extract.ts
@@ -9,6 +9,15 @@ const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')]+/gi;
 
 const MAX_SIGNAL_ENTITY_LINK_CANDIDATES = 10;
 const TRAILING_LABEL_PUNCTUATION_PATTERN = /[.,;:!?]+$/g;
+const RESERVED_X_TWITTER_PATH_SEGMENTS = new Set([
+  "home",
+  "i",
+  "intent",
+  "messages",
+  "notifications",
+  "search",
+  "share",
+]);
 
 type DeterministicMentionKind = Extract<
   SignalEntityMentionKind,
@@ -29,22 +38,31 @@ interface TextRange {
   end: number;
 }
 
+interface UrlMatch extends TextRange {
+  label: string;
+}
+
 export function extractDeterministicSignalEntityLinks(input: {
   input: string;
 }): SignalEntityLinkCandidate[] {
+  const emailMatches = findEmailMatches(input.input);
+  const urlMatches = findUrlMatches(input.input);
   const deterministicMatches = [
-    ...findEmailMatches(input.input),
-    ...findRecognizedProfileUrlMatches(input.input),
+    ...emailMatches,
+    ...findRecognizedProfileUrlMatches(urlMatches),
   ];
-  const occupiedRanges = deterministicMatches.map(({ start, end }) => ({
-    start,
-    end,
-  }));
+  const occupiedRanges = [...emailMatches, ...urlMatches].map(
+    ({ start, end }) => ({
+      start,
+      end,
+    })
+  );
 
   deterministicMatches.push(...findHandleMatches(input.input, occupiedRanges));
 
   return deterministicMatches
     .sort((left, right) => left.start - right.start)
+    .slice(0, MAX_SIGNAL_ENTITY_LINK_CANDIDATES)
     .map((match, index) => ({
       targetType: "person",
       localEntityKey: `person_${index + 1}`,
@@ -127,25 +145,40 @@ function findEmailMatches(input: string): DeterministicMatch[] {
   return matches;
 }
 
-function findRecognizedProfileUrlMatches(input: string): DeterministicMatch[] {
-  const matches: DeterministicMatch[] = [];
+function findUrlMatches(input: string): UrlMatch[] {
+  const matches: UrlMatch[] = [];
 
   for (const match of input.matchAll(URL_PATTERN)) {
     const rawLabel = match[0];
     const label = stripTrailingLabelPunctuation(rawLabel);
-
-    if (!isRecognizedPersonProfileUrl(label)) {
-      continue;
-    }
-
     const start = match.index ?? 0;
 
     matches.push({
-      mentionKind: "profile_url",
       label,
-      anchorText: label,
       start,
       end: start + label.length,
+    });
+  }
+
+  return matches;
+}
+
+function findRecognizedProfileUrlMatches(
+  urlMatches: UrlMatch[]
+): DeterministicMatch[] {
+  const matches: DeterministicMatch[] = [];
+
+  for (const urlMatch of urlMatches) {
+    if (!isRecognizedPersonProfileUrl(urlMatch.label)) {
+      continue;
+    }
+
+    matches.push({
+      mentionKind: "profile_url",
+      label: urlMatch.label,
+      anchorText: urlMatch.label,
+      start: urlMatch.start,
+      end: urlMatch.end,
       rationale: "Profile URL matched deterministic extractor.",
     });
   }
@@ -201,18 +234,32 @@ function isRecognizedPersonProfileUrl(label: string): boolean {
 
   if (hostname === "linkedin.com") {
     return (
+      pathSegments.length === 2 &&
       pathSegments[0]?.toLowerCase() === "in" &&
       typeof pathSegments[1] === "string" &&
       pathSegments[1].length > 0
     );
   }
 
-  if (
-    hostname === "x.com" ||
-    hostname === "twitter.com" ||
-    hostname === "github.com"
-  ) {
-    return pathSegments.length > 0;
+  if (hostname === "github.com") {
+    const profilePathSegment = pathSegments[0];
+
+    return (
+      pathSegments.length === 1 &&
+      typeof profilePathSegment === "string" &&
+      profilePathSegment.length > 0
+    );
+  }
+
+  if (hostname === "x.com" || hostname === "twitter.com") {
+    const profilePathSegment = pathSegments[0]?.toLowerCase();
+
+    return (
+      pathSegments.length === 1 &&
+      typeof profilePathSegment === "string" &&
+      profilePathSegment.length > 0 &&
+      !RESERVED_X_TWITTER_PATH_SEGMENTS.has(profilePathSegment)
+    );
   }
 
   return false;

--- a/ai/src/signal-entity-linker/extract.ts
+++ b/ai/src/signal-entity-linker/extract.ts
@@ -8,15 +8,24 @@ const HANDLE_PATTERN = /(^|[^\w@.])@[A-Z0-9_]{1,30}\b/gi;
 const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')]+/gi;
 
 const MAX_SIGNAL_ENTITY_LINK_CANDIDATES = 10;
-const TRAILING_LABEL_PUNCTUATION_PATTERN = /[.,;:!?]+$/g;
+const TRAILING_LABEL_PUNCTUATION_PATTERN = /[.,;:!?\])]+$/g;
 const RESERVED_X_TWITTER_PATH_SEGMENTS = new Set([
+  "compose",
+  "download",
+  "explore",
   "home",
   "i",
   "intent",
+  "login",
+  "logout",
   "messages",
   "notifications",
+  "privacy",
   "search",
+  "settings",
   "share",
+  "signup",
+  "tos",
 ]);
 
 type DeterministicMentionKind = Extract<

--- a/ai/src/signal-entity-linker/extract.ts
+++ b/ai/src/signal-entity-linker/extract.ts
@@ -34,17 +34,17 @@ type DeterministicMentionKind = Extract<
 >;
 
 interface DeterministicMatch {
-  mentionKind: DeterministicMentionKind;
-  label: string;
   anchorText: string;
-  start: number;
   end: number;
+  label: string;
+  mentionKind: DeterministicMentionKind;
   rationale: string;
+  start: number;
 }
 
 interface TextRange {
-  start: number;
   end: number;
+  start: number;
 }
 
 interface UrlMatch extends TextRange {

--- a/ai/src/signal-entity-linker/index.ts
+++ b/ai/src/signal-entity-linker/index.ts
@@ -1,0 +1,2 @@
+export * from "./constants";
+export * from "./schema";

--- a/ai/src/signal-entity-linker/index.ts
+++ b/ai/src/signal-entity-linker/index.ts
@@ -1,2 +1,3 @@
 export * from "./constants";
+export * from "./extract";
 export * from "./schema";

--- a/ai/src/signal-entity-linker/index.ts
+++ b/ai/src/signal-entity-linker/index.ts
@@ -1,3 +1,6 @@
+export * from "./classify";
 export * from "./constants";
+export * from "./errors";
 export * from "./extract";
+export * from "./prompt";
 export * from "./schema";

--- a/ai/src/signal-entity-linker/prompt.ts
+++ b/ai/src/signal-entity-linker/prompt.ts
@@ -1,0 +1,35 @@
+export const SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT = `You are the Lightfast signal entity linker.
+
+You receive raw signal input, the persisted signal classification, and deterministic entity link candidates.
+Your job is to extract explicit person references from the raw input so Lightfast can link signal text to local person entities.
+
+Do not execute the action.
+Do not browse.
+Do not use outside knowledge.
+Do not infer identities or facts that are not explicitly present in the raw input.
+Do not decide whether a person is confirmed, canonical, or globally merged.
+Do not perform global merge or deduplication across people.
+Do not rewrite deterministic candidates.
+Do not extract role-only references.
+Do not extract coreferences or pronouns.
+Do not extract projects, companies, accounts, teams, documents, tickets, tasks, or other non-person entities.
+Do not create a person name from inside an email address or URL unless that name is separately present in the raw input.
+
+Name-only person references are allowed when the raw input explicitly names a person.
+Preserve uncertainty.
+
+Output rules:
+- Return only person candidates. targetType must always be "person".
+- Return an empty candidates array when no explicit person reference is present.
+- localEntityKey is required and must match /^person_[1-9][0-9]*$/.
+- localEntityKey values should be local to this output and stable within the response.
+- label is the human-readable person reference from the raw input.
+- mentionKind must be one of: name, email, handle, profile_url.
+- anchorText must be an exact substring of the raw input.
+- anchorOccurrence is the 1-based occurrence of anchorText in the raw input.
+- rationale should explain the raw-input-only evidence for the candidate.
+- confidence is a number from 0 to 1.
+
+Use deterministic candidates only as context for already-extracted anchors.
+Do not change, repair, replace, or emit deterministic extractionMethod values.
+Model-owned candidates must omit extractionMethod; Lightfast stamps it after validation.`;

--- a/ai/src/signal-entity-linker/schema.ts
+++ b/ai/src/signal-entity-linker/schema.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+import { SIGNAL_ENTITY_LINKS_SCHEMA_VERSION } from "./constants";
+
+export const signalEntityTargetTypeSchema = z.enum(["person"]);
+export const signalEntityMentionKindSchema = z.enum([
+  "name",
+  "email",
+  "handle",
+  "profile_url",
+]);
+export const signalEntityExtractionMethodSchema = z.enum([
+  "deterministic",
+  "ai",
+]);
+export const signalEntityLocalEntityKeySchema = z
+  .string()
+  .regex(/^person_[1-9][0-9]*$/, "Invalid local entity key");
+
+export const signalEntityLinkCandidateSchema = z.object({
+  targetType: signalEntityTargetTypeSchema,
+  localEntityKey: signalEntityLocalEntityKeySchema,
+  label: z.string().trim().min(1).max(160),
+  mentionKind: signalEntityMentionKindSchema,
+  anchorText: z.string().trim().min(1).max(240),
+  anchorOccurrence: z.number().int().positive().max(100),
+  extractionMethod: signalEntityExtractionMethodSchema,
+  rationale: z.string().trim().min(1),
+  confidence: z.number().min(0).max(1),
+});
+
+export const signalEntityLinkingSchema = z.object({
+  schemaVersion: z.literal(SIGNAL_ENTITY_LINKS_SCHEMA_VERSION),
+  candidates: z.array(signalEntityLinkCandidateSchema).max(10),
+});
+
+export const signalEntityLinkCandidateModelSchema =
+  signalEntityLinkCandidateSchema.omit({
+    extractionMethod: true,
+  });
+
+export const signalEntityLinkingModelSchema = z.object({
+  candidates: z.array(signalEntityLinkCandidateModelSchema).max(10),
+});
+
+export type SignalEntityTargetType = z.infer<
+  typeof signalEntityTargetTypeSchema
+>;
+export type SignalEntityMentionKind = z.infer<
+  typeof signalEntityMentionKindSchema
+>;
+export type SignalEntityExtractionMethod = z.infer<
+  typeof signalEntityExtractionMethodSchema
+>;
+export type SignalEntityLocalEntityKey = z.infer<
+  typeof signalEntityLocalEntityKeySchema
+>;
+export type SignalEntityLinkCandidate = z.infer<
+  typeof signalEntityLinkCandidateSchema
+>;
+export type SignalEntityLinking = z.infer<typeof signalEntityLinkingSchema>;
+export type SignalEntityLinkCandidateModelOutput = z.infer<
+  typeof signalEntityLinkCandidateModelSchema
+>;
+export type SignalEntityLinkingModelOutput = z.infer<
+  typeof signalEntityLinkingModelSchema
+>;

--- a/api/app/src/__tests__/entity-index-workflow.test.ts
+++ b/api/app/src/__tests__/entity-index-workflow.test.ts
@@ -1,0 +1,411 @@
+import type { Database } from "@db/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSignalByPublicIdMock = vi.fn();
+const buildSignalEntityLinkingRequestMock = vi.fn();
+const classifySignalEntityLinksMock = vi.fn();
+const extractDeterministicSignalEntityLinksMock = vi.fn();
+const getSignalEntityLinkingFailureMock = vi.fn();
+const mergeSignalEntityLinkCandidatesMock = vi.fn();
+const logWarnMock = vi.fn();
+const db = { kind: "mock-db" } as unknown as Database;
+
+type WorkflowCallback = (input: {
+  event: {
+    data: {
+      clerkOrgId: string;
+      signalId: string;
+    };
+  };
+  step: ReturnType<typeof createStep>;
+}) => Promise<unknown>;
+
+type WorkflowFailureCallback = (input: {
+  error: Error;
+  event: {
+    data: {
+      event: {
+        data: {
+          clerkOrgId: string;
+          signalId: string;
+        };
+      };
+    };
+  };
+}) => Promise<unknown>;
+
+let workflowCallback: WorkflowCallback | undefined;
+let workflowFailureCallback: WorkflowFailureCallback | undefined;
+const createFunctionMock = vi.fn(
+  (
+    config: { onFailure?: WorkflowFailureCallback },
+    handler: WorkflowCallback
+  ): { id: string } => {
+    workflowCallback = handler;
+    workflowFailureCallback = config.onFailure;
+    return { id: "index-signal-entities" };
+  }
+);
+
+vi.mock("@db/app", () => ({
+  getSignalByPublicId: getSignalByPublicIdMock,
+}));
+
+vi.mock("@db/app/client", () => ({ db }));
+
+vi.mock("@repo/ai/signal-entity-linker", () => ({
+  buildSignalEntityLinkingRequest: buildSignalEntityLinkingRequestMock,
+  classifySignalEntityLinks: classifySignalEntityLinksMock,
+  extractDeterministicSignalEntityLinks:
+    extractDeterministicSignalEntityLinksMock,
+  getSignalEntityLinkingFailure: getSignalEntityLinkingFailureMock,
+  mergeSignalEntityLinkCandidates: mergeSignalEntityLinkCandidatesMock,
+}));
+
+vi.mock("@vendor/observability/log/next", () => ({
+  log: {
+    warn: logWarnMock,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../env", () => ({
+  env: {
+    VERCEL_ENV: "development",
+  },
+}));
+
+vi.mock("../inngest/client", () => ({
+  inngest: {
+    createFunction: createFunctionMock,
+  },
+}));
+
+const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
+const classification = {
+  schemaVersion: "signal.classification.v2",
+  disposition: "needs_context",
+  title: "Discuss dev flow",
+  summary: "Talk with Jordi and Archer about workflow.",
+  kind: "follow_up",
+  nextAction: "Ask Jordi and Archer about dev flow.",
+  priority: "normal",
+  rationale: "The signal mentions people.",
+  confidence: 0.55,
+  routing: {
+    visibility: {
+      scope: "user",
+      rationale: "Creator-visible context.",
+    },
+    review: {
+      required: false,
+      reason: null,
+      rationale: null,
+    },
+    routes: {
+      people: {
+        shouldRun: false,
+        confidence: 0.1,
+        rationale: "No durable identity is present.",
+      },
+    },
+  },
+};
+const signal = {
+  id: 1,
+  publicId: signalId,
+  clerkOrgId: "org_test",
+  input: "Talk to Jordi & Archer about their dev flow. See @archer.",
+  status: "classified",
+  classification,
+  visibilityScope: "user",
+};
+const deterministicCandidate = {
+  targetType: "person",
+  localEntityKey: "person_1",
+  label: "@archer",
+  mentionKind: "handle",
+  anchorText: "@archer",
+  anchorOccurrence: 1,
+  extractionMethod: "deterministic",
+  rationale: "Handle matched deterministic extractor.",
+  confidence: 1,
+};
+const aiCandidate = {
+  targetType: "person",
+  localEntityKey: "person_2",
+  label: "Jordi",
+  mentionKind: "name",
+  anchorText: "Jordi",
+  anchorOccurrence: 1,
+  extractionMethod: "ai",
+  rationale: "Jordi appears as a person.",
+  confidence: 0.74,
+};
+
+const { appEvents } = await import("../inngest/schemas/app");
+const { indexSignalEntities } = await import(
+  "../inngest/workflow/index-signal-entities"
+);
+
+function createStep() {
+  return {
+    run: vi.fn(<T>(_name: string, fn: () => T | Promise<T>) => fn()),
+    ai: {
+      wrap: vi.fn(
+        <T>(
+          _name: string,
+          fn: (request: Record<string, unknown>) => T | Promise<T>,
+          request: Record<string, unknown>
+        ) => fn(request)
+      ),
+    },
+  };
+}
+
+function runWorkflow(step: ReturnType<typeof createStep>) {
+  if (!workflowCallback) {
+    throw new Error("workflow callback was not registered");
+  }
+
+  return workflowCallback({
+    event: {
+      data: {
+        clerkOrgId: "org_test",
+        signalId,
+      },
+    },
+    step,
+  });
+}
+
+function runWorkflowFailure(error: Error) {
+  if (!workflowFailureCallback) {
+    throw new Error("workflow failure callback was not registered");
+  }
+
+  return workflowFailureCallback({
+    error,
+    event: {
+      data: {
+        event: {
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  getSignalByPublicIdMock.mockReset();
+  extractDeterministicSignalEntityLinksMock.mockReset();
+  buildSignalEntityLinkingRequestMock.mockReset();
+  classifySignalEntityLinksMock.mockReset();
+  mergeSignalEntityLinkCandidatesMock.mockReset();
+  getSignalEntityLinkingFailureMock.mockReset();
+  logWarnMock.mockReset();
+
+  getSignalByPublicIdMock.mockResolvedValue(signal);
+  extractDeterministicSignalEntityLinksMock.mockReturnValue([
+    deterministicCandidate,
+  ]);
+  buildSignalEntityLinkingRequestMock.mockReturnValue({
+    clerkOrgId: "org_test",
+    deploymentEnvironment: "development",
+    deterministicCandidates: [deterministicCandidate],
+    inputLength: signal.input.length,
+    model: "openai/gpt-5.4-nano",
+    prompt: "Extract explicit person references.",
+    signalId,
+    system: "You are the Lightfast signal entity linker.",
+  });
+  classifySignalEntityLinksMock.mockResolvedValue({
+    schemaVersion: "signal.entity-links.v1",
+    candidates: [aiCandidate],
+  });
+  mergeSignalEntityLinkCandidatesMock.mockReturnValue([
+    deterministicCandidate,
+    aiCandidate,
+  ]);
+  getSignalEntityLinkingFailureMock.mockImplementation((error: unknown) => ({
+    errorCode: "SIGNAL_ENTITY_LINKING_FAILED",
+    errorMessage: error instanceof Error ? error.message : String(error),
+  }));
+});
+
+describe("indexSignalEntities", () => {
+  it("registers the workflow and event schema", () => {
+    expect(indexSignalEntities).toEqual({ id: "index-signal-entities" });
+    expect(appEvents["app/signal.entity-index.requested"]).toEqual(
+      expect.objectContaining({
+        event: "app/signal.entity-index.requested",
+      })
+    );
+    expect(() =>
+      appEvents["app/signal.entity-index.requested"].schema.parse({
+        clerkOrgId: "org_test",
+        signalId,
+      })
+    ).not.toThrow();
+    expect(() =>
+      appEvents["app/signal.entity-index.requested"].schema.parse({
+        clerkOrgId: "",
+        signalId,
+      })
+    ).toThrow();
+    expect(createFunctionMock).toHaveBeenCalledWith(
+      {
+        id: "index-signal-entities",
+        idempotency: 'event.data.clerkOrgId + "-" + event.data.signalId',
+        onFailure: expect.any(Function),
+        retries: 3,
+        timeouts: { finish: "10m", start: "10m" },
+        triggers: expect.objectContaining({
+          event: "app/signal.entity-index.requested",
+        }),
+      },
+      expect.any(Function)
+    );
+  });
+
+  it("extracts deterministic and AI candidates and merges without persistence", async () => {
+    const step = createStep();
+
+    await expect(runWorkflow(step)).resolves.toEqual({
+      aiCandidates: 1,
+      candidates: 2,
+      deterministicCandidates: 1,
+      status: "indexed",
+    });
+
+    expect(getSignalByPublicIdMock).toHaveBeenCalledWith(db, {
+      clerkOrgId: "org_test",
+      publicId: signalId,
+    });
+    expect(extractDeterministicSignalEntityLinksMock).toHaveBeenCalledWith({
+      input: signal.input,
+    });
+    expect(buildSignalEntityLinkingRequestMock).toHaveBeenCalledWith({
+      classification,
+      clerkOrgId: "org_test",
+      deploymentEnvironment: "development",
+      deterministicCandidates: [deterministicCandidate],
+      input: signal.input,
+      signalId,
+    });
+    expect(step.ai.wrap).toHaveBeenCalledWith(
+      "link signal entities",
+      expect.any(Function),
+      expect.objectContaining({ signalId })
+    );
+    expect(classifySignalEntityLinksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ signalId }),
+      expect.objectContaining({ logger: expect.any(Object) })
+    );
+    expect(mergeSignalEntityLinkCandidatesMock).toHaveBeenCalledWith({
+      aiCandidates: [aiCandidate],
+      deterministicCandidates: [deterministicCandidate],
+      input: signal.input,
+    });
+  });
+
+  it("returns missing when the source signal is gone", async () => {
+    const step = createStep();
+    getSignalByPublicIdMock.mockResolvedValueOnce(undefined);
+
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "missing" });
+
+    expect(step.ai.wrap).not.toHaveBeenCalled();
+    expect(mergeSignalEntityLinkCandidatesMock).not.toHaveBeenCalled();
+  });
+
+  it("skips signals that are not classified", async () => {
+    const step = createStep();
+    getSignalByPublicIdMock.mockResolvedValueOnce({
+      ...signal,
+      status: "processing",
+      classification: null,
+    });
+
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "skipped" });
+
+    expect(extractDeterministicSignalEntityLinksMock).not.toHaveBeenCalled();
+    expect(step.ai.wrap).not.toHaveBeenCalled();
+    expect(mergeSignalEntityLinkCandidatesMock).not.toHaveBeenCalled();
+  });
+
+  it("skips signals whose classification visibility needs review", async () => {
+    const step = createStep();
+    getSignalByPublicIdMock.mockResolvedValueOnce({
+      ...signal,
+      classification: {
+        ...classification,
+        routing: {
+          ...classification.routing,
+          visibility: {
+            scope: "needs_review",
+            rationale: "Needs review.",
+          },
+          review: {
+            required: true,
+            reason: "sensitive_person",
+            rationale: "Sensitive person context.",
+          },
+        },
+      },
+      visibilityScope: "needs_review",
+    });
+
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "skipped" });
+
+    expect(extractDeterministicSignalEntityLinksMock).not.toHaveBeenCalled();
+    expect(step.ai.wrap).not.toHaveBeenCalled();
+    expect(mergeSignalEntityLinkCandidatesMock).not.toHaveBeenCalled();
+  });
+
+  it("skips signals whose persisted visibility needs review", async () => {
+    const step = createStep();
+    getSignalByPublicIdMock.mockResolvedValueOnce({
+      ...signal,
+      visibilityScope: "needs_review",
+    });
+
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "skipped" });
+
+    expect(extractDeterministicSignalEntityLinksMock).not.toHaveBeenCalled();
+    expect(step.ai.wrap).not.toHaveBeenCalled();
+    expect(mergeSignalEntityLinkCandidatesMock).not.toHaveBeenCalled();
+  });
+
+  it("lets AI failures bubble for Inngest retries", async () => {
+    const step = createStep();
+    classifySignalEntityLinksMock.mockRejectedValueOnce(
+      new Error("model unavailable")
+    );
+
+    await expect(runWorkflow(step)).rejects.toThrow("model unavailable");
+
+    expect(mergeSignalEntityLinkCandidatesMock).not.toHaveBeenCalled();
+  });
+
+  it("logs exhausted failures without mutating the signal", async () => {
+    await expect(
+      runWorkflowFailure(new Error("model unavailable"))
+    ).resolves.toEqual({ status: "failed" });
+
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "[entity-links] indexing exhausted retries",
+      expect.objectContaining({
+        clerkOrgId: "org_test",
+        errorCode: "SIGNAL_ENTITY_LINKING_FAILED",
+        errorMessage: "model unavailable",
+        signalId,
+      })
+    );
+  });
+});

--- a/api/app/src/__tests__/inngest-route.test.ts
+++ b/api/app/src/__tests__/inngest-route.test.ts
@@ -9,6 +9,7 @@ const serveMock = vi.fn(() => routeHandlers);
 const inngestClient = { id: "app-inngest-client" };
 const systemHealth = { id: "system-health" };
 const classifySignal = { id: "classify-signal" };
+const indexSignalEntities = { id: "index-signal-entities" };
 const classifyPeople = { id: "classify-people" };
 const cleanupDeveloperSandboxRuns = { id: "cleanup-developer-sandbox-runs" };
 const automationScheduler = { id: "automation-scheduler" };
@@ -42,6 +43,10 @@ vi.mock("../inngest/workflow/system-health", () => ({
 
 vi.mock("../inngest/workflow/classify-signal", () => ({
   classifySignal,
+}));
+
+vi.mock("../inngest/workflow/index-signal-entities", () => ({
+  indexSignalEntities,
 }));
 
 vi.mock("../inngest/workflow/classify-people", () => ({
@@ -97,6 +102,7 @@ describe("createInngestRouteContext", () => {
       functions: [
         systemHealth,
         classifySignal,
+        indexSignalEntities,
         classifyPeople,
         cleanupDeveloperSandboxRuns,
         automationScheduler,

--- a/api/app/src/__tests__/signal-workflow.test.ts
+++ b/api/app/src/__tests__/signal-workflow.test.ts
@@ -407,6 +407,12 @@ describe("classifySignal", () => {
         publicId: signalId,
       })
     );
+    const stepRunNames = step.run.mock.calls.map(([name]) => name);
+    expect(stepRunNames).toContain("persist signal classification");
+    expect(stepRunNames).toContain("queue classified signal downstream workflows");
+    expect(stepRunNames.indexOf("persist signal classification")).toBeLessThan(
+      stepRunNames.indexOf("queue classified signal downstream workflows")
+    );
     expect(sendMock).toHaveBeenCalledTimes(2);
     expect(sendMock).toHaveBeenNthCalledWith(1, {
       name: "app/people.classification.requested",

--- a/api/app/src/__tests__/signal-workflow.test.ts
+++ b/api/app/src/__tests__/signal-workflow.test.ts
@@ -235,6 +235,9 @@ const { classifySignal } = await import("../inngest/workflow/classify-signal");
 function createStep() {
   const step = {
     run: vi.fn(<T>(_name: string, fn: () => T | Promise<T>) => fn()),
+    sendEvent: vi.fn((_name: string, event: unknown) =>
+      Promise.resolve({ ids: ["event_test"], event })
+    ),
     ai: {
       wrap: vi.fn(
         <T>(
@@ -407,27 +410,30 @@ describe("classifySignal", () => {
         publicId: signalId,
       })
     );
-    const stepRunNames = step.run.mock.calls.map(([name]) => name);
-    expect(stepRunNames).toContain("persist signal classification");
-    expect(stepRunNames).toContain("queue classified signal downstream workflows");
-    expect(stepRunNames.indexOf("persist signal classification")).toBeLessThan(
-      stepRunNames.indexOf("queue classified signal downstream workflows")
+    expect(step.sendEvent).toHaveBeenCalledTimes(1);
+    expect(step.sendEvent).toHaveBeenCalledWith(
+      "queue classified signal downstream workflows",
+      [
+        {
+          name: "app/people.classification.requested",
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+        {
+          name: "app/signal.entity-index.requested",
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+      ]
     );
-    expect(sendMock).toHaveBeenCalledTimes(2);
-    expect(sendMock).toHaveBeenNthCalledWith(1, {
-      name: "app/people.classification.requested",
-      data: {
-        clerkOrgId: "org_test",
-        signalId,
-      },
-    });
-    expect(sendMock).toHaveBeenNthCalledWith(2, {
-      name: "app/signal.entity-index.requested",
-      data: {
-        clerkOrgId: "org_test",
-        signalId,
-      },
-    });
+    expect(markSignalClassifiedMock.mock.invocationCallOrder[0]).toBeLessThan(
+      step.sendEvent.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(sendMock).not.toHaveBeenCalled();
     expect(markSignalFailedMock).not.toHaveBeenCalled();
   });
 
@@ -442,14 +448,20 @@ describe("classifySignal", () => {
       routedPeople: false,
     });
 
-    expect(sendMock).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledWith({
-      name: "app/signal.entity-index.requested",
-      data: {
-        clerkOrgId: "org_test",
-        signalId,
-      },
-    });
+    expect(step.sendEvent).toHaveBeenCalledTimes(1);
+    expect(step.sendEvent).toHaveBeenCalledWith(
+      "queue classified signal downstream workflows",
+      [
+        {
+          name: "app/signal.entity-index.requested",
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+      ]
+    );
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
   it("queues entity indexing for non-actionable visible signals", async () => {
@@ -463,14 +475,20 @@ describe("classifySignal", () => {
       routedPeople: false,
     });
 
-    expect(sendMock).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledWith({
-      name: "app/signal.entity-index.requested",
-      data: {
-        clerkOrgId: "org_test",
-        signalId,
-      },
-    });
+    expect(step.sendEvent).toHaveBeenCalledTimes(1);
+    expect(step.sendEvent).toHaveBeenCalledWith(
+      "queue classified signal downstream workflows",
+      [
+        {
+          name: "app/signal.entity-index.requested",
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+      ]
+    );
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
   it("does not queue people classification when v2 routing requires review", async () => {
@@ -492,6 +510,7 @@ describe("classifySignal", () => {
         publicId: signalId,
       })
     );
+    expect(step.sendEvent).not.toHaveBeenCalled();
     expect(sendMock).not.toHaveBeenCalled();
   });
 
@@ -511,21 +530,27 @@ describe("classifySignal", () => {
     });
 
     expect(claimSignalForClassificationMock).not.toHaveBeenCalled();
-    expect(sendMock).toHaveBeenCalledTimes(2);
-    expect(sendMock).toHaveBeenNthCalledWith(1, {
-      name: "app/people.classification.requested",
-      data: {
-        clerkOrgId: "org_test",
-        signalId,
-      },
-    });
-    expect(sendMock).toHaveBeenNthCalledWith(2, {
-      name: "app/signal.entity-index.requested",
-      data: {
-        clerkOrgId: "org_test",
-        signalId,
-      },
-    });
+    expect(step.sendEvent).toHaveBeenCalledTimes(1);
+    expect(step.sendEvent).toHaveBeenCalledWith(
+      "queue classified signal downstream workflows",
+      [
+        {
+          name: "app/people.classification.requested",
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+        {
+          name: "app/signal.entity-index.requested",
+          data: {
+            clerkOrgId: "org_test",
+            signalId,
+          },
+        },
+      ]
+    );
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
   it("does not claim or send when a retry sees an already classified review-required signal", async () => {
@@ -544,6 +569,7 @@ describe("classifySignal", () => {
     });
 
     expect(claimSignalForClassificationMock).not.toHaveBeenCalled();
+    expect(step.sendEvent).not.toHaveBeenCalled();
     expect(sendMock).not.toHaveBeenCalled();
   });
 
@@ -610,6 +636,8 @@ describe("classifySignal", () => {
 
     await expect(runWorkflow(step)).resolves.toEqual({ status: "skipped" });
 
+    expect(step.sendEvent).not.toHaveBeenCalled();
+    expect(sendMock).not.toHaveBeenCalled();
     expect(markSignalFailedMock).not.toHaveBeenCalled();
   });
 
@@ -622,6 +650,8 @@ describe("classifySignal", () => {
     expect(step.ai.wrap).not.toHaveBeenCalled();
     expect(classifySignalInputMock).not.toHaveBeenCalled();
     expect(markSignalClassifiedMock).not.toHaveBeenCalled();
+    expect(step.sendEvent).not.toHaveBeenCalled();
+    expect(sendMock).not.toHaveBeenCalled();
     expect(markSignalFailedMock).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/signal-workflow.test.ts
+++ b/api/app/src/__tests__/signal-workflow.test.ts
@@ -159,6 +159,17 @@ const userClassification = {
     },
   },
 };
+const notActionableClassification = {
+  ...userClassification,
+  disposition: "not_actionable",
+  title: "FYI from Jordi",
+  summary: "The input mentions Jordi but does not require action.",
+  kind: "other",
+  nextAction: "No action required.",
+  priority: "low",
+  rationale: "The signal is informational.",
+  confidence: 0.64,
+};
 const identityContext = {
   provenance: {
     surface: "signal" as const,
@@ -396,8 +407,16 @@ describe("classifySignal", () => {
         publicId: signalId,
       })
     );
-    expect(sendMock).toHaveBeenCalledWith({
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenNthCalledWith(1, {
       name: "app/people.classification.requested",
+      data: {
+        clerkOrgId: "org_test",
+        signalId,
+      },
+    });
+    expect(sendMock).toHaveBeenNthCalledWith(2, {
+      name: "app/signal.entity-index.requested",
       data: {
         clerkOrgId: "org_test",
         signalId,
@@ -406,7 +425,7 @@ describe("classifySignal", () => {
     expect(markSignalFailedMock).not.toHaveBeenCalled();
   });
 
-  it("does not queue people classification for user-visible signals", async () => {
+  it("queues only entity indexing for user-visible signals", async () => {
     const step = createStep();
     classifySignalInputMock.mockResolvedValueOnce(userClassification);
 
@@ -417,7 +436,35 @@ describe("classifySignal", () => {
       routedPeople: false,
     });
 
-    expect(sendMock).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith({
+      name: "app/signal.entity-index.requested",
+      data: {
+        clerkOrgId: "org_test",
+        signalId,
+      },
+    });
+  });
+
+  it("queues entity indexing for non-actionable visible signals", async () => {
+    const step = createStep();
+    classifySignalInputMock.mockResolvedValueOnce(notActionableClassification);
+
+    await expect(runWorkflow(step)).resolves.toEqual({
+      status: "classified",
+      visibilityScope: "user",
+      reviewRequired: false,
+      routedPeople: false,
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith({
+      name: "app/signal.entity-index.requested",
+      data: {
+        clerkOrgId: "org_test",
+        signalId,
+      },
+    });
   });
 
   it("does not queue people classification when v2 routing requires review", async () => {
@@ -458,8 +505,16 @@ describe("classifySignal", () => {
     });
 
     expect(claimSignalForClassificationMock).not.toHaveBeenCalled();
-    expect(sendMock).toHaveBeenCalledWith({
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenNthCalledWith(1, {
       name: "app/people.classification.requested",
+      data: {
+        clerkOrgId: "org_test",
+        signalId,
+      },
+    });
+    expect(sendMock).toHaveBeenNthCalledWith(2, {
+      name: "app/signal.entity-index.requested",
       data: {
         clerkOrgId: "org_test",
         signalId,

--- a/api/app/src/inngest/index.ts
+++ b/api/app/src/inngest/index.ts
@@ -5,6 +5,7 @@ import { automationScheduler } from "./workflow/automation-scheduler";
 import { classifyPeople } from "./workflow/classify-people";
 import { classifySignal } from "./workflow/classify-signal";
 import { cleanupDeveloperSandboxRuns } from "./workflow/cleanup-developer-sandbox-runs";
+import { indexSignalEntities } from "./workflow/index-signal-entities";
 import { queueLightfastIndexRefreshesFromSourceControl } from "./workflow/queue-skill-refresh-from-source-control";
 import { reconcileIdentityIndexes } from "./workflow/reconcile-identity-indexes";
 import { reconcileSkillIndexes } from "./workflow/reconcile-skill-indexes";
@@ -22,6 +23,7 @@ export function createInngestRouteContext() {
     functions: [
       systemHealth,
       classifySignal,
+      indexSignalEntities,
       classifyPeople,
       cleanupDeveloperSandboxRuns,
       automationScheduler,

--- a/api/app/src/inngest/schemas/app.ts
+++ b/api/app/src/inngest/schemas/app.ts
@@ -42,6 +42,15 @@ export const appEvents = {
       clerkOrgId: z.string().min(1),
     }),
   }),
+  "app/signal.entity-index.requested": eventType(
+    "app/signal.entity-index.requested",
+    {
+      schema: z.object({
+        signalId: signalIdSchema,
+        clerkOrgId: z.string().min(1),
+      }),
+    }
+  ),
   "app/github.repository.push.received": eventType(
     "app/github.repository.push.received",
     {

--- a/api/app/src/inngest/workflow/classify-signal.ts
+++ b/api/app/src/inngest/workflow/classify-signal.ts
@@ -30,6 +30,16 @@ import {
 import { inngest } from "../client";
 import { appEvents } from "../schemas/app";
 
+type ClassifiedSignalDownstreamEvent = {
+  name:
+    | "app/people.classification.requested"
+    | "app/signal.entity-index.requested";
+  data: {
+    clerkOrgId: string;
+    signalId: string;
+  };
+};
+
 function getVisibilityScope(
   classification: SignalClassification
 ): SignalVisibilityScope {
@@ -63,14 +73,46 @@ function shouldIndexSignalEntities(
   );
 }
 
-async function queueSignalEntityIndexing(input: {
+function getClassifiedSignalDownstreamEvents(input: {
+  classification: SignalClassification;
   clerkOrgId: string;
   signalId: string;
-}) {
-  await inngest.send({
-    name: "app/signal.entity-index.requested",
-    data: input,
-  });
+}): {
+  routedPeople: boolean;
+  events: ClassifiedSignalDownstreamEvent[];
+} {
+  const routedPeople = shouldClassifyPeople(input.classification);
+  const events: ClassifiedSignalDownstreamEvent[] = [];
+
+  if (routedPeople) {
+    events.push({
+      name: "app/people.classification.requested",
+      data: {
+        clerkOrgId: input.clerkOrgId,
+        signalId: input.signalId,
+      },
+    });
+  }
+
+  if (shouldIndexSignalEntities(input.classification)) {
+    events.push({
+      name: "app/signal.entity-index.requested",
+      data: {
+        clerkOrgId: input.clerkOrgId,
+        signalId: input.signalId,
+      },
+    });
+  }
+
+  return { events, routedPeople };
+}
+
+async function queueClassifiedSignalDownstreamEvents(
+  events: ClassifiedSignalDownstreamEvent[]
+) {
+  for (const event of events) {
+    await inngest.send(event);
+  }
 }
 
 function classifiedResult(
@@ -126,30 +168,19 @@ export const classifySignal = inngest.createFunction(
     }
 
     if (signal.status === "classified" && signal.classification) {
-      if (shouldClassifyPeople(signal.classification)) {
-        await step.run("queue people classification", () =>
-          inngest.send({
-            name: "app/people.classification.requested",
-            data: {
-              clerkOrgId,
-              signalId,
-            },
-          })
+      const { events, routedPeople } = getClassifiedSignalDownstreamEvents({
+        classification: signal.classification,
+        clerkOrgId,
+        signalId,
+      });
+
+      if (events.length > 0) {
+        await step.run("queue classified signal downstream workflows", () =>
+          queueClassifiedSignalDownstreamEvents(events)
         );
-        if (shouldIndexSignalEntities(signal.classification)) {
-          await step.run("queue signal entity indexing", () =>
-            queueSignalEntityIndexing({ clerkOrgId, signalId })
-          );
-        }
-        return classifiedResult(signal.classification, true);
       }
 
-      if (shouldIndexSignalEntities(signal.classification)) {
-        await step.run("queue signal entity indexing", () =>
-          queueSignalEntityIndexing({ clerkOrgId, signalId })
-        );
-      }
-      return classifiedResult(signal.classification, false);
+      return classifiedResult(signal.classification, routedPeople);
     }
 
     const claimed = await step.run("claim signal", () =>
@@ -204,33 +235,19 @@ export const classifySignal = inngest.createFunction(
       return { status: "skipped" };
     }
 
-    if (shouldClassifyPeople(classification)) {
-      await step.run("queue people classification", () =>
-        inngest.send({
-          name: "app/people.classification.requested",
-          data: {
-            clerkOrgId,
-            signalId,
-          },
-        })
-      );
+    const { events, routedPeople } = getClassifiedSignalDownstreamEvents({
+      classification,
+      clerkOrgId,
+      signalId,
+    });
 
-      if (shouldIndexSignalEntities(classification)) {
-        await step.run("queue signal entity indexing", () =>
-          queueSignalEntityIndexing({ clerkOrgId, signalId })
-        );
-      }
-
-      return classifiedResult(classification, true);
-    }
-
-    if (shouldIndexSignalEntities(classification)) {
-      await step.run("queue signal entity indexing", () =>
-        queueSignalEntityIndexing({ clerkOrgId, signalId })
+    if (events.length > 0) {
+      await step.run("queue classified signal downstream workflows", () =>
+        queueClassifiedSignalDownstreamEvents(events)
       );
     }
 
-    return classifiedResult(classification, false);
+    return classifiedResult(classification, routedPeople);
   }
 );
 

--- a/api/app/src/inngest/workflow/classify-signal.ts
+++ b/api/app/src/inngest/workflow/classify-signal.ts
@@ -54,6 +54,25 @@ function shouldClassifyPeople(
   );
 }
 
+function shouldIndexSignalEntities(
+  classification: SignalClassification | null
+): boolean {
+  return (
+    classification?.schemaVersion === "signal.classification.v2" &&
+    classification.routing.visibility.scope !== "needs_review"
+  );
+}
+
+async function queueSignalEntityIndexing(input: {
+  clerkOrgId: string;
+  signalId: string;
+}) {
+  await inngest.send({
+    name: "app/signal.entity-index.requested",
+    data: input,
+  });
+}
+
 function classifiedResult(
   classification: SignalClassification,
   routedPeople: boolean
@@ -117,9 +136,19 @@ export const classifySignal = inngest.createFunction(
             },
           })
         );
+        if (shouldIndexSignalEntities(signal.classification)) {
+          await step.run("queue signal entity indexing", () =>
+            queueSignalEntityIndexing({ clerkOrgId, signalId })
+          );
+        }
         return classifiedResult(signal.classification, true);
       }
 
+      if (shouldIndexSignalEntities(signal.classification)) {
+        await step.run("queue signal entity indexing", () =>
+          queueSignalEntityIndexing({ clerkOrgId, signalId })
+        );
+      }
       return classifiedResult(signal.classification, false);
     }
 
@@ -186,7 +215,19 @@ export const classifySignal = inngest.createFunction(
         })
       );
 
+      if (shouldIndexSignalEntities(classification)) {
+        await step.run("queue signal entity indexing", () =>
+          queueSignalEntityIndexing({ clerkOrgId, signalId })
+        );
+      }
+
       return classifiedResult(classification, true);
+    }
+
+    if (shouldIndexSignalEntities(classification)) {
+      await step.run("queue signal entity indexing", () =>
+        queueSignalEntityIndexing({ clerkOrgId, signalId })
+      );
     }
 
     return classifiedResult(classification, false);

--- a/api/app/src/inngest/workflow/classify-signal.ts
+++ b/api/app/src/inngest/workflow/classify-signal.ts
@@ -30,15 +30,15 @@ import {
 import { inngest } from "../client";
 import { appEvents } from "../schemas/app";
 
-type ClassifiedSignalDownstreamEvent = {
-  name:
-    | "app/people.classification.requested"
-    | "app/signal.entity-index.requested";
+interface ClassifiedSignalDownstreamEvent {
   data: {
     clerkOrgId: string;
     signalId: string;
   };
-};
+  name:
+    | "app/people.classification.requested"
+    | "app/signal.entity-index.requested";
+}
 
 function getVisibilityScope(
   classification: SignalClassification

--- a/api/app/src/inngest/workflow/classify-signal.ts
+++ b/api/app/src/inngest/workflow/classify-signal.ts
@@ -107,14 +107,6 @@ function getClassifiedSignalDownstreamEvents(input: {
   return { events, routedPeople };
 }
 
-async function queueClassifiedSignalDownstreamEvents(
-  events: ClassifiedSignalDownstreamEvent[]
-) {
-  for (const event of events) {
-    await inngest.send(event);
-  }
-}
-
 function classifiedResult(
   classification: SignalClassification,
   routedPeople: boolean
@@ -175,8 +167,9 @@ export const classifySignal = inngest.createFunction(
       });
 
       if (events.length > 0) {
-        await step.run("queue classified signal downstream workflows", () =>
-          queueClassifiedSignalDownstreamEvents(events)
+        await step.sendEvent(
+          "queue classified signal downstream workflows",
+          events
         );
       }
 
@@ -242,8 +235,9 @@ export const classifySignal = inngest.createFunction(
     });
 
     if (events.length > 0) {
-      await step.run("queue classified signal downstream workflows", () =>
-        queueClassifiedSignalDownstreamEvents(events)
+      await step.sendEvent(
+        "queue classified signal downstream workflows",
+        events
       );
     }
 

--- a/api/app/src/inngest/workflow/index-signal-entities.ts
+++ b/api/app/src/inngest/workflow/index-signal-entities.ts
@@ -1,0 +1,111 @@
+import { getSignalByPublicId } from "@db/app";
+import { db } from "@db/app/client";
+import {
+  buildSignalEntityLinkingRequest,
+  classifySignalEntityLinks,
+  extractDeterministicSignalEntityLinks,
+  getSignalEntityLinkingFailure,
+  mergeSignalEntityLinkCandidates,
+} from "@repo/ai/signal-entity-linker";
+import type { SignalClassification } from "@repo/api-contract";
+import { log } from "@vendor/observability/log/next";
+
+import { env } from "../../env";
+import { inngest } from "../client";
+import { appEvents } from "../schemas/app";
+
+function shouldIndexSignalEntities(signal: {
+  classification: SignalClassification | null;
+  status: string;
+  visibilityScope: string;
+}): boolean {
+  if (signal.status !== "classified" || !signal.classification) {
+    return false;
+  }
+
+  return (
+    signal.classification.schemaVersion === "signal.classification.v2" &&
+    signal.classification.routing.visibility.scope !== "needs_review" &&
+    signal.visibilityScope !== "needs_review"
+  );
+}
+
+export const indexSignalEntities = inngest.createFunction(
+  {
+    id: "index-signal-entities",
+    idempotency: 'event.data.clerkOrgId + "-" + event.data.signalId',
+    retries: 3,
+    timeouts: {
+      finish: "10m",
+      start: "10m",
+    },
+    triggers: appEvents["app/signal.entity-index.requested"],
+    onFailure: async ({ event, error }) => {
+      const { clerkOrgId, signalId } = event.data.event.data;
+      const failure = getSignalEntityLinkingFailure(error);
+
+      log.warn("[entity-links] indexing exhausted retries", {
+        clerkOrgId,
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+        signalId,
+      });
+
+      return { status: "failed" };
+    },
+  },
+  async ({ event, step }) => {
+    const { clerkOrgId, signalId } = event.data;
+
+    const signal = await step.run("load signal", () =>
+      getSignalByPublicId(db, {
+        clerkOrgId,
+        publicId: signalId,
+      })
+    );
+
+    if (!signal) {
+      return { status: "missing" };
+    }
+
+    if (!shouldIndexSignalEntities(signal)) {
+      return { status: "skipped" };
+    }
+
+    const deterministicCandidates = await step.run(
+      "extract deterministic entity links",
+      () => extractDeterministicSignalEntityLinks({ input: signal.input })
+    );
+
+    const request = buildSignalEntityLinkingRequest({
+      classification: signal.classification,
+      clerkOrgId,
+      deploymentEnvironment: env.VERCEL_ENV,
+      deterministicCandidates,
+      input: signal.input,
+      signalId,
+    });
+
+    const aiResult = await step.ai.wrap(
+      "link signal entities",
+      (linkingRequest) =>
+        classifySignalEntityLinks(linkingRequest, { logger: log }),
+      request
+    );
+
+    const candidates = await step.run("merge entity link candidates", () =>
+      mergeSignalEntityLinkCandidates({
+        aiCandidates: aiResult.candidates,
+        deterministicCandidates,
+        input: signal.input,
+      })
+    );
+
+    return {
+      status: "indexed",
+      deterministicCandidates: deterministicCandidates.length,
+      aiCandidates: aiResult.candidates.length,
+      candidates: candidates.length,
+    };
+  }
+);

--- a/docs/superpowers/plans/2026-06-06-signal-entity-links-ai.md
+++ b/docs/superpowers/plans/2026-06-06-signal-entity-links-ai.md
@@ -1,0 +1,2171 @@
+# Signal Entity Links AI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the AI-first Signal Entity Links extraction pipeline: deterministic extraction, AI extraction, live Inngest wiring, and tests, with no persistence or UI changes.
+
+**Architecture:** Mirror the existing `@repo/ai/signal-classifier` and `@repo/ai/people-classifier` structure with a new `@repo/ai/signal-entity-linker` capability. The capability combines deterministic candidates with AI-generated explicit person mentions, validates anchors, and returns counts through a no-persistence `index-signal-entities` workflow. `classify-signal` queues entity indexing after successful classification for non-needs-review signals.
+
+**Tech Stack:** TypeScript, Zod, Vitest, AI SDK via `@vendor/ai`, Inngest, pnpm/Turborepo.
+
+---
+
+## File Structure
+
+- Create `ai/src/signal-entity-linker/schema.ts`: Zod schemas and exported types for entity-link candidates and model output.
+- Create `ai/src/signal-entity-linker/constants.ts`: model, telemetry, schema version, and failure constants.
+- Create `ai/src/signal-entity-linker/prompt.ts`: system prompt for explicit person-reference extraction.
+- Create `ai/src/signal-entity-linker/errors.ts`: durable error-code mapping for provider, invalid-output, timeout, and generic failures.
+- Create `ai/src/signal-entity-linker/extract.ts`: deterministic extractor, anchor validation, and deterministic/AI candidate merge helpers.
+- Create `ai/src/signal-entity-linker/classify.ts`: request builder and AI classifier wrapper using the shared object-classification runner.
+- Create `ai/src/signal-entity-linker/index.ts`: public exports.
+- Modify `ai/src/_internal/agent-graphs/signal-intake.ts`: add `signalEntityLinker` node.
+- Modify `ai/package.json`: export `./signal-entity-linker`.
+- Add tests under `ai/src/__tests__/signal-entity-linker/`.
+- Modify `ai/src/__tests__/_internal/agent-graphs/signal-intake.test.ts` and `ai/src/__tests__/telemetry/metadata.test.ts`.
+- Modify `api/app/src/inngest/schemas/app.ts`: add `app/signal.entity-index.requested`.
+- Create `api/app/src/inngest/workflow/index-signal-entities.ts`: no-persistence extraction workflow.
+- Add `api/app/src/__tests__/entity-index-workflow.test.ts`.
+- Modify `api/app/src/inngest/workflow/classify-signal.ts`: queue entity indexing after classification.
+- Modify `api/app/src/__tests__/signal-workflow.test.ts`: assert entity-index event behavior.
+- Modify `api/app/src/inngest/index.ts` and `api/app/src/__tests__/inngest-route.test.ts`: register the new workflow.
+
+## Task 1: Add Signal Entity Linker Schemas And Graph Node
+
+**Files:**
+- Create: `ai/src/signal-entity-linker/schema.ts`
+- Create: `ai/src/signal-entity-linker/constants.ts`
+- Create: `ai/src/signal-entity-linker/index.ts`
+- Modify: `ai/src/_internal/agent-graphs/signal-intake.ts`
+- Modify: `ai/package.json`
+- Test: `ai/src/__tests__/signal-entity-linker/schema.test.ts`
+- Test: `ai/src/__tests__/_internal/agent-graphs/signal-intake.test.ts`
+- Test: `ai/src/__tests__/telemetry/metadata.test.ts`
+
+- [ ] **Step 1: Write failing schema and graph tests**
+
+Create `ai/src/__tests__/signal-entity-linker/schema.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+  signalEntityLinkCandidateModelSchema,
+  signalEntityLinkCandidateSchema,
+  signalEntityLinkingModelSchema,
+  signalEntityLinkingSchema,
+} from "../../signal-entity-linker";
+
+describe("signal entity linker schema", () => {
+  it("accepts explicit person candidates from deterministic and AI extractors", () => {
+    expect(
+      signalEntityLinkCandidateSchema.parse({
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "Jordi",
+        mentionKind: "name",
+        anchorText: "Jordi",
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "Jordi appears as a person to talk with.",
+        confidence: 0.74,
+      })
+    ).toEqual({
+      targetType: "person",
+      localEntityKey: "person_1",
+      label: "Jordi",
+      mentionKind: "name",
+      anchorText: "Jordi",
+      anchorOccurrence: 1,
+      extractionMethod: "ai",
+      rationale: "Jordi appears as a person to talk with.",
+      confidence: 0.74,
+    });
+  });
+
+  it("stamps the public result schema version in application code", () => {
+    expect(
+      signalEntityLinkingSchema.parse({
+        schemaVersion: SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+        candidates: [
+          {
+            targetType: "person",
+            localEntityKey: "person_1",
+            label: "jordi@doccy.com.au",
+            mentionKind: "email",
+            anchorText: "jordi@doccy.com.au",
+            anchorOccurrence: 1,
+            extractionMethod: "deterministic",
+            rationale: "Email address matched deterministic extractor.",
+            confidence: 1,
+          },
+        ],
+      })
+    ).toMatchObject({
+      schemaVersion: "signal.entity-links.v1",
+      candidates: [{ extractionMethod: "deterministic" }],
+    });
+  });
+
+  it("uses a model-facing schema without extractionMethod or schemaVersion", () => {
+    expect(
+      signalEntityLinkCandidateModelSchema.parse({
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "Louie",
+        mentionKind: "name",
+        anchorText: "Louie",
+        anchorOccurrence: 1,
+        rationale: "Louie appears as a person to connect.",
+        confidence: 0.76,
+      })
+    ).toEqual({
+      targetType: "person",
+      localEntityKey: "person_1",
+      label: "Louie",
+      mentionKind: "name",
+      anchorText: "Louie",
+      anchorOccurrence: 1,
+      rationale: "Louie appears as a person to connect.",
+      confidence: 0.76,
+    });
+
+    expect(
+      signalEntityLinkingModelSchema.parse({
+        candidates: [
+          {
+            targetType: "person",
+            localEntityKey: "person_1",
+            label: "Louie",
+            mentionKind: "name",
+            anchorText: "Louie",
+            anchorOccurrence: 1,
+            rationale: "Louie appears as a person to connect.",
+            confidence: 0.76,
+          },
+        ],
+      })
+    ).toMatchObject({ candidates: [{ label: "Louie" }] });
+  });
+
+  it("rejects unsupported entity types and creative local entity keys", () => {
+    expect(() =>
+      signalEntityLinkCandidateSchema.parse({
+        targetType: "project",
+        localEntityKey: "person_1",
+        label: "Doccy onboarding",
+        mentionKind: "name",
+        anchorText: "Doccy onboarding",
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "Projects are not part of v1.",
+        confidence: 0.8,
+      })
+    ).toThrow();
+
+    expect(() =>
+      signalEntityLinkCandidateSchema.parse({
+        targetType: "person",
+        localEntityKey: "jordi",
+        label: "Jordi",
+        mentionKind: "name",
+        anchorText: "Jordi",
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "Invalid grouping token.",
+        confidence: 0.8,
+      })
+    ).toThrow();
+  });
+});
+```
+
+Update `ai/src/__tests__/_internal/agent-graphs/signal-intake.test.ts` to expect the new node:
+
+```ts
+signalEntityLinker: {
+  id: "signal-entity-linker",
+  role: "extractor",
+  schemaVersion: "signal.entity-links.v1",
+  upstreamNodeIds: ["signal-classifier"],
+},
+```
+
+Update `ai/src/__tests__/telemetry/metadata.test.ts` by adding `signalEntityLinker` to the test graph and asserting metadata:
+
+```ts
+signalEntityLinker: {
+  feature: "entity-links",
+  id: "signal-entity-linker",
+  kind: "llm",
+  promptId: "signal-entity-linker",
+  role: "extractor",
+  schemaVersion: "signal.entity-links.v1",
+  upstreamNodeIds: ["signal-classifier"],
+  workflow: "index-signal-entities",
+},
+```
+
+Expected metadata assertion:
+
+```ts
+expect(
+  createAgentNodeMetadata(graph, graph.nodes.signalEntityLinker, {
+    agentRunId: "sig_123",
+    clerkOrgId: "org_test",
+    deploymentEnvironment: "production",
+    inputLength: 42,
+  })
+).toEqual({
+  agentGraphId: "signal-intake",
+  agentGraphVersion: "v1",
+  agentRunId: "sig_123",
+  clerkOrgId: "org_test",
+  deploymentEnvironment: "production",
+  feature: "entity-links",
+  inputLength: 42,
+  nodeId: "signal-entity-linker",
+  nodeKind: "llm",
+  nodeRole: "extractor",
+  promptId: "signal-entity-linker",
+  routerId: "signals",
+  schemaVersion: "signal.entity-links.v1",
+  upstreamNodeId: "signal-classifier",
+  workflow: "index-signal-entities",
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker/schema.test.ts src/__tests__/_internal/agent-graphs/signal-intake.test.ts src/__tests__/telemetry/metadata.test.ts
+```
+
+Expected: FAIL because `../../signal-entity-linker` and `signalEntityLinker` do not exist.
+
+- [ ] **Step 3: Implement schema, constants, exports, package export, and graph node**
+
+Create `ai/src/signal-entity-linker/schema.ts`:
+
+```ts
+import { z } from "zod";
+
+import { SIGNAL_ENTITY_LINKS_SCHEMA_VERSION } from "./constants";
+
+export const signalEntityTargetTypeSchema = z.enum(["person"]);
+export const signalEntityMentionKindSchema = z.enum([
+  "name",
+  "email",
+  "handle",
+  "profile_url",
+]);
+export const signalEntityExtractionMethodSchema = z.enum([
+  "deterministic",
+  "ai",
+]);
+export const signalEntityLocalEntityKeySchema = z
+  .string()
+  .regex(/^person_[1-9][0-9]*$/, "Invalid local entity key");
+
+export const signalEntityLinkCandidateSchema = z.object({
+  targetType: signalEntityTargetTypeSchema,
+  localEntityKey: signalEntityLocalEntityKeySchema,
+  label: z.string().trim().min(1).max(160),
+  mentionKind: signalEntityMentionKindSchema,
+  anchorText: z.string().trim().min(1).max(240),
+  anchorOccurrence: z.number().int().positive().max(100),
+  extractionMethod: signalEntityExtractionMethodSchema,
+  rationale: z.string().trim().min(1),
+  confidence: z.number().min(0).max(1),
+});
+
+export const signalEntityLinkingSchema = z.object({
+  schemaVersion: z.literal(SIGNAL_ENTITY_LINKS_SCHEMA_VERSION),
+  candidates: z.array(signalEntityLinkCandidateSchema).max(10),
+});
+
+export const signalEntityLinkCandidateModelSchema =
+  signalEntityLinkCandidateSchema.omit({ extractionMethod: true });
+
+export const signalEntityLinkingModelSchema = z.object({
+  candidates: z.array(signalEntityLinkCandidateModelSchema).max(10),
+});
+
+export type SignalEntityTargetType = z.infer<
+  typeof signalEntityTargetTypeSchema
+>;
+export type SignalEntityMentionKind = z.infer<
+  typeof signalEntityMentionKindSchema
+>;
+export type SignalEntityExtractionMethod = z.infer<
+  typeof signalEntityExtractionMethodSchema
+>;
+export type SignalEntityLinkCandidate = z.infer<
+  typeof signalEntityLinkCandidateSchema
+>;
+export type SignalEntityLinking = z.infer<typeof signalEntityLinkingSchema>;
+export type SignalEntityLinkCandidateModelOutput = z.infer<
+  typeof signalEntityLinkCandidateModelSchema
+>;
+export type SignalEntityLinkingModelOutput = z.infer<
+  typeof signalEntityLinkingModelSchema
+>;
+```
+
+Create `ai/src/signal-entity-linker/constants.ts`:
+
+```ts
+import { signalIntakeAgentGraph } from "../_internal/agent-graphs/signal-intake";
+
+const signalEntityLinkerNode = signalIntakeAgentGraph.nodes.signalEntityLinker;
+
+export const SIGNAL_ENTITY_LINKS_SCHEMA_VERSION =
+  signalEntityLinkerNode.schemaVersion;
+export const SIGNAL_ENTITY_LINKER_MAX_OUTPUT_TOKENS = 768;
+export const SIGNAL_ENTITY_LINKER_MODEL = "openai/gpt-5.4-nano";
+export const SIGNAL_ENTITY_LINKER_FEATURE = signalEntityLinkerNode.feature;
+export const SIGNAL_ENTITY_LINKER_PROMPT_ID = signalEntityLinkerNode.promptId;
+export const SIGNAL_ENTITY_LINKER_WORKFLOW = signalEntityLinkerNode.workflow;
+export const SIGNAL_ENTITY_LINKER_TELEMETRY_FUNCTION_ID =
+  "app.inngest.index-signal-entities";
+export const SIGNAL_ENTITY_LINKER_TIMEOUT_MS = 30_000;
+
+export const SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_FAILED";
+export const SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_PROVIDER_ERROR";
+export const SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_INVALID_OUTPUT";
+export const SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE =
+  "SIGNAL_ENTITY_LINKING_TIMEOUT";
+
+export type SignalEntityLinkingFailureCode =
+  | typeof SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE
+  | typeof SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE
+  | typeof SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE
+  | typeof SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE;
+```
+
+Create `ai/src/signal-entity-linker/index.ts`:
+
+```ts
+export * from "./constants";
+export * from "./schema";
+```
+
+Modify `ai/src/_internal/agent-graphs/signal-intake.ts`:
+
+```ts
+signalEntityLinker: {
+  feature: "entity-links",
+  id: "signal-entity-linker",
+  kind: "llm",
+  promptId: "signal-entity-linker",
+  role: "extractor",
+  schemaVersion: "signal.entity-links.v1",
+  upstreamNodeIds: ["signal-classifier"],
+  workflow: "index-signal-entities",
+},
+```
+
+Modify `ai/package.json` exports:
+
+```json
+"./signal-entity-linker": {
+  "types": "./src/signal-entity-linker/index.ts",
+  "default": "./src/signal-entity-linker/index.ts"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker/schema.test.ts src/__tests__/_internal/agent-graphs/signal-intake.test.ts src/__tests__/telemetry/metadata.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai/package.json ai/src/_internal/agent-graphs/signal-intake.ts ai/src/signal-entity-linker ai/src/__tests__/signal-entity-linker/schema.test.ts ai/src/__tests__/_internal/agent-graphs/signal-intake.test.ts ai/src/__tests__/telemetry/metadata.test.ts
+git commit -m "feat: add signal entity linker schema"
+```
+
+## Task 2: Add Deterministic Extraction And Candidate Merge Helpers
+
+**Files:**
+- Create: `ai/src/signal-entity-linker/extract.ts`
+- Modify: `ai/src/signal-entity-linker/index.ts`
+- Test: `ai/src/__tests__/signal-entity-linker/extract.test.ts`
+
+- [ ] **Step 1: Write failing deterministic extractor tests**
+
+Create `ai/src/__tests__/signal-entity-linker/extract.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  extractDeterministicSignalEntityLinks,
+  mergeSignalEntityLinkCandidates,
+} from "../../signal-entity-linker";
+
+describe("extractDeterministicSignalEntityLinks", () => {
+  it("extracts email candidates with exact anchors", () => {
+    expect(
+      extractDeterministicSignalEntityLinks({
+        input: "Email Jordi at jordi@doccy.com.au.",
+      })
+    ).toEqual([
+      {
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "jordi@doccy.com.au",
+        mentionKind: "email",
+        anchorText: "jordi@doccy.com.au",
+        anchorOccurrence: 1,
+        extractionMethod: "deterministic",
+        rationale: "Email address matched deterministic extractor.",
+        confidence: 1,
+      },
+    ]);
+  });
+
+  it("extracts recognized person profile URLs", () => {
+    expect(
+      extractDeterministicSignalEntityLinks({
+        input: "Review https://www.linkedin.com/in/JordiExample and https://x.com/archer.",
+      })
+    ).toEqual([
+      expect.objectContaining({
+        localEntityKey: "person_1",
+        label: "https://www.linkedin.com/in/JordiExample",
+        mentionKind: "profile_url",
+        anchorOccurrence: 1,
+      }),
+      expect.objectContaining({
+        localEntityKey: "person_2",
+        label: "https://x.com/archer",
+        mentionKind: "profile_url",
+        anchorOccurrence: 1,
+      }),
+    ]);
+  });
+
+  it("extracts provider-obvious handles without treating emails as handles", () => {
+    expect(
+      extractDeterministicSignalEntityLinks({
+        input: "DM @jordi but do not split jordi@doccy.com.au.",
+      })
+    ).toEqual([
+      expect.objectContaining({
+        label: "jordi@doccy.com.au",
+        mentionKind: "email",
+      }),
+      expect.objectContaining({
+        label: "@jordi",
+        mentionKind: "handle",
+      }),
+    ]);
+  });
+});
+
+describe("mergeSignalEntityLinkCandidates", () => {
+  it("keeps deterministic candidates first, filters invalid anchors, and dedupes", () => {
+    const deterministic = extractDeterministicSignalEntityLinks({
+      input: "Email Jordi at jordi@doccy.com.au.",
+    });
+
+    expect(
+      mergeSignalEntityLinkCandidates({
+        aiCandidates: [
+          {
+            targetType: "person",
+            localEntityKey: "person_1",
+            label: "Jordi",
+            mentionKind: "name",
+            anchorText: "Jordi",
+            anchorOccurrence: 1,
+            extractionMethod: "ai",
+            rationale: "Jordi appears as a person.",
+            confidence: 0.8,
+          },
+          {
+            targetType: "person",
+            localEntityKey: "person_2",
+            label: "Ghost",
+            mentionKind: "name",
+            anchorText: "Ghost",
+            anchorOccurrence: 1,
+            extractionMethod: "ai",
+            rationale: "Ghost is not in the input.",
+            confidence: 0.8,
+          },
+          deterministic[0],
+        ],
+        deterministicCandidates: deterministic,
+        input: "Email Jordi at jordi@doccy.com.au.",
+      })
+    ).toEqual([
+      deterministic[0],
+      {
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "Jordi",
+        mentionKind: "name",
+        anchorText: "Jordi",
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "Jordi appears as a person.",
+        confidence: 0.8,
+      },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker/extract.test.ts
+```
+
+Expected: FAIL because `extractDeterministicSignalEntityLinks` is not exported.
+
+- [ ] **Step 3: Implement deterministic extractor and merge helpers**
+
+Create `ai/src/signal-entity-linker/extract.ts`:
+
+```ts
+import type { SignalEntityLinkCandidate } from "./schema";
+
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const HANDLE_PATTERN = /(^|[^\w@.])@[A-Z0-9_]{1,30}\b/gi;
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')]+/gi;
+
+export interface ExtractDeterministicSignalEntityLinksInput {
+  input: string;
+}
+
+export interface MergeSignalEntityLinkCandidatesInput {
+  aiCandidates: SignalEntityLinkCandidate[];
+  deterministicCandidates: SignalEntityLinkCandidate[];
+  input: string;
+}
+
+export function extractDeterministicSignalEntityLinks({
+  input,
+}: ExtractDeterministicSignalEntityLinksInput): SignalEntityLinkCandidate[] {
+  const candidates: SignalEntityLinkCandidate[] = [];
+  let localIndex = 1;
+
+  for (const match of input.matchAll(EMAIL_PATTERN)) {
+    const label = trimTrailingPunctuation(match[0]);
+    candidates.push(
+      createDeterministicCandidate({
+        input,
+        label,
+        localEntityKey: `person_${localIndex++}`,
+        matchIndex: match.index ?? 0,
+        mentionKind: "email",
+        rationale: "Email address matched deterministic extractor.",
+      })
+    );
+  }
+
+  for (const match of input.matchAll(URL_PATTERN)) {
+    const label = trimTrailingPunctuation(match[0]);
+    if (!isRecognizedPersonProfileUrl(label)) {
+      continue;
+    }
+    candidates.push(
+      createDeterministicCandidate({
+        input,
+        label,
+        localEntityKey: `person_${localIndex++}`,
+        matchIndex: match.index ?? 0,
+        mentionKind: "profile_url",
+        rationale: "Recognized person profile URL matched deterministic extractor.",
+      })
+    );
+  }
+
+  for (const match of input.matchAll(HANDLE_PATTERN)) {
+    const label = match[0].trim().replace(/^[^\w@]+/, "");
+    if (!label.startsWith("@")) {
+      continue;
+    }
+    candidates.push(
+      createDeterministicCandidate({
+        input,
+        label,
+        localEntityKey: `person_${localIndex++}`,
+        matchIndex: match.index ?? 0,
+        mentionKind: "handle",
+        rationale: "Provider-style handle matched deterministic extractor.",
+      })
+    );
+  }
+
+  return mergeSignalEntityLinkCandidates({
+    aiCandidates: [],
+    deterministicCandidates: candidates,
+    input,
+  });
+}
+
+export function mergeSignalEntityLinkCandidates({
+  aiCandidates,
+  deterministicCandidates,
+  input,
+}: MergeSignalEntityLinkCandidatesInput): SignalEntityLinkCandidate[] {
+  const merged: SignalEntityLinkCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of [...deterministicCandidates, ...aiCandidates]) {
+    if (!hasAnchorOccurrence(input, candidate.anchorText, candidate.anchorOccurrence)) {
+      continue;
+    }
+
+    const key = [
+      candidate.targetType,
+      candidate.mentionKind,
+      candidate.anchorText,
+      candidate.anchorOccurrence,
+    ].join("\0");
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    merged.push(candidate);
+
+    if (merged.length >= 10) {
+      break;
+    }
+  }
+
+  return merged;
+}
+
+function createDeterministicCandidate(input: {
+  input: string;
+  label: string;
+  localEntityKey: `person_${number}`;
+  matchIndex: number;
+  mentionKind: SignalEntityLinkCandidate["mentionKind"];
+  rationale: string;
+}): SignalEntityLinkCandidate {
+  return {
+    targetType: "person",
+    localEntityKey: input.localEntityKey,
+    label: input.label,
+    mentionKind: input.mentionKind,
+    anchorText: input.label,
+    anchorOccurrence: getAnchorOccurrenceAtIndex(
+      input.input,
+      input.label,
+      input.matchIndex
+    ),
+    extractionMethod: "deterministic",
+    rationale: input.rationale,
+    confidence: 1,
+  };
+}
+
+function getAnchorOccurrenceAtIndex(
+  input: string,
+  anchorText: string,
+  matchIndex: number
+): number {
+  let occurrence = 0;
+  let index = input.indexOf(anchorText);
+  while (index !== -1) {
+    occurrence += 1;
+    if (index >= matchIndex) {
+      return occurrence;
+    }
+    index = input.indexOf(anchorText, index + anchorText.length);
+  }
+  return 1;
+}
+
+function hasAnchorOccurrence(
+  input: string,
+  anchorText: string,
+  anchorOccurrence: number
+): boolean {
+  let occurrence = 0;
+  let index = input.indexOf(anchorText);
+  while (index !== -1) {
+    occurrence += 1;
+    if (occurrence === anchorOccurrence) {
+      return true;
+    }
+    index = input.indexOf(anchorText, index + anchorText.length);
+  }
+  return false;
+}
+
+function trimTrailingPunctuation(value: string): string {
+  return value.replace(/[.,;:!?]+$/, "");
+}
+
+function isRecognizedPersonProfileUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  const parts = url.pathname.split("/").filter(Boolean);
+
+  if (["x.com", "twitter.com", "github.com"].includes(host)) {
+    return parts.length >= 1;
+  }
+
+  if (host === "linkedin.com") {
+    return parts[0] === "in" && Boolean(parts[1]);
+  }
+
+  return false;
+}
+```
+
+Modify `ai/src/signal-entity-linker/index.ts`:
+
+```ts
+export * from "./constants";
+export * from "./extract";
+export * from "./schema";
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker/extract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai/src/signal-entity-linker/extract.ts ai/src/signal-entity-linker/index.ts ai/src/__tests__/signal-entity-linker/extract.test.ts
+git commit -m "feat: add deterministic signal entity extraction"
+```
+
+## Task 3: Add AI Prompt, Error Mapping, And Classifier Wrapper
+
+**Files:**
+- Create: `ai/src/signal-entity-linker/prompt.ts`
+- Create: `ai/src/signal-entity-linker/errors.ts`
+- Create: `ai/src/signal-entity-linker/classify.ts`
+- Modify: `ai/src/signal-entity-linker/index.ts`
+- Test: `ai/src/__tests__/signal-entity-linker/classify.test.ts`
+
+- [ ] **Step 1: Write failing classifier tests**
+
+Create `ai/src/__tests__/signal-entity-linker/classify.test.ts`:
+
+```ts
+import { MockLanguageModelV3 } from "@vendor/ai/test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildSignalEntityLinkingRequest,
+  classifySignalEntityLinks,
+  getSignalEntityLinkingFailure,
+  SIGNAL_ENTITY_LINKER_MODEL,
+  SIGNAL_ENTITY_LINKER_PROMPT_ID,
+  SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT,
+  SIGNAL_ENTITY_LINKER_WORKFLOW,
+  SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE,
+} from "../../signal-entity-linker";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
+
+const classification = {
+  schemaVersion: "signal.classification.v2",
+  disposition: "needs_context",
+  title: "Discuss dev flow",
+  summary: "Request to talk with Jordi and Archer about their development workflow.",
+  kind: "follow_up",
+  nextAction: "Ask Jordi and Archer about their dev flow.",
+  priority: "normal",
+  rationale: "The request lacks scope but contains person references.",
+  confidence: 0.55,
+  routing: {
+    visibility: {
+      scope: "user",
+      rationale: "The signal is private to the creator.",
+    },
+    review: { required: false, reason: null, rationale: null },
+    routes: {
+      people: {
+        shouldRun: false,
+        confidence: 0.1,
+        rationale: "No durable identity is present.",
+      },
+    },
+  },
+} as const;
+
+const usage = {
+  inputTokens: {
+    total: 24,
+    noCache: 24,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 52, text: 52, reasoning: undefined },
+};
+
+function createClassifierModel(text: string) {
+  return new MockLanguageModelV3({
+    provider: "openai",
+    modelId: "gpt-5.4-nano",
+    doGenerate: async () => ({
+      content: [{ type: "text", text }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage,
+      warnings: [],
+    }),
+  });
+}
+
+beforeEach(() => {
+  logger.info.mockReset();
+  logger.warn.mockReset();
+});
+
+describe("classifySignalEntityLinks", () => {
+  it("builds a request with raw input, classification, and deterministic candidates", () => {
+    const request = buildSignalEntityLinkingRequest({
+      classification,
+      clerkOrgId: "org_test",
+      deploymentEnvironment: "development",
+      deterministicCandidates: [
+        {
+          targetType: "person",
+          localEntityKey: "person_1",
+          label: "jordi@doccy.com.au",
+          mentionKind: "email",
+          anchorText: "jordi@doccy.com.au",
+          anchorOccurrence: 1,
+          extractionMethod: "deterministic",
+          rationale: "Email address matched deterministic extractor.",
+          confidence: 1,
+        },
+      ],
+      input: "Email Jordi at jordi@doccy.com.au",
+      signalId,
+    });
+
+    expect(SIGNAL_ENTITY_LINKER_MODEL).toBe("openai/gpt-5.4-nano");
+    expect(SIGNAL_ENTITY_LINKER_WORKFLOW).toBe("index-signal-entities");
+    expect(SIGNAL_ENTITY_LINKER_PROMPT_ID).toBe("signal-entity-linker");
+    expect(request).toEqual(
+      expect.objectContaining({
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "development",
+        inputLength: "Email Jordi at jordi@doccy.com.au".length,
+        model: SIGNAL_ENTITY_LINKER_MODEL,
+        signalId,
+        system: SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT,
+      })
+    );
+    expect(request.prompt).toContain("Email Jordi at jordi@doccy.com.au");
+    expect(request.prompt).toContain("jordi@doccy.com.au");
+    expect(request.prompt).toContain("Discuss dev flow");
+  });
+
+  it("uses structured output and stamps schema version plus ai extraction method", async () => {
+    const model = createClassifierModel(
+      JSON.stringify({
+        candidates: [
+          {
+            targetType: "person",
+            localEntityKey: "person_1",
+            label: "Jordi",
+            mentionKind: "name",
+            anchorText: "Jordi",
+            anchorOccurrence: 1,
+            rationale: "Jordi appears as a person to talk with.",
+            confidence: 0.74,
+          },
+        ],
+      })
+    );
+    const request = {
+      ...buildSignalEntityLinkingRequest({
+        classification,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "production",
+        deterministicCandidates: [],
+        input: "Talk to Jordi",
+        signalId,
+      }),
+      model,
+    };
+
+    await expect(classifySignalEntityLinks(request, { logger })).resolves.toEqual({
+      schemaVersion: "signal.entity-links.v1",
+      candidates: [
+        {
+          targetType: "person",
+          localEntityKey: "person_1",
+          label: "Jordi",
+          mentionKind: "name",
+          anchorText: "Jordi",
+          anchorOccurrence: 1,
+          extractionMethod: "ai",
+          rationale: "Jordi appears as a person to talk with.",
+          confidence: 0.74,
+        },
+      ],
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "[entity-links] classification completed",
+      expect.objectContaining({
+        agentGraphId: "signal-intake",
+        agentRunId: signalId,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "production",
+        feature: "entity-links",
+        nodeId: "signal-entity-linker",
+        nodeKind: "llm",
+        nodeRole: "extractor",
+        promptId: "signal-entity-linker",
+        routerId: "signals",
+        signalId,
+        upstreamNodeId: "signal-classifier",
+        workflow: "index-signal-entities",
+      })
+    );
+  });
+
+  it("maps invalid output to a durable entity-linking failure code", async () => {
+    const model = createClassifierModel(
+      JSON.stringify({ candidates: [{ localEntityKey: "jordi" }] })
+    );
+    const request = {
+      ...buildSignalEntityLinkingRequest({
+        classification,
+        clerkOrgId: "org_test",
+        deploymentEnvironment: "preview",
+        deterministicCandidates: [],
+        input: "Talk to Jordi",
+        signalId,
+      }),
+      model,
+    };
+
+    const failure = await classifySignalEntityLinks(request, { logger }).catch(
+      (error) => getSignalEntityLinkingFailure(error)
+    );
+
+    expect(failure.errorCode).toBe(
+      SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE
+    );
+  });
+
+  it("instructs the model to extract explicit names without inferring identities", () => {
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain(
+      "Name-only person references are allowed"
+    );
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain(
+      "Do not extract role-only"
+    );
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain(
+      "anchorText must be an exact substring"
+    );
+    expect(SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT).toContain("Do not browse");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker/classify.test.ts
+```
+
+Expected: FAIL because prompt, errors, and classify exports do not exist.
+
+- [ ] **Step 3: Implement prompt, errors, and classifier wrapper**
+
+Create `ai/src/signal-entity-linker/prompt.ts`:
+
+```ts
+export const SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT = `You are the Lightfast signal entity linker.
+
+You receive one raw signal input, its persisted signal classification, and deterministic candidates already extracted by application code.
+Your job is to extract additional explicit person references from the raw signal input.
+
+Do not execute the action.
+Do not browse the web.
+Do not infer identities that are not present in the signal input.
+Do not decide whether a person is confirmed.
+Do not merge global People records.
+Do not rewrite deterministic candidates.
+
+In v1, extract only person references.
+Name-only person references are allowed.
+Extract explicit names, email addresses, provider handles, and person profile URLs.
+Do not extract role-only or coreference-only references such as "the designer", "their CTO", "my manager", or "the person from Doccy".
+Do not extract projects, companies, accounts, documents, or unsupported entity types.
+Do not create a name candidate from inside an email address or URL unless that name appears separately as human-readable text in the input.
+
+Every candidate must use targetType "person".
+Every candidate must include localEntityKey matching /^person_[1-9][0-9]*$/.
+Use the same localEntityKey for multiple candidates that refer to the same person inside this signal.
+localEntityKey is scoped only to this signal and is not a database id.
+
+Every candidate label and anchorText must come from the raw signal input.
+Do not create candidates from names that appear only in the classification JSON.
+anchorText must be an exact substring from the raw input.
+anchorOccurrence is 1-based among exact anchorText matches in the raw input.
+
+Return only references that a reasonable user would expect Lightfast to remember as people-related context.
+Preserve uncertainty in rationale and confidence.
+Return an empty candidates array when no person reference is present.`;
+```
+
+Create `ai/src/signal-entity-linker/errors.ts` by following the existing people classifier error mapper with entity-link constants:
+
+```ts
+import { APICallError, NoObjectGeneratedError, RetryError } from "@vendor/ai";
+
+import {
+  SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE,
+  SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE,
+  SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE,
+  SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE,
+  type SignalEntityLinkingFailureCode,
+} from "./constants";
+
+export interface SignalEntityLinkingFailure {
+  errorCode: SignalEntityLinkingFailureCode;
+  errorMessage: string;
+}
+
+export function getSignalEntityLinkingFailure(
+  error: unknown
+): SignalEntityLinkingFailure {
+  const message = getErrorMessage(error);
+
+  if (isTimeoutError(error)) {
+    return {
+      errorCode: SIGNAL_ENTITY_LINKING_TIMEOUT_ERROR_CODE,
+      errorMessage: message,
+    };
+  }
+
+  if (isInvalidOutputError(error)) {
+    return {
+      errorCode: SIGNAL_ENTITY_LINKING_INVALID_OUTPUT_ERROR_CODE,
+      errorMessage: message,
+    };
+  }
+
+  if (isProviderError(error)) {
+    return {
+      errorCode: SIGNAL_ENTITY_LINKING_PROVIDER_ERROR_CODE,
+      errorMessage: message,
+    };
+  }
+
+  return {
+    errorCode: SIGNAL_ENTITY_LINKING_FAILED_ERROR_CODE,
+    errorMessage: message,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isProviderError(error: unknown): boolean {
+  return (
+    APICallError.isInstance(error) ||
+    hasErrorName(error, "AI_APICallError") ||
+    hasErrorName(error, "GatewayError") ||
+    hasCauseMatching(error, isProviderError)
+  );
+}
+
+function isInvalidOutputError(error: unknown): boolean {
+  return (
+    NoObjectGeneratedError.isInstance(error) ||
+    hasErrorName(error, "AI_NoObjectGeneratedError") ||
+    hasCauseMatching(error, isInvalidOutputError)
+  );
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    hasErrorName(error, "AbortError") ||
+    hasErrorName(error, "TimeoutError") ||
+    (RetryError.isInstance(error) && error.reason === "abort") ||
+    hasCauseMatching(error, isTimeoutError)
+  );
+}
+
+function hasErrorName(error: unknown, name: string): boolean {
+  return (
+    error instanceof Error && (error.name === name || error.name.includes(name))
+  );
+}
+
+function hasCauseMatching(
+  error: unknown,
+  predicate: (error: unknown) => boolean
+): boolean {
+  if (!(error instanceof Error && "cause" in error)) {
+    return false;
+  }
+
+  return predicate(error.cause);
+}
+```
+
+Create `ai/src/signal-entity-linker/classify.ts`:
+
+```ts
+import "server-only";
+
+import { createAgentNodeMetadata } from "@repo/ai/telemetry";
+import type { SignalClassification } from "@repo/api-contract";
+import type { LanguageModel } from "@vendor/ai";
+
+import { signalIntakeAgentGraph } from "../_internal/agent-graphs/signal-intake";
+import {
+  type ObjectClassificationLogger,
+  runObjectClassification,
+} from "../_internal/object-classification/run-object-classification";
+import {
+  SIGNAL_ENTITY_LINKER_MAX_OUTPUT_TOKENS,
+  SIGNAL_ENTITY_LINKER_MODEL,
+  SIGNAL_ENTITY_LINKER_TELEMETRY_FUNCTION_ID,
+  SIGNAL_ENTITY_LINKER_TIMEOUT_MS,
+  SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+} from "./constants";
+import { getSignalEntityLinkingFailure } from "./errors";
+import { SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT } from "./prompt";
+import {
+  type SignalEntityLinkCandidate,
+  type SignalEntityLinking,
+  signalEntityLinkingModelSchema,
+} from "./schema";
+
+const noopLogger: ObjectClassificationLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+};
+
+const signalEntityLinkerNode = signalIntakeAgentGraph.nodes.signalEntityLinker;
+
+export type DeploymentEnvironment = "development" | "preview" | "production";
+
+export interface SignalEntityLinkingRequest {
+  classification: SignalClassification | null;
+  clerkOrgId: string;
+  deploymentEnvironment: DeploymentEnvironment;
+  deterministicCandidates: SignalEntityLinkCandidate[];
+  inputLength: number;
+  model: LanguageModel;
+  prompt: string;
+  signalId: string;
+  system: string;
+}
+
+export interface BuildSignalEntityLinkingRequestInput {
+  classification: SignalClassification | null;
+  clerkOrgId: string;
+  deploymentEnvironment: DeploymentEnvironment;
+  deterministicCandidates: SignalEntityLinkCandidate[];
+  input: string;
+  signalId: string;
+}
+
+export interface ClassifySignalEntityLinksOptions {
+  logger?: ObjectClassificationLogger;
+}
+
+export function buildSignalEntityLinkingRequest({
+  classification,
+  clerkOrgId,
+  deploymentEnvironment,
+  deterministicCandidates,
+  input,
+  signalId,
+}: BuildSignalEntityLinkingRequestInput): SignalEntityLinkingRequest {
+  return {
+    classification,
+    clerkOrgId,
+    deploymentEnvironment,
+    deterministicCandidates,
+    inputLength: input.length,
+    model: SIGNAL_ENTITY_LINKER_MODEL,
+    prompt: [
+      "Extract explicit person references from this signal.",
+      "",
+      "Signal input:",
+      input,
+      "",
+      "Deterministic candidates already found:",
+      JSON.stringify(deterministicCandidates),
+      "",
+      "Signal classification:",
+      JSON.stringify(classification),
+    ].join("\n"),
+    signalId,
+    system: SIGNAL_ENTITY_LINKER_SYSTEM_PROMPT,
+  };
+}
+
+export async function classifySignalEntityLinks(
+  {
+    clerkOrgId,
+    deploymentEnvironment,
+    inputLength,
+    model,
+    prompt,
+    signalId,
+    system,
+  }: SignalEntityLinkingRequest,
+  { logger = noopLogger }: ClassifySignalEntityLinksOptions = {}
+): Promise<SignalEntityLinking> {
+  const output = await runObjectClassification({
+    failureMessage: "[entity-links] classification failed",
+    getFailure: getSignalEntityLinkingFailure,
+    logger,
+    maxOutputTokens: SIGNAL_ENTITY_LINKER_MAX_OUTPUT_TOKENS,
+    metadata: {
+      ...createAgentNodeMetadata(
+        signalIntakeAgentGraph,
+        signalEntityLinkerNode,
+        {
+          agentRunId: signalId,
+          clerkOrgId,
+          deploymentEnvironment,
+          inputLength,
+        }
+      ),
+      signalId,
+    },
+    model,
+    prompt,
+    schema: signalEntityLinkingModelSchema,
+    successMessage: "[entity-links] classification completed",
+    system,
+    telemetryFunctionId: SIGNAL_ENTITY_LINKER_TELEMETRY_FUNCTION_ID,
+    timeoutMs: SIGNAL_ENTITY_LINKER_TIMEOUT_MS,
+  });
+
+  return {
+    candidates: output.candidates.map((candidate) => ({
+      ...candidate,
+      extractionMethod: "ai" as const,
+    })),
+    schemaVersion: SIGNAL_ENTITY_LINKS_SCHEMA_VERSION,
+  };
+}
+```
+
+Modify `ai/src/signal-entity-linker/index.ts`:
+
+```ts
+export * from "./classify";
+export * from "./constants";
+export * from "./errors";
+export * from "./extract";
+export * from "./prompt";
+export * from "./schema";
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker/classify.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai/src/signal-entity-linker ai/src/__tests__/signal-entity-linker/classify.test.ts
+git commit -m "feat: add signal entity linker classifier"
+```
+
+## Task 4: Add No-Persistence Entity Index Workflow
+
+**Files:**
+- Modify: `api/app/src/inngest/schemas/app.ts`
+- Create: `api/app/src/inngest/workflow/index-signal-entities.ts`
+- Test: `api/app/src/__tests__/entity-index-workflow.test.ts`
+
+- [ ] **Step 1: Write failing workflow tests**
+
+Create `api/app/src/__tests__/entity-index-workflow.test.ts`:
+
+```ts
+import type { Database } from "@db/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSignalByPublicIdMock = vi.fn();
+const extractDeterministicSignalEntityLinksMock = vi.fn();
+const buildSignalEntityLinkingRequestMock = vi.fn();
+const classifySignalEntityLinksMock = vi.fn();
+const mergeSignalEntityLinkCandidatesMock = vi.fn();
+const getSignalEntityLinkingFailureMock = vi.fn();
+const logWarnMock = vi.fn();
+const db = { kind: "mock-db" } as unknown as Database;
+
+type WorkflowCallback = (input: {
+  event: {
+    data: {
+      clerkOrgId: string;
+      signalId: string;
+    };
+  };
+  step: ReturnType<typeof createStep>;
+}) => Promise<unknown>;
+
+type WorkflowFailureCallback = (input: {
+  error: Error;
+  event: {
+    data: {
+      event: {
+        data: {
+          clerkOrgId: string;
+          signalId: string;
+        };
+      };
+    };
+  };
+}) => Promise<unknown>;
+
+let workflowCallback: WorkflowCallback | undefined;
+let workflowFailureCallback: WorkflowFailureCallback | undefined;
+const createFunctionMock = vi.fn(
+  (
+    config: { onFailure?: WorkflowFailureCallback },
+    handler: WorkflowCallback
+  ): { id: string } => {
+    workflowCallback = handler;
+    workflowFailureCallback = config.onFailure;
+    return { id: "index-signal-entities" };
+  }
+);
+
+vi.mock("@db/app", () => ({
+  getSignalByPublicId: getSignalByPublicIdMock,
+}));
+
+vi.mock("@db/app/client", () => ({ db }));
+
+vi.mock("@repo/ai/signal-entity-linker", () => ({
+  buildSignalEntityLinkingRequest: buildSignalEntityLinkingRequestMock,
+  classifySignalEntityLinks: classifySignalEntityLinksMock,
+  extractDeterministicSignalEntityLinks:
+    extractDeterministicSignalEntityLinksMock,
+  getSignalEntityLinkingFailure: getSignalEntityLinkingFailureMock,
+  mergeSignalEntityLinkCandidates: mergeSignalEntityLinkCandidatesMock,
+}));
+
+vi.mock("@vendor/observability/log/next", () => ({
+  log: {
+    warn: logWarnMock,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../env", () => ({
+  env: {
+    VERCEL_ENV: "development",
+  },
+}));
+
+vi.mock("../inngest/client", () => ({
+  inngest: {
+    createFunction: createFunctionMock,
+  },
+}));
+
+const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
+const classification = {
+  schemaVersion: "signal.classification.v2",
+  disposition: "needs_context",
+  title: "Discuss dev flow",
+  summary: "Talk with Jordi and Archer about workflow.",
+  kind: "follow_up",
+  nextAction: "Ask Jordi and Archer about dev flow.",
+  priority: "normal",
+  rationale: "The signal mentions people.",
+  confidence: 0.55,
+  routing: {
+    visibility: {
+      scope: "user",
+      rationale: "Creator-visible context.",
+    },
+    review: {
+      required: false,
+      reason: null,
+      rationale: null,
+    },
+    routes: {
+      people: {
+        shouldRun: false,
+        confidence: 0.1,
+        rationale: "No durable identity is present.",
+      },
+    },
+  },
+};
+const signal = {
+  id: 1,
+  publicId: signalId,
+  clerkOrgId: "org_test",
+  input: "Talk to Jordi & Archer about their dev flow",
+  status: "classified",
+  classification,
+  visibilityScope: "user",
+};
+
+const { indexSignalEntities } = await import(
+  "../inngest/workflow/index-signal-entities"
+);
+
+function createStep() {
+  return {
+    run: vi.fn(<T>(_name: string, fn: () => T | Promise<T>) => fn()),
+    ai: {
+      wrap: vi.fn(
+        <T>(
+          _name: string,
+          fn: (request: Record<string, unknown>) => T | Promise<T>,
+          request: Record<string, unknown>
+        ) => fn(request)
+      ),
+    },
+  };
+}
+
+function runWorkflow(step: ReturnType<typeof createStep>) {
+  if (!workflowCallback) {
+    throw new Error("workflow callback was not registered");
+  }
+
+  return workflowCallback({
+    event: {
+      data: {
+        clerkOrgId: "org_test",
+        signalId,
+      },
+    },
+    step,
+  });
+}
+
+beforeEach(() => {
+  getSignalByPublicIdMock.mockReset();
+  extractDeterministicSignalEntityLinksMock.mockReset();
+  buildSignalEntityLinkingRequestMock.mockReset();
+  classifySignalEntityLinksMock.mockReset();
+  mergeSignalEntityLinkCandidatesMock.mockReset();
+  getSignalEntityLinkingFailureMock.mockReset();
+  logWarnMock.mockReset();
+
+  getSignalByPublicIdMock.mockResolvedValue(signal);
+  extractDeterministicSignalEntityLinksMock.mockReturnValue([]);
+  buildSignalEntityLinkingRequestMock.mockReturnValue({
+    clerkOrgId: "org_test",
+    deploymentEnvironment: "development",
+    deterministicCandidates: [],
+    inputLength: signal.input.length,
+    model: "openai/gpt-5.4-nano",
+    prompt: "Extract explicit person references.",
+    signalId,
+    system: "You are the Lightfast signal entity linker.",
+  });
+  classifySignalEntityLinksMock.mockResolvedValue({
+    schemaVersion: "signal.entity-links.v1",
+    candidates: [
+      {
+        targetType: "person",
+        localEntityKey: "person_1",
+        label: "Jordi",
+        mentionKind: "name",
+        anchorText: "Jordi",
+        anchorOccurrence: 1,
+        extractionMethod: "ai",
+        rationale: "Jordi appears as a person.",
+        confidence: 0.74,
+      },
+    ],
+  });
+  mergeSignalEntityLinkCandidatesMock.mockReturnValue([
+    {
+      targetType: "person",
+      localEntityKey: "person_1",
+      label: "Jordi",
+      mentionKind: "name",
+      anchorText: "Jordi",
+      anchorOccurrence: 1,
+      extractionMethod: "ai",
+      rationale: "Jordi appears as a person.",
+      confidence: 0.74,
+    },
+  ]);
+  getSignalEntityLinkingFailureMock.mockImplementation((error: unknown) => ({
+    errorCode: "SIGNAL_ENTITY_LINKING_FAILED",
+    errorMessage: error instanceof Error ? error.message : String(error),
+  }));
+});
+
+describe("indexSignalEntities", () => {
+  it("registers the workflow", () => {
+    expect(indexSignalEntities).toEqual({ id: "index-signal-entities" });
+    expect(createFunctionMock).toHaveBeenCalledWith(
+      {
+        id: "index-signal-entities",
+        idempotency: 'event.data.clerkOrgId + "-" + event.data.signalId',
+        onFailure: expect.any(Function),
+        retries: 3,
+        timeouts: { finish: "10m", start: "10m" },
+        triggers: expect.objectContaining({
+          event: "app/signal.entity-index.requested",
+        }),
+      },
+      expect.any(Function)
+    );
+  });
+
+  it("extracts deterministic and AI candidates without persistence", async () => {
+    const step = createStep();
+
+    await expect(runWorkflow(step)).resolves.toEqual({
+      aiCandidates: 1,
+      candidates: 1,
+      deterministicCandidates: 0,
+      status: "indexed",
+    });
+
+    expect(getSignalByPublicIdMock).toHaveBeenCalledWith(db, {
+      clerkOrgId: "org_test",
+      publicId: signalId,
+    });
+    expect(extractDeterministicSignalEntityLinksMock).toHaveBeenCalledWith({
+      input: signal.input,
+    });
+    expect(buildSignalEntityLinkingRequestMock).toHaveBeenCalledWith({
+      classification,
+      clerkOrgId: "org_test",
+      deploymentEnvironment: "development",
+      deterministicCandidates: [],
+      input: signal.input,
+      signalId,
+    });
+    expect(step.ai.wrap).toHaveBeenCalledWith(
+      "link signal entities",
+      expect.any(Function),
+      expect.objectContaining({ signalId })
+    );
+    expect(mergeSignalEntityLinkCandidatesMock).toHaveBeenCalledWith({
+      aiCandidates: expect.any(Array),
+      deterministicCandidates: [],
+      input: signal.input,
+    });
+  });
+
+  it("skips missing, unclassified, and needs-review signals", async () => {
+    const step = createStep();
+    getSignalByPublicIdMock.mockResolvedValueOnce(undefined);
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "missing" });
+
+    getSignalByPublicIdMock.mockResolvedValueOnce({
+      ...signal,
+      status: "processing",
+      classification: null,
+    });
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "skipped" });
+
+    getSignalByPublicIdMock.mockResolvedValueOnce({
+      ...signal,
+      classification: {
+        ...classification,
+        routing: {
+          ...classification.routing,
+          visibility: {
+            scope: "needs_review",
+            rationale: "Needs review.",
+          },
+          review: {
+            required: true,
+            reason: "sensitive_person",
+            rationale: "Sensitive person context.",
+          },
+        },
+      },
+      visibilityScope: "needs_review",
+    });
+    await expect(runWorkflow(step)).resolves.toEqual({ status: "skipped" });
+  });
+
+  it("logs exhausted failures without mutating the signal", async () => {
+    if (!workflowFailureCallback) {
+      throw new Error("workflow failure callback was not registered");
+    }
+
+    await expect(
+      workflowFailureCallback({
+        error: new Error("model unavailable"),
+        event: {
+          data: {
+            event: {
+              data: {
+                clerkOrgId: "org_test",
+                signalId,
+              },
+            },
+          },
+        },
+      })
+    ).resolves.toEqual({ status: "failed" });
+
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "[entity-links] indexing exhausted retries",
+      expect.objectContaining({
+        clerkOrgId: "org_test",
+        errorCode: "SIGNAL_ENTITY_LINKING_FAILED",
+        signalId,
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/entity-index-workflow.test.ts
+```
+
+Expected: FAIL because the event and workflow do not exist.
+
+- [ ] **Step 3: Add event schema and workflow**
+
+Modify `api/app/src/inngest/schemas/app.ts`:
+
+```ts
+"app/signal.entity-index.requested": eventType(
+  "app/signal.entity-index.requested",
+  {
+    schema: z.object({
+      signalId: signalIdSchema,
+      clerkOrgId: z.string().min(1),
+    }),
+  }
+),
+```
+
+Create `api/app/src/inngest/workflow/index-signal-entities.ts`:
+
+```ts
+import { getSignalByPublicId } from "@db/app";
+import { db } from "@db/app/client";
+import {
+  buildSignalEntityLinkingRequest,
+  classifySignalEntityLinks,
+  extractDeterministicSignalEntityLinks,
+  getSignalEntityLinkingFailure,
+  mergeSignalEntityLinkCandidates,
+} from "@repo/ai/signal-entity-linker";
+import type { SignalClassification } from "@repo/api-contract";
+import { log } from "@vendor/observability/log/next";
+
+import { env } from "../../env";
+import { inngest } from "../client";
+import { appEvents } from "../schemas/app";
+
+function shouldIndexSignalEntities(signal: {
+  classification: SignalClassification | null;
+  status: string;
+  visibilityScope: string;
+}): boolean {
+  if (signal.status !== "classified" || !signal.classification) {
+    return false;
+  }
+
+  return (
+    signal.classification.schemaVersion === "signal.classification.v2" &&
+    signal.classification.routing.visibility.scope !== "needs_review" &&
+    signal.visibilityScope !== "needs_review"
+  );
+}
+
+export const indexSignalEntities = inngest.createFunction(
+  {
+    id: "index-signal-entities",
+    idempotency: 'event.data.clerkOrgId + "-" + event.data.signalId',
+    retries: 3,
+    timeouts: {
+      finish: "10m",
+      start: "10m",
+    },
+    triggers: appEvents["app/signal.entity-index.requested"],
+    onFailure: async ({ event, error }) => {
+      const { clerkOrgId, signalId } = event.data.event.data;
+      const failure = getSignalEntityLinkingFailure(error);
+
+      log.warn("[entity-links] indexing exhausted retries", {
+        clerkOrgId,
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+        signalId,
+      });
+
+      return { status: "failed" };
+    },
+  },
+  async ({ event, step }) => {
+    const { clerkOrgId, signalId } = event.data;
+
+    const signal = await step.run("load signal", () =>
+      getSignalByPublicId(db, {
+        clerkOrgId,
+        publicId: signalId,
+      })
+    );
+
+    if (!signal) {
+      return { status: "missing" };
+    }
+
+    if (!shouldIndexSignalEntities(signal)) {
+      return { status: "skipped" };
+    }
+
+    const deterministicCandidates = await step.run(
+      "extract deterministic entity links",
+      () => extractDeterministicSignalEntityLinks({ input: signal.input })
+    );
+
+    const request = buildSignalEntityLinkingRequest({
+      classification: signal.classification,
+      clerkOrgId,
+      deploymentEnvironment: env.VERCEL_ENV,
+      deterministicCandidates,
+      input: signal.input,
+      signalId,
+    });
+
+    const aiResult = await step.ai.wrap(
+      "link signal entities",
+      (linkingRequest) =>
+        classifySignalEntityLinks(linkingRequest, { logger: log }),
+      request
+    );
+
+    const candidates = await step.run("merge entity link candidates", () =>
+      mergeSignalEntityLinkCandidates({
+        aiCandidates: aiResult.candidates,
+        deterministicCandidates,
+        input: signal.input,
+      })
+    );
+
+    return {
+      aiCandidates: aiResult.candidates.length,
+      candidates: candidates.length,
+      deterministicCandidates: deterministicCandidates.length,
+      status: "indexed",
+    };
+  }
+);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/entity-index-workflow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/src/inngest/schemas/app.ts api/app/src/inngest/workflow/index-signal-entities.ts api/app/src/__tests__/entity-index-workflow.test.ts
+git commit -m "feat: add signal entity indexing workflow"
+```
+
+## Task 5: Wire Entity Indexing From Signal Classification
+
+**Files:**
+- Modify: `api/app/src/inngest/workflow/classify-signal.ts`
+- Modify: `api/app/src/__tests__/signal-workflow.test.ts`
+
+- [ ] **Step 1: Update failing workflow tests**
+
+In `api/app/src/__tests__/signal-workflow.test.ts`, update the main classified test to expect both events:
+
+```ts
+expect(sendMock).toHaveBeenCalledWith({
+  name: "app/people.classification.requested",
+  data: {
+    clerkOrgId: "org_test",
+    signalId,
+  },
+});
+expect(sendMock).toHaveBeenCalledWith({
+  name: "app/signal.entity-index.requested",
+  data: {
+    clerkOrgId: "org_test",
+    signalId,
+  },
+});
+```
+
+Replace the user-visible no-send assertion with:
+
+```ts
+expect(sendMock).toHaveBeenCalledTimes(1);
+expect(sendMock).toHaveBeenCalledWith({
+  name: "app/signal.entity-index.requested",
+  data: {
+    clerkOrgId: "org_test",
+    signalId,
+  },
+});
+expect(sendMock).not.toHaveBeenCalledWith({
+  name: "app/people.classification.requested",
+  data: {
+    clerkOrgId: "org_test",
+    signalId,
+  },
+});
+```
+
+Keep needs-review tests asserting no sends:
+
+```ts
+expect(sendMock).not.toHaveBeenCalled();
+```
+
+Add a not-actionable user-visible classification fixture:
+
+```ts
+const notActionableClassification = {
+  ...userClassification,
+  disposition: "not_actionable",
+  title: "FYI from Jordi",
+  summary: "The input mentions Jordi but does not require action.",
+  kind: "other",
+  nextAction: "No action required.",
+  priority: "low",
+  rationale: "The signal is informational.",
+  confidence: 0.64,
+} as const;
+```
+
+Add the test:
+
+```ts
+it("queues entity indexing for non-actionable visible signals", async () => {
+  const step = createStep();
+  classifySignalInputMock.mockResolvedValueOnce(notActionableClassification);
+
+  await expect(runWorkflow(step)).resolves.toEqual({
+    status: "classified",
+    visibilityScope: "user",
+    reviewRequired: false,
+    routedPeople: false,
+  });
+
+  expect(sendMock).toHaveBeenCalledWith({
+    name: "app/signal.entity-index.requested",
+    data: {
+      clerkOrgId: "org_test",
+      signalId,
+    },
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/signal-workflow.test.ts
+```
+
+Expected: FAIL because `classify-signal` does not queue entity-index events.
+
+- [ ] **Step 3: Implement entity-index queueing in classify-signal**
+
+Modify `api/app/src/inngest/workflow/classify-signal.ts`:
+
+```ts
+function shouldIndexSignalEntities(
+  classification: SignalClassification | null
+): boolean {
+  return (
+    classification?.schemaVersion === "signal.classification.v2" &&
+    classification.routing.visibility.scope !== "needs_review"
+  );
+}
+
+async function queueSignalEntityIndexing(input: {
+  clerkOrgId: string;
+  signalId: string;
+}) {
+  await inngest.send({
+    name: "app/signal.entity-index.requested",
+    data: input,
+  });
+}
+```
+
+Refactor the already-classified branch from early returns into one return:
+
+```ts
+if (signal.status === "classified" && signal.classification) {
+  const routedPeople = shouldClassifyPeople(signal.classification);
+  if (routedPeople) {
+    await step.run("queue people classification", () =>
+      inngest.send({
+        name: "app/people.classification.requested",
+        data: {
+          clerkOrgId,
+          signalId,
+        },
+      })
+    );
+  }
+
+  if (shouldIndexSignalEntities(signal.classification)) {
+    await step.run("queue signal entity indexing", () =>
+      queueSignalEntityIndexing({ clerkOrgId, signalId })
+    );
+  }
+
+  return classifiedResult(signal.classification, routedPeople);
+}
+```
+
+Refactor the newly-classified branch from early returns into one return:
+
+```ts
+const routedPeople = shouldClassifyPeople(classification);
+if (routedPeople) {
+  await step.run("queue people classification", () =>
+    inngest.send({
+      name: "app/people.classification.requested",
+      data: {
+        clerkOrgId,
+        signalId,
+      },
+    })
+  );
+}
+
+if (shouldIndexSignalEntities(classification)) {
+  await step.run("queue signal entity indexing", () =>
+    queueSignalEntityIndexing({ clerkOrgId, signalId })
+  );
+}
+
+return classifiedResult(classification, routedPeople);
+```
+
+Keep `classifiedResult(classification, routedPeople)` unchanged so existing workflow consumers do not need a result-shape migration.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/signal-workflow.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/src/inngest/workflow/classify-signal.ts api/app/src/__tests__/signal-workflow.test.ts
+git commit -m "feat: queue signal entity indexing"
+```
+
+## Task 6: Register Workflow In Inngest Route
+
+**Files:**
+- Modify: `api/app/src/inngest/index.ts`
+- Modify: `api/app/src/__tests__/inngest-route.test.ts`
+
+- [ ] **Step 1: Write failing route registration test update**
+
+Modify `api/app/src/__tests__/inngest-route.test.ts`:
+
+```ts
+const indexSignalEntities = { id: "index-signal-entities" };
+```
+
+Add mock:
+
+```ts
+vi.mock("../inngest/workflow/index-signal-entities", () => ({
+  indexSignalEntities,
+}));
+```
+
+Add `indexSignalEntities` to the expected `functions` array immediately after `classifySignal`:
+
+```ts
+functions: [
+  systemHealth,
+  classifySignal,
+  indexSignalEntities,
+  classifyPeople,
+  cleanupDeveloperSandboxRuns,
+  automationScheduler,
+  runAutomation,
+  refreshSkillIndex,
+  refreshIdentityIndex,
+  reconcileSkillIndexes,
+  reconcileIdentityIndexes,
+  queueLightfastIndexRefreshesFromSourceControl,
+],
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/inngest-route.test.ts
+```
+
+Expected: FAIL because the route does not include `indexSignalEntities`.
+
+- [ ] **Step 3: Register workflow**
+
+Modify `api/app/src/inngest/index.ts`:
+
+```ts
+import { indexSignalEntities } from "./workflow/index-signal-entities";
+```
+
+Add it to the served functions list immediately after `classifySignal`:
+
+```ts
+systemHealth,
+classifySignal,
+indexSignalEntities,
+classifyPeople,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/inngest-route.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/src/inngest/index.ts api/app/src/__tests__/inngest-route.test.ts
+git commit -m "feat: register signal entity indexing workflow"
+```
+
+## Task 7: Package-Level Verification
+
+**Files:**
+- Verify only; no source changes expected.
+
+- [ ] **Step 1: Run focused AI tests**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai test -- src/__tests__/signal-entity-linker src/__tests__/_internal/agent-graphs/signal-intake.test.ts src/__tests__/telemetry/metadata.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused API workflow tests**
+
+Run:
+
+```bash
+pnpm --filter @api/app test -- src/__tests__/entity-index-workflow.test.ts src/__tests__/signal-workflow.test.ts src/__tests__/inngest-route.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typechecks for touched packages**
+
+Run:
+
+```bash
+pnpm --filter @repo/ai typecheck
+pnpm --filter @api/app typecheck
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 4: Commit any verification-only fixes**
+
+If verification required small type/test fixes, commit only those fixes:
+
+```bash
+git add ai api/app
+git commit -m "fix: verify signal entity indexing types"
+```
+
+If there were no fixes, do not create an empty commit.
+
+## Self-Review
+
+- Spec coverage: The plan covers the AI capability, deterministic extraction, shared candidate schema, `localEntityKey`, raw-input-only prompt rules, live workflow integration, needs-review skip behavior, no persistence, no backfill, and no UI.
+- Deferred scope: Persistence tables, reconciliation, `signals.get` entity links, UI rendering, Project entities, and classifier consolidation remain out of this first implementation slice.
+- Red-flag scan: The plan contains no unresolved marker tokens and no unspecified "write tests" steps.
+- Type consistency: The plan consistently uses `SignalEntityLinkCandidate`, `signalEntityLinkingModelSchema`, `classifySignalEntityLinks`, `extractDeterministicSignalEntityLinks`, `mergeSignalEntityLinkCandidates`, and `indexSignalEntities`.

--- a/docs/superpowers/specs/2026-06-06-signal-entity-links-ai-design.md
+++ b/docs/superpowers/specs/2026-06-06-signal-entity-links-ai-design.md
@@ -34,6 +34,10 @@ implementation slice to the AI extraction layer.
 - No inline Signal rendering requirement in this slice. Inline links can come
   later from optional render anchors.
 - No broad People UI redesign in this slice.
+- No backfill for already-classified historical signals in the first
+  implementation slice.
+- No replacement or consolidation of the existing people classifier in the
+  first implementation slice.
 
 ## Core Model
 
@@ -163,13 +167,47 @@ The capability receives:
 }
 ```
 
-The classifier returns model-only candidates:
+The entity-linking layer has two extractors:
+
+1. **Deterministic extractor**: real code extracts emails, recognized profile
+   URLs, and provider handles where provider context is obvious.
+2. **AI extractor**: model extracts explicit natural-language person references
+   such as `Jordi`, `Archer`, `Louie`, and `Mahesh`.
+
+Deterministic extraction runs first. Its candidates are passed into the AI
+prompt as authoritative context so the model can avoid duplicate work and can
+reuse local grouping keys. The model may add candidates but must not rewrite or
+invalidate deterministic candidates.
+
+Both extractors normalize into one internal candidate shape:
+
+```ts
+{
+  targetType: "person";
+  localEntityKey: `person_${number}`;
+  label: string;
+  mentionKind: "name" | "email" | "handle" | "profile_url";
+  anchorText: string;
+  anchorOccurrence: number;
+  extractionMethod: "deterministic" | "ai";
+  rationale: string;
+  confidence: number;
+}
+```
+
+`localEntityKey` is required, scoped only to one signal extraction result, and
+must match `/^person_[1-9][0-9]*$/`. It groups multiple mentions that refer to
+the same person inside a single signal. It is not a database id and must never
+merge global People records.
+
+The AI classifier returns model-only candidates:
 
 ```ts
 {
   schemaVersion: "signal.entity-links.v1";
   candidates: Array<{
     targetType: "person";
+    localEntityKey: `person_${number}`;
     label: string;
     mentionKind: "name" | "email" | "handle" | "profile_url";
     anchorText: string;
@@ -181,8 +219,15 @@ The classifier returns model-only candidates:
 ```
 
 The model must not emit `personPublicId`, `identityKey`, or any durable database
-id. It identifies text-level candidates only. Application code normalizes labels,
-dedupes candidates, creates or resolves people, and writes entity links.
+id. It identifies text-level candidates only. Application code validates anchors,
+normalizes labels, and dedupes candidates in the first slice. Later persistence
+code creates or resolves people and writes entity links.
+
+The current `@repo/ai/people-classifier` remains in place for now. It continues
+to handle durable identity extraction where the existing `routes.people` path
+runs. The new entity linker runs alongside it and covers name-only references.
+Consolidating the two classifiers is deferred until canonical People,
+identities, and entity links are persisted end to end.
 
 ### Prompt Rules
 
@@ -191,16 +236,30 @@ The system prompt should say:
 - Extract entity references from the raw signal input.
 - In v1, extract only person references.
 - Name-only person references are allowed.
+- Extract only explicit person references: names, emails, handles, and person
+  profile URLs.
 - Emails, handles, and profile URLs are allowed when they identify a person.
+- Do not extract role-only or coreference-only references such as "the
+  designer", "their CTO", "my manager", or "the person from Doccy".
+- Do not extract projects, companies, accounts, documents, or unsupported entity
+  types in v1.
 - Do not browse.
 - Do not infer identities that are not present in the signal.
+- Do not create a name candidate from inside an email address or URL unless that
+  name appears separately as human-readable text in the input.
 - Do not decide whether a person is confirmed.
 - Do not execute the requested action.
 - Return only references that a reasonable user would expect Lightfast to
   remember as people-related context.
 - Preserve uncertainty in `rationale` and `confidence`.
+- Every candidate must include a required `localEntityKey` matching
+  `/^person_[1-9][0-9]*$/`.
+- Use the same `localEntityKey` for multiple candidates that refer to the same
+  person inside this signal.
 - `anchorText` must be an exact substring from `input`.
 - `anchorOccurrence` is 1-based among exact `anchorText` matches in `input`.
+- Every candidate label and anchor must come from the raw signal input, not only
+  from the classification summary, title, rationale, or next action.
 - Return an empty array when no person reference is present.
 
 This prompt intentionally differs from the current people classifier. The
@@ -223,6 +282,7 @@ Output:
   "candidates": [
     {
       "targetType": "person",
+      "localEntityKey": "person_1",
       "label": "Louie",
       "mentionKind": "name",
       "anchorText": "Louie",
@@ -232,6 +292,7 @@ Output:
     },
     {
       "targetType": "person",
+      "localEntityKey": "person_2",
       "label": "Mahesh",
       "mentionKind": "name",
       "anchorText": "Mahesh",
@@ -257,6 +318,7 @@ Output:
   "candidates": [
     {
       "targetType": "person",
+      "localEntityKey": "person_1",
       "label": "Jordi",
       "mentionKind": "name",
       "anchorText": "Jordi",
@@ -266,6 +328,7 @@ Output:
     },
     {
       "targetType": "person",
+      "localEntityKey": "person_2",
       "label": "Archer",
       "mentionKind": "name",
       "anchorText": "Archer",
@@ -279,7 +342,8 @@ Output:
 
 ## Data Flow
 
-The first AI-only slice can be built and tested without changing UI:
+The first AI-only slice can be built and tested without changing UI or database
+schema. It should be wired into the live workflow, but it persists nothing:
 
 ```text
 signal.create
@@ -287,13 +351,23 @@ signal.create
 
 classify-signal
   -> stores classification as today
-  -> queues app/signal.entity-index.requested
+  -> queues app/signal.entity-index.requested for classified, non-needs-review
+     signals
 
 index-signal-entities
   -> loads the signal
-  -> calls @repo/ai/signal-entity-linker
-  -> returns candidates
+  -> runs deterministic extraction
+  -> calls @repo/ai/signal-entity-linker with deterministic candidates as context
+  -> merges and validates candidates
+  -> logs and returns candidate count
+  -> persists nothing
 ```
+
+Entity indexing runs after signal classification because classification owns
+visibility and review state. It does not require
+`classification.disposition === "actionable"`; `not_actionable` and
+`needs_context` signals may still contain useful entity evidence. It must skip
+signals whose effective visibility is `needs_review`.
 
 The next persistence slice will:
 
@@ -378,9 +452,11 @@ This keeps the link graph useful even if text rendering hints become stale.
 ## Error Handling
 
 - Missing signals return `missing`.
+- Signals that are not classified return `skipped`.
+- Needs-review signals return `skipped`.
 - Signals with no person references return `indexed` with zero candidates.
 - AI/provider failures bubble to Inngest for retry.
-- Invalid candidates are skipped by application validation.
+- Invalid candidates are skipped by application validation after extraction.
 - Anchor render failures do not fail the workflow. They only affect inline UI.
 - Needs-review or private visibility violations fail closed by not creating
   org-visible links.
@@ -391,11 +467,22 @@ AI-first tests:
 
 - Schema accepts person name, email, handle, and profile URL candidates.
 - Schema rejects unsupported target types in v1.
-- Prompt contains the name-only allowance and the no-inference rule.
+- Schema requires `localEntityKey` and rejects values outside the strict
+  `person_N` pattern.
+- Prompt contains the name-only allowance, explicit-reference limit,
+  raw-input-only rule, and no-inference rule.
+- Deterministic extractor finds email/profile URL/known handle candidates
+  without AI.
+- AI request builder passes deterministic candidates as context.
 - Request builder includes raw input and signal classification.
 - Classifier stamps `signal.entity-links.v1`.
 - Fixtures cover "Connect Louie with Mahesh" and "Talk to Jordi & Archer about
   their dev flow".
+- Workflow tests verify `classify-signal` queues
+  `app/signal.entity-index.requested` after successful classification and that
+  `index-signal-entities` extracts but does not persist candidates.
+- Workflow tests verify entity indexing skips needs-review signals and does not
+  require actionable disposition.
 - Telemetry follows the existing classifier privacy posture: metadata only,
   no prompt or output recording.
 
@@ -412,14 +499,34 @@ Persistence tests in the next slice:
 
 1. Add `@repo/ai/signal-entity-linker` schema, prompt, constants, errors, and
    request/classify functions.
-2. Add unit tests and fixtures for the new AI capability.
-3. Add `app/signal.entity-index.requested` event and an `index-signal-entities`
-   workflow that loads signals and calls the capability.
-4. Add persistence tables and DB helpers for canonical people, identities, and
+2. Add deterministic extraction helpers that emit the shared normalized
+   candidate schema.
+3. Add unit tests and fixtures for the new AI and deterministic extraction
+   capability.
+4. Add `app/signal.entity-index.requested` event and an `index-signal-entities`
+   workflow that loads signals, extracts candidates, validates them, and returns
+   counts without persistence.
+5. Wire `classify-signal` to enqueue entity indexing for newly classified,
+   non-needs-review signals.
+6. Add persistence tables and DB helpers for canonical people, identities, and
    signal entity links.
-5. Persist entity-link candidates and reconcile deterministic matches.
-6. Extend `signals.get` to return entity links.
-7. Add Signal detail UI rendering and People unresolved/confirmed UI.
+7. Persist entity-link candidates and reconcile deterministic matches.
+8. Extend `signals.get` to return entity links.
+9. Add Signal detail UI rendering and People unresolved/confirmed UI.
 
-The first implementation pass should stop after step 3 unless persistence is
-explicitly approved for the same branch.
+The first implementation pass should stop after live workflow extraction is
+integrated and verified. Persistence, backfill, UI, smarter clustering, project
+entities, and classifier consolidation are explicitly deferred.
+
+## Deferred Follow-Ups
+
+- Create a GitHub issue for smarter unresolved-person clustering beyond exact
+  normalized label. Future inputs should include source, project, conversation,
+  organization domain, and temporal proximity.
+- Create a GitHub issue for consolidating the existing people classifier into
+  the entity-link indexing pipeline after canonical People and identities are
+  persisted.
+- Create a GitHub issue for entity-link backfill over already-classified
+  signals with rate limits, replay controls, date filters, visibility filters,
+  and dry-run support.
+- Create a GitHub issue for adding `project` as the next `entityType`.

--- a/docs/superpowers/specs/2026-06-06-signal-entity-links-ai-design.md
+++ b/docs/superpowers/specs/2026-06-06-signal-entity-links-ai-design.md
@@ -1,0 +1,425 @@
+# Signal Entity Links AI Design
+
+## Context
+
+People v1 is intentionally identity-centric. `lightfast_org_people` stores one
+row per durable identity, and the current people classifier refuses name-only
+candidates. This is correct for a safe first version, but it means signals like
+"Connect Louie with Mahesh" or "Talk to Jordi & Archer about their dev flow" do
+not produce People data.
+
+The next version should let Lightfast remember unresolved entity references and
+resolve them later. If Gmail later shows that Jordi is `jordi@doccy.com.au`, old
+signals that mentioned Jordi should become linked to the resolved Person without
+rewriting the original signal classification JSON.
+
+This design defines the product superstructure and scopes the first
+implementation slice to the AI extraction layer.
+
+## Goals
+
+- Keep Signals as plain captured artifacts with raw input and classification.
+- Keep signal classification JSON focused on triage, visibility, and routing.
+- Add a generic entity-link layer that can support People first and Projects
+  later.
+- Allow name-only person references to be indexed as unresolved links.
+- Automatically resolve old links when stronger identity evidence appears.
+- Build the AI extraction capability first, before UI work.
+
+## Non-Goals
+
+- No rich text document storage for Signals in this slice.
+- No Project entity implementation in this slice.
+- No manual merge UI in this slice.
+- No inline Signal rendering requirement in this slice. Inline links can come
+  later from optional render anchors.
+- No broad People UI redesign in this slice.
+
+## Core Model
+
+Lightfast should separate four concepts:
+
+1. **Signal**: the source artifact, such as raw text submitted by a user, MCP
+   client, automation, or connector.
+2. **Classification**: triage and routing JSON for the signal.
+3. **Entity**: canonical memory, such as a Person now or Project later.
+4. **Entity Link**: evidence that a source artifact mentions, tags, or refers to
+   an entity.
+
+The important rule is that Entity Links are durable evidence records. Optional
+text anchors are only render hints.
+
+## Data Shape
+
+The existing `lightfast_org_signals` table remains the Signal source of truth.
+
+People should evolve from one row per identity toward one row per canonical
+person:
+
+```text
+lightfast_org_people
+- publicId
+- clerkOrgId
+- visibilityScope: user | team
+- createdByUserId nullable
+- displayName
+- status: unresolved | confirmed | ambiguous
+- primaryIdentityId nullable
+- createdAt
+- updatedAt
+```
+
+Identities attach to canonical people:
+
+```text
+lightfast_org_person_identities
+- publicId
+- clerkOrgId
+- personPublicId
+- visibilityScope: user | team
+- createdByUserId nullable
+- provider: email | gmail | github | x | linkedin | website
+- type: email | handle | profile_url | provider_user_id
+- value
+- normalizedValue
+- identityKey
+- confidence
+- sourceKind: signal | user_tag | gmail | team_member | connector
+- sourceRef nullable
+- metadata json
+- createdAt
+- updatedAt
+```
+
+Generic source-to-entity evidence lives in one link table:
+
+```text
+lightfast_org_signal_entity_links
+- publicId
+- clerkOrgId
+- signalPublicId
+- visibilityScope: user | team
+- createdByUserId nullable
+- entityType: person
+- entityPublicId nullable
+- label
+- normalizedLabel
+- status: unresolved | resolved | ambiguous | stale
+- sourceKind: ai_extracted | user_tag | connector
+- confidence
+- inputHash
+- anchorText nullable
+- anchorOccurrence nullable
+- metadata json
+- createdAt
+- updatedAt
+```
+
+`entityType` starts with `person`. `project` can be added later without changing
+the signal storage model.
+
+## Privacy And Visibility
+
+Entity links must inherit visibility from their source signal or source
+connector. The AI extractor does not decide sharing policy.
+
+For the first persistence implementation:
+
+- Team-visible signals may create org-visible unresolved people and links.
+- User-visible signals may create private links for the creator, but those links
+  must not make unresolved people appear in the org-wide People list.
+- Needs-review signals must not create org-visible links until review is
+  resolved.
+- Reconciliation may use private evidence for the same user, but org-wide
+  profiles should only expose org-visible evidence.
+
+This is why the AI layer only extracts candidates. The application layer owns
+visibility, persistence, and reconciliation.
+
+## AI Layer First
+
+Add a new AI capability:
+
+```text
+@repo/ai/signal-entity-linker
+```
+
+The workflow name will be:
+
+```text
+index-signal-entities
+```
+
+The capability receives:
+
+```ts
+{
+  clerkOrgId: string;
+  deploymentEnvironment: "development" | "preview" | "production";
+  input: string;
+  inputLength: number;
+  signalId: string;
+  classification: SignalClassification | null;
+}
+```
+
+The classifier returns model-only candidates:
+
+```ts
+{
+  schemaVersion: "signal.entity-links.v1";
+  candidates: Array<{
+    targetType: "person";
+    label: string;
+    mentionKind: "name" | "email" | "handle" | "profile_url";
+    anchorText: string;
+    anchorOccurrence: number;
+    rationale: string;
+    confidence: number;
+  }>;
+}
+```
+
+The model must not emit `personPublicId`, `identityKey`, or any durable database
+id. It identifies text-level candidates only. Application code normalizes labels,
+dedupes candidates, creates or resolves people, and writes entity links.
+
+### Prompt Rules
+
+The system prompt should say:
+
+- Extract entity references from the raw signal input.
+- In v1, extract only person references.
+- Name-only person references are allowed.
+- Emails, handles, and profile URLs are allowed when they identify a person.
+- Do not browse.
+- Do not infer identities that are not present in the signal.
+- Do not decide whether a person is confirmed.
+- Do not execute the requested action.
+- Return only references that a reasonable user would expect Lightfast to
+  remember as people-related context.
+- Preserve uncertainty in `rationale` and `confidence`.
+- `anchorText` must be an exact substring from `input`.
+- `anchorOccurrence` is 1-based among exact `anchorText` matches in `input`.
+- Return an empty array when no person reference is present.
+
+This prompt intentionally differs from the current people classifier. The
+current people classifier extracts durable identities. The new entity linker
+extracts mention evidence.
+
+### Example Outputs
+
+Input:
+
+```text
+Connect Louie with Mahesh
+```
+
+Output:
+
+```json
+{
+  "schemaVersion": "signal.entity-links.v1",
+  "candidates": [
+    {
+      "targetType": "person",
+      "label": "Louie",
+      "mentionKind": "name",
+      "anchorText": "Louie",
+      "anchorOccurrence": 1,
+      "rationale": "Louie appears as a person to connect.",
+      "confidence": 0.76
+    },
+    {
+      "targetType": "person",
+      "label": "Mahesh",
+      "mentionKind": "name",
+      "anchorText": "Mahesh",
+      "anchorOccurrence": 1,
+      "rationale": "Mahesh appears as a person to connect.",
+      "confidence": 0.76
+    }
+  ]
+}
+```
+
+Input:
+
+```text
+Talk to Jordi & Archer about their dev flow
+```
+
+Output:
+
+```json
+{
+  "schemaVersion": "signal.entity-links.v1",
+  "candidates": [
+    {
+      "targetType": "person",
+      "label": "Jordi",
+      "mentionKind": "name",
+      "anchorText": "Jordi",
+      "anchorOccurrence": 1,
+      "rationale": "Jordi appears as a person to talk with.",
+      "confidence": 0.74
+    },
+    {
+      "targetType": "person",
+      "label": "Archer",
+      "mentionKind": "name",
+      "anchorText": "Archer",
+      "anchorOccurrence": 1,
+      "rationale": "Archer appears as a person to talk with.",
+      "confidence": 0.74
+    }
+  ]
+}
+```
+
+## Data Flow
+
+The first AI-only slice can be built and tested without changing UI:
+
+```text
+signal.create
+  -> stores signal as today
+
+classify-signal
+  -> stores classification as today
+  -> queues app/signal.entity-index.requested
+
+index-signal-entities
+  -> loads the signal
+  -> calls @repo/ai/signal-entity-linker
+  -> returns candidates
+```
+
+The next persistence slice will:
+
+```text
+index-signal-entities
+  -> normalize and dedupe candidates
+  -> create unresolved person records as needed
+  -> write signal entity links
+  -> run reconciliation
+```
+
+Future connector slices will produce identity evidence:
+
+```text
+gmail.message.synced
+  -> observes "Jordi Example <jordi@doccy.com.au>"
+  -> upserts person identity
+  -> reconciles unresolved links with normalized label "jordi"
+```
+
+## Reconciliation Rules
+
+The reconciliation engine should be deterministic first:
+
+- Exact identity key match always resolves to the same person.
+- Exact normalized alias match may auto-resolve if there is exactly one candidate
+  person in the applicable visibility scope.
+- Name-only matches with multiple candidates become ambiguous, not guessed.
+- Connector identity evidence can confirm a person, but source visibility still
+  controls which evidence appears to which viewer.
+
+The AI model should not perform reconciliation. It extracts text-level evidence
+only.
+
+## Signal API Shape
+
+`signal.create` can stay unchanged for ordinary text input.
+
+Later, a rich composer can send explicit user-authored links:
+
+```ts
+{
+  input: "Talk to @Jordi about dev flow",
+  links: [
+    {
+      entityType: "person",
+      entityPublicId: "person_123",
+      label: "@Jordi",
+      sourceKind: "user_tag",
+      anchorText: "@Jordi",
+      anchorOccurrence: 1
+    }
+  ]
+}
+```
+
+The backend still stores plain input plus normalized entity links. If a rich text
+document model arrives later, it can produce the same entity-link rows.
+
+## UI Direction
+
+Signal detail should eventually fetch:
+
+```ts
+{
+  ...signal,
+  entityLinks: [...]
+}
+```
+
+Inline rendering is best-effort:
+
+- If `inputHash`, `anchorText`, and `anchorOccurrence` match the current input,
+  render inline links.
+- If anchor rendering fails, show entity links as "Linked context" chips below
+  the signal body.
+- Resolved people link to People.
+- Unresolved people can open a lightweight "Needs identity" person view.
+
+This keeps the link graph useful even if text rendering hints become stale.
+
+## Error Handling
+
+- Missing signals return `missing`.
+- Signals with no person references return `indexed` with zero candidates.
+- AI/provider failures bubble to Inngest for retry.
+- Invalid candidates are skipped by application validation.
+- Anchor render failures do not fail the workflow. They only affect inline UI.
+- Needs-review or private visibility violations fail closed by not creating
+  org-visible links.
+
+## Testing
+
+AI-first tests:
+
+- Schema accepts person name, email, handle, and profile URL candidates.
+- Schema rejects unsupported target types in v1.
+- Prompt contains the name-only allowance and the no-inference rule.
+- Request builder includes raw input and signal classification.
+- Classifier stamps `signal.entity-links.v1`.
+- Fixtures cover "Connect Louie with Mahesh" and "Talk to Jordi & Archer about
+  their dev flow".
+- Telemetry follows the existing classifier privacy posture: metadata only,
+  no prompt or output recording.
+
+Persistence tests in the next slice:
+
+- Normalize and dedupe repeated candidates.
+- Create unresolved people from name-only links.
+- Write `inputHash` and anchor fields.
+- Auto-resolve a unique normalized alias when identity evidence arrives.
+- Mark ambiguous when multiple people share a normalized alias.
+- Enforce visibility inheritance from source signal.
+
+## Implementation Order
+
+1. Add `@repo/ai/signal-entity-linker` schema, prompt, constants, errors, and
+   request/classify functions.
+2. Add unit tests and fixtures for the new AI capability.
+3. Add `app/signal.entity-index.requested` event and an `index-signal-entities`
+   workflow that loads signals and calls the capability.
+4. Add persistence tables and DB helpers for canonical people, identities, and
+   signal entity links.
+5. Persist entity-link candidates and reconcile deterministic matches.
+6. Extend `signals.get` to return entity links.
+7. Add Signal detail UI rendering and People unresolved/confirmed UI.
+
+The first implementation pass should stop after step 3 unless persistence is
+explicitly approved for the same branch.


### PR DESCRIPTION
## Summary
- Add the Signal Entity Links AI/no-persistence layer for deterministic email/handle/profile URL candidates and AI-backed person/project/entity mention candidates.
- Queue `app/signal.entity-index.requested` durably from `classify-signal` for classified non-`needs_review` signals, then run the new `index-signal-entities` Inngest workflow.
- Register the workflow and cover the schema, extraction, classifier, downstream routing, and no-persistence workflow behavior with tests.

## Verification
- `pnpm check`
- `pnpm test` — 44/44 Turbo tasks successful
- `pnpm typecheck` — 67/67 Turbo tasks successful
- Final code-review subagent: no PR blockers or important issues found

## E2E Evidence
- Provisioned branch-scoped local PlanetScale/Upstash infra via `lightfast-local-infra`.
- Sent AgentMail inputs through `lf-e2e-20260606154545@agentmail.to` and created Signals through the real UI with `agent-browser`.
- `SIG-1` / `signal_ff53b056-2e9d-42c5-888e-8997696ad712`: direct email/contact info classified as `needs_review`, correctly stopping entity indexing.
- `SIG-2` / `signal_a2b4762a-1d55-4d74-990e-853777a96d8a`: team/actionable signal emitted `app/signal.entity-index.requested` and completed `index-signal-entities`.
- Inngest output for `index-signal-entities`: `{ "status": "indexed", "deterministicCandidates": 0, "aiCandidates": 4, "candidates": 4 }`.

## Notes
- This intentionally does not persist entity links yet; the workflow returns counts/candidates for the next persistence/UI slice.
