### PR TITLE
Skip unauthenticated app-tanstack route prefetch

### DIFF
--- a/apps/app-tanstack/src/__tests__/product-route-prefetch-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/product-route-prefetch-source.test.ts
@@ -23,6 +23,15 @@ describe("app-tanstack product route data prefetch", () => {
     expect(prefetchSource).not.toContain("next/");
   });
 
+  it("does not turn unauthenticated protected-route prefetches into route-loader 500s", () => {
+    const prefetchSource = source("src/trpc/route-prefetch.tsx");
+
+    expect(prefetchSource).toContain("createEmptyPrefetchState");
+    expect(prefetchSource).toContain("isUnauthorizedTRPCError");
+    expect(prefetchSource).toContain("return createEmptyPrefetchState()");
+    expect(prefetchSource).toContain('error.code === "UNAUTHORIZED"');
+  });
+
   it("prefetches the non-chat product route queries owned by the migrated pages", () => {
     const prefetchSource = source("src/trpc/route-prefetch.tsx");
 

--- a/apps/app-tanstack/src/trpc/route-prefetch.tsx
+++ b/apps/app-tanstack/src/trpc/route-prefetch.tsx
@@ -96,12 +96,33 @@ function serializePrefetchState(
   return JSON.parse(JSON.stringify(state)) as SerializableRoutePrefetchState;
 }
 
+function createEmptyPrefetchState(): SerializableRoutePrefetchState {
+  return { mutations: [], queries: [] };
+}
+
 function isDehydratedState(state: unknown): state is DehydratedState {
   if (!state || typeof state !== "object") {
     return false;
   }
   const candidate = state as { mutations?: unknown; queries?: unknown };
   return Array.isArray(candidate.mutations) && Array.isArray(candidate.queries);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isUnauthorizedTRPCError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  if (error.code === "UNAUTHORIZED") {
+    return true;
+  }
+
+  const data = error.data;
+  return isRecord(data) && data.code === "UNAUTHORIZED";
 }
 
 export const loadRoutePrefetch = createServerFn({ method: "GET" })
@@ -133,144 +154,151 @@ export const loadRoutePrefetch = createServerFn({ method: "GET" })
       queryClient: () => queryClient,
     });
 
