### PR TITLE
Fix desktop sqlite ABI lifecycle

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -64,12 +64,14 @@ All commands below run from the repo root:
 
 - After `pnpm install` you have a Node-ABI prebuilt —
   `pnpm -F @lightfast/desktop test` works.
-- `pnpm -F @lightfast/desktop dev` (electron-forge start) rebuilds in-tree to
-  Electron's ABI — `pnpm -F @lightfast/desktop test` will then fail with
-  `NODE_MODULE_VERSION` mismatch.
-- Run `pnpm -F @lightfast/desktop rebuild:sqlite:node` to flip back to Node ABI
-  before testing, `pnpm -F @lightfast/desktop rebuild:sqlite` to flip back to
-  Electron ABI before dev/package.
+- `pnpm -F @lightfast/desktop dev` runs `predev`, which rebuilds in-tree to
+  Electron's ABI before Electron opens the database.
+- `pnpm -F @lightfast/desktop test` runs `pretest`, which flips back to the
+  host Node ABI before Vitest imports `better-sqlite3`.
+- For focused one-off commands that bypass package lifecycle scripts, run
+  `pnpm -F @lightfast/desktop rebuild:sqlite:node` before Node/Vitest commands,
+  or `pnpm -F @lightfast/desktop rebuild:sqlite` before Electron dev/package
+  commands.
 
 CI runs `pnpm test` before `pnpm package`, so the ordering is already correct
 in `desktop-ci.yml`.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,8 @@
     "playwright:repl": "node scripts/playwright-electron-cdp.mjs",
     "pretest:e2e": "electron-forge package",
     "publish": "electron-forge publish",
+    "predev": "pnpm rebuild:sqlite",
+    "pretest": "pnpm rebuild:sqlite:node",
     "rebuild:sqlite": "node scripts/rebuild-sqlite.mjs --target=electron",
     "rebuild:sqlite:node": "node scripts/rebuild-sqlite.mjs --target=node",
     "sourcemaps:upload": "node scripts/upload-sourcemaps.mjs",

--- a/apps/desktop/src/main/__tests__/package-scripts.test.ts
+++ b/apps/desktop/src/main/__tests__/package-scripts.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type PackageJson = {
+  scripts: Record<string, string | undefined>;
+};
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../../package.json", import.meta.url), "utf8")
+) as PackageJson;
+
+describe("package lifecycle scripts", () => {
+  it("rebuilds native sqlite for Electron before dev starts", () => {
+    expect(packageJson.scripts.predev).toBe("pnpm rebuild:sqlite");
+    expect(packageJson.scripts.dev).toContain("electron-forge start");
+  });
+
+  it("rebuilds native sqlite for host Node before Vitest starts", () => {
+    expect(packageJson.scripts.pretest).toBe("pnpm rebuild:sqlite:node");
+    expect(packageJson.scripts.test).toBe("vitest run");
+  });
+});


### PR DESCRIPTION
## Summary
- Add desktop lifecycle hooks that rebuild `better-sqlite3` for Electron before dev and host Node before Vitest.
- Add a package-script regression test covering the native sqlite ABI prehooks.
- Update desktop README guidance for normal and one-off native module rebuild flows.

## Test Plan
- `pnpm --filter @lightfast/desktop test`
- `pnpm --filter @lightfast/desktop typecheck`
- `pnpm --filter @lightfast/desktop test:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build setup tasks that execute before development and testing sessions to ensure proper environment configuration.

* **Tests**
  * Added automated verification for build environment setup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->