### PR TITLE
test: add app-tanstack auth route smoke

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,15 +7,16 @@
   "sideEffects": false,
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
+    "app-tanstack:auth-routes": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/auth-route-smoke.ts",
     "connectors:x:local": "pnpm with-env tsx src/connectors/x-local-agent-smoke.ts",
     "decisions:real-clerk": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/decisions/real-clerk-smoke.ts",
     "github:setup:real-clerk": "pnpm with-env tsx src/github-setup/real-clerk-smoke.ts",
     "provider-routine-proxy:real-cli": "pnpm --dir ../core/cli build && pnpm with-env tsx src/provider-routine-proxy/real-cli-smoke.ts",
     "sdk": "pnpm --dir ../core/lightfast build && pnpm with-env vitest run src/sdk/system-health.e2e.test.ts",
     "signals": "pnpm with-env vitest run src/signals/signal-pipeline.e2e.test.ts",
-    "test": "vitest run src/helpers/*.test.ts src/github-setup/*.test.ts src/decisions/*.test.ts src/connectors/*.test.ts --passWithNoTests",
+    "test": "vitest run src/helpers/*.test.ts src/github-setup/*.test.ts src/decisions/*.test.ts src/connectors/*.test.ts src/app-tanstack/*.test.ts --passWithNoTests",
     "typecheck": "pnpm --dir ../core/lightfast build && tsc --noEmit",
