### PR TITLE
Fix automation connector selection

### DIFF
--- a/api/app/src/__tests__/automations-router.test.ts
+++ b/api/app/src/__tests__/automations-router.test.ts
@@ -243,6 +243,40 @@ describe("automationsRouter", () => {
     });
   });
 
+  it("creates an automation without a connector for org admins", async () => {
+    createAutomationMock.mockResolvedValueOnce({
+      ...automation,
+      connectorProvider: null,
+    });
+
+    await expect(
+      caller().automations.create({
+        name: "Morning check",
+        prompt: "Check the workspace",
+        schedule: {
+          kind: "daily",
+          config: { time: "09:00" },
+        },
+        timezone: "UTC",
+      })
+    ).resolves.toMatchObject({
+      connectorProvider: null,
+    });
+
+    expect(createAutomationMock).toHaveBeenCalledWith(expect.anything(), {
+      clerkOrgId: "org_acme",
+      connectorProvider: null,
+      createdByUserId: "user_current",
+      name: "Morning check",
+      prompt: "Check the workspace",
+      schedule: {
+        kind: "daily",
+        config: { time: "09:00" },
+      },
+      timezone: "UTC",
+    });
+  });
+
   it("rejects create for non-admin org members", async () => {
     await expect(
       caller(nonAdminAccess()).automations.create({

--- a/api/app/src/services/automations/ai-execution.test.ts
+++ b/api/app/src/services/automations/ai-execution.test.ts
@@ -97,6 +97,46 @@ beforeEach(() => {
 });
 
 describe("executeAutomationRun", () => {
+  it("runs without connector tools when no connector is selected", async () => {
+    const automationWithoutConnector = {
+      ...automation,
+      connectorProvider: null,
+      name: "Daily summary",
+      prompt: "Summarize the workspace.",
+    } as Automation;
+
+    const output = await executeAutomationRun({
+      automation: automationWithoutConnector,
+      deploymentEnvironment: "preview",
+      now: () => new Date("2026-06-06T00:00:00.000Z"),
+      run,
+    });
+
+    expect(output).toMatchObject({
+      automationId: "automation_123",
+      connectorProvider: null,
+      finalText: "Posted the launch update.",
+      providerRoutineCallIds: [],
+      runId: "automation_run_123",
+    });
+    expect(findAutomationProviderRoutinesMock).not.toHaveBeenCalled();
+    expect(toolMock).not.toHaveBeenCalled();
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: undefined,
+      })
+    );
+    expect(generateTextMock.mock.calls[0]?.[0].system).toEqual(
+      expect.stringContaining("No connector selected")
+    );
+    expect(generateTextMock.mock.calls[0]?.[0].system).not.toEqual(
+      expect.stringContaining("Use only routines from the selected connector.")
+    );
+    expect(
+      generateTextMock.mock.calls[0]?.[0].providerOptions.gateway.tags
+    ).toEqual(expect.arrayContaining(["connector:none"]));
+  });
+
   it("preflights the selected connector routines and runs the model with automation-scoped tools", async () => {
     const output = await executeAutomationRun({
       automation,

--- a/api/app/src/services/automations/ai-execution.ts
+++ b/api/app/src/services/automations/ai-execution.ts
@@ -60,7 +60,7 @@ export type ExecuteAutomationRunAutomation = Pick<
   | "scheduleKind"
   | "timezone"
 > & {
-  connectorProvider: ConnectableConnectorProvider;
+  connectorProvider: ConnectableConnectorProvider | null;
   scheduleConfig: AutomationScheduleConfig;
   scheduleKind: AutomationScheduleKind;
 };
@@ -78,28 +78,34 @@ export async function executeAutomationRun(
   const now = input.now ?? (() => new Date());
   const startedAt = now();
   const currentTime = startedAt;
-  const context = providerRoutineContext(input);
+  const selectedProvider = input.automation.connectorProvider;
+  const context = selectedProvider
+    ? providerRoutineContext(input, selectedProvider)
+    : null;
   const metadata = automationRunTelemetryMetadata(input);
   const toolFailureState = createAutomationToolFailureState();
 
   try {
-    const preflight = await findAutomationProviderRoutines(context, {
-      includeSchema: true,
-      limit: 1,
-    });
+    if (context) {
+      const preflight = await findAutomationProviderRoutines(context, {
+        includeSchema: true,
+        limit: 1,
+      });
 
-    if (preflight.routines.length === 0) {
-      if (preflight.reason === "no_enabled_providers") {
+      if (preflight.routines.length === 0) {
+        if (preflight.reason === "no_enabled_providers") {
+          throw automationExecutionError({
+            code: "AUTOMATION_CONNECTOR_NOT_ENABLED",
+            message: "The selected connector is not enabled for automations.",
+          });
+        }
+
         throw automationExecutionError({
-          code: "AUTOMATION_CONNECTOR_NOT_ENABLED",
-          message: "The selected connector is not enabled for automations.",
+          code: "AUTOMATION_CONNECTOR_NO_TOOLS",
+          message:
+            "The selected connector has no automation routines available.",
         });
       }
-
-      throw automationExecutionError({
-        code: "AUTOMATION_CONNECTOR_NO_TOOLS",
-        message: "The selected connector has no automation routines available.",
-      });
     }
 
     const system = buildAutomationSystemPrompt(input);
@@ -126,13 +132,17 @@ export async function executeAutomationRun(
           user: input.automation.createdByUserId,
         },
       },
-      stopWhen: stepCountIs(AUTOMATION_RUN_MAX_TOOL_STEPS),
+      stopWhen: context
+        ? stepCountIs(AUTOMATION_RUN_MAX_TOOL_STEPS)
+        : undefined,
       system,
-      tools: createAutomationProviderRoutineTools({
-        context,
-        recorder,
-        toolFailureState,
-      }),
+      tools: context
+        ? createAutomationProviderRoutineTools({
+            context,
+            recorder,
+            toolFailureState,
+          })
+        : undefined,
     });
     throwCapturedToolFailure(toolFailureState);
 
@@ -283,28 +293,38 @@ function createAutomationProviderRoutineTools(input: {
 }
 
 function providerRoutineContext(
-  input: ExecuteAutomationRunInput
+  input: ExecuteAutomationRunInput,
+  selectedProvider: ConnectableConnectorProvider
 ): AutomationProviderRoutineContext {
   return {
     automationPublicId: input.automation.publicId,
     calledByUserId: input.automation.createdByUserId,
     clerkOrgId: input.automation.clerkOrgId,
     runPublicId: input.run.publicId,
-    selectedProvider: input.automation.connectorProvider,
+    selectedProvider,
   };
 }
 
 function buildAutomationSystemPrompt(input: ExecuteAutomationRunInput) {
+  const connectorInstructions = input.automation.connectorProvider
+    ? [
+        `Selected connector: ${input.automation.connectorProvider}`,
+        "Use only routines from the selected connector.",
+        "Do not use routines from any connector other than the selected connector.",
+        "Write-capable routines are allowed when needed to satisfy the automation prompt.",
+        "Use findProviderRoutines before callProviderRoutine unless a valid routine id is already known from this same run.",
+        "If required tools are unavailable, stop and explain the limitation.",
+      ]
+    : [
+        "No connector selected.",
+        "Provider routines are not available for this automation.",
+      ];
+
   return [
     "You are executing a scheduled Lightfast automation.",
     `Automation: ${input.automation.name}`,
     `Run ID: ${input.run.publicId}`,
-    `Selected connector: ${input.automation.connectorProvider}`,
-    "Use only routines from the selected connector.",
-    "Do not use routines from any connector other than the selected connector.",
-    "Write-capable routines are allowed when needed to satisfy the automation prompt.",
-    "Use findProviderRoutines before callProviderRoutine unless a valid routine id is already known from this same run.",
-    "If required tools are unavailable, stop and explain the limitation.",
+    ...connectorInstructions,
     "Return a concise final summary of what you did.",
   ].join("\n");
 }
@@ -329,7 +349,7 @@ function automationRunTelemetryMetadata(input: ExecuteAutomationRunInput) {
   return {
     automationId: input.automation.publicId,
     clerkOrgId: input.automation.clerkOrgId,
-    connectorProvider: input.automation.connectorProvider,
+    connectorProvider: input.automation.connectorProvider ?? "none",
     environment: input.deploymentEnvironment,
     model: AUTOMATION_RUN_MODEL,
     runId: input.run.publicId,
@@ -342,7 +362,7 @@ function automationRunGatewayTags(input: ExecuteAutomationRunInput) {
     `org:${input.automation.clerkOrgId}`,
     `automation:${input.automation.publicId}`,
     `run:${input.run.publicId}`,
-    `connector:${input.automation.connectorProvider}`,
+    `connector:${input.automation.connectorProvider ?? "none"}`,
     `env:${input.deploymentEnvironment}`,
   ];
 }

--- a/api/app/src/services/automations/output.ts
+++ b/api/app/src/services/automations/output.ts
@@ -60,7 +60,7 @@ export type AutomationRunAiUsage = Record<string, unknown>;
 
 export interface AutomationRunAiOutput {
   automationId: string;
-  connectorProvider: ConnectableConnectorProvider;
+  connectorProvider: ConnectableConnectorProvider | null;
   finalText: string;
   finishedAt: string;
   finishReason: string;
@@ -75,7 +75,7 @@ export interface AutomationRunAiOutput {
 
 export interface BuildAutomationRunOutputInput {
   automation: {
-    connectorProvider: ConnectableConnectorProvider;
+    connectorProvider: ConnectableConnectorProvider | null;
     name: string;
     prompt: string;
     publicId: string;

--- a/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-new-page.test.tsx
+++ b/apps/app/src/__tests__/app/(app)/(pending-not-allowed)/[slug]/automations-new-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hasMock = vi.fn();
@@ -9,6 +10,7 @@ const redirectMock = vi.fn((url: string) => {
 const automationCreateFormMock = vi.fn(({ slug }: { slug: string }) => (
   <div data-testid="automation-create-form">{slug}</div>
 ));
+const fetchQueryMock = vi.fn();
 
 vi.mock("@vendor/clerk/server", () => ({
   auth: authMock,
@@ -16,6 +18,26 @@ vi.mock("@vendor/clerk/server", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: redirectMock,
+}));
+
+vi.mock("~/trpc/server", () => ({
+  getQueryClient: () => ({
+    fetchQuery: fetchQueryMock,
+  }),
+  HydrateClient: ({ children }: { children: ReactNode }) => (
+    <div data-testid="hydrate-client">{children}</div>
+  ),
+  trpc: {
+    org: {
+      workspace: {
+        connectors: {
+          list: {
+            queryOptions: () => ({ queryKey: ["connectors", "list"] }),
+          },
+        },
+      },
+    },
+  },
 }));
 
 vi.mock(
@@ -40,6 +62,8 @@ beforeEach(() => {
   authMock.mockClear();
   redirectMock.mockClear();
   automationCreateFormMock.mockClear();
+  fetchQueryMock.mockReset();
+  fetchQueryMock.mockResolvedValue([]);
 });
 
 describe("new automation page", () => {
@@ -50,6 +74,10 @@ describe("new automation page", () => {
     render(element);
 
     expect(hasMock).toHaveBeenCalledWith({ role: "org:admin" });
+    expect(fetchQueryMock).toHaveBeenCalledWith({
+      queryKey: ["connectors", "list"],
+    });
+    expect(screen.getByTestId("hydrate-client")).toBeInTheDocument();
     expect(screen.getByTestId("automation-create-form")).toHaveTextContent(
       "acme"
     );

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-run-ai-output.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-run-ai-output.tsx
@@ -9,7 +9,7 @@ const CONNECTOR_LABELS = {
 type ConnectorProvider = keyof typeof CONNECTOR_LABELS;
 
 interface AutomationRunAiOutput {
-  connectorProvider: ConnectorProvider;
+  connectorProvider: ConnectorProvider | null;
   finalText: string;
   finishReason: string;
   model: string;
@@ -31,7 +31,8 @@ export function isAutomationRunAiOutput(
     typeof output.finalText === "string" &&
     typeof output.finishReason === "string" &&
     typeof output.model === "string" &&
-    isConnectorProvider(output.connectorProvider) &&
+    (output.connectorProvider === null ||
+      isConnectorProvider(output.connectorProvider)) &&
     Array.isArray(output.providerRoutineCallIds) &&
     output.providerRoutineCallIds.every((id) => typeof id === "string") &&
     Array.isArray(output.transcript) &&
@@ -58,7 +59,9 @@ export function AutomationRunAiOutputView({
 
       <div className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
         <OutputMeta label="Connector">
-          {CONNECTOR_LABELS[output.connectorProvider]}
+          {output.connectorProvider
+            ? CONNECTOR_LABELS[output.connectorProvider]
+            : "—"}
         </OutputMeta>
         <OutputMeta label="Finish">{output.finishReason}</OutputMeta>
         <OutputMeta label="Model">{output.model}</OutputMeta>

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-run-detail-content.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/[automationId]/_components/automation-run-detail-content.test.tsx
@@ -87,6 +87,46 @@ describe("AutomationRunDetailContent", () => {
     expect(screen.queryByText(/schemaVersion/)).not.toBeInTheDocument();
   });
 
+  it("renders automation ai output without a connector", () => {
+    render(
+      <AutomationRunDetailContent
+        onCopyLink={vi.fn()}
+        run={run({
+          output: {
+            automationId: "automation_123",
+            connectorProvider: null,
+            finalText: "Summarized the workspace.",
+            finishedAt: "2026-06-06T00:00:10.000Z",
+            finishReason: "stop",
+            model: "anthropic/claude-sonnet-4.6",
+            providerRoutineCallIds: [],
+            runId: "automation_run_123",
+            schemaVersion: "automation.run.ai.v1",
+            startedAt: "2026-06-06T00:00:00.000Z",
+            transcript: [
+              {
+                content: "Summarize the workspace.",
+                contentHash: "sha256:abc",
+                contentLength: 24,
+                kind: "user",
+                timestamp: "2026-06-06T00:00:00.000Z",
+              },
+            ],
+            usage: { totalTokens: 22 },
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText("Summarized the workspace.")).toBeInTheDocument();
+    expect(screen.getByText("Connector").parentElement).toHaveTextContent(
+      "Connector—"
+    );
+    expect(
+      screen.queryByText("Provider routine calls")
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps JSON fallback for unknown output schemas", () => {
     render(
       <AutomationRunDetailContent

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.test.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.test.tsx
@@ -4,6 +4,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mutateMock = vi.fn();
 const pushMock = vi.fn();
+let connectorRows: ConnectorRow[];
+
+interface ConnectorRow {
+  availableForAutomations: boolean;
+  connection: { enabledForAutomations: boolean } | null;
+  displayName: string;
+  provider: "linear" | "x";
+}
+
+function connectorRow(
+  provider: "linear" | "x",
+  enabledForAutomations: boolean
+): ConnectorRow {
+  return {
+    availableForAutomations: enabledForAutomations,
+    connection: { enabledForAutomations },
+    displayName: provider === "linear" ? "Linear" : "X",
+    provider,
+  };
+}
 
 vi.mock("~/trpc/react", () => ({
   useTRPC: () => ({
@@ -22,6 +42,13 @@ vi.mock("~/trpc/react", () => ({
             }),
           },
         },
+        connectors: {
+          list: {
+            queryOptions: () => ({
+              queryKey: ["connectors", "list"],
+            }),
+          },
+        },
       },
     },
   }),
@@ -32,6 +59,7 @@ vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({
     setQueryData: vi.fn(),
   }),
+  useSuspenseQuery: () => ({ data: connectorRows }),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -80,15 +108,44 @@ const { AutomationCreateForm } = await import("./automation-create-form");
 beforeEach(() => {
   mutateMock.mockReset();
   pushMock.mockReset();
+  connectorRows = [connectorRow("linear", true), connectorRow("x", true)];
 });
 
 describe("AutomationCreateForm", () => {
-  it("submits the selected connector provider with the new automation", async () => {
+  it("submits no connector by default", async () => {
     render(<AutomationCreateForm slug="acme" />);
 
     expect(
       screen.getByRole("combobox", { name: "Connector" })
-    ).toHaveDisplayValue("Linear");
+    ).toHaveDisplayValue("No connector");
+
+    fireEvent.change(screen.getByPlaceholderText("Daily code review"), {
+      target: { value: "Daily digest" },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Describe what the agent should do in each run."
+      ),
+      {
+        target: { value: "Summarize posts from the workspace." },
+      }
+    );
+
+    fireEvent.submit(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(mutateMock).toHaveBeenCalledWith({
+        connectorProvider: null,
+        name: "Daily digest",
+        prompt: "Summarize posts from the workspace.",
+        schedule: { kind: "daily", config: { time: "09:00" } },
+        timezone: "UTC",
+      })
+    );
+  });
+
+  it("submits the selected enabled connector provider with the new automation", async () => {
+    render(<AutomationCreateForm slug="acme" />);
 
     fireEvent.change(screen.getByPlaceholderText("Daily code review"), {
       target: { value: "X daily digest" },
@@ -116,5 +173,19 @@ describe("AutomationCreateForm", () => {
         timezone: "UTC",
       })
     );
+  });
+
+  it("excludes connectors disabled for automations from the selector", () => {
+    connectorRows = [connectorRow("linear", false), connectorRow("x", false)];
+
+    render(<AutomationCreateForm slug="acme" />);
+
+    const connectorSelect = screen.getByRole("combobox", {
+      name: "Connector",
+    });
+
+    expect(connectorSelect).toHaveDisplayValue("No connector");
+    expect(screen.queryByRole("option", { name: "Linear" })).toBeNull();
+    expect(screen.queryByRole("option", { name: "X" })).toBeNull();
   });
 });

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/_components/automation-create-form.tsx
@@ -6,10 +6,7 @@ import {
   AUTOMATION_PROMPT_MAX_LENGTH,
   type AutomationScheduleInput,
 } from "@repo/app-validation/schemas";
-import {
-  CONNECTOR_CATALOG,
-  connectableConnectorProviderSchema,
-} from "@repo/connector-contract";
+import { connectableConnectorProviderSchema } from "@repo/connector-contract";
 import { Badge } from "@repo/ui/components/ui/badge";
 import { Button } from "@repo/ui/components/ui/button";
 import {
@@ -24,11 +21,16 @@ import {
 import { Input } from "@repo/ui/components/ui/input";
 import { toast } from "@repo/ui/components/ui/sonner";
 import { Textarea } from "@repo/ui/components/ui/textarea";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useEffect, useMemo } from "react";
 import { z } from "zod";
 import { useTRPC } from "~/trpc/react";
 import { LfSelect } from "../../../_components/lf-select";
@@ -42,7 +44,7 @@ import {
 } from "../../_components/schedule-options";
 
 const formSchema = z.object({
-  connectorProvider: connectableConnectorProviderSchema,
+  connectorProvider: connectableConnectorProviderSchema.nullable(),
   name: z
     .string()
     .trim()
@@ -61,6 +63,8 @@ const formSchema = z.object({
 });
 
 type FormValues = z.infer<typeof formSchema>;
+
+const NO_CONNECTOR_VALUE = "__none__";
 
 function buildSchedule(values: FormValues): AutomationScheduleInput {
   switch (values.scheduleKind) {
@@ -89,13 +93,17 @@ export function AutomationCreateForm({ slug }: { slug: string }) {
   const router = useRouter();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const { data: connectors } = useSuspenseQuery({
+    ...trpc.org.workspace.connectors.list.queryOptions(),
+    staleTime: 30_000,
+  });
 
   const listHref = `/${slug}/automations` as Route;
 
   const form = useFormCompat<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      connectorProvider: "linear",
+      connectorProvider: null,
       name: "",
       prompt: "",
       scheduleKind: "daily",
@@ -112,6 +120,35 @@ export function AutomationCreateForm({ slug }: { slug: string }) {
   const dayOfWeek = form.watch("dayOfWeek");
   const timezone = form.watch("timezone");
   const promptValue = form.watch("prompt");
+
+  const enabledConnectorOptions = useMemo(
+    () =>
+      connectors
+        .filter((connector) => connector.availableForAutomations)
+        .map((connector) => ({
+          label: connector.displayName,
+          value: connector.provider,
+        })),
+    [connectors]
+  );
+  const connectorOptions = useMemo(
+    () => [
+      { label: "No connector", value: NO_CONNECTOR_VALUE },
+      ...enabledConnectorOptions,
+    ],
+    [enabledConnectorOptions]
+  );
+
+  useEffect(() => {
+    if (
+      connectorProvider &&
+      !enabledConnectorOptions.some(
+        (option) => option.value === connectorProvider
+      )
+    ) {
+      form.setValue("connectorProvider", null, { shouldValidate: true });
+    }
+  }, [connectorProvider, enabledConnectorOptions, form]);
 
   const createMutation = useMutation(
     trpc.org.workspace.automations.create.mutationOptions({
@@ -134,7 +171,7 @@ export function AutomationCreateForm({ slug }: { slug: string }) {
 
   const onSubmit = (values: FormValues) => {
     createMutation.mutate({
-      connectorProvider: values.connectorProvider,
+      connectorProvider: values.connectorProvider ?? null,
       name: values.name,
       prompt: values.prompt,
       schedule: buildSchedule(values),
@@ -207,28 +244,6 @@ export function AutomationCreateForm({ slug }: { slug: string }) {
                 </FormItem>
               )}
             />
-
-            <div className="space-y-2">
-              <FormLabel className="font-normal text-muted-foreground text-sm">
-                Connector
-              </FormLabel>
-              <LfSelect
-                aria-label="Connector"
-                className="w-full"
-                onValueChange={(value) =>
-                  form.setValue(
-                    "connectorProvider",
-                    connectableConnectorProviderSchema.parse(value),
-                    { shouldValidate: true }
-                  )
-                }
-                options={CONNECTOR_CATALOG.map((connector) => ({
-                  label: connector.displayName,
-                  value: connector.provider,
-                }))}
-                value={connectorProvider}
-              />
-            </div>
 
             <div className="space-y-2">
               <FormLabel className="font-normal text-muted-foreground text-sm">
@@ -378,7 +393,28 @@ export function AutomationCreateForm({ slug }: { slug: string }) {
               </div>
             )}
 
-            <div className="flex items-center justify-end gap-2.5 border-border border-t pt-5">
+            <div className="space-y-2">
+              <FormLabel className="font-normal text-muted-foreground text-sm">
+                Connector
+              </FormLabel>
+              <LfSelect
+                aria-label="Connector"
+                className="w-48"
+                onValueChange={(value) => {
+                  const nextProvider =
+                    value === NO_CONNECTOR_VALUE
+                      ? null
+                      : connectableConnectorProviderSchema.parse(value);
+                  form.setValue("connectorProvider", nextProvider, {
+                    shouldValidate: true,
+                  });
+                }}
+                options={connectorOptions}
+                value={connectorProvider ?? NO_CONNECTOR_VALUE}
+              />
+            </div>
+
+            <div className="flex items-center justify-end gap-2.5 pt-5">
               <Button asChild size="lf" type="button" variant="ghost">
                 <Link href={listHref}>Cancel</Link>
               </Button>

--- a/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/page.tsx
+++ b/apps/app/src/app/(app)/(pending-not-allowed)/[slug]/(workspace)/automations/new/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@vendor/clerk/server";
 import type { Route } from "next";
 import { redirect } from "next/navigation";
+import { getQueryClient, HydrateClient, trpc } from "~/trpc/server";
 
 import { AutomationCreateForm } from "./_components/automation-create-form";
 
@@ -18,5 +19,13 @@ export default async function NewAutomationPage({
     redirect(`/${slug}/automations` as Route);
   }
 
-  return <AutomationCreateForm slug={slug} />;
+  await getQueryClient().fetchQuery(
+    trpc.org.workspace.connectors.list.queryOptions()
+  );
+
+  return (
+    <HydrateClient>
+      <AutomationCreateForm slug={slug} />
+    </HydrateClient>
+  );
 }

--- a/db/app/src/__tests__/automations.test.ts
+++ b/db/app/src/__tests__/automations.test.ts
@@ -184,6 +184,66 @@ describe("createAutomation", () => {
       })
     );
   });
+
+  it("persists no connector provider when the automation has no connector", async () => {
+    let insertedPublicId = "";
+    const valuesMock = vi.fn((values: { publicId: string }) => {
+      insertedPublicId = values.publicId;
+      return Promise.resolve();
+    });
+    const limitMock = vi.fn(async () => [
+      {
+        id: 1,
+        publicId: insertedPublicId,
+        clerkOrgId: "org_test",
+        connectorProvider: null,
+        createdByUserId: "user_test",
+        name: "Daily summary",
+        prompt: "Summarize the workspace.",
+        scheduleKind: "manual",
+        scheduleConfig: {},
+        timezone: "UTC",
+        status: "active",
+        nextRunAt: null,
+        lastRunAt: null,
+        scheduleVersion: 1,
+        createdAt: new Date("2026-05-27T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-27T00:00:00.000Z"),
+      },
+    ]);
+    const db = {
+      insert: vi.fn(() => ({ values: valuesMock })),
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: limitMock,
+          }),
+        }),
+      })),
+    } as unknown as Database;
+
+    await expect(
+      createAutomation(
+        db,
+        {
+          clerkOrgId: "org_test",
+          createdByUserId: "user_test",
+          name: "Daily summary",
+          prompt: "Summarize the workspace.",
+          schedule: { kind: "manual", config: {} },
+        },
+        { now: new Date("2026-05-27T00:00:00.000Z") }
+      )
+    ).resolves.toMatchObject({
+      connectorProvider: null,
+    });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectorProvider: null,
+      })
+    );
+  });
 });
 
 describe("markAutomationRunFailed", () => {

--- a/db/app/src/migrations/0025_shocking_smasher.sql
+++ b/db/app/src/migrations/0025_shocking_smasher.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `lightfast_org_automations` MODIFY COLUMN `connector_provider` varchar(32);

--- a/db/app/src/migrations/meta/0025_snapshot.json
+++ b/db/app/src/migrations/meta/0025_snapshot.json
@@ -1,0 +1,5298 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "86fc3f39-4cab-4ab5-a735-6794d3d682de",
+  "prevId": "79bb0113-a47f-4337-914e-ac5bca6e7cdf",
+  "tables": {
+    "lightfast_org_automation_runs": {
+      "name": "lightfast_org_automation_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_public_id": {
+          "name": "automation_public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_version": {
+          "name": "schedule_version",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_automation_runs_public_id_uq": {
+          "name": "org_automation_runs_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_automation_runs_idempotency_key_uq": {
+          "name": "org_automation_runs_idempotency_key_uq",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "org_automation_runs_automation_created_idx": {
+          "name": "org_automation_runs_automation_created_idx",
+          "columns": [
+            "automation_public_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_automation_runs_org_status_created_idx": {
+          "name": "org_automation_runs_org_status_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "status",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_automation_runs_id": {
+          "name": "lightfast_org_automation_runs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_automations": {
+      "name": "lightfast_org_automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_provider": {
+          "name": "connector_provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_version": {
+          "name": "schedule_version",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_automations_public_id_uq": {
+          "name": "org_automations_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_automations_org_status_next_run_idx": {
+          "name": "org_automations_org_status_next_run_idx",
+          "columns": [
+            "clerk_org_id",
+            "status",
+            "next_run_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_automations_due_idx": {
+          "name": "org_automations_due_idx",
+          "columns": [
+            "status",
+            "next_run_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_automations_id": {
+          "name": "lightfast_org_automations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_connector_connections": {
+      "name": "lightfast_org_connector_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_org_provider_key": {
+          "name": "current_org_provider_key",
+          "type": "varchar(97)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_workspace_id": {
+          "name": "provider_workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_workspace_name": {
+          "name": "provider_workspace_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_actor_id": {
+          "name": "provider_actor_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_actor_name": {
+          "name": "provider_actor_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_endpoint": {
+          "name": "mcp_endpoint",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_manifest": {
+          "name": "tool_manifest",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_tool_refresh_at": {
+          "name": "last_tool_refresh_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tool_refresh_error_at": {
+          "name": "last_tool_refresh_error_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tool_refresh_error_code": {
+          "name": "last_tool_refresh_error_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled_for_automations": {
+          "name": "enabled_for_automations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enabled_for_agents": {
+          "name": "enabled_for_agents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_connector_connections_current_org_provider_uq": {
+          "name": "org_connector_connections_current_org_provider_uq",
+          "columns": [
+            "current_org_provider_key"
+          ],
+          "isUnique": true
+        },
+        "org_connector_connections_org_provider_status_idx": {
+          "name": "org_connector_connections_org_provider_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "provider",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_connector_connections_provider_workspace_idx": {
+          "name": "org_connector_connections_provider_workspace_idx",
+          "columns": [
+            "provider",
+            "provider_workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_connector_connections_id": {
+          "name": "lightfast_org_connector_connections_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_decision_views": {
+      "name": "lightfast_org_decision_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_decision_views_public_id_uq": {
+          "name": "org_decision_views_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_decision_views_org_user_created_idx": {
+          "name": "org_decision_views_org_user_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_by_user_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_decision_views_id": {
+          "name": "lightfast_org_decision_views_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_developer_connection_leases": {
+      "name": "lightfast_org_developer_connection_leases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_run_id": {
+          "name": "sandbox_run_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_developer_connection_leases_public_id_uq": {
+          "name": "org_developer_connection_leases_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_developer_connection_leases_org_actor_idx": {
+          "name": "org_developer_connection_leases_org_actor_idx",
+          "columns": [
+            "clerk_org_id",
+            "actor_user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_developer_connection_leases_workflow_idx": {
+          "name": "org_developer_connection_leases_workflow_idx",
+          "columns": [
+            "workflow_run_id",
+            "provider"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_developer_connection_leases_id": {
+          "name": "lightfast_org_developer_connection_leases_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_developer_connections": {
+      "name": "lightfast_org_developer_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_org_provider_key": {
+          "name": "current_org_provider_key",
+          "type": "varchar(97)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_account_name": {
+          "name": "provider_account_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled_for_sandboxes": {
+          "name": "enabled_for_sandboxes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "credential_kind": {
+          "name": "credential_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_by_user_id": {
+          "name": "last_used_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_developer_connections_public_id_uq": {
+          "name": "org_developer_connections_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_developer_connections_current_org_provider_uq": {
+          "name": "org_developer_connections_current_org_provider_uq",
+          "columns": [
+            "current_org_provider_key"
+          ],
+          "isUnique": true
+        },
+        "org_developer_connections_org_provider_status_idx": {
+          "name": "org_developer_connections_org_provider_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "provider",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_developer_connections_id": {
+          "name": "lightfast_org_developer_connections_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_developer_sandbox_commands": {
+      "name": "lightfast_org_developer_sandbox_commands",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_run_id": {
+          "name": "sandbox_run_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cmd": {
+          "name": "cmd",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_rule_id": {
+          "name": "policy_rule_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_reason": {
+          "name": "policy_reason",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stdout_bytes": {
+          "name": "stdout_bytes",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stderr_bytes": {
+          "name": "stderr_bytes",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "redaction_count": {
+          "name": "redaction_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_developer_sandbox_commands_public_id_uq": {
+          "name": "org_developer_sandbox_commands_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_developer_sandbox_commands_run_status_idx": {
+          "name": "org_developer_sandbox_commands_run_status_idx",
+          "columns": [
+            "sandbox_run_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_developer_sandbox_commands_org_actor_created_idx": {
+          "name": "org_developer_sandbox_commands_org_actor_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "actor_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_developer_sandbox_commands_id": {
+          "name": "lightfast_org_developer_sandbox_commands_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_developer_sandbox_runs": {
+      "name": "lightfast_org_developer_sandbox_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_sandbox_id": {
+          "name": "vercel_sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials_loaded_at": {
+          "name": "credentials_loaded_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cleanup_attempted_at": {
+          "name": "cleanup_attempted_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cleanup_failure_code": {
+          "name": "cleanup_failure_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_developer_sandbox_runs_public_id_uq": {
+          "name": "org_developer_sandbox_runs_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_developer_sandbox_runs_org_actor_status_idx": {
+          "name": "org_developer_sandbox_runs_org_actor_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "actor_user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_developer_sandbox_runs_expires_status_idx": {
+          "name": "org_developer_sandbox_runs_expires_status_idx",
+          "columns": [
+            "expires_at",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_developer_sandbox_runs_id": {
+          "name": "lightfast_org_developer_sandbox_runs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_identity_index_files": {
+      "name": "lightfast_org_identity_index_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "identity_index_state_id": {
+          "name": "identity_index_state_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_commit_sha": {
+          "name": "indexed_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_markdown": {
+          "name": "source_markdown",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_size": {
+          "name": "content_size",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diagnostics": {
+          "name": "diagnostics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_ARRAY())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_identity_index_files_state_kind_uq": {
+          "name": "org_identity_index_files_state_kind_uq",
+          "columns": [
+            "identity_index_state_id",
+            "kind"
+          ],
+          "isUnique": true
+        },
+        "org_identity_index_files_state_status_idx": {
+          "name": "org_identity_index_files_state_status_idx",
+          "columns": [
+            "identity_index_state_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_identity_index_files_id": {
+          "name": "lightfast_org_identity_index_files_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_identity_index_states": {
+      "name": "lightfast_org_identity_index_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_control_repository_id": {
+          "name": "source_control_repository_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_commit_sha": {
+          "name": "indexed_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexed_tree_sha": {
+          "name": "indexed_tree_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "present_file_count": {
+          "name": "present_file_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "missing_file_count": {
+          "name": "missing_file_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "too_large_file_count": {
+          "name": "too_large_file_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "read_error_file_count": {
+          "name": "read_error_file_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_checked_commit_sha": {
+          "name": "last_checked_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_ref_etag": {
+          "name": "github_ref_etag",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_status": {
+          "name": "last_refresh_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'never'"
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error_message": {
+          "name": "last_refresh_error_message",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_succeeded_at": {
+          "name": "last_refresh_succeeded_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index_diagnostics": {
+          "name": "index_diagnostics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_ARRAY())"
+        },
+        "refresh_lock_token": {
+          "name": "refresh_lock_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_locked_until": {
+          "name": "refresh_locked_until",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_identity_index_states_source_control_repository_uq": {
+          "name": "org_identity_index_states_source_control_repository_uq",
+          "columns": [
+            "source_control_repository_id"
+          ],
+          "isUnique": true
+        },
+        "org_identity_index_states_last_checked_idx": {
+          "name": "org_identity_index_states_last_checked_idx",
+          "columns": [
+            "last_checked_at"
+          ],
+          "isUnique": false
+        },
+        "org_identity_index_states_refresh_locked_until_idx": {
+          "name": "org_identity_index_states_refresh_locked_until_idx",
+          "columns": [
+            "refresh_locked_until"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_identity_index_states_id": {
+          "name": "lightfast_org_identity_index_states_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_people": {
+      "name": "lightfast_org_people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_provider": {
+          "name": "identity_provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_type": {
+          "name": "identity_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_identity_value": {
+          "name": "normalized_identity_value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_signal_id": {
+          "name": "first_seen_signal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_signal_id": {
+          "name": "last_seen_signal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_count": {
+          "name": "seen_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_source": {
+          "name": "person_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'signal'"
+        },
+        "member_status": {
+          "name": "member_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "member_role": {
+          "name": "member_role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "member_synced_at": {
+          "name": "member_synced_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_people_public_id_uq": {
+          "name": "org_people_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_people_org_identity_key_uq": {
+          "name": "org_people_org_identity_key_uq",
+          "columns": [
+            "clerk_org_id",
+            "identity_key"
+          ],
+          "isUnique": true
+        },
+        "org_people_org_created_idx": {
+          "name": "org_people_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_people_org_person_source_idx": {
+          "name": "org_people_org_person_source_idx",
+          "columns": [
+            "clerk_org_id",
+            "person_source",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_people_org_member_status_idx": {
+          "name": "org_people_org_member_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "member_status",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_people_id": {
+          "name": "lightfast_org_people_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_people_views": {
+      "name": "lightfast_org_people_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_people_views_public_id_uq": {
+          "name": "org_people_views_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_people_views_org_user_created_idx": {
+          "name": "org_people_views_org_user_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_by_user_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_people_views_id": {
+          "name": "lightfast_org_people_views_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_provider_routine_calls": {
+      "name": "lightfast_org_provider_routine_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "called_by_kind": {
+          "name": "called_by_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "called_by_id": {
+          "name": "called_by_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "called_by_user_id": {
+          "name": "called_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_tool_name": {
+          "name": "provider_tool_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_workspace_id": {
+          "name": "provider_workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_actor_id": {
+          "name": "provider_actor_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_attempted": {
+          "name": "provider_attempted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_surface": {
+          "name": "source_surface",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_client_id": {
+          "name": "source_client_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_redacted": {
+          "name": "input_redacted",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_redacted": {
+          "name": "output_redacted",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_provider_routine_calls_public_id_uq": {
+          "name": "org_provider_routine_calls_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_provider_routine_calls_org_created_idx": {
+          "name": "org_provider_routine_calls_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_provider_routine_calls_org_caller_created_idx": {
+          "name": "org_provider_routine_calls_org_caller_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "called_by_kind",
+            "called_by_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_provider_routine_calls_connection_created_idx": {
+          "name": "org_provider_routine_calls_connection_created_idx",
+          "columns": [
+            "provider_connection_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_provider_routine_calls_provider_routine_created_idx": {
+          "name": "org_provider_routine_calls_provider_routine_created_idx",
+          "columns": [
+            "provider",
+            "routine_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_provider_routine_calls_id": {
+          "name": "lightfast_org_provider_routine_calls_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_signal_views": {
+      "name": "lightfast_org_signal_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_signal_views_public_id_uq": {
+          "name": "org_signal_views_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_signal_views_org_user_created_idx": {
+          "name": "org_signal_views_org_user_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_by_user_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_signal_views_id": {
+          "name": "lightfast_org_signal_views_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_signals": {
+      "name": "lightfast_org_signals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_api_key_id": {
+          "name": "created_by_api_key_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_mcp_client_id": {
+          "name": "created_by_mcp_client_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_mcp_grant_id": {
+          "name": "created_by_mcp_grant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility_scope": {
+          "name": "visibility_scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classification_metadata": {
+          "name": "classification_metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_signals_public_id_uq": {
+          "name": "org_signals_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_signals_org_created_idx": {
+          "name": "org_signals_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_signals_org_status_created_idx": {
+          "name": "org_signals_org_status_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "status",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_signals_org_visibility_created_idx": {
+          "name": "org_signals_org_visibility_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "visibility_scope",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_signals_mcp_attribution_idx": {
+          "name": "org_signals_mcp_attribution_idx",
+          "columns": [
+            "created_by_mcp_client_id",
+            "created_by_mcp_grant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_signals_id": {
+          "name": "lightfast_org_signals_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_skill_index_entries": {
+      "name": "lightfast_org_skill_index_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "skill_index_state_id": {
+          "name": "skill_index_state_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_commit_sha": {
+          "name": "indexed_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compatibility": {
+          "name": "compatibility",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "source_markdown": {
+          "name": "source_markdown",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_size": {
+          "name": "content_size",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "diagnostics": {
+          "name": "diagnostics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_ARRAY())"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resources_truncated": {
+          "name": "resources_truncated",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "non_standard_resource_count": {
+          "name": "non_standard_resource_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_skill_index_entries_state_slug_uq": {
+          "name": "org_skill_index_entries_state_slug_uq",
+          "columns": [
+            "skill_index_state_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "org_skill_index_entries_state_validation_idx": {
+          "name": "org_skill_index_entries_state_validation_idx",
+          "columns": [
+            "skill_index_state_id",
+            "validation_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_skill_index_entries_id": {
+          "name": "lightfast_org_skill_index_entries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_skill_index_states": {
+      "name": "lightfast_org_skill_index_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_control_repository_id": {
+          "name": "source_control_repository_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_commit_sha": {
+          "name": "indexed_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexed_tree_sha": {
+          "name": "indexed_tree_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_count": {
+          "name": "skill_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "invalid_skill_count": {
+          "name": "invalid_skill_count",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_checked_commit_sha": {
+          "name": "last_checked_commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_ref_etag": {
+          "name": "github_ref_etag",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_status": {
+          "name": "last_refresh_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'never'"
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error_message": {
+          "name": "last_refresh_error_message",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index_diagnostics": {
+          "name": "index_diagnostics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_ARRAY())"
+        },
+        "refresh_lock_token": {
+          "name": "refresh_lock_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_locked_until": {
+          "name": "refresh_locked_until",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_skill_index_states_source_control_repository_uq": {
+          "name": "org_skill_index_states_source_control_repository_uq",
+          "columns": [
+            "source_control_repository_id"
+          ],
+          "isUnique": true
+        },
+        "org_skill_index_states_last_checked_idx": {
+          "name": "org_skill_index_states_last_checked_idx",
+          "columns": [
+            "last_checked_at"
+          ],
+          "isUnique": false
+        },
+        "org_skill_index_states_refresh_locked_until_idx": {
+          "name": "org_skill_index_states_refresh_locked_until_idx",
+          "columns": [
+            "refresh_locked_until"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_skill_index_states_id": {
+          "name": "lightfast_org_skill_index_states_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_source_control_bindings": {
+      "name": "lightfast_org_source_control_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_clerk_org_id": {
+          "name": "active_clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_account_login": {
+          "name": "provider_account_login",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_installation_id": {
+          "name": "provider_installation_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_source_control_bindings_active_per_org_uq": {
+          "name": "org_source_control_bindings_active_per_org_uq",
+          "columns": [
+            "active_clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "org_source_control_bindings_installation_uq": {
+          "name": "org_source_control_bindings_installation_uq",
+          "columns": [
+            "provider_installation_id"
+          ],
+          "isUnique": true
+        },
+        "org_source_control_bindings_org_status_idx": {
+          "name": "org_source_control_bindings_org_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_source_control_bindings_provider_account_idx": {
+          "name": "org_source_control_bindings_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_source_control_bindings_id": {
+          "name": "lightfast_org_source_control_bindings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_source_control_repositories": {
+      "name": "lightfast_org_source_control_repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "org_source_control_binding_id": {
+          "name": "org_source_control_binding_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_repository_id": {
+          "name": "provider_repository_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_path_globs": {
+          "name": "watched_path_globs",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_source_control_repositories_binding_repository_uq": {
+          "name": "org_source_control_repositories_binding_repository_uq",
+          "columns": [
+            "org_source_control_binding_id",
+            "provider_repository_id"
+          ],
+          "isUnique": true
+        },
+        "org_source_control_repositories_provider_repository_idx": {
+          "name": "org_source_control_repositories_provider_repository_idx",
+          "columns": [
+            "provider_repository_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_source_control_repositories_id": {
+          "name": "lightfast_org_source_control_repositories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_source_control_webhook_deliveries": {
+      "name": "lightfast_org_source_control_webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_installation_id": {
+          "name": "provider_installation_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_repository_id": {
+          "name": "provider_repository_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_source_control_webhook_deliveries_delivery_id_uq": {
+          "name": "org_source_control_webhook_deliveries_delivery_id_uq",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "org_source_control_webhook_deliveries_installation_repo_idx": {
+          "name": "org_source_control_webhook_deliveries_installation_repo_idx",
+          "columns": [
+            "provider_installation_id",
+            "provider_repository_id"
+          ],
+          "isUnique": false
+        },
+        "org_source_control_webhook_deliveries_status_updated_idx": {
+          "name": "org_source_control_webhook_deliveries_status_updated_idx",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_source_control_webhook_deliveries_id": {
+          "name": "lightfast_org_source_control_webhook_deliveries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_workspace_assistant_context_items": {
+      "name": "lightfast_org_workspace_assistant_context_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_public_id": {
+          "name": "source_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_slug": {
+          "name": "source_slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_workspace_assistant_context_items_public_id_uq": {
+          "name": "org_workspace_assistant_context_items_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_context_items_conversation_kind_idx": {
+          "name": "org_workspace_assistant_context_items_conversation_kind_idx",
+          "columns": [
+            "conversation_id",
+            "kind",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_context_items_message_kind_idx": {
+          "name": "org_workspace_assistant_context_items_message_kind_idx",
+          "columns": [
+            "message_id",
+            "kind",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_context_items_org_created_idx": {
+          "name": "org_workspace_assistant_context_items_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_workspace_assistant_context_items_id": {
+          "name": "lightfast_org_workspace_assistant_context_items_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_workspace_assistant_conversations": {
+      "name": "lightfast_org_workspace_assistant_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_workspace_assistant_conversations_public_id_uq": {
+          "name": "org_workspace_assistant_conversations_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_conversations_user_status_updated_idx": {
+          "name": "org_workspace_assistant_conversations_user_status_updated_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_by_user_id",
+            "status",
+            "updated_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_conversations_org_created_idx": {
+          "name": "org_workspace_assistant_conversations_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_workspace_assistant_conversations_id": {
+          "name": "lightfast_org_workspace_assistant_conversations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_workspace_assistant_generations": {
+      "name": "lightfast_org_workspace_assistant_generations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assistant_message_public_id": {
+          "name": "assistant_message_public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "request_metadata": {
+          "name": "request_metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_workspace_assistant_generations_public_id_uq": {
+          "name": "org_workspace_assistant_generations_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_generations_assistant_message_uq": {
+          "name": "org_workspace_assistant_generations_assistant_message_uq",
+          "columns": [
+            "assistant_message_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_generations_org_status_idx": {
+          "name": "org_workspace_assistant_generations_org_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "status",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_generations_org_user_status_idx": {
+          "name": "org_workspace_assistant_generations_org_user_status_idx",
+          "columns": [
+            "clerk_org_id",
+            "requested_by_user_id",
+            "status",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_generations_conversation_created_idx": {
+          "name": "org_workspace_assistant_generations_conversation_created_idx",
+          "columns": [
+            "conversation_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_workspace_assistant_generations_id": {
+          "name": "lightfast_org_workspace_assistant_generations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_workspace_assistant_messages": {
+      "name": "lightfast_org_workspace_assistant_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_public_id": {
+          "name": "conversation_public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'completed'"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_ARRAY())"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_workspace_assistant_messages_public_id_uq": {
+          "name": "org_workspace_assistant_messages_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_messages_conversation_sequence_uq": {
+          "name": "org_workspace_assistant_messages_conversation_sequence_uq",
+          "columns": [
+            "conversation_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_messages_conv_idempotency_key_uq": {
+          "name": "org_workspace_assistant_messages_conv_idempotency_key_uq",
+          "columns": [
+            "conversation_id",
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_messages_conversation_created_idx": {
+          "name": "org_workspace_assistant_messages_conversation_created_idx",
+          "columns": [
+            "conversation_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_messages_user_conversation_sequence_idx": {
+          "name": "org_workspace_assistant_messages_user_conversation_sequence_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_by_user_id",
+            "conversation_id",
+            "sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_messages_org_created_idx": {
+          "name": "org_workspace_assistant_messages_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_workspace_assistant_messages_id": {
+          "name": "lightfast_org_workspace_assistant_messages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_org_workspace_assistant_tool_calls": {
+      "name": "lightfast_org_workspace_assistant_tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation_public_id": {
+          "name": "generation_public_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(JSON_OBJECT())"
+        },
+        "output": {
+          "name": "output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_workspace_assistant_tool_calls_public_id_uq": {
+          "name": "org_workspace_assistant_tool_calls_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_tool_calls_generation_tool_call_uq": {
+          "name": "org_workspace_assistant_tool_calls_generation_tool_call_uq",
+          "columns": [
+            "generation_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "org_workspace_assistant_tool_calls_message_idx": {
+          "name": "org_workspace_assistant_tool_calls_message_idx",
+          "columns": [
+            "message_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "org_workspace_assistant_tool_calls_org_created_idx": {
+          "name": "org_workspace_assistant_tool_calls_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_org_workspace_assistant_tool_calls_id": {
+          "name": "lightfast_org_workspace_assistant_tool_calls_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_audit_events": {
+      "name": "lightfast_system_mcp_audit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_public_id": {
+          "name": "client_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_public_id": {
+          "name": "grant_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_audit_org_created_idx": {
+          "name": "system_mcp_audit_org_created_idx",
+          "columns": [
+            "clerk_org_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "system_mcp_audit_client_created_idx": {
+          "name": "system_mcp_audit_client_created_idx",
+          "columns": [
+            "client_public_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_audit_events_id": {
+          "name": "lightfast_system_mcp_audit_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_oauth_authorization_codes": {
+      "name": "lightfast_system_mcp_oauth_authorization_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_public_id": {
+          "name": "client_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_hash": {
+          "name": "resource_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_authorization_codes_hash_uq": {
+          "name": "system_mcp_authorization_codes_hash_uq",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "system_mcp_authorization_client_user_idx": {
+          "name": "system_mcp_authorization_client_user_idx",
+          "columns": [
+            "client_public_id",
+            "clerk_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_oauth_authorization_codes_id": {
+          "name": "lightfast_system_mcp_oauth_authorization_codes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_oauth_client_redirect_uris": {
+      "name": "lightfast_system_mcp_oauth_client_redirect_uris",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "client_public_id": {
+          "name": "client_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_redirect_uris_client_idx": {
+          "name": "system_mcp_redirect_uris_client_idx",
+          "columns": [
+            "client_public_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_oauth_client_redirect_uris_id": {
+          "name": "lightfast_system_mcp_oauth_client_redirect_uris_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_oauth_clients": {
+      "name": "lightfast_system_mcp_oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_client_id": {
+          "name": "public_client_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_oauth_clients_public_id_uq": {
+          "name": "system_mcp_oauth_clients_public_id_uq",
+          "columns": [
+            "public_client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_oauth_clients_id": {
+          "name": "lightfast_system_mcp_oauth_clients_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_oauth_grants": {
+      "name": "lightfast_system_mcp_oauth_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_public_id": {
+          "name": "client_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_hash": {
+          "name": "resource_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_grants_public_id_uq": {
+          "name": "system_mcp_grants_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "system_mcp_grants_lookup_idx": {
+          "name": "system_mcp_grants_lookup_idx",
+          "columns": [
+            "clerk_user_id",
+            "clerk_org_id",
+            "client_public_id",
+            "resource_hash",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "system_mcp_grants_org_active_idx": {
+          "name": "system_mcp_grants_org_active_idx",
+          "columns": [
+            "clerk_org_id",
+            "status",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_oauth_grants_id": {
+          "name": "lightfast_system_mcp_oauth_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_oauth_refresh_tokens": {
+      "name": "lightfast_system_mcp_oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_public_id": {
+          "name": "grant_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_public_id": {
+          "name": "client_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_token_hash": {
+          "name": "parent_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_to_token_hash": {
+          "name": "rotated_to_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reuse_detected_at": {
+          "name": "reuse_detected_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_refresh_token_hash_uq": {
+          "name": "system_mcp_refresh_token_hash_uq",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "system_mcp_refresh_grant_status_idx": {
+          "name": "system_mcp_refresh_grant_status_idx",
+          "columns": [
+            "grant_public_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_oauth_refresh_tokens_id": {
+          "name": "lightfast_system_mcp_oauth_refresh_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_mcp_oauth_registration_tokens": {
+      "name": "lightfast_system_mcp_oauth_registration_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_public_id": {
+          "name": "client_public_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_mcp_registration_public_id_uq": {
+          "name": "system_mcp_registration_public_id_uq",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "system_mcp_registration_token_hash_uq": {
+          "name": "system_mcp_registration_token_hash_uq",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "system_mcp_registration_client_status_idx": {
+          "name": "system_mcp_registration_client_status_idx",
+          "columns": [
+            "client_public_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_mcp_oauth_registration_tokens_id": {
+          "name": "lightfast_system_mcp_oauth_registration_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_namespace_operations": {
+      "name": "lightfast_system_namespace_operations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_kind": {
+          "name": "owner_kind",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_clerk_user_id": {
+          "name": "idempotency_clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_clerk_org_id": {
+          "name": "idempotency_clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "system_namespace_operations_org_idempotency_uq": {
+          "name": "system_namespace_operations_org_idempotency_uq",
+          "columns": [
+            "idempotency_clerk_org_id",
+            "operation_type",
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "system_namespace_operations_org_idx": {
+          "name": "system_namespace_operations_org_idx",
+          "columns": [
+            "clerk_org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "system_namespace_operations_status_idx": {
+          "name": "system_namespace_operations_status_idx",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "system_namespace_operations_user_idempotency_uq": {
+          "name": "system_namespace_operations_user_idempotency_uq",
+          "columns": [
+            "idempotency_clerk_user_id",
+            "operation_type",
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "system_namespace_operations_user_idx": {
+          "name": "system_namespace_operations_user_idx",
+          "columns": [
+            "clerk_user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_namespace_operations_id": {
+          "name": "lightfast_system_namespace_operations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_system_namespaces": {
+      "name": "lightfast_system_namespaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_clerk_user_id": {
+          "name": "claimed_clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_clerk_org_id": {
+          "name": "claimed_clerk_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_operation_id": {
+          "name": "active_operation_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "system_namespaces_active_operation_uq": {
+          "name": "system_namespaces_active_operation_uq",
+          "columns": [
+            "active_operation_id"
+          ],
+          "isUnique": true
+        },
+        "system_namespaces_claimed_org_uq": {
+          "name": "system_namespaces_claimed_org_uq",
+          "columns": [
+            "claimed_clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "system_namespaces_claimed_user_uq": {
+          "name": "system_namespaces_claimed_user_uq",
+          "columns": [
+            "claimed_clerk_user_id"
+          ],
+          "isUnique": true
+        },
+        "system_namespaces_handle_uq": {
+          "name": "system_namespaces_handle_uq",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": true
+        },
+        "system_namespaces_org_idx": {
+          "name": "system_namespaces_org_idx",
+          "columns": [
+            "clerk_org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "system_namespaces_user_idx": {
+          "name": "system_namespaces_user_idx",
+          "columns": [
+            "clerk_user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_system_namespaces_id": {
+          "name": "lightfast_system_namespaces_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lightfast_user_source_control_accounts": {
+      "name": "lightfast_user_source_control_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_clerk_user_id": {
+          "name": "active_clerk_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_provider_user_key": {
+          "name": "active_provider_user_key",
+          "type": "varchar(192)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_source_control_accounts_active_user_uq": {
+          "name": "user_source_control_accounts_active_user_uq",
+          "columns": [
+            "active_clerk_user_id"
+          ],
+          "isUnique": true
+        },
+        "user_source_control_accounts_active_provider_user_uq": {
+          "name": "user_source_control_accounts_active_provider_user_uq",
+          "columns": [
+            "active_provider_user_key"
+          ],
+          "isUnique": true
+        },
+        "user_source_control_accounts_user_status_idx": {
+          "name": "user_source_control_accounts_user_status_idx",
+          "columns": [
+            "clerk_user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "user_source_control_accounts_provider_user_idx": {
+          "name": "user_source_control_accounts_provider_user_idx",
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "lightfast_user_source_control_accounts_id": {
+          "name": "lightfast_user_source_control_accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/db/app/src/migrations/meta/_journal.json
+++ b/db/app/src/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1780737690542,
       "tag": "0024_hesitant_midnight",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "5",
+      "when": 1780742442925,
+      "tag": "0025_shocking_smasher",
+      "breakpoints": true
     }
   ]
 }

--- a/db/app/src/schema/tables/org-automations.ts
+++ b/db/app/src/schema/tables/org-automations.ts
@@ -73,10 +73,9 @@ export const orgAutomations = mysqlTable(
       length: CLERK_ID_LENGTH,
     }).notNull(),
 
-    connectorProvider: varchar("connector_provider", { length: CODE_LENGTH })
-      .$type<ConnectableConnectorProvider>()
-      .default("linear")
-      .notNull(),
+    connectorProvider: varchar("connector_provider", {
+      length: CODE_LENGTH,
+    }).$type<ConnectableConnectorProvider>(),
 
     name: varchar("name", { length: NAME_LENGTH }).notNull(),
 

--- a/db/app/src/utils/automations.ts
+++ b/db/app/src/utils/automations.ts
@@ -164,7 +164,7 @@ export function calculateNextRunAt(input: {
 
 export interface CreateAutomationInput {
   clerkOrgId: string;
-  connectorProvider: ConnectableConnectorProvider;
+  connectorProvider?: ConnectableConnectorProvider | null;
   createdByUserId: string;
   name: string;
   prompt: string;
@@ -185,7 +185,7 @@ export async function createAutomation(
   await db.insert(automations).values({
     publicId,
     clerkOrgId: input.clerkOrgId,
-    connectorProvider: input.connectorProvider,
+    connectorProvider: input.connectorProvider ?? null,
     createdByUserId: input.createdByUserId,
     name: input.name,
     prompt: input.prompt,

--- a/packages/app-validation/src/__tests__/automations.test.ts
+++ b/packages/app-validation/src/__tests__/automations.test.ts
@@ -198,7 +198,7 @@ describe("automation schemas", () => {
     });
   });
 
-  it("requires a single supported connector provider when creating an automation", () => {
+  it("accepts an optional supported connector provider when creating an automation", () => {
     expect(
       createAutomationSchema.parse({
         connectorProvider: "x",
@@ -214,9 +214,8 @@ describe("automation schemas", () => {
       timezone: "UTC",
     });
 
-    expect(() =>
+    expect(
       createAutomationSchema.parse({
-        connectorProvider: "github",
         name: "Daily summary",
         prompt: "Summarize my day",
         schedule: {
@@ -224,10 +223,29 @@ describe("automation schemas", () => {
           config: { time: "09:00" },
         },
       })
-    ).toThrow();
+    ).toMatchObject({
+      connectorProvider: null,
+      timezone: "UTC",
+    });
+
+    expect(
+      createAutomationSchema.parse({
+        connectorProvider: null,
+        name: "Daily summary",
+        prompt: "Summarize my day",
+        schedule: {
+          kind: "daily",
+          config: { time: "09:00" },
+        },
+      })
+    ).toMatchObject({
+      connectorProvider: null,
+      timezone: "UTC",
+    });
 
     expect(() =>
       createAutomationSchema.parse({
+        connectorProvider: "github",
         name: "Daily summary",
         prompt: "Summarize my day",
         schedule: {

--- a/packages/app-validation/src/schemas/automations.ts
+++ b/packages/app-validation/src/schemas/automations.ts
@@ -86,7 +86,9 @@ export const automationScheduleSchema = z.discriminatedUnion("kind", [
 ]);
 
 export const createAutomationSchema = z.object({
-  connectorProvider: connectableConnectorProviderSchema,
+  connectorProvider: connectableConnectorProviderSchema
+    .nullable()
+    .default(null),
   name: z.string().trim().min(1).max(AUTOMATION_NAME_MAX_LENGTH),
   prompt: z.string().trim().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH),
   schedule: automationScheduleSchema,


### PR DESCRIPTION
## Summary
- Make automation connectors optional end-to-end, including nullable DB/schema validation and connectorless execution/output handling.
- Filter the automation connector select to connectors enabled for automations, while preserving a compact optional "No connector" choice as the last form field.
- Add migration and focused coverage for connectorless, disabled connector, and X/Linear selection behavior.

## Test Plan
- pnpm check
- pnpm typecheck
- agent-browser e2e: disabled Linear/X shows only No connector
- agent-browser e2e: X-only and Linear+X dropdowns allow selecting non-first options
- agent-browser e2e: created connectorless automation persisted connectorProvider null
- agent-browser e2e: created X automation persisted connectorProvider "x"