### PR TITLE
Add native Sentry feedback dialog

### DIFF
--- a/apps/app/src/__tests__/components/app-sidebar.test.tsx
+++ b/apps/app/src/__tests__/components/app-sidebar.test.tsx
@@ -80,6 +80,23 @@ vi.mock("@tanstack/react-query", () => ({
   useQuery: () => ({ data: conversationsData, isError: conversationsIsError }),
 }));
 
+vi.mock("~/components/feedback-dialog", () => ({
+  FeedbackDialog: ({
+    onOpenChange,
+    open,
+  }: {
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+  }) =>
+    open ? (
+      <div aria-label="Send feedback" role="dialog">
+        <button onClick={() => onOpenChange(false)} type="button">
+          Close feedback
+        </button>
+      </div>
+    ) : null,
+}));
+
 vi.mock("@repo/ui/components/ui/sidebar", () => ({
   useSidebar: () => ({
     isMobile,
@@ -157,6 +174,36 @@ vi.mock("@repo/ui/components/ui/popover", () => ({
     <div>{children}</div>
   ),
   PopoverTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@repo/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    asChild,
+    children,
+    onClick,
+  }: {
+    asChild?: boolean;
+    children?: ReactNode;
+    onClick?: () => void;
+  }) => {
+    if (asChild && isValidElement(children)) {
+      return children;
+    }
+    return (
+      <button onClick={onClick} type="button">
+        {children}
+      </button>
+    );
+  },
+  DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 const { AppSidebar } = await import("~/components/app-sidebar");
@@ -314,6 +361,20 @@ describe("AppSidebar", () => {
     const newChat = screen.getByRole("link", { name: "New chat" });
     expect(newChat).toHaveAttribute("href", "/acme/chat");
     expect(newChat).toHaveAttribute("data-prefetch", "false");
+  });
+
+  it("keeps contact support while opening feedback from the help menu", () => {
+    render(<AppSidebar />);
+
+    expect(
+      screen.getByRole("link", { name: /contact support/i })
+    ).toHaveAttribute("href", "mailto:support@lightfast.ai");
+
+    fireEvent.click(screen.getByRole("button", { name: /send feedback/i }));
+
+    expect(
+      screen.getByRole("dialog", { name: /send feedback/i })
+    ).toBeInTheDocument();
   });
 
   it("hides the chats group when there are no conversations", () => {

--- a/apps/app/src/__tests__/components/feedback-dialog.test.tsx
+++ b/apps/app/src/__tests__/components/feedback-dialog.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const submitSentryFeedbackMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("~/sentry-feedback", () => ({
+  FEEDBACK_MESSAGE_PLACEHOLDER:
+    "Tell us what happened, what you expected, and any useful context.",
+  submitSentryFeedback: submitSentryFeedbackMock,
+}));
+
+vi.mock("@repo/ui/components/ui/sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+vi.mock("@repo/ui/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children?: ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  DialogDescription: ({ children }: { children?: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}));
+
+const { FeedbackDialog } = await import("~/components/feedback-dialog");
+
+beforeEach(() => {
+  submitSentryFeedbackMock.mockReset();
+  toastErrorMock.mockReset();
+  toastSuccessMock.mockReset();
+});
+
+describe("FeedbackDialog", () => {
+  it("submits trimmed feedback to Sentry and closes", async () => {
+    const onOpenChange = vi.fn();
+    submitSentryFeedbackMock.mockResolvedValue("feedback_event");
+
+    render(<FeedbackDialog onOpenChange={onOpenChange} open />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "  Ada Lovelace  " },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "  ada@example.com  " },
+    });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "  The signals page failed to load.  " },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    await waitFor(() => {
+      expect(submitSentryFeedbackMock).toHaveBeenCalledWith({
+        email: "ada@example.com",
+        message: "The signals page failed to load.",
+        name: "Ada Lovelace",
+      });
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Feedback sent", {
+      description: "Thanks for helping us improve Lightfast.",
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("requires a description before submitting", async () => {
+    render(<FeedbackDialog onOpenChange={vi.fn()} open />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    expect(
+      await screen.findByText("Add a description before sending feedback.")
+    ).toBeInTheDocument();
+    expect(submitSentryFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open and shows an error toast when submission fails", async () => {
+    const onOpenChange = vi.fn();
+    submitSentryFeedbackMock.mockRejectedValue(new Error("network down"));
+
+    render(<FeedbackDialog onOpenChange={onOpenChange} open />);
+
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Something went sideways." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("Unable to send feedback", {
+        description: "Please try again or contact support.",
+      });
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/app/src/__tests__/sentry-config.test.ts
+++ b/apps/app/src/__tests__/sentry-config.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react";
 import { TRPCClientError } from "@trpc/client";
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it, vi } from "vitest";
@@ -8,6 +9,7 @@ const sentryMocks = vi.hoisted(() => ({
   consoleLoggingIntegration: vi.fn(() => ({ name: "console-logging" })),
   extraErrorDataIntegration: vi.fn(() => ({ name: "extra-error-data" })),
   feedbackIntegration: vi.fn(() => ({ name: "feedback" })),
+  getFeedback: vi.fn(() => undefined),
   httpClientIntegration: vi.fn(() => ({ name: "http-client" })),
   init: vi.fn(),
   replayIntegration: vi.fn(() => ({ name: "replay" })),
@@ -19,6 +21,7 @@ vi.mock("@sentry/nextjs", () => ({
   consoleLoggingIntegration: sentryMocks.consoleLoggingIntegration,
   extraErrorDataIntegration: sentryMocks.extraErrorDataIntegration,
   feedbackIntegration: sentryMocks.feedbackIntegration,
+  getFeedback: sentryMocks.getFeedback,
   httpClientIntegration: sentryMocks.httpClientIntegration,
   init: sentryMocks.init,
   replayIntegration: sentryMocks.replayIntegration,
@@ -84,5 +87,23 @@ describe("Sentry config", () => {
     expect(options?.beforeSend?.(event, { originalException: error })).toBe(
       event
     );
+  });
+
+  it("lazy-loads replay without installing Sentry's feedback widget", async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    await import("../instrumentation-client");
+    window.dispatchEvent(new Event("load"));
+
+    await waitFor(() => {
+      expect(sentryMocks.replayIntegration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blockAllMedia: true,
+          maskAllText: true,
+        })
+      );
+    });
+    expect(sentryMocks.feedbackIntegration).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/__tests__/sentry-feedback.test.ts
+++ b/apps/app/src/__tests__/sentry-feedback.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureFeedbackMock = vi.hoisted(() => vi.fn(() => "feedback_event"));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureFeedback: captureFeedbackMock,
+}));
+
+const { submitSentryFeedback } = await import("../sentry-feedback");
+
+beforeEach(() => {
+  captureFeedbackMock.mockClear();
+});
+
+describe("submitSentryFeedback", () => {
+  it("sends trimmed native feedback through Sentry captureFeedback", async () => {
+    await expect(
+      submitSentryFeedback({
+        email: "  ada@example.com  ",
+        message: "  Something broke on signals.  ",
+        name: "  Ada Lovelace  ",
+      })
+    ).resolves.toBe("feedback_event");
+
+    expect(captureFeedbackMock).toHaveBeenCalledWith(
+      {
+        email: "ada@example.com",
+        message: "Something broke on signals.",
+        name: "Ada Lovelace",
+        source: "custom-app-feedback",
+        tags: {
+          feedback_source: "app-sidebar",
+        },
+        url: expect.any(String),
+      },
+      { includeReplay: true }
+    );
+  });
+
+  it("omits optional contact fields when they are blank", async () => {
+    await submitSentryFeedback({
+      email: " ",
+      message: "Only the message matters.",
+      name: "",
+    });
+
+    expect(captureFeedbackMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        email: expect.anything(),
+        name: expect.anything(),
+      }),
+      { includeReplay: true }
+    );
+  });
+});

--- a/apps/app/src/__tests__/sentry-feedback.test.ts
+++ b/apps/app/src/__tests__/sentry-feedback.test.ts
@@ -1,15 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const captureFeedbackMock = vi.hoisted(() => vi.fn(() => "feedback_event"));
+const flushMock = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
 
 vi.mock("@sentry/nextjs", () => ({
   captureFeedback: captureFeedbackMock,
+  flush: flushMock,
 }));
 
 const { submitSentryFeedback } = await import("../sentry-feedback");
 
 beforeEach(() => {
   captureFeedbackMock.mockClear();
+  flushMock.mockClear();
+  flushMock.mockResolvedValue(true);
 });
 
 describe("submitSentryFeedback", () => {
@@ -35,6 +39,7 @@ describe("submitSentryFeedback", () => {
       },
       { includeReplay: true }
     );
+    expect(flushMock).toHaveBeenCalledWith(5000);
   });
 
   it("omits optional contact fields when they are blank", async () => {
@@ -51,5 +56,16 @@ describe("submitSentryFeedback", () => {
       }),
       { includeReplay: true }
     );
+    expect(flushMock).toHaveBeenCalledWith(5000);
+  });
+
+  it("throws when Sentry does not flush feedback before the timeout", async () => {
+    flushMock.mockResolvedValue(false);
+
+    await expect(
+      submitSentryFeedback({
+        message: "This should report a send failure.",
+      })
+    ).rejects.toThrow("Unable to send feedback");
   });
 });

--- a/apps/app/src/components/app-sidebar.tsx
+++ b/apps/app/src/components/app-sidebar.tsx
@@ -40,7 +40,8 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
+import { FeedbackDialog } from "~/components/feedback-dialog";
 import { TeamSwitcher, TeamSwitcherSkeleton } from "~/components/team-switcher";
 import { useTRPC } from "~/trpc/react";
 
@@ -257,128 +258,139 @@ function getConversationSidebarTitle(
 export function AppSidebar() {
   const pathname = usePathname();
   const { isMobile, setOpenMobile } = useSidebar();
+  const [isFeedbackOpen, setFeedbackOpen] = useState(false);
 
   const pathParts = pathname.split("/").filter(Boolean);
   const orgSlug = pathParts[0] ?? "";
 
   return (
-    <Sidebar collapsible="offcanvas">
-      <SidebarHeader className="h-14 flex-row items-center px-4 py-0">
-        <Suspense fallback={<TeamSwitcherSkeleton />}>
-          <TeamSwitcher />
-        </Suspense>
-        <div className="ml-auto flex items-center gap-1">
+    <>
+      <Sidebar collapsible="offcanvas">
+        <SidebarHeader className="h-14 flex-row items-center px-4 py-0">
+          <Suspense fallback={<TeamSwitcherSkeleton />}>
+            <TeamSwitcher />
+          </Suspense>
+          <div className="ml-auto flex items-center gap-1">
+            {orgSlug && (
+              <Button
+                aria-label="New chat"
+                asChild
+                className="size-11 rounded-full lg:h-6 lg:w-6"
+                size="sm"
+                title="New chat"
+                variant="ghost"
+              >
+                <Link
+                  href={{ pathname: `/${orgSlug}/chat` }}
+                  onClick={() => {
+                    if (isMobile) {
+                      setOpenMobile(false);
+                    }
+                  }}
+                  prefetch={false}
+                >
+                  <MessageCirclePlus className="size-3.5" />
+                </Link>
+              </Button>
+            )}
+            {isMobile && (
+              <Button
+                aria-label="Close sidebar"
+                className="size-11 rounded-xl text-muted-foreground"
+                onClick={() => setOpenMobile(false)}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <X className="size-4" />
+              </Button>
+            )}
+          </div>
+        </SidebarHeader>
+        <SidebarContent>
           {orgSlug && (
-            <Button
-              aria-label="New chat"
-              asChild
-              className="size-11 rounded-full lg:h-6 lg:w-6"
-              size="sm"
-              title="New chat"
-              variant="ghost"
-            >
-              <Link
-                href={{ pathname: `/${orgSlug}/chat` }}
-                onClick={() => {
-                  if (isMobile) {
-                    setOpenMobile(false);
-                  }
-                }}
-                prefetch={false}
-              >
-                <MessageCirclePlus className="size-3.5" />
-              </Link>
-            </Button>
-          )}
-          {isMobile && (
-            <Button
-              aria-label="Close sidebar"
-              className="size-11 rounded-xl text-muted-foreground"
-              onClick={() => setOpenMobile(false)}
-              size="icon"
-              type="button"
-              variant="ghost"
-            >
-              <X className="size-4" />
-            </Button>
-          )}
-        </div>
-      </SidebarHeader>
-      <SidebarContent>
-        {orgSlug && (
-          <>
-            <SidebarGroup>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  <NavItems
-                    items={getOrgStandaloneItems(orgSlug)}
-                    pathname={pathname}
-                  />
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-            <SidebarGroup collapsible defaultOpen label="Workspace">
-              <SidebarGroupContent>
-                <nav aria-label="Workspace">
+            <>
+              <SidebarGroup>
+                <SidebarGroupContent>
                   <SidebarMenu>
                     <NavItems
-                      items={getOrgWorkspaceItems(orgSlug)}
+                      items={getOrgStandaloneItems(orgSlug)}
                       pathname={pathname}
                     />
                   </SidebarMenu>
-                </nav>
-              </SidebarGroupContent>
-            </SidebarGroup>
-            <SidebarGroup collapsible defaultOpen label="Manage">
-              <SidebarGroupContent>
-                <nav aria-label="Manage">
-                  <SidebarMenu>
-                    <NavItems
-                      items={getOrgManageItems(orgSlug)}
-                      pathname={pathname}
-                    />
-                  </SidebarMenu>
-                </nav>
-              </SidebarGroupContent>
-            </SidebarGroup>
-            <Suspense fallback={null}>
-              <ChatHistory orgSlug={orgSlug} pathname={pathname} />
-            </Suspense>
-          </>
-        )}
-      </SidebarContent>
-      <SidebarFooter>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              className="size-11 rounded-full bg-muted p-1 lg:h-8 lg:w-8"
-              size="icon"
-              title="Help"
-              variant="outline"
-            >
-              <HelpCircle className="size-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="center" className="w-48">
-            <DropdownMenuItem asChild>
-              <a href="mailto:support@lightfast.ai">
-                <Mail className="size-3.5" />
-                Contact Support
-              </a>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link
-                href="https://lightfast.ai/docs/get-started/overview"
-                rel="noopener noreferrer"
-                target="_blank"
+                </SidebarGroupContent>
+              </SidebarGroup>
+              <SidebarGroup collapsible defaultOpen label="Workspace">
+                <SidebarGroupContent>
+                  <nav aria-label="Workspace">
+                    <SidebarMenu>
+                      <NavItems
+                        items={getOrgWorkspaceItems(orgSlug)}
+                        pathname={pathname}
+                      />
+                    </SidebarMenu>
+                  </nav>
+                </SidebarGroupContent>
+              </SidebarGroup>
+              <SidebarGroup collapsible defaultOpen label="Manage">
+                <SidebarGroupContent>
+                  <nav aria-label="Manage">
+                    <SidebarMenu>
+                      <NavItems
+                        items={getOrgManageItems(orgSlug)}
+                        pathname={pathname}
+                      />
+                    </SidebarMenu>
+                  </nav>
+                </SidebarGroupContent>
+              </SidebarGroup>
+              <Suspense fallback={null}>
+                <ChatHistory orgSlug={orgSlug} pathname={pathname} />
+              </Suspense>
+            </>
+          )}
+        </SidebarContent>
+        <SidebarFooter>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                className="size-11 rounded-full bg-muted p-1 lg:h-8 lg:w-8"
+                size="icon"
+                title="Help"
+                variant="outline"
               >
-                <BookOpen className="size-3.5" />
-                Help Docs
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarFooter>
-    </Sidebar>
+                <HelpCircle className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center" className="w-48">
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => setFeedbackOpen(true)}
+              >
+                <MessageCircle className="size-3.5" />
+                Send feedback
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="mailto:support@lightfast.ai">
+                  <Mail className="size-3.5" />
+                  Contact Support
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link
+                  href="https://lightfast.ai/docs/get-started/overview"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <BookOpen className="size-3.5" />
+                  Help Docs
+                </Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SidebarFooter>
+      </Sidebar>
+      <FeedbackDialog onOpenChange={setFeedbackOpen} open={isFeedbackOpen} />
+    </>
   );
 }

--- a/apps/app/src/components/feedback-dialog.tsx
+++ b/apps/app/src/components/feedback-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/ui/dialog";
+import { Input } from "@repo/ui/components/ui/input";
+import { Label } from "@repo/ui/components/ui/label";
+import { toast } from "@repo/ui/components/ui/sonner";
+import { Textarea } from "@repo/ui/components/ui/textarea";
+import { useState } from "react";
+import {
+  FEEDBACK_MESSAGE_PLACEHOLDER,
+  submitSentryFeedback,
+} from "~/sentry-feedback";
+
+interface FeedbackDialogProps {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export function FeedbackDialog({ onOpenChange, open }: FeedbackDialogProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetForm = () => {
+    setName("");
+    setEmail("");
+    setMessage("");
+    setFormError(null);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isSubmitting) {
+      return;
+    }
+
+    if (!nextOpen) {
+      resetForm();
+    }
+
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) {
+      setFormError("Add a description before sending feedback.");
+      return;
+    }
+
+    setFormError(null);
+    setIsSubmitting(true);
+
+    try {
+      await submitSentryFeedback({
+        email: email.trim(),
+        message: trimmedMessage,
+        name: name.trim(),
+      });
+      toast.success("Feedback sent", {
+        description: "Thanks for helping us improve Lightfast.",
+      });
+      resetForm();
+      onOpenChange(false);
+    } catch {
+      toast.error("Unable to send feedback", {
+        description: "Please try again or contact support.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent className="gap-5 sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Send feedback</DialogTitle>
+          <DialogDescription>
+            Tell us what happened and what would have helped.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <div className="grid gap-2">
+            <Label htmlFor="feedback-name">Name</Label>
+            <Input
+              autoComplete="name"
+              disabled={isSubmitting}
+              id="feedback-name"
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Your name"
+              value={name}
+              variant="lf"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="feedback-email">Email</Label>
+            <Input
+              autoComplete="email"
+              disabled={isSubmitting}
+              id="feedback-email"
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              type="email"
+              value={email}
+              variant="lf"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="feedback-message">Description</Label>
+            <Textarea
+              aria-describedby={
+                formError ? "feedback-message-error" : undefined
+              }
+              aria-invalid={formError ? true : undefined}
+              autoFocus
+              disabled={isSubmitting}
+              id="feedback-message"
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder={FEEDBACK_MESSAGE_PLACEHOLDER}
+              rows={6}
+              value={message}
+              variant="lf"
+            />
+            {formError && (
+              <p
+                className="text-destructive text-sm"
+                id="feedback-message-error"
+              >
+                {formError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={isSubmitting}
+              onClick={() => handleOpenChange(false)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button disabled={isSubmitting} type="submit">
+              {isSubmitting ? "Sending..." : "Send feedback"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -46,13 +46,12 @@ initSentry({
     extraErrorDataIntegration({
       depth: 3,
     }),
-    // feedbackIntegration lazy-loaded below
   ],
 });
 
 export const onRouterTransitionStart = captureRouterTransitionStart;
 
-// Lazy-load replay and feedback after page is fully interactive
+// Lazy-load replay after page is fully interactive
 // This defers ~418KB of Sentry integrations from the initial bundle
 if (typeof window !== "undefined") {
   const loadLazySentryIntegrations = async () => {
@@ -62,14 +61,6 @@ if (typeof window !== "undefined") {
       Sentry.replayIntegration({
         maskAllText: true,
         blockAllMedia: true,
-      })
-    );
-
-    Sentry.addIntegration(
-      Sentry.feedbackIntegration({
-        colorScheme: "system",
-        showBranding: false,
-        enableScreenshot: true,
       })
     );
   };

--- a/apps/app/src/sentry-feedback.ts
+++ b/apps/app/src/sentry-feedback.ts
@@ -1,0 +1,37 @@
+export const FEEDBACK_MESSAGE_PLACEHOLDER =
+  "Tell us what happened, what you expected, and any useful context.";
+
+export interface SubmitSentryFeedbackInput {
+  email?: string;
+  message: string;
+  name?: string;
+}
+
+export async function submitSentryFeedback(input: SubmitSentryFeedbackInput) {
+  const message = input.message.trim();
+
+  if (!message) {
+    throw new Error("Feedback message is required");
+  }
+
+  const Sentry = await import("@sentry/nextjs");
+  const payload = {
+    message,
+    source: "custom-app-feedback",
+    tags: {
+      feedback_source: "app-sidebar",
+    },
+    url: typeof window === "undefined" ? undefined : window.location.href,
+  };
+  const name = input.name?.trim();
+  const email = input.email?.trim();
+
+  return Sentry.captureFeedback(
+    {
+      ...payload,
+      ...(name ? { name } : {}),
+      ...(email ? { email } : {}),
+    },
+    { includeReplay: true }
+  );
+}

--- a/apps/app/src/sentry-feedback.ts
+++ b/apps/app/src/sentry-feedback.ts
@@ -1,6 +1,8 @@
 export const FEEDBACK_MESSAGE_PLACEHOLDER =
   "Tell us what happened, what you expected, and any useful context.";
 
+const FEEDBACK_FLUSH_TIMEOUT_MS = 5000;
+
 export interface SubmitSentryFeedbackInput {
   email?: string;
   message: string;
@@ -26,7 +28,7 @@ export async function submitSentryFeedback(input: SubmitSentryFeedbackInput) {
   const name = input.name?.trim();
   const email = input.email?.trim();
 
-  return Sentry.captureFeedback(
+  const eventId = Sentry.captureFeedback(
     {
       ...payload,
       ...(name ? { name } : {}),
@@ -34,4 +36,12 @@ export async function submitSentryFeedback(input: SubmitSentryFeedbackInput) {
     },
     { includeReplay: true }
   );
+
+  const didFlush = await Sentry.flush(FEEDBACK_FLUSH_TIMEOUT_MS);
+
+  if (!didFlush) {
+    throw new Error("Unable to send feedback");
+  }
+
+  return eventId;
 }


### PR DESCRIPTION
## Summary
- Replace the default Sentry feedback widget with a Lightfast-native feedback dialog launched from the sidebar help menu
- Keep Contact Support and Help Docs in the same menu
- Submit feedback through Sentry.captureFeedback with app-sidebar tagging and replay inclusion

## Verification
- pnpm --filter @lightfast/app exec vitest run src/__tests__/components/app-sidebar.test.tsx src/__tests__/components/feedback-dialog.test.tsx src/__tests__/sentry-feedback.test.ts src/__tests__/sentry-config.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm exec biome check apps/app/src/components/app-sidebar.tsx apps/app/src/components/feedback-dialog.tsx apps/app/src/sentry-feedback.ts apps/app/src/instrumentation-client.ts apps/app/src/__tests__/components/app-sidebar.test.tsx apps/app/src/__tests__/components/feedback-dialog.test.tsx apps/app/src/__tests__/sentry-feedback.test.ts apps/app/src/__tests__/sentry-config.test.ts
- npx sentry event view 45b1d145a26f4d95893cbaf6e365fac3 confirmed a real feedback smoke event with feedback_source=app-sidebar
