### PR TITLE
Prefetch app-tanstack settings routes

### DIFF
--- a/apps/app-tanstack/src/__tests__/product-route-prefetch-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/product-route-prefetch-source.test.ts
@@ -59,6 +59,23 @@ describe("app-tanstack product route data prefetch", () => {
     }
   });
 
+  it("prefetches settings and account task route queries owned by migrated pages", () => {
+    const prefetchSource = source("src/trpc/route-prefetch.tsx");
+
+    for (const query of [
+      "org.settings.identity.get.queryOptions",
+      "org.settings.organization.listDomains.queryOptions",
+      "org.settings.orgApiKeys.list.queryOptions",
+      "org.settings.orgMembers.list.queryOptions",
+      "org.settings.sourceControl.listRepositories.queryOptions",
+      "org.settings.orgBilling.overview.queryOptions",
+      "viewer.githubAccount.status.queryOptions",
+      "viewer.account.get.queryOptions",
+    ]) {
+      expect(prefetchSource).toContain(query);
+    }
+  });
+
   it("wires product pages through route loaders and hydration boundaries", () => {
     const routeFiles = [
       "src/routes/_authenticated/$slug/signals.tsx",
@@ -76,6 +93,15 @@ describe("app-tanstack product route data prefetch", () => {
       "src/routes/_authenticated/$slug/tasks/connectors/x/index.tsx",
       "src/routes/_authenticated/$slug/settings/mcp.tsx",
       "src/routes/_authenticated/account/mcp.tsx",
+      "src/routes/_authenticated/$slug/settings/general.tsx",
+      "src/routes/_authenticated/$slug/settings/source-control.tsx",
+      "src/routes/_authenticated/$slug/settings/members.tsx",
+      "src/routes/_authenticated/$slug/settings/billing.tsx",
+      "src/routes/_authenticated/$slug/settings/api-keys.tsx",
+      "src/routes/_authenticated/account/settings/general.tsx",
+      "src/routes/_authenticated/account/settings/source-control.tsx",
+      "src/routes/_authenticated/account/tasks/github/index.tsx",
+      "src/routes/_authenticated/account/tasks/username.tsx",
     ];
 
     for (const routeFile of routeFiles) {

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/api-keys.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/api-keys.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OrgApiKeyCreate } from "~/org/settings/api-keys/org-api-key-create";
 import { OrgApiKeyList } from "~/org/settings/api-keys/org-api-key-list";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute("/_authenticated/$slug/settings/api-keys")(
   {
+    loader: () =>
+      loadRoutePrefetch({ data: { route: "org.settings.apiKeys" } }),
     head: ({ params }) => ({
       meta: [
         { title: `API Keys - ${params.slug} - Lightfast` },
@@ -18,22 +24,26 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/api-keys")(
 );
 
 function ApiKeysSettingsPage() {
-  return (
-    <div className="space-y-8">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="font-medium font-pp text-2xl text-foreground">
-            API Keys
-          </h2>
-          <p className="mt-1 text-muted-foreground text-sm">
-            Manage API keys for programmatic access to your organization's
-            resources.
-          </p>
-        </div>
-        <OrgApiKeyCreate />
-      </div>
+  const prefetchState = Route.useLoaderData();
 
-      <OrgApiKeyList />
-    </div>
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <div className="space-y-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="font-medium font-pp text-2xl text-foreground">
+              API Keys
+            </h2>
+            <p className="mt-1 text-muted-foreground text-sm">
+              Manage API keys for programmatic access to your organization's
+              resources.
+            </p>
+          </div>
+          <OrgApiKeyCreate />
+        </div>
+
+        <OrgApiKeyList />
+      </div>
+    </RoutePrefetchBoundary>
   );
 }

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/billing.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/billing.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { BillingSettingsClient } from "~/org/settings/billing/billing-settings-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute("/_authenticated/$slug/settings/billing")({
+  loader: () => loadRoutePrefetch({ data: { route: "org.settings.billing" } }),
   head: ({ params }) => ({
     meta: [
       { title: `Billing - ${params.slug} - Lightfast` },
@@ -11,5 +16,15 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/billing")({
       },
     ],
   }),
-  component: BillingSettingsClient,
+  component: BillingSettingsPage,
 });
+
+function BillingSettingsPage() {
+  const prefetchState = Route.useLoaderData();
+
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <BillingSettingsClient />
+    </RoutePrefetchBoundary>
+  );
+}

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/general.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/general.tsx
@@ -1,8 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { IdentitySoulCard } from "~/org/settings/general/identity-soul-card";
 import { TeamGeneralSettingsClient } from "~/org/settings/general/team-general-settings-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute("/_authenticated/$slug/settings/general")({
+  loader: ({ params }) =>
+    loadRoutePrefetch({
+      data: { route: "org.settings.general", slug: params.slug },
+    }),
   head: ({ params }) => ({
     meta: [
       { title: `General Settings - ${params.slug} - Lightfast` },
@@ -16,21 +24,24 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/general")({
 });
 
 function GeneralSettingsPage() {
+  const prefetchState = Route.useLoaderData();
   const { slug } = Route.useParams();
 
   return (
-    <div className="space-y-10">
-      <div>
-        <h2 className="font-medium font-pp text-2xl text-foreground">
-          General
-        </h2>
-        <p className="mt-1 text-muted-foreground text-sm">
-          Manage your team's profile and preferences.
-        </p>
-      </div>
+    <RoutePrefetchBoundary state={prefetchState}>
+      <div className="space-y-10">
+        <div>
+          <h2 className="font-medium font-pp text-2xl text-foreground">
+            General
+          </h2>
+          <p className="mt-1 text-muted-foreground text-sm">
+            Manage your team's profile and preferences.
+          </p>
+        </div>
 
-      <TeamGeneralSettingsClient slug={slug} />
-      <IdentitySoulCard slug={slug} />
-    </div>
+        <TeamGeneralSettingsClient slug={slug} />
+        <IdentitySoulCard slug={slug} />
+      </div>
+    </RoutePrefetchBoundary>
   );
 }

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/members.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/members.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OrgMembersClient } from "~/org/settings/members/org-members-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute("/_authenticated/$slug/settings/members")({
+  loader: () => loadRoutePrefetch({ data: { route: "org.settings.members" } }),
   head: ({ params }) => ({
     meta: [
       { title: `Members - ${params.slug} - Lightfast` },
@@ -15,18 +20,22 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/members")({
 });
 
 function MembersSettingsPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="font-medium font-pp text-2xl text-foreground">
-          Members
-        </h2>
-        <p className="mt-1 text-muted-foreground text-sm">
-          Manage the people who can access this workspace.
-        </p>
-      </div>
+  const prefetchState = Route.useLoaderData();
 
-      <OrgMembersClient />
-    </div>
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <div className="space-y-8">
+        <div>
+          <h2 className="font-medium font-pp text-2xl text-foreground">
+            Members
+          </h2>
+          <p className="mt-1 text-muted-foreground text-sm">
+            Manage the people who can access this workspace.
+          </p>
+        </div>
+
+        <OrgMembersClient />
+      </div>
+    </RoutePrefetchBoundary>
   );
 }

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/source-control.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/source-control.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourceControlSettingsClient } from "~/org/settings/source-control/source-control-settings-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute(
   "/_authenticated/$slug/settings/source-control"
 )({
+  loader: () =>
+    loadRoutePrefetch({ data: { route: "org.settings.sourceControl" } }),
   head: ({ params }) => ({
     meta: [
       { title: `Source Control Settings - ${params.slug} - Lightfast` },
@@ -17,7 +23,12 @@ export const Route = createFileRoute(
 });
 
 function WorkspaceSourceControlSettingsPage() {
+  const prefetchState = Route.useLoaderData();
   const { slug } = Route.useParams();
 
-  return <SourceControlSettingsClient slug={slug} />;
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <SourceControlSettingsClient slug={slug} />
+    </RoutePrefetchBoundary>
+  );
 }

--- a/apps/app-tanstack/src/routes/_authenticated/account/settings/general.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/account/settings/general.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ProfileDataDisplay } from "~/account/settings/profile-data-display";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute(
   "/_authenticated/account/settings/general"
 )({
+  loader: () =>
+    loadRoutePrefetch({ data: { route: "account.settings.general" } }),
   head: () => ({
     meta: [
       { title: "General Account Settings - Lightfast" },
@@ -13,5 +19,15 @@ export const Route = createFileRoute(
       },
     ],
   }),
-  component: ProfileDataDisplay,
+  component: GeneralAccountSettingsPage,
 });
+
+function GeneralAccountSettingsPage() {
+  const prefetchState = Route.useLoaderData();
+
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <ProfileDataDisplay />
+    </RoutePrefetchBoundary>
+  );
+}

--- a/apps/app-tanstack/src/routes/_authenticated/account/settings/source-control.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/account/settings/source-control.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AccountSourceControlClient } from "~/account/settings/account-source-control-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute(
   "/_authenticated/account/settings/source-control"
 )({
+  loader: () =>
+    loadRoutePrefetch({ data: { route: "account.settings.sourceControl" } }),
   head: () => ({
     meta: [
       { title: "Source Control Account Settings - Lightfast" },
@@ -13,5 +19,15 @@ export const Route = createFileRoute(
       },
     ],
   }),
-  component: AccountSourceControlClient,
+  component: AccountSourceControlSettingsPage,
 });
