### PR TITLE
Log GitHub webhook rejections

### DIFF
--- a/api/app/src/__tests__/github-webhook.test.ts
+++ b/api/app/src/__tests__/github-webhook.test.ts
@@ -7,6 +7,8 @@ const markDeliveryMock = vi.fn();
 const recordDeliveryMock = vi.fn();
 const recordPrDeliveryMock = vi.fn();
 const inngestSendMock = vi.fn();
+const logErrorMock = vi.fn();
+const logWarnMock = vi.fn();
 
 vi.mock("@db/app/client", () => ({ db: {} }));
 
@@ -27,6 +29,13 @@ vi.mock("../env", () => ({
 vi.mock("../inngest/client", () => ({
   inngest: {
     send: inngestSendMock,
+  },
+}));
+
+vi.mock("@vendor/observability/log/next", () => ({
+  log: {
+    error: logErrorMock,
+    warn: logWarnMock,
   },
 }));
 
@@ -115,6 +124,42 @@ describe("handleGitHubWebhook", () => {
     recordDeliveryMock.mockReset();
     recordPrDeliveryMock.mockReset();
     inngestSendMock.mockReset();
+    logErrorMock.mockReset();
+    logWarnMock.mockReset();
+  });
+
+  it("logs missing webhook secret as a configuration rejection", async () => {
+    const { env } = await import("../env");
+    const originalSecret = env.GITHUB_APP_WEBHOOK_SECRET;
+    (
+      env as {
+        GITHUB_APP_WEBHOOK_SECRET?: string;
+      }
+    ).GITHUB_APP_WEBHOOK_SECRET = "";
+
+    try {
+      const { handleGitHubWebhook } = await import(
+        "../services/github/webhook"
+      );
+      const res = await handleGitHubWebhook({
+        request: signedRequest(pushPayload),
+      });
+
+      expect(res.status).toBe(500);
+      expect(recordDeliveryMock).not.toHaveBeenCalled();
+      expect(logErrorMock).toHaveBeenCalledWith("[github-webhook] rejected", {
+        deliveryId: "delivery-1",
+        event: "push",
+        reason: "missing_webhook_secret",
+        status: 500,
+      });
+    } finally {
+      (
+        env as {
+          GITHUB_APP_WEBHOOK_SECRET?: string;
+        }
+      ).GITHUB_APP_WEBHOOK_SECRET = originalSecret;
+    }
   });
 
   it("rejects invalid signatures before durable work", async () => {
@@ -136,6 +181,12 @@ describe("handleGitHubWebhook", () => {
 
     expect(res.status).toBe(401);
     expect(recordDeliveryMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith("[github-webhook] rejected", {
+      deliveryId: "delivery-1",
+      event: "push",
+      reason: "invalid_signature",
+      status: 401,
+    });
   });
 
   it("rejects missing signatures as unauthorized before durable work", async () => {
@@ -156,6 +207,12 @@ describe("handleGitHubWebhook", () => {
 
     expect(res.status).toBe(401);
     expect(recordDeliveryMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith("[github-webhook] rejected", {
+      deliveryId: "delivery-1",
+      event: "push",
+      reason: "missing_signature",
+      status: 401,
+    });
   });
 
   it("returns 400 for signed malformed JSON", async () => {
@@ -182,6 +239,12 @@ describe("handleGitHubWebhook", () => {
 
     expect(res.status).toBe(400);
     expect(recordDeliveryMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith("[github-webhook] rejected", {
+      deliveryId: "delivery-1",
+      event: "push",
+      reason: "malformed_json",
+      status: 400,
+    });
   });
 
   it("rejects signed push payloads with malformed routing fields before durable work", async () => {

--- a/api/app/src/services/github/webhook/handler.ts
+++ b/api/app/src/services/github/webhook/handler.ts
@@ -21,6 +21,7 @@ import {
   sourceControlRepositoryPushEventSchema,
   watchesWebhookEvent,
 } from "@repo/source-control-contract";
+import { log } from "@vendor/observability/log/next";
 
 import { env } from "../../../env";
 import { inngest } from "../../../inngest/client";
@@ -39,6 +40,41 @@ function readHeaders(request: Request) {
   });
 }
 
+function readWebhookLogHeaders(request: Request) {
+  return {
+    deliveryId: request.headers.get("x-github-delivery"),
+    event: request.headers.get("x-github-event"),
+  };
+}
+
+function webhookRejectionMeta(input: {
+  deliveryId?: string | null;
+  event?: string | null;
+  reason: string;
+  status: number;
+}) {
+  const meta: Record<string, unknown> = {
+    reason: input.reason,
+    status: input.status,
+  };
+  if (input.deliveryId) {
+    meta.deliveryId = input.deliveryId;
+  }
+  if (input.event) {
+    meta.event = input.event;
+  }
+  return meta;
+}
+
+function logWebhookRejection(input: {
+  deliveryId?: string | null;
+  event?: string | null;
+  reason: string;
+  status: number;
+}) {
+  log.warn("[github-webhook] rejected", webhookRejectionMeta(input));
+}
+
 async function handleGitHubPrWebhook(input: {
   deliveryId: string;
   event: string;
@@ -51,6 +87,12 @@ async function handleGitHubPrWebhook(input: {
 
   const parsedPayload = githubPrWebhookPayloadSchema.safeParse(input.json);
   if (!parsedPayload.success) {
+    logWebhookRejection({
+      deliveryId: input.deliveryId,
+      event: input.event,
+      reason: "invalid_pr_payload",
+      status: 400,
+    });
     return response(400, { ok: false });
   }
   const rawPayload = input.json as Record<string, unknown>;
@@ -62,6 +104,12 @@ async function handleGitHubPrWebhook(input: {
       payload: parsedPayload.data,
     });
   } catch {
+    logWebhookRejection({
+      deliveryId: input.deliveryId,
+      event: input.event,
+      reason: "invalid_pr_payload_normalization",
+      status: 400,
+    });
     return response(400, { ok: false });
   }
 
@@ -111,17 +159,35 @@ export async function handleGitHubWebhook(input: {
 }): Promise<Response> {
   const secret = env.GITHUB_APP_WEBHOOK_SECRET;
   if (!secret) {
+    log.error(
+      "[github-webhook] rejected",
+      webhookRejectionMeta({
+        ...readWebhookLogHeaders(input.request),
+        reason: "missing_webhook_secret",
+        status: 500,
+      })
+    );
     return response(500, { ok: false });
   }
 
   const body = await input.request.text();
   const signature256 = input.request.headers.get("x-hub-signature-256");
   if (!signature256) {
+    logWebhookRejection({
+      ...readWebhookLogHeaders(input.request),
+      reason: "missing_signature",
+      status: 401,
+    });
     return response(401, { ok: false });
   }
 
   const parsedHeaders = readHeaders(input.request);
   if (!parsedHeaders.success) {
+    logWebhookRejection({
+      ...readWebhookLogHeaders(input.request),
+      reason: "invalid_headers",
+      status: 400,
+    });
     return response(400, { ok: false });
   }
 
@@ -132,6 +198,12 @@ export async function handleGitHubWebhook(input: {
     signature256: headers.signature256,
   });
   if (!signatureOk) {
+    logWebhookRejection({
+      deliveryId: headers.deliveryId,
+      event: headers.event,
+      reason: "invalid_signature",
+      status: 401,
+    });
     return response(401, { ok: false });
   }
 
@@ -150,14 +222,27 @@ export async function handleGitHubWebhook(input: {
   try {
     json = JSON.parse(body);
   } catch {
+    logWebhookRejection({
+      deliveryId: headers.deliveryId,
+      event: headers.event,
+      reason: "malformed_json",
+      status: 400,
+    });
     return response(400, { ok: false });
   }
 
   if (headers.event === "ping") {
     const parsedPing = githubPingWebhookPayloadSchema.safeParse(json);
-    return parsedPing.success
-      ? response(202, { ok: true })
-      : response(400, { ok: false });
+    if (!parsedPing.success) {
+      logWebhookRejection({
+        deliveryId: headers.deliveryId,
+        event: headers.event,
+        reason: "invalid_ping_payload",
+        status: 400,
+      });
+      return response(400, { ok: false });
+    }
+    return response(202, { ok: true });
   }
 
   if (isPrWebhookEvent) {
@@ -170,6 +255,12 @@ export async function handleGitHubWebhook(input: {
 
   const parsedPush = githubPushWebhookPayloadSchema.safeParse(json);
   if (!parsedPush.success) {
+    logWebhookRejection({
+      deliveryId: headers.deliveryId,
+      event: headers.event,
+      reason: "invalid_push_payload",
+      status: 400,
+    });
     return response(400, { ok: false });
   }
 

--- a/apps/app/src/__tests__/local-env-overrides.test.ts
+++ b/apps/app/src/__tests__/local-env-overrides.test.ts
@@ -114,4 +114,14 @@ describe("local env overrides", () => {
       ])
     );
   });
+
+  it("passes X connector server env through the app production build", () => {
+    const appTurbo = readJson<{
+      tasks: { build: { passThroughEnv: string[] } };
+    }>("apps/app/turbo.json");
+
+    expect(appTurbo.tasks.build.passThroughEnv).toEqual(
+      expect.arrayContaining(["X_CLIENT_ID", "X_CLIENT_SECRET"])
+    );
+  });
 });

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -41,6 +41,8 @@
         "GITHUB_APP_WEBHOOK_SECRET",
         "LINEAR_CLIENT_ID",
         "LINEAR_CLIENT_SECRET",
+        "X_CLIENT_ID",
+        "X_CLIENT_SECRET",
         "DATABASE_HOST",
         "DATABASE_USERNAME",
         "DATABASE_PASSWORD",


### PR DESCRIPTION
## Summary
- Add X connector server env passthrough to the app production build config.
- Emit sanitized GitHub webhook rejection logs for handled 400/401/500 paths so Sentry Logs and Vercel logs show failures that do not throw.
- Add regression coverage for missing secret, missing/invalid signatures, malformed JSON, and app env passthrough.

## Test Plan
- pnpm --filter @api/app exec vitest run src/__tests__/github-webhook.test.ts
- pnpm --filter @lightfast/app exec vitest run src/__tests__/local-env-overrides.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for GitHub webhook logging and rejection scenarios.
  * Added verification for X connector environment variable configuration in builds.

* **Improvements**
  * GitHub webhook handler now emits structured log entries for rejection cases with detailed error information.

* **Chores**
  * Updated build configuration to forward X connector environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->