### PR TITLE
Limit Inngest health cron to production

### DIFF
--- a/api/app/src/__tests__/inngest-route.test.ts
+++ b/api/app/src/__tests__/inngest-route.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  vercelEnv: "production",
+}));
+
 const routeHandlers = {
   GET: vi.fn(),
   POST: vi.fn(),
@@ -31,6 +35,9 @@ vi.mock("inngest/next", () => ({
 vi.mock("../env", () => ({
   env: {
     INNGEST_SERVE_ORIGIN: "https://lightfast.localhost",
+    get VERCEL_ENV() {
+      return mocks.vercelEnv;
+    },
   },
 }));
 
@@ -97,7 +104,9 @@ vi.mock("../inngest/workflow/queue-skill-refresh-from-source-control", () => ({
 const { createInngestRouteContext, inngest } = await import("../inngest");
 
 describe("createInngestRouteContext", () => {
-  it("serves the app Inngest client with automation and health workflows", () => {
+  it("serves the app Inngest client with automation and production health workflows", () => {
+    mocks.vercelEnv = "production";
+
     const handlers = createInngestRouteContext();
 
     expect(inngest).toBe(inngestClient);
@@ -106,6 +115,33 @@ describe("createInngestRouteContext", () => {
       client: inngestClient,
       functions: [
         systemHealth,
+        classifySignal,
+        indexSignalEntities,
+        backfillSignalEntityLinks,
+        classifyPeople,
+        cleanupDeveloperSandboxRuns,
+        automationScheduler,
+        runAutomation,
+        refreshSkillIndex,
+        refreshIdentityIndex,
+        reconcileSkillIndexes,
+        reconcileIdentityIndexes,
+        teamMemberReconciler,
+        queueLightfastIndexRefreshesFromSourceControl,
+      ],
+      serveOrigin: "https://lightfast.localhost",
+      servePath: "/api/inngest",
+    });
+  });
+
+  it("omits cron health workflows outside production", () => {
+    mocks.vercelEnv = "preview";
+
+    createInngestRouteContext();
+
+    expect(serveMock).toHaveBeenLastCalledWith({
+      client: inngestClient,
+      functions: [
         classifySignal,
         indexSignalEntities,
         backfillSignalEntityLinks,

--- a/api/app/src/inngest/index.ts
+++ b/api/app/src/inngest/index.ts
@@ -18,11 +18,15 @@ import { teamMemberReconciler } from "./workflow/team-member-reconciler";
 
 export { inngest };
 
+function getProductionOnlyFunctions() {
+  return env.VERCEL_ENV === "production" ? [systemHealth] : [];
+}
+
 export function createInngestRouteContext() {
   return serve({
     client: inngest,
     functions: [
-      systemHealth,
+      ...getProductionOnlyFunctions(),
       classifySignal,
       indexSignalEntities,
       backfillSignalEntityLinks,

--- a/api/platform/src/__tests__/inngest-route.test.ts
+++ b/api/platform/src/__tests__/inngest-route.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  vercelEnv: "production",
+}));
+
 const routeHandlers = {
   GET: vi.fn(),
   POST: vi.fn(),
@@ -16,6 +20,9 @@ vi.mock("inngest/next", () => ({
 vi.mock("../env", () => ({
   env: {
     INNGEST_SERVE_ORIGIN: "https://platform.lightfast.localhost",
+    get VERCEL_ENV() {
+      return mocks.vercelEnv;
+    },
   },
 }));
 
@@ -31,6 +38,8 @@ const { createInngestRouteContext, inngest } = await import("../inngest");
 
 describe("createInngestRouteContext", () => {
   it("serves the platform Inngest client with system health workflow", () => {
+    mocks.vercelEnv = "production";
+
     const handlers = createInngestRouteContext();
 
     expect(inngest).toBe(inngestClient);
@@ -38,6 +47,19 @@ describe("createInngestRouteContext", () => {
     expect(serveMock).toHaveBeenCalledWith({
       client: inngestClient,
       functions: [systemHealth],
+      serveOrigin: "https://platform.lightfast.localhost",
+      servePath: "/api/inngest",
+    });
+  });
+
+  it("omits cron health workflows outside production", () => {
+    mocks.vercelEnv = "preview";
+
+    createInngestRouteContext();
+
+    expect(serveMock).toHaveBeenLastCalledWith({
+      client: inngestClient,
+      functions: [],
       serveOrigin: "https://platform.lightfast.localhost",
       servePath: "/api/inngest",
     });

--- a/api/platform/src/inngest/index.ts
+++ b/api/platform/src/inngest/index.ts
@@ -6,10 +6,14 @@ import { systemHealth } from "./workflow/system-health";
 
 export { inngest };
 
+function getProductionOnlyFunctions() {
+  return env.VERCEL_ENV === "production" ? [systemHealth] : [];
+}
+
 export function createInngestRouteContext() {
   return serve({
     client: inngest,
-    functions: [systemHealth],
+    functions: [...getProductionOnlyFunctions()],
     serveOrigin: env.INNGEST_SERVE_ORIGIN,
     servePath: "/api/inngest",
   });


### PR DESCRIPTION
## Summary
- Registers app/platform `system-health` cron workflows only when `VERCEL_ENV === \"production\"`.
- Keeps all non-cron app workflows synced in preview/branch environments.
- Prevents preview/merge-queue Inngest environments from burning quota on scheduled health checks.

## Ops Context
- Archived 68 stale active Inngest environments after allowlisting production/main/branch, open PRs, local worktree branches, and detached codex SHAs.
- Active Inngest environments went from 79 to 11.
- Direct function execution is still rate-limited, likely because the Hobby quota window is already exceeded; this change prevents further preview health-check burn once deployed.

## Test Plan
- [x] pnpm --filter @api/app test -- inngest-route.test.ts
- [x] pnpm --filter @api/platform test -- inngest-route.test.ts
- [x] pnpm --filter @api/app typecheck
- [x] pnpm --filter @api/platform typecheck
- [x] pnpm check