-    switch (data.route) {
-      case "account.mcp":
-        await queryClient.fetchQuery(
-          trpc.viewer.account.mcpConnections.list.queryOptions()
-        );
-        break;
-      case "automations.detail":
-        await Promise.all([
-          queryClient.fetchQuery(
-            trpc.org.workspace.automations.get.queryOptions({
-              id: data.automationId,
-            })
-          ),
-          queryClient.fetchQuery(
-            trpc.org.workspace.automations.listRuns.queryOptions({
-              id: data.automationId,
-              limit: AUTOMATION_RUNS_PAGE_LIMIT,
-            })
-          ),
-        ]);
-        break;
-      case "automations.list":
-        await queryClient.fetchQuery(
-          trpc.org.workspace.automations.list.queryOptions()
-        );
-        break;
-      case "automations.new":
-        await queryClient.fetchQuery(
-          trpc.org.workspace.connectors.list.queryOptions()
-        );
-        break;
-      case "connectors":
-        await queryClient.fetchQuery(
-          trpc.org.workspace.connectors.listSections.queryOptions()
-        );
-        break;
-      case "decisions":
-        await Promise.all([
-          queryClient.fetchInfiniteQuery(
-            trpc.org.workspace.decisions.list.infiniteQueryOptions(
-              { limit: DECISIONS_PAGE_SIZE },
-              {
-                getNextPageParam: (lastPage) => lastPage.nextCursor,
-                staleTime: 60_000,
-              }
-            )
-          ),
-          queryClient.fetchQuery({
-            ...trpc.org.workspace.decisions.views.list.queryOptions(),
-            staleTime: 60_000,
-          }),
-        ]);
-        break;
-      case "developerConnections":
-        await queryClient.fetchQuery(
-          trpc.org.workspace.developerConnections.list.queryOptions()
-        );
-        break;
-      case "org.mcp":
-        await queryClient.fetchQuery(
-          trpc.org.settings.mcpConnections.list.queryOptions()
-        );
-        break;
-      case "people":
-        await Promise.all([
-          queryClient.fetchInfiniteQuery(
-            trpc.org.workspace.people.list.infiniteQueryOptions(
-              { limit: PEOPLE_PAGE_SIZE },
-              {
-                getNextPageParam: (lastPage) => lastPage.nextCursor,
-                staleTime: 60_000,
-              }
-            )
-          ),
-          queryClient.fetchQuery({
-            ...trpc.org.workspace.people.views.list.queryOptions(),
-            staleTime: 60_000,
-          }),
-        ]);
-        break;
-      case "signals":
-        await Promise.all([
-          queryClient.fetchQuery({
-            ...trpc.org.workspace.signals.workingSet.queryOptions(),
-            staleTime: 30_000,
-          }),
-          queryClient.fetchQuery({
-            ...trpc.org.workspace.signals.list.queryOptions({
-              limit: PROCESSING_SIGNALS_LIMIT,
-              statuses: [...signalProcessingStatuses],
-            }),
-            staleTime: 5000,
-          }),
-          queryClient.fetchQuery({
-            ...trpc.org.workspace.signals.views.list.queryOptions(),
-            staleTime: 60_000,
-          }),
-        ]);
-        break;
-      case "skills":
-        await queryClient.fetchQuery(
-          trpc.org.workspace.skills.list.queryOptions(undefined, {
-            staleTime: 0,
-          })
-        );
-        break;
-      case "tasks.bind":
-        await queryClient.fetchQuery(
-          trpc.viewer.organization.getBySlug.queryOptions({ slug: data.slug })
-        );
-        break;
-      case "tasks.index":
-      case "tasks.lightfastRepo":
-        await Promise.all([
-          queryClient.fetchQuery(
-            trpc.viewer.organization.getBySlug.queryOptions({
-              slug: data.slug,
-            })
-          ),
-          queryClient.fetchQuery(
-            trpc.org.settings.sourceControl.get.queryOptions()
-          ),
-        ]);
-        break;
-      case "tasks.xConnector":
-        await Promise.all([
-          queryClient.fetchQuery(
-            trpc.viewer.organization.getBySlug.queryOptions({
-              slug: data.slug,
-            })
-          ),
-          queryClient.fetchQuery(
+    try {
+      switch (data.route) {
+        case "account.mcp":
+          await queryClient.fetchQuery(
+            trpc.viewer.account.mcpConnections.list.queryOptions()
+          );
+          break;
+        case "automations.detail":
+          await Promise.all([
+            queryClient.fetchQuery(
+              trpc.org.workspace.automations.get.queryOptions({
+                id: data.automationId,
+              })
+            ),
+            queryClient.fetchQuery(
+              trpc.org.workspace.automations.listRuns.queryOptions({
+                id: data.automationId,
+                limit: AUTOMATION_RUNS_PAGE_LIMIT,
+              })
+            ),
+          ]);
+          break;
+        case "automations.list":
+          await queryClient.fetchQuery(
+            trpc.org.workspace.automations.list.queryOptions()
+          );
+          break;
+        case "automations.new":
+          await queryClient.fetchQuery(
             trpc.org.workspace.connectors.list.queryOptions()
-          ),
-        ]);
-        break;
-      default:
-        throw new Error("Unsupported route prefetch route");
+          );
+          break;
+        case "connectors":
+          await queryClient.fetchQuery(
+            trpc.org.workspace.connectors.listSections.queryOptions()
+          );
+          break;
+        case "decisions":
+          await Promise.all([
+            queryClient.fetchInfiniteQuery(
+              trpc.org.workspace.decisions.list.infiniteQueryOptions(
+                { limit: DECISIONS_PAGE_SIZE },
+                {
+                  getNextPageParam: (lastPage) => lastPage.nextCursor,
+                  staleTime: 60_000,
+                }
+              )
+            ),
+            queryClient.fetchQuery({
+              ...trpc.org.workspace.decisions.views.list.queryOptions(),
+              staleTime: 60_000,
+            }),
+          ]);
+          break;
+        case "developerConnections":
+          await queryClient.fetchQuery(
+            trpc.org.workspace.developerConnections.list.queryOptions()
+          );
+          break;
+        case "org.mcp":
+          await queryClient.fetchQuery(
+            trpc.org.settings.mcpConnections.list.queryOptions()
+          );
+          break;
+        case "people":
+          await Promise.all([
+            queryClient.fetchInfiniteQuery(
+              trpc.org.workspace.people.list.infiniteQueryOptions(
+                { limit: PEOPLE_PAGE_SIZE },
+                {
+                  getNextPageParam: (lastPage) => lastPage.nextCursor,
+                  staleTime: 60_000,
+                }
+              )
+            ),
+            queryClient.fetchQuery({
+              ...trpc.org.workspace.people.views.list.queryOptions(),
+              staleTime: 60_000,
+            }),
+          ]);
+          break;
+        case "signals":
+          await Promise.all([
+            queryClient.fetchQuery({
+              ...trpc.org.workspace.signals.workingSet.queryOptions(),
+              staleTime: 30_000,
+            }),
+            queryClient.fetchQuery({
+              ...trpc.org.workspace.signals.list.queryOptions({
+                limit: PROCESSING_SIGNALS_LIMIT,
+                statuses: [...signalProcessingStatuses],
+              }),
+              staleTime: 5000,
+            }),
+            queryClient.fetchQuery({
+              ...trpc.org.workspace.signals.views.list.queryOptions(),
+              staleTime: 60_000,
+            }),
+          ]);
+          break;
+        case "skills":
+          await queryClient.fetchQuery(
+            trpc.org.workspace.skills.list.queryOptions(undefined, {
+              staleTime: 0,
+            })
+          );
+          break;
+        case "tasks.bind":
+          await queryClient.fetchQuery(
+            trpc.viewer.organization.getBySlug.queryOptions({ slug: data.slug })
+          );
+          break;
+        case "tasks.index":
+        case "tasks.lightfastRepo":
+          await Promise.all([
+            queryClient.fetchQuery(
+              trpc.viewer.organization.getBySlug.queryOptions({
+                slug: data.slug,
+              })
+            ),
+            queryClient.fetchQuery(
+              trpc.org.settings.sourceControl.get.queryOptions()
+            ),
+          ]);
+          break;
+        case "tasks.xConnector":
+          await Promise.all([
+            queryClient.fetchQuery(
+              trpc.viewer.organization.getBySlug.queryOptions({
+                slug: data.slug,
+              })
+            ),
+            queryClient.fetchQuery(
+              trpc.org.workspace.connectors.list.queryOptions()
+            ),
+          ]);
+          break;
+        default:
+          throw new Error("Unsupported route prefetch route");
+      }
+    } catch (error) {
+      if (isUnauthorizedTRPCError(error)) {
+        return createEmptyPrefetchState();
+      }
+      throw error;
     }
 
     return serializePrefetchState(dehydrate(queryClient));


### PR DESCRIPTION
## Summary
- return an empty dehydrated prefetch state when protected route prefetching hits an unauthenticated tRPC error
- keep non-auth prefetch errors propagating normally
- add source regression coverage for the unauthenticated prefetch guard

## Verification
- pnpm --filter @lightfast/app-tanstack test -- src/__tests__/product-route-prefetch-source.test.ts
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm --filter @lightfast/app-tanstack build
- Browser: unauthenticated /lightfast/skills redirects to /sign-in?redirect_url=%2Flightfast%2Fskills with 0 console errors