### PR TITLE
Add Lightfast MCP to Codex config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,3 @@
-# Project-scoped Codex MCP configuration.
-# Docs: https://developers.openai.com/codex/mcp
-#
-# Standardized with .mcp.json (Claude Code): both harnesses run the same
-# MCP server set. Keep these two files in sync.
-
 [mcp_servers.exa]
 url = "https://mcp.exa.ai/mcp"
 
@@ -12,4 +6,10 @@ url = "http://127.0.0.1:8288/mcp"
 
 [mcp_servers.next-devtools]
 command = "npx"
-args = ["-y", "next-devtools-mcp@0.3.10"]
+args = [
+    "-y",
+    "next-devtools-mcp@0.3.10",
+]
+
+[mcp_servers.lightfast]
+url = "https://mcp.lightfast.ai/mcp"


### PR DESCRIPTION
## Summary
- Add the hosted Lightfast MCP server to the project Codex MCP config.
- Keep the existing next-devtools MCP args in TOML multiline array form.

## Verification
- pnpm dlx @tanstack/intent@latest list
- git diff --check -- .codex/config.toml
- pnpm dlx @taplo/cli validate .codex/config.toml