### PR TITLE
Guard CodeQL on private repos without Code Security

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   codeql-analyze:
     name: codeql-analyze-${{ matrix.language }}
+    if: ${{ github.event.repository.private == false || vars.CODEQL_ADVANCED_SECURITY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary
- Skip the CodeQL job when the repository is private unless `CODEQL_ADVANCED_SECURITY_ENABLED` is set to `true`.
- Prevents private-repo CodeQL upload failures when GitHub Code Security/Advanced Security is not enabled.

## Test Plan
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL workflow to conditionally execute based on repository privacy settings or feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->