+
+function AccountSourceControlSettingsPage() {
+  const prefetchState = Route.useLoaderData();
+
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <AccountSourceControlClient />
+    </RoutePrefetchBoundary>
+  );
+}

--- a/apps/app-tanstack/src/routes/_authenticated/account/tasks/github/index.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/account/tasks/github/index.tsx
@@ -1,8 +1,13 @@
 import { githubUserAccountBindErrorCodeSchema } from "@repo/github-app-contract";
 import { createFileRoute } from "@tanstack/react-router";
 import { GithubAccountTaskClient } from "~/account/tasks/github-account-task-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute("/_authenticated/account/tasks/github/")({
+  loader: () => loadRoutePrefetch({ data: { route: "account.githubTask" } }),
   head: () => ({
     meta: [
       { title: "Connect GitHub Account - Lightfast" },
@@ -24,6 +29,11 @@ export const Route = createFileRoute("/_authenticated/account/tasks/github/")({
 });
 
 function GithubAccountTaskPage() {
+  const prefetchState = Route.useLoaderData();
   const search = Route.useSearch();
-  return <GithubAccountTaskClient githubError={search.github_error} />;
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <GithubAccountTaskClient githubError={search.github_error} />
+    </RoutePrefetchBoundary>
+  );
 }

--- a/apps/app-tanstack/src/routes/_authenticated/account/tasks/username.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/account/tasks/username.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { UsernameAccountTaskClient } from "~/account/tasks/username-account-task-client";
+import {
+  loadRoutePrefetch,
+  RoutePrefetchBoundary,
+} from "~/trpc/route-prefetch";
 
 export const Route = createFileRoute("/_authenticated/account/tasks/username")({
+  loader: () => loadRoutePrefetch({ data: { route: "account.usernameTask" } }),
   head: () => ({
     meta: [
       { title: "Choose Username - Lightfast" },
@@ -19,6 +24,11 @@ export const Route = createFileRoute("/_authenticated/account/tasks/username")({
 });
 
 function UsernameAccountTaskPage() {
+  const prefetchState = Route.useLoaderData();
   const search = Route.useSearch();
-  return <UsernameAccountTaskClient returnTo={search.return_to} />;
+  return (
+    <RoutePrefetchBoundary state={prefetchState}>
+      <UsernameAccountTaskClient returnTo={search.return_to} />
+    </RoutePrefetchBoundary>
+  );
 }

--- a/apps/app-tanstack/src/trpc/route-prefetch.tsx
+++ b/apps/app-tanstack/src/trpc/route-prefetch.tsx
@@ -10,7 +10,11 @@ import {
 } from "~/signals/signals-model";
 
 type RoutePrefetchInput =
+  | { route: "account.githubTask" }
   | { route: "account.mcp" }
+  | { route: "account.settings.general" }
+  | { route: "account.settings.sourceControl" }
+  | { route: "account.usernameTask" }
   | { route: "automations.detail"; automationId: string }
   | { route: "automations.list" }
   | { route: "automations.new" }
@@ -18,6 +22,11 @@ type RoutePrefetchInput =
   | { route: "decisions" }
   | { route: "developerConnections" }
   | { route: "org.mcp" }
+  | { route: "org.settings.apiKeys" }
+  | { route: "org.settings.billing" }
+  | { route: "org.settings.general"; slug: string }
+  | { route: "org.settings.members" }
+  | { route: "org.settings.sourceControl" }
   | { route: "people" }
   | { route: "signals" }
   | { route: "skills" }
@@ -35,7 +44,11 @@ interface SerializableRoutePrefetchState {
 }
 
 const ROUTES = new Set<RoutePrefetchRoute>([
+  "account.githubTask",
   "account.mcp",
+  "account.settings.general",
+  "account.settings.sourceControl",
+  "account.usernameTask",
   "automations.detail",
   "automations.list",
   "automations.new",
@@ -43,6 +56,11 @@ const ROUTES = new Set<RoutePrefetchRoute>([
   "decisions",
   "developerConnections",
   "org.mcp",
+  "org.settings.apiKeys",
+  "org.settings.billing",
+  "org.settings.general",
+  "org.settings.members",
+  "org.settings.sourceControl",
   "people",
   "signals",
   "skills",
@@ -78,7 +96,8 @@ function validateRoutePrefetchInput(input: RoutePrefetchInput) {
   }
 
   if (
-    (route === "tasks.bind" ||
+    (route === "org.settings.general" ||
+      route === "tasks.bind" ||
       route === "tasks.index" ||
       route === "tasks.lightfastRepo" ||
       route === "tasks.xConnector") &&
@@ -156,10 +175,20 @@ export const loadRoutePrefetch = createServerFn({ method: "GET" })
 
     try {
       switch (data.route) {
+        case "account.githubTask":
+        case "account.settings.sourceControl":
+          await queryClient.fetchQuery(
+            trpc.viewer.githubAccount.status.queryOptions()
+          );
+          break;
         case "account.mcp":
           await queryClient.fetchQuery(
             trpc.viewer.account.mcpConnections.list.queryOptions()
           );
+          break;
+        case "account.settings.general":
+        case "account.usernameTask":
+          await queryClient.fetchQuery(trpc.viewer.account.get.queryOptions());
           break;
         case "automations.detail":
           await Promise.all([
@@ -217,6 +246,46 @@ export const loadRoutePrefetch = createServerFn({ method: "GET" })
           await queryClient.fetchQuery(
             trpc.org.settings.mcpConnections.list.queryOptions()
           );
+          break;
+        case "org.settings.apiKeys":
+          await queryClient.fetchQuery(
+            trpc.org.settings.orgApiKeys.list.queryOptions()
+          );
+          break;
+        case "org.settings.billing":
+          await queryClient.fetchQuery(
+            trpc.org.settings.orgBilling.overview.queryOptions()
+          );
+          break;
+        case "org.settings.general":
+          await Promise.all([
+            queryClient.fetchQuery(
+              trpc.org.settings.identity.get.queryOptions()
+            ),
+            queryClient.fetchQuery(
+              trpc.org.settings.organization.listDomains.queryOptions({
+                slug: data.slug,
+              })
+            ),
+            queryClient.fetchQuery(
+              trpc.viewer.organization.listUserOrganizations.queryOptions()
+            ),
+          ]);
+          break;
+        case "org.settings.members":
+          await queryClient.fetchQuery(
+            trpc.org.settings.orgMembers.list.queryOptions()
+          );
+          break;
+        case "org.settings.sourceControl":
+          await Promise.all([
+            queryClient.fetchQuery(
+              trpc.org.settings.sourceControl.get.queryOptions()
+            ),
+            queryClient.fetchQuery(
+              trpc.org.settings.sourceControl.listRepositories.queryOptions()
+            ),
+          ]);
           break;
         case "people":
           await Promise.all([


### PR DESCRIPTION
## Summary
- add route-prefetch cases for workspace settings and account task/settings pages
- wrap migrated settings/account routes in TanStack route loaders and hydration boundaries
- extend route-prefetch source coverage for the settings/account parity slice

## Verification
- pnpm check
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm --filter @lightfast/app-tanstack test
- pnpm --filter @lightfast/app-tanstack build
- Browser: unauthenticated /account/settings/general, /lightfast/settings/source-control, and /account/tasks/username redirect to sign-in with 0 console errors