-    "with-env": "dotenv -e ../apps/app/.vercel/.env.development.local --"
+    "with-env": "dotenv -e ../apps/app/.env.overrides.local -e ../apps/app/.vercel/.env.development.local --"
   },
   "dependencies": {
     "@api/app": "workspace:*",

--- a/e2e/src/app-tanstack/auth-route-smoke.test.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.test.ts
@@ -7,6 +7,7 @@ import {
   collectRouteBodyProblems,
   createUniqueAppTanstackAuthOrgSlug,
   formatCommandForError,
+  readAppTanstackAuthEncryptionKey,
 } from "./auth-route-smoke";
 
 describe("app-tanstack auth route smoke helpers", () => {
@@ -24,6 +25,7 @@ describe("app-tanstack auth route smoke helpers", () => {
       env: {
         CLERK_SECRET_KEY: "sk_test_123",
         LIGHTFAST_E2E_AGENT_BROWSER_SESSION: "app-tanstack-session",
+        LIGHTFAST_E2E_APP_TANSTACK_AUTH_CLERK_API_TIMEOUT_MS: "45000",
         LIGHTFAST_E2E_APP_TANSTACK_AUTH_EMAIL_PREFIX: "TanStack Auth",
         LIGHTFAST_E2E_APP_TANSTACK_AUTH_ORG_SLUG: "lf-app-tanstack-fixed",
         LIGHTFAST_E2E_APP_TANSTACK_URL:
@@ -35,6 +37,7 @@ describe("app-tanstack auth route smoke helpers", () => {
 
     expect(config).toMatchObject({
       appOrigin: "https://custom.app-tanstack.lightfast.localhost",
+      clerkApiTimeoutMs: 45_000,
       clerkSecretKey: "sk_test_123",
       emailAddress: "tanstack-auth-1780876800000@lightfast.ai",
       orgSlug: "lf-app-tanstack-fixed",
@@ -54,6 +57,7 @@ describe("app-tanstack auth route smoke helpers", () => {
     expect(config).toMatchObject({
       appOrigin:
         "https://route-smoke.app-tanstack.lightfast.localhost",
+      clerkApiTimeoutMs: 30_000,
       emailAddress: "app-tanstack-auth-smoke-1780876800000@lightfast.ai",
       orgSlug: "lf-app-tanstack-auth-e2e-1780876800000",
       sessionName: "lightfast-app-tanstack-auth-smoke-1780876800000",
@@ -95,6 +99,55 @@ describe("app-tanstack auth route smoke helpers", () => {
     ]);
   });
 
+  it("flags no-org setup as a distinct auth-boundary failure", () => {
+    const problems = collectRouteBodyProblems({
+      bodyText:
+        "Organization setup required\nComplete setup before using Lightfast features.",
+      expectedText: ["Signals"],
+      finalPathname: "/lf-tanstack/signals",
+      routeName: "signals",
+      routePath: "/lf-tanstack/signals",
+    });
+
+    expect(problems).toEqual([
+      "signals rendered forbidden text: Organization setup required",
+      "signals did not render expected text: Signals",
+    ]);
+  });
+
+  it("flags wrong-org route access by pathname and not-found content", () => {
+    const problems = collectRouteBodyProblems({
+      bodyText: "Team not found",
+      expectedText: ["Signals"],
+      finalPathname: "/unknown-team/signals",
+      routeName: "signals",
+      routePath: "/lf-tanstack/signals",
+    });
+
+    expect(problems).toEqual([
+      "signals landed on /unknown-team/signals instead of /lf-tanstack/signals",
+      "signals rendered forbidden text: Team not found",
+      "signals did not render expected text: Signals",
+    ]);
+  });
+
+  it("flags expired-session redirects as an auth-boundary failure", () => {
+    const problems = collectRouteBodyProblems({
+      bodyText: "Session expired\nLog in to Lightfast",
+      expectedText: ["Signals"],
+      finalPathname: "/sign-in",
+      routeName: "signals",
+      routePath: "/lf-tanstack/signals",
+    });
+
+    expect(problems).toEqual([
+      "signals landed on /sign-in instead of /lf-tanstack/signals",
+      "signals rendered forbidden text: Log in to Lightfast",
+      "signals rendered forbidden text: Session expired",
+      "signals did not render expected text: Signals",
+    ]);
+  });
+
   it("redacts agent-browser eval scripts from command failure messages", () => {
     const formatted = formatCommandForError("agent-browser", [
       "--session",
@@ -115,5 +168,17 @@ describe("app-tanstack auth route smoke helpers", () => {
         nowMs: Date.parse("2026-06-08T00:00:00.000Z"),
       })
     ).toThrow("CLERK_SECRET_KEY");
+  });
+
+  it("reads the connector encryption key from injected env", () => {
+    expect(
+      readAppTanstackAuthEncryptionKey({
+        ENCRYPTION_KEY: " smoke-encryption-key ",
+      })
+    ).toBe("smoke-encryption-key");
+
+    expect(() => readAppTanstackAuthEncryptionKey({})).toThrow(
+      "ENCRYPTION_KEY"
+    );
   });
 });

--- a/e2e/src/app-tanstack/auth-route-smoke.test.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  APP_TANSTACK_AUTH_ROUTE_SPECS,
+  buildAppTanstackAuthRouteSmokeConfig,
+  buildRouteChecks,
+  collectRouteBodyProblems,
+  createUniqueAppTanstackAuthOrgSlug,
+  formatCommandForError,
+} from "./auth-route-smoke";
+
+describe("app-tanstack auth route smoke helpers", () => {
+  it("creates stable slug-safe org names from a timestamp", () => {
+    expect(
+      createUniqueAppTanstackAuthOrgSlug({
+        nowMs: Date.parse("2026-06-08T00:00:00.000Z"),
+        prefix: "App TanStack Auth!",
+      })
+    ).toBe("app-tanstack-auth-1780876800000");
+  });
+
+  it("resolves config from explicit smoke inputs", () => {
+    const config = buildAppTanstackAuthRouteSmokeConfig({
+      env: {
+        CLERK_SECRET_KEY: "sk_test_123",
+        LIGHTFAST_E2E_AGENT_BROWSER_SESSION: "app-tanstack-session",
+        LIGHTFAST_E2E_APP_TANSTACK_AUTH_EMAIL_PREFIX: "TanStack Auth",
+        LIGHTFAST_E2E_APP_TANSTACK_AUTH_ORG_SLUG: "lf-app-tanstack-fixed",
+        LIGHTFAST_E2E_APP_TANSTACK_URL:
+          "https://custom.app-tanstack.lightfast.localhost/",
+      },
+      getPortlessUrl: (name) => `https://${name}.localhost`,
+      nowMs: Date.parse("2026-06-08T00:00:00.000Z"),
+    });
+
+    expect(config).toMatchObject({
+      appOrigin: "https://custom.app-tanstack.lightfast.localhost",
+      clerkSecretKey: "sk_test_123",
+      emailAddress: "tanstack-auth-1780876800000@lightfast.ai",
+      orgSlug: "lf-app-tanstack-fixed",
+      sessionName: "app-tanstack-session",
+    });
+  });
+
+  it("uses the app-tanstack Portless service by default", () => {
+    const config = buildAppTanstackAuthRouteSmokeConfig({
+      env: {
+        CLERK_SECRET_KEY: "sk_test_123",
+      },
+      getPortlessUrl: (name) => `https://route-smoke.${name}.localhost`,
+      nowMs: Date.parse("2026-06-08T00:00:00.000Z"),
+    });
+
+    expect(config).toMatchObject({
+      appOrigin:
+        "https://route-smoke.app-tanstack.lightfast.localhost",
+      emailAddress: "app-tanstack-auth-smoke-1780876800000@lightfast.ai",
+      orgSlug: "lf-app-tanstack-auth-e2e-1780876800000",
+      sessionName: "lightfast-app-tanstack-auth-smoke-1780876800000",
+    });
+  });
+
+  it("builds route checks for account and org-authenticated pages", () => {
+    const checks = buildRouteChecks("lf-tanstack");
+
+    expect(checks.map((check) => check.path)).toContain(
+      "/account/settings/general"
+    );
+    expect(checks.map((check) => check.path)).toContain(
+      "/lf-tanstack/settings/source-control"
+    );
+    expect(checks.map((check) => check.path)).toContain(
+      "/lf-tanstack/signals"
+    );
+    expect(checks).toHaveLength(APP_TANSTACK_AUTH_ROUTE_SPECS.length);
+    expect(checks.some((check) => check.path.includes("$slug"))).toBe(false);
+  });
+
+  it("flags auth, setup, and generic error states in route body text", () => {
+    const problems = collectRouteBodyProblems({
+      bodyText:
+        "Log in to Lightfast\nOrganization setup required\nApplication Error",
+      expectedText: ["Signals"],
+      finalPathname: "/sign-in",
+      routeName: "signals",
+      routePath: "/lf-tanstack/signals",
+    });
+
+    expect(problems).toEqual([
+      "signals landed on /sign-in instead of /lf-tanstack/signals",
+      "signals rendered forbidden text: Log in to Lightfast",
+      "signals rendered forbidden text: Organization setup required",
+      "signals rendered forbidden text: Application Error",
+      "signals did not render expected text: Signals",
+    ]);
+  });
+
+  it("redacts agent-browser eval scripts from command failure messages", () => {
+    const formatted = formatCommandForError("agent-browser", [
+      "--session",
+      "smoke",
+      "eval",
+      "const ticket = 'secret-sign-in-ticket'",
+    ]);
+
+    expect(formatted).toContain("agent-browser --session smoke eval <script>");
+    expect(formatted).not.toContain("secret-sign-in-ticket");
+  });
+
+  it("requires a Clerk secret key so smoke runs can create dev users", () => {
+    expect(() =>
+      buildAppTanstackAuthRouteSmokeConfig({
+        env: {},
+        getPortlessUrl: (name) => `https://${name}.localhost`,
+        nowMs: Date.parse("2026-06-08T00:00:00.000Z"),
+      })
+    ).toThrow("CLERK_SECRET_KEY");
+  });
+});

--- a/e2e/src/app-tanstack/auth-route-smoke.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.ts
@@ -1,0 +1,760 @@
+import { execFile, execFileSync } from "node:child_process";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import {
+  allowLocalhostTls,
+  normalizeUrl,
+  trimTrailingSlash,
+} from "../helpers/env";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_SESSION_NAME = "lightfast-app-tanstack-auth-smoke";
+const DEFAULT_EMAIL_DOMAIN = "lightfast.ai";
+const APP_TANSTACK_PORTLESS_NAME = "app-tanstack.lightfast";
+const DEFAULT_ROUTE_TIMEOUT_MS = 120_000;
+const X_EMULATOR_ACCESS_TOKEN = "x_access_valid";
+const X_EMULATOR_REFRESH_TOKEN = "x_refresh_valid";
+const X_EMULATOR_TOOL_NAME = "getUsersMe";
+
+type Env = Record<string, string | undefined>;
+
+export interface AppTanstackAuthRouteSmokeConfig {
+  appOrigin: string;
+  clerkSecretKey: string;
+  emailAddress: string;
+  orgSlug: string;
+  routeTimeoutMs: number;
+  sessionName: string;
+}
+
+export interface BuildAppTanstackAuthRouteSmokeConfigInput {
+  env?: Env;
+  getPortlessUrl?: (name: string) => string;
+  nowMs?: number;
+}
+
+interface ClerkUser {
+  id: string;
+}
+
+interface ClerkOrganization {
+  id: string;
+  slug: string;
+}
+
+interface RouteSpec {
+  expectedText: string[];
+  name: string;
+  pathTemplate: string;
+}
+
+interface RouteCheck {
+  expectedText: string[];
+  name: string;
+  path: string;
+}
+
+interface RouteBodyProblemInput {
+  bodyText: string;
+  expectedText: string[];
+  finalPathname: string;
+  routeName: string;
+  routePath: string;
+}
+
+const FORBIDDEN_ROUTE_TEXT = [
+  "Log in to Lightfast",
+  "Create your account",
+  "Organization setup required",
+  "Team not found",
+  "Application Error",
+  "Something went wrong",
+  "Unable to load",
+  "Failed to load",
+  "UNAUTHORIZED",
+  "Authentication required",
+] as const;
+
+export const APP_TANSTACK_AUTH_ROUTE_SPECS: RouteSpec[] = [
+  {
+    expectedText: ["General", "Profile", "Display name"],
+    name: "account general settings",
+    pathTemplate: "/account/settings/general",
+  },
+  {
+    expectedText: ["Source Control & Git", "No GitHub account connected"],
+    name: "account source control settings",
+    pathTemplate: "/account/settings/source-control",
+  },
+  {
+    expectedText: ["MCP Connections", "Manage MCP clients authorized"],
+    name: "account mcp connections",
+    pathTemplate: "/account/mcp",
+  },
+  {
+    expectedText: ["Connect your GitHub account", "Link your personal GitHub"],
+    name: "account github task",
+    pathTemplate: "/account/tasks/github",
+  },
+  {
+    expectedText: ["Choose your username", "Username"],
+    name: "account username task",
+    pathTemplate: "/account/tasks/username?return_to=%2Faccount%2Fteams%2Fnew",
+  },
+  {
+    expectedText: ["Create your team", "Your Team Name"],
+    name: "create team",
+    pathTemplate: "/account/teams/new",
+  },
+  {
+    expectedText: ["Signals", "Add Signal"],
+    name: "signals",
+    pathTemplate: "/$slug/signals",
+  },
+  {
+    expectedText: ["Make Lightfast work your way", "No skills indexed."],
+    name: "skills",
+    pathTemplate: "/$slug/skills",
+  },
+  {
+    expectedText: ["Automations", "New automation"],
+    name: "automations",
+    pathTemplate: "/$slug/automations",
+  },
+  {
+    expectedText: ["Connectors", "Team connectors"],
+    name: "connectors",
+    pathTemplate: "/$slug/connectors",
+  },
+  {
+    expectedText: ["General", "Profile"],
+    name: "org general settings",
+    pathTemplate: "/$slug/settings/general",
+  },
+  {
+    expectedText: ["Source Control & Git"],
+    name: "org source control settings",
+    pathTemplate: "/$slug/settings/source-control",
+  },
+  {
+    expectedText: ["Members", "Manage the people"],
+    name: "org members settings",
+    pathTemplate: "/$slug/settings/members",
+  },
+  {
+    expectedText: ["Billing", "Payment", "Invoices"],
+    name: "org billing settings",
+    pathTemplate: "/$slug/settings/billing",
+  },
+  {
+    expectedText: ["API Keys", "No API keys yet"],
+    name: "org api keys settings",
+    pathTemplate: "/$slug/settings/api-keys",
+  },
+  {
+    expectedText: ["MCP Connections", "No MCP connections"],
+    name: "org mcp settings",
+    pathTemplate: "/$slug/settings/mcp",
+  },
+];
+
+export function createUniqueAppTanstackAuthOrgSlug(input: {
+  nowMs?: number;
+  prefix?: string;
+}) {
+  const prefix = slugPart(input.prefix ?? "lf-app-tanstack-auth-e2e");
+  const timestampMs = input.nowMs ?? Date.now();
+  return `${prefix || "lf-app-tanstack-auth-e2e"}-${timestampMs}`;
+}
+
+export function buildAppTanstackAuthRouteSmokeConfig(
+  input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
+): AppTanstackAuthRouteSmokeConfig {
+  const env = input.env ?? process.env;
+  const clerkSecretKey = env.CLERK_SECRET_KEY?.trim();
+  if (!clerkSecretKey) {
+    throw new Error(
+      "CLERK_SECRET_KEY is missing. Run this script through `pnpm with-env` from @lightfast/e2e."
+    );
+  }
+
+  const getPortlessUrl = input.getPortlessUrl ?? readPortlessUrl;
+  const nowMs = input.nowMs ?? Date.now();
+  const orgSlug =
+    env.LIGHTFAST_E2E_APP_TANSTACK_AUTH_ORG_SLUG?.trim() ||
+    createUniqueAppTanstackAuthOrgSlug({
+      nowMs,
+      prefix: env.LIGHTFAST_E2E_APP_TANSTACK_AUTH_ORG_SLUG_PREFIX,
+    });
+  const emailAddress =
+    env.LIGHTFAST_E2E_APP_TANSTACK_AUTH_EMAIL?.trim() ||
+    `${slugPart(
+      env.LIGHTFAST_E2E_APP_TANSTACK_AUTH_EMAIL_PREFIX ??
+        "app-tanstack-auth-smoke"
+    )}-${nowMs}@${DEFAULT_EMAIL_DOMAIN}`;
+  const routeTimeoutMs = readPositiveInteger(
+    env.LIGHTFAST_E2E_APP_TANSTACK_AUTH_ROUTE_TIMEOUT_MS,
+    DEFAULT_ROUTE_TIMEOUT_MS,
+    "LIGHTFAST_E2E_APP_TANSTACK_AUTH_ROUTE_TIMEOUT_MS"
+  );
+
+  return {
+    appOrigin: normalizeUrl(
+      env.LIGHTFAST_E2E_APP_TANSTACK_URL?.trim() ||
+        env.LIGHTFAST_E2E_APP_URL?.trim() ||
+        getPortlessUrl(APP_TANSTACK_PORTLESS_NAME),
+      "LIGHTFAST_E2E_APP_TANSTACK_URL"
+    ),
+    clerkSecretKey,
+    emailAddress,
+    orgSlug,
+    routeTimeoutMs,
+    sessionName:
+      env.LIGHTFAST_E2E_AGENT_BROWSER_SESSION?.trim() ||
+      `${DEFAULT_SESSION_NAME}-${nowMs}`,
+  };
+}
+
+export function buildRouteChecks(orgSlug: string): RouteCheck[] {
+  return APP_TANSTACK_AUTH_ROUTE_SPECS.map((spec) => ({
+    expectedText: spec.expectedText,
+    name: spec.name,
+    path: spec.pathTemplate.replaceAll("$slug", orgSlug),
+  }));
+}
+
+export function collectRouteBodyProblems(input: RouteBodyProblemInput) {
+  const problems: string[] = [];
+  const expectedPathname = new URL(input.routePath, "https://lightfast.local")
+    .pathname;
+  if (input.finalPathname !== expectedPathname) {
+    problems.push(
+      `${input.routeName} landed on ${input.finalPathname} instead of ${expectedPathname}`
+    );
+  }
+
+  for (const forbidden of FORBIDDEN_ROUTE_TEXT) {
+    if (input.bodyText.includes(forbidden)) {
+      problems.push(`${input.routeName} rendered forbidden text: ${forbidden}`);
+    }
+  }
+
+  const missing = input.expectedText.filter(
+    (text) => !input.bodyText.includes(text)
+  );
+  if (missing.length > 0) {
+    problems.push(
+      `${input.routeName} did not render expected text: ${missing.join(", ")}`
+    );
+  }
+  return problems;
+}
+
+function slugPart(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-");
+}
+
+function readPositiveInteger(
+  raw: string | undefined,
+  fallback: number,
+  name: string
+) {
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function boundPublicMetadata() {
+  return {
+    lf_binding_status: "bound",
+    lightfast: {
+      binding: {
+        provider: "github",
+        status: "bound",
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  };
+}
+
+async function fetchClerkJson<T>(
+  config: AppTanstackAuthRouteSmokeConfig,
+  path: `/${string}`,
+  init: Omit<RequestInit, "body" | "headers"> & {
+    body?: Record<string, unknown>;
+  }
+): Promise<T> {
+  const res = await fetch(`https://api.clerk.com/v1${path}`, {
+    ...init,
+    body: init.body ? JSON.stringify(init.body) : undefined,
+    headers: {
+      authorization: `Bearer ${config.clerkSecretKey}`,
+      "content-type": "application/json",
+    },
+  });
+  const body = (await res.json().catch(() => null)) as
+    | {
+        errors?: Array<{ long_message?: string; message?: string }>;
+      }
+    | T
+    | null;
+  if (!res.ok) {
+    const errorBody =
+      body && typeof body === "object" && "errors" in body
+        ? (body as {
+            errors?: Array<{ long_message?: string; message?: string }>;
+          })
+        : null;
+    const message =
+      errorBody?.errors?.[0]?.long_message ?? errorBody?.errors?.[0]?.message;
+    throw new Error(
+      `Clerk ${init.method ?? "GET"} ${path} failed: ${message ?? `HTTP ${res.status}`}`
+    );
+  }
+  return body as T;
+}
+
+async function createClerkUser(config: AppTanstackAuthRouteSmokeConfig) {
+  return await fetchClerkJson<ClerkUser>(config, "/users", {
+    body: {
+      email_address: [config.emailAddress],
+      first_name: "TanStack",
+      last_name: "Smoke",
+      legal_accepted_at: new Date().toISOString(),
+    },
+    method: "POST",
+  });
+}
+
+async function createClerkOrganization(
+  config: AppTanstackAuthRouteSmokeConfig,
+  userId: string
+) {
+  return await fetchClerkJson<ClerkOrganization>(config, "/organizations", {
+    body: {
+      created_by: userId,
+      name: config.orgSlug,
+      public_metadata: boundPublicMetadata(),
+      slug: config.orgSlug,
+    },
+    method: "POST",
+  });
+}
+
+async function updateClerkUserLastActiveOrg(
+  config: AppTanstackAuthRouteSmokeConfig,
+  input: { orgId: string; userId: string }
+) {
+  await fetchClerkJson(config, `/users/${input.userId}/metadata`, {
+    body: {
+      public_metadata: {
+        last_active_org: {
+          id: input.orgId,
+          slug: config.orgSlug,
+        },
+      },
+    },
+    method: "PATCH",
+  });
+}
+
+async function updateClerkOrgBoundMetadata(
+  config: AppTanstackAuthRouteSmokeConfig,
+  orgId: string
+) {
+  const org = await fetchClerkJson<{ public_metadata?: Record<string, unknown> }>(
+    config,
+    `/organizations/${orgId}`,
+    {
+      method: "GET",
+    }
+  );
+  const currentMetadata = record(org.public_metadata);
+  const currentLightfast = record(currentMetadata.lightfast);
+
+  await fetchClerkJson(config, `/organizations/${orgId}`, {
+    body: {
+      public_metadata: {
+        ...currentMetadata,
+        lightfast: {
+          ...currentLightfast,
+          binding: {
+            provider: "github",
+            status: "bound",
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      },
+    },
+    method: "PATCH",
+  });
+}
+
+async function createClerkSignInToken(
+  config: AppTanstackAuthRouteSmokeConfig,
+  userId: string
+) {
+  const body = await fetchClerkJson<{ token: string }>(
+    config,
+    "/sign_in_tokens",
+    {
+      body: {
+        expires_in_seconds: 600,
+        user_id: userId,
+      },
+      method: "POST",
+    }
+  );
+  if (!body.token) {
+    throw new Error("Clerk sign-in token response did not include a token.");
+  }
+  return body.token;
+}
+
+function requireEncryptionKey() {
+  const value = process.env.ENCRYPTION_KEY?.trim();
+  if (!value) {
+    throw new Error(
+      "ENCRYPTION_KEY is missing. Run this script through `pnpm with-env` from @lightfast/e2e."
+    );
+  }
+  return value;
+}
+
+async function createBoundSourceControlBinding(input: {
+  orgId: string;
+  orgSlug: string;
+  userId: string;
+}) {
+  const [
+    { db },
+    { finalizeActiveOrgProviderBinding, upsertWatchedSourceControlRepository },
+  ] = await Promise.all([import("@db/app/client"), import("@db/app")]);
+  const installationId = `install-${input.orgSlug}`;
+  const lightfastRepository = {
+    fullName: `${input.orgSlug}/.lightfast`,
+    id: `repo-${input.orgSlug}`,
+    installationId,
+    name: ".lightfast",
+    verifiedAt: new Date().toISOString(),
+  };
+  const binding = await finalizeActiveOrgProviderBinding(db, {
+    clerkOrgId: input.orgId,
+    connectedByUserId: input.userId,
+    metadata: {
+      lightfastRepository,
+    },
+    provider: "github",
+    providerAccountId: `acct-${input.orgSlug}`,
+    providerAccountLogin: input.orgSlug,
+    providerInstallationId: installationId,
+  });
+  await upsertWatchedSourceControlRepository(db, {
+    fullName: lightfastRepository.fullName,
+    orgSourceControlBindingId: binding.id,
+    providerRepositoryId: lightfastRepository.id,
+    watchedPathGlobs: ["skills/**"],
+    watchedWebhookEvents: [],
+  });
+}
+
+async function createActiveXConnectorConnection(input: {
+  config: AppTanstackAuthRouteSmokeConfig;
+  orgId: string;
+  orgSlug: string;
+  userId: string;
+}) {
+  const [
+    { db },
+    {
+      finalizeCurrentOrgConnectorConnection,
+      setConnectorAgentEnabled,
+      setConnectorAutomationEnabled,
+    },
+    { encrypt },
+  ] = await Promise.all([
+    import("@db/app/client"),
+    import("@db/app"),
+    import("@repo/app-encryption"),
+  ]);
+  const encryptionKey = requireEncryptionKey();
+
+  await finalizeCurrentOrgConnectorConnection(db, {
+    accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    clerkOrgId: input.orgId,
+    connectedByUserId: input.userId,
+    encryptedAccessToken: await encrypt(X_EMULATOR_ACCESS_TOKEN, encryptionKey),
+    encryptedRefreshToken: await encrypt(
+      X_EMULATOR_REFRESH_TOKEN,
+      encryptionKey
+    ),
+    enabledForAutomations: true,
+    lastToolRefreshAt: new Date(),
+    mcpEndpoint: new URL("/api/connectors/x/mcp", input.config.appOrigin)
+      .toString(),
+    metadata: {
+      smoke: "app-tanstack-auth-routes",
+      username: input.orgSlug,
+    },
+    provider: "x",
+    providerActorId: `x-${input.orgSlug}`,
+    providerActorName: `@${input.orgSlug}`,
+    providerWorkspaceId: null,
+    providerWorkspaceName: "X",
+    refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    scopes: ["tweet.read", "users.read", "offline.access"],
+    toolManifest: [
+      {
+        description: "Emulated X profile lookup",
+        inputSchema: { additionalProperties: true, type: "object" },
+        name: X_EMULATOR_TOOL_NAME,
+      },
+    ],
+  });
+  await setConnectorAgentEnabled(db, {
+    clerkOrgId: input.orgId,
+    enabled: true,
+    provider: "x",
+  });
+  await setConnectorAutomationEnabled(db, {
+    clerkOrgId: input.orgId,
+    enabled: true,
+    provider: "x",
+  });
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+async function agentBrowser(
+  config: AppTanstackAuthRouteSmokeConfig,
+  args: string[]
+) {
+  return await runCommand("agent-browser", [
+    "--session",
+    config.sessionName,
+    ...args,
+  ]);
+}
+
+async function agentEval(
+  config: AppTanstackAuthRouteSmokeConfig,
+  js: string
+) {
+  return await agentBrowser(config, ["eval", js]);
+}
+
+async function signInWithClerkTicket(
+  config: AppTanstackAuthRouteSmokeConfig,
+  input: { destinationPath: string; orgId: string; ticket: string }
+) {
+  await agentBrowser(config, ["open", `${config.appOrigin}/sign-in`]);
+  await agentEval(
+    config,
+    `(async () => {
+      const ticket = ${JSON.stringify(input.ticket)};
+      const orgId = ${JSON.stringify(input.orgId)};
+      const destination = ${JSON.stringify(input.destinationPath)};
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if (window.Clerk?.client?.signIn && window.Clerk?.setActive) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      if (!window.Clerk?.client?.signIn || !window.Clerk?.setActive) {
+        throw new Error("Clerk did not load");
+      }
+      const signIn = await window.Clerk.client.signIn.create({
+        strategy: "ticket",
+        ticket,
+      });
+      const sessionId = signIn.createdSessionId || signIn.created_session_id;
+      if (!sessionId) {
+        throw new Error("Clerk ticket sign-in did not create a session");
+      }
+      await window.Clerk.setActive({ organization: orgId, session: sessionId });
+      window.location.assign(destination);
+      return {
+        orgId: window.Clerk.organization?.id ?? null,
+        sessionId: window.Clerk.session?.id ?? null,
+        status: signIn.status,
+        userId: window.Clerk.user?.id ?? null,
+      };
+    })()`
+  );
+}
+
+async function readPageState(config: AppTanstackAuthRouteSmokeConfig) {
+  const raw = await agentEval(
+    config,
+    `({
+      bodyText: document.body.innerText,
+      href: location.href,
+      pathname: location.pathname,
+    })`
+  );
+  return JSON.parse(raw) as {
+    bodyText: string;
+    href: string;
+    pathname: string;
+  };
+}
+
+async function assertRouteRendered(
+  config: AppTanstackAuthRouteSmokeConfig,
+  route: RouteCheck
+) {
+  const targetUrl = new URL(route.path, config.appOrigin);
+  await agentBrowser(config, ["open", targetUrl.toString()]);
+
+  const deadline = Date.now() + config.routeTimeoutMs;
+  let latestState:
+    | {
+        bodyText: string;
+        href: string;
+        pathname: string;
+      }
+    | undefined;
+  let latestProblems: string[] = [];
+
+  while (Date.now() < deadline) {
+    latestState = await readPageState(config);
+    latestProblems = collectRouteBodyProblems({
+      bodyText: latestState.bodyText,
+      expectedText: route.expectedText,
+      finalPathname: latestState.pathname,
+      routeName: route.name,
+      routePath: route.path,
+    });
+    if (latestProblems.length === 0) {
+      console.log(`[smoke] ok ${route.path}`);
+      return;
+    }
+    await delay(1000);
+  }
+
+  const snapshot = await agentBrowser(config, ["snapshot", "-i", "-u"]).catch(
+    (error) => String(error)
+  );
+  throw new Error(
+    [
+      `Route smoke failed for ${route.name} (${route.path}).`,
+      ...latestProblems,
+      latestState ? `Last URL: ${latestState.href}` : "Last URL: <unknown>",
+      snapshot,
+    ].join("\n")
+  );
+}
+
+async function runCommand(command: string, args: string[]) {
+  try {
+    const result = await execFileAsync(command, args, {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return result.stdout.trim();
+  } catch (error) {
+    const failed = error as Error & { stderr?: string; stdout?: string };
+    throw new Error(
+      `${formatCommandForError(command, args)} failed:\n${
+        failed.stderr || failed.stdout || failed.message
+      }`
+    );
+  }
+}
+
+export function formatCommandForError(command: string, args: string[]) {
+  const evalIndex = command === "agent-browser" ? args.indexOf("eval") : -1;
+  if (evalIndex >= 0) {
+    return `${command} ${[...args.slice(0, evalIndex + 1), "<script>"].join(" ")}`;
+  }
+  return `${command} ${args.join(" ")}`;
+}
+
+function readPortlessUrl(name: string): string {
+  return trimTrailingSlash(
+    execFileSync("pnpm", ["--silent", "exec", "portless", "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim()
+  );
+}
+
+export async function runAppTanstackAuthRouteSmoke(
+  input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
+) {
+  const config = buildAppTanstackAuthRouteSmokeConfig(input);
+  allowLocalhostTls(config.appOrigin);
+  const routes = buildRouteChecks(config.orgSlug);
+
+  console.log(`[smoke] app=${config.appOrigin}`);
+  console.log(`[smoke] org=${config.orgSlug}`);
+  console.log(`[smoke] email=${config.emailAddress}`);
+  console.log(`[smoke] routes=${routes.length}`);
+
+  try {
+    const user = await createClerkUser(config);
+    const org = await createClerkOrganization(config, user.id);
+    await updateClerkUserLastActiveOrg(config, {
+      orgId: org.id,
+      userId: user.id,
+    });
+    await createBoundSourceControlBinding({
+      orgId: org.id,
+      orgSlug: config.orgSlug,
+      userId: user.id,
+    });
+    await createActiveXConnectorConnection({
+      config,
+      orgId: org.id,
+      orgSlug: config.orgSlug,
+      userId: user.id,
+    });
+    await updateClerkOrgBoundMetadata(config, org.id);
+
+    const ticket = await createClerkSignInToken(config, user.id);
+    await signInWithClerkTicket(config, {
+      destinationPath: routes[0]?.path ?? "/account/settings/general",
+      orgId: org.id,
+      ticket,
+    });
+
+    for (const route of routes) {
+      await assertRouteRendered(config, route);
+    }
+
+    console.log(`[smoke] completed ${routes.length} routes`);
+  } finally {
+    await agentBrowser(config, ["close"]).catch(() => undefined);
+  }
+}
+
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return Boolean(
+    entrypoint && path.resolve(entrypoint) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isMainModule()) {
+  runAppTanstackAuthRouteSmoke().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/e2e/src/app-tanstack/auth-route-smoke.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.ts
@@ -15,6 +15,7 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_SESSION_NAME = "lightfast-app-tanstack-auth-smoke";
 const DEFAULT_EMAIL_DOMAIN = "lightfast.ai";
 const APP_TANSTACK_PORTLESS_NAME = "app-tanstack.lightfast";
+const DEFAULT_CLERK_API_TIMEOUT_MS = 30_000;
 const DEFAULT_ROUTE_TIMEOUT_MS = 120_000;
 const X_EMULATOR_ACCESS_TOKEN = "x_access_valid";
 const X_EMULATOR_REFRESH_TOKEN = "x_refresh_valid";
@@ -24,6 +25,7 @@ type Env = Record<string, string | undefined>;
 
 export interface AppTanstackAuthRouteSmokeConfig {
   appOrigin: string;
+  clerkApiTimeoutMs: number;
   clerkSecretKey: string;
   emailAddress: string;
   orgSlug: string;
@@ -77,6 +79,7 @@ const FORBIDDEN_ROUTE_TEXT = [
   "Failed to load",
   "UNAUTHORIZED",
   "Authentication required",
+  "Session expired",
 ] as const;
 
 export const APP_TANSTACK_AUTH_ROUTE_SPECS: RouteSpec[] = [
@@ -201,6 +204,11 @@ export function buildAppTanstackAuthRouteSmokeConfig(
     DEFAULT_ROUTE_TIMEOUT_MS,
     "LIGHTFAST_E2E_APP_TANSTACK_AUTH_ROUTE_TIMEOUT_MS"
   );
+  const clerkApiTimeoutMs = readPositiveInteger(
+    env.LIGHTFAST_E2E_APP_TANSTACK_AUTH_CLERK_API_TIMEOUT_MS,
+    DEFAULT_CLERK_API_TIMEOUT_MS,
+    "LIGHTFAST_E2E_APP_TANSTACK_AUTH_CLERK_API_TIMEOUT_MS"
+  );
 
   return {
     appOrigin: normalizeUrl(
@@ -209,6 +217,7 @@ export function buildAppTanstackAuthRouteSmokeConfig(
         getPortlessUrl(APP_TANSTACK_PORTLESS_NAME),
       "LIGHTFAST_E2E_APP_TANSTACK_URL"
     ),
+    clerkApiTimeoutMs,
     clerkSecretKey,
     emailAddress,
     orgSlug,
@@ -297,6 +306,10 @@ async function fetchClerkJson<T>(
     body?: Record<string, unknown>;
   }
 ): Promise<T> {
+  const timeoutSignal = AbortSignal.timeout(config.clerkApiTimeoutMs);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
   const res = await fetch(`https://api.clerk.com/v1${path}`, {
     ...init,
     body: init.body ? JSON.stringify(init.body) : undefined,
@@ -304,6 +317,7 @@ async function fetchClerkJson<T>(
       authorization: `Bearer ${config.clerkSecretKey}`,
       "content-type": "application/json",
     },
+    signal,
   });
   const body = (await res.json().catch(() => null)) as
     | {
@@ -424,8 +438,8 @@ async function createClerkSignInToken(
   return body.token;
 }
 
-function requireEncryptionKey() {
-  const value = process.env.ENCRYPTION_KEY?.trim();
+export function readAppTanstackAuthEncryptionKey(env: Env = process.env) {
+  const value = env.ENCRYPTION_KEY?.trim();
   if (!value) {
     throw new Error(
       "ENCRYPTION_KEY is missing. Run this script through `pnpm with-env` from @lightfast/e2e."
@@ -473,6 +487,7 @@ async function createBoundSourceControlBinding(input: {
 
 async function createActiveXConnectorConnection(input: {
   config: AppTanstackAuthRouteSmokeConfig;
+  env: Env;
   orgId: string;
   orgSlug: string;
   userId: string;
@@ -490,7 +505,7 @@ async function createActiveXConnectorConnection(input: {
     import("@db/app"),
     import("@repo/app-encryption"),
   ]);
-  const encryptionKey = requireEncryptionKey();
+  const encryptionKey = readAppTanstackAuthEncryptionKey(input.env);
 
   await finalizeCurrentOrgConnectorConnection(db, {
     accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
@@ -699,6 +714,7 @@ function readPortlessUrl(name: string): string {
 export async function runAppTanstackAuthRouteSmoke(
   input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
 ) {
+  const env = input.env ?? process.env;
   const config = buildAppTanstackAuthRouteSmokeConfig(input);
   allowLocalhostTls(config.appOrigin);
   const routes = buildRouteChecks(config.orgSlug);
@@ -722,6 +738,7 @@ export async function runAppTanstackAuthRouteSmoke(
     });
     await createActiveXConnectorConnection({
       config,
+      env,
       orgId: org.id,
       orgSlug: config.orgSlug,
       userId: user.id,


### PR DESCRIPTION
## Summary
- Adds an authenticated app-tanstack route smoke runner that provisions a Clerk user/org, seeds GitHub source-control binding plus X connector state, signs in through agent-browser, and checks account/org product routes.
- Adds helper unit coverage for smoke config, slug/path resolution, forbidden route text detection, and eval-script redaction.
- Wires the new smoke into @lightfast/e2e scripts and loads app env overrides for DB-backed e2e runs.

## Verification
- pnpm --filter @lightfast/e2e exec vitest run src/app-tanstack/auth-route-smoke.test.ts
- pnpm --filter @lightfast/e2e test
- pnpm --filter @lightfast/e2e typecheck
- pnpm --filter @lightfast/e2e app-tanstack:auth-routes

## Notes
- The browser smoke completed 16 routes against the branch app-tanstack dev server.
- Runtime logs still show existing hydration mismatch warnings around Clerk/avatar skeletons.
- Skills refresh logs an Inngest 404 when only @lightfast/app-tanstack is running; full root dev should provide local Inngest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive smoke tests to validate authentication flows and route rendering
  * Enhanced test infrastructure to verify proper page behavior across multiple authenticated user scenarios
  * Extended test configuration to support end-to-end testing with multiple environment configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->