### PR TITLE
fix: stabilize app-tanstack auth shell hydration

### DIFF
--- a/api/app/src/__tests__/skills-index-service.test.ts
+++ b/api/app/src/__tests__/skills-index-service.test.ts
@@ -1014,8 +1014,11 @@ describe("skills index refresh/read service", () => {
     const deps = createDeps({
       targetState: staleState({ indexedCommitSha: "old-index" }),
     });
+    const enqueueError = new Error(
+      "Inngest API Error: 404 Event key not found"
+    );
     deps.enqueueRefresh = vi.fn(async () => {
-      throw new Error("Inngest API Error: 404 Event key not found");
+      throw enqueueError;
     });
 
     await expect(
@@ -1035,6 +1038,17 @@ describe("skills index refresh/read service", () => {
       sourceControlRepositoryId: 1,
       targetCommitSha: undefined,
     });
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "[skills] read-triggered skill index refresh enqueue failed",
+      {
+        error: enqueueError,
+        errorMessage: "Inngest API Error: 404 Event key not found",
+        errorStack: expect.any(String),
+        reason: "read",
+        sourceControlRepositoryId: 1,
+        targetCommitSha: undefined,
+      }
+    );
   });
 
   it("propagates setup-triggered enqueue failures", async () => {
@@ -1053,6 +1067,7 @@ describe("skills index refresh/read service", () => {
         sourceControlRepositoryId: 1,
       })
     ).rejects.toThrow("setup enqueue failed");
+    expect(logWarnMock).not.toHaveBeenCalled();
   });
 
   it("does not enqueue a refresh when repository access is not verified", async () => {

--- a/api/app/src/__tests__/skills-index-service.test.ts
+++ b/api/app/src/__tests__/skills-index-service.test.ts
@@ -1010,6 +1010,51 @@ describe("skills index refresh/read service", () => {
     expect(deps.readSkillRepositoryTree).not.toHaveBeenCalled();
   });
 
+  it("treats read-triggered enqueue failures as non-blocking", async () => {
+    const deps = createDeps({
+      targetState: staleState({ indexedCommitSha: "old-index" }),
+    });
+    deps.enqueueRefresh = vi.fn(async () => {
+      throw new Error("Inngest API Error: 404 Event key not found");
+    });
+
+    await expect(
+      requestSkillIndexRefresh({
+        clerkOrgId: "org_123",
+        deps,
+        reason: "read",
+        sourceControlRepositoryId: 1,
+      })
+    ).resolves.toEqual({
+      enqueued: false,
+      sourceControlRepositoryId: 1,
+    });
+
+    expect(deps.enqueueRefresh).toHaveBeenCalledWith({
+      reason: "read",
+      sourceControlRepositoryId: 1,
+      targetCommitSha: undefined,
+    });
+  });
+
+  it("propagates setup-triggered enqueue failures", async () => {
+    const deps = createDeps({
+      targetState: staleState({ indexedCommitSha: "old-index" }),
+    });
+    deps.enqueueRefresh = vi.fn(async () => {
+      throw new Error("setup enqueue failed");
+    });
+
+    await expect(
+      requestSkillIndexRefresh({
+        clerkOrgId: "org_123",
+        deps,
+        reason: "setup",
+        sourceControlRepositoryId: 1,
+      })
+    ).rejects.toThrow("setup enqueue failed");
+  });
+
   it("does not enqueue a refresh when repository access is not verified", async () => {
     const deps = createDeps({ candidate: null });
     deps.enqueueRefresh = vi.fn(async () => undefined);

--- a/api/app/src/services/skills/refresh-request.ts
+++ b/api/app/src/services/skills/refresh-request.ts
@@ -1,3 +1,5 @@
+import { log } from "@vendor/observability/log/next";
+
 import { createSkillRefreshDedupeKey } from "../../inngest/workflow/skill-refresh-event";
 import { resolveSkillIndexServiceDeps } from "./deps";
 import { getVerifiedCandidateByRepositoryId } from "./repository";
@@ -61,6 +63,15 @@ export async function requestSkillIndexRefresh(input: {
     if (input.reason !== "read") {
       throw error;
     }
+
+    log.warn("[skills] read-triggered skill index refresh enqueue failed", {
+      error,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      errorStack: error instanceof Error ? error.stack : undefined,
+      reason: input.reason,
+      sourceControlRepositoryId: input.sourceControlRepositoryId,
+      targetCommitSha: input.targetCommitSha,
+    });
 
     return {
       enqueued: false,

--- a/api/app/src/services/skills/refresh-request.ts
+++ b/api/app/src/services/skills/refresh-request.ts
@@ -51,11 +51,22 @@ export async function requestSkillIndexRefresh(input: {
   }
 
   const enqueue = deps.enqueueRefresh ?? enqueueSkillIndexRefresh;
-  await enqueue({
-    reason: input.reason,
-    sourceControlRepositoryId: input.sourceControlRepositoryId,
-    targetCommitSha: input.targetCommitSha,
-  });
+  try {
+    await enqueue({
+      reason: input.reason,
+      sourceControlRepositoryId: input.sourceControlRepositoryId,
+      targetCommitSha: input.targetCommitSha,
+    });
+  } catch (error) {
+    if (input.reason !== "read") {
+      throw error;
+    }
+
+    return {
+      enqueued: false,
+      sourceControlRepositoryId: input.sourceControlRepositoryId,
+    };
+  }
 
   return {
     enqueued: true,

--- a/apps/app-tanstack/src/__tests__/account-settings-routes-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/account-settings-routes-source.test.ts
@@ -24,4 +24,14 @@ describe("app-tanstack account settings routes", () => {
     );
     expect(settingsIndexRouteSource).toContain("search={search}");
   });
+
+  it("keeps profile data on the loading shell until client mount", () => {
+    const profileSource = source(
+      "src/account/settings/profile-data-display.tsx"
+    );
+
+    expect(profileSource).toContain('from "@repo/ui/hooks/use-mounted"');
+    expect(profileSource).toContain("const mounted = useMounted();");
+    expect(profileSource).toContain("if (!mounted || isPending || !profile)");
+  });
 });

--- a/apps/app-tanstack/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/authenticated-routes-source.test.ts
@@ -153,6 +153,9 @@ describe("app-tanstack authenticated route migration", () => {
     expect(shellSource).toContain("isAuthRoute");
     expect(teamSwitcherSource).toContain("function TeamSwitcherSlot()");
     expect(teamSwitcherSource).toContain("<TeamSwitcherSkeleton />");
+    expect(teamSwitcherSource).toContain('from "@repo/ui/hooks/use-mounted"');
+    expect(teamSwitcherSource).toContain("const mounted = useMounted();");
+    expect(teamSwitcherSource).toContain("if (!mounted || isPending)");
     expect(shellSource).toContain(
       "<AuthenticatedTopbar left={<TeamSwitcherSlot />} />"
     );

--- a/apps/app-tanstack/src/__tests__/components-user-menu-model.test.ts
+++ b/apps/app-tanstack/src/__tests__/components-user-menu-model.test.ts
@@ -25,6 +25,9 @@ describe("TanStack user menu", () => {
     );
     expect(menuSource).toContain("viewer.account.get.queryOptions()");
     expect(menuSource).toContain('enabled: typeof window !== "undefined"');
+    expect(menuSource).toContain('from "@repo/ui/hooks/use-mounted"');
+    expect(menuSource).toContain("const mounted = useMounted();");
+    expect(menuSource).toContain("if (!mounted || isPending || !profile)");
     expect(menuSource).not.toContain("useSuspenseQuery");
     expect(menuSource).toContain("to={SETTINGS_HREF}");
     expect(menuSource).toContain('signOut({ redirectUrl: "/sign-in" })');

--- a/apps/app-tanstack/src/account/settings/profile-data-display.tsx
+++ b/apps/app-tanstack/src/account/settings/profile-data-display.tsx
@@ -17,6 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@repo/ui/components/ui/tooltip";
+import { useMounted } from "@repo/ui/hooks/use-mounted";
 import { useQuery } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useCallback, useEffect } from "react";
@@ -27,6 +28,7 @@ import { ProfileDataLoading } from "./profile-data-loading";
 
 export function ProfileDataDisplay() {
   const trpc = useTRPC();
+  const mounted = useMounted();
   const accountQuery = trpc.viewer.account.get.queryOptions();
   const { data: profile, isPending } = useQuery({
     ...accountQuery,
@@ -59,7 +61,7 @@ export function ProfileDataDisplay() {
     [updateDisplayName]
   );
 
-  if (isPending || !profile) {
+  if (!mounted || isPending || !profile) {
     return <ProfileDataLoading />;
   }
 

--- a/apps/app-tanstack/src/components/team-switcher.tsx
+++ b/apps/app-tanstack/src/components/team-switcher.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
 } from "@repo/ui/components/ui/dropdown-menu";
 import { Skeleton } from "@repo/ui/components/ui/skeleton";
+import { useMounted } from "@repo/ui/hooks/use-mounted";
 import { cn } from "@repo/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
@@ -37,6 +38,7 @@ export function TeamSwitcher() {
   const navigate = useNavigate();
   const { setActive } = useOrganizationList();
   const [open, setOpen] = useState(false);
+  const mounted = useMounted();
 
   const { data: organizations = [], isPending } = useQuery({
     ...trpc.viewer.organization.listUserOrganizations.queryOptions(),
@@ -69,7 +71,7 @@ export function TeamSwitcher() {
     await navigate({ to: "/$slug", params: { slug } });
   };
 
-  if (isPending) {
+  if (!mounted || isPending) {
     return <TeamSwitcherSkeleton />;
   }
 

--- a/apps/app-tanstack/src/components/user-menu.tsx
+++ b/apps/app-tanstack/src/components/user-menu.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@repo/ui/components/ui/dropdown-menu";
 import { Skeleton } from "@repo/ui/components/ui/skeleton";
+import { useMounted } from "@repo/ui/hooks/use-mounted";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Settings } from "lucide-react";
@@ -18,6 +19,7 @@ import { getUserMenuIdentity, SETTINGS_HREF } from "./user-menu-model";
 export function UserMenu() {
   const trpc = useTRPC();
   const { signOut } = useClerk();
+  const mounted = useMounted();
 
   const { data: profile, isPending } = useQuery({
     ...trpc.viewer.account.get.queryOptions(),
@@ -25,7 +27,7 @@ export function UserMenu() {
     staleTime: 5 * 60 * 1000,
   });
 
-  if (isPending || !profile) {
+  if (!mounted || isPending || !profile) {
     return <UserMenuSkeleton />;
   }
 

--- a/e2e/src/app-tanstack/auth-route-smoke.test.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.test.ts
@@ -55,8 +55,7 @@ describe("app-tanstack auth route smoke helpers", () => {
     });
 
     expect(config).toMatchObject({
-      appOrigin:
-        "https://route-smoke.app-tanstack.lightfast.localhost",
+      appOrigin: "https://route-smoke.app-tanstack.lightfast.localhost",
       clerkApiTimeoutMs: 30_000,
       emailAddress: "app-tanstack-auth-smoke-1780876800000@lightfast.ai",
       orgSlug: "lf-app-tanstack-auth-e2e-1780876800000",
@@ -73,9 +72,7 @@ describe("app-tanstack auth route smoke helpers", () => {
     expect(checks.map((check) => check.path)).toContain(
       "/lf-tanstack/settings/source-control"
     );
-    expect(checks.map((check) => check.path)).toContain(
-      "/lf-tanstack/signals"
-    );
+    expect(checks.map((check) => check.path)).toContain("/lf-tanstack/signals");
     expect(checks).toHaveLength(APP_TANSTACK_AUTH_ROUTE_SPECS.length);
     expect(checks.some((check) => check.path.includes("$slug"))).toBe(false);
   });

--- a/e2e/src/app-tanstack/auth-route-smoke.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.ts
@@ -389,13 +389,11 @@ async function updateClerkOrgBoundMetadata(
   config: AppTanstackAuthRouteSmokeConfig,
   orgId: string
 ) {
-  const org = await fetchClerkJson<{ public_metadata?: Record<string, unknown> }>(
-    config,
-    `/organizations/${orgId}`,
-    {
-      method: "GET",
-    }
-  );
+  const org = await fetchClerkJson<{
+    public_metadata?: Record<string, unknown>;
+  }>(config, `/organizations/${orgId}`, {
+    method: "GET",
+  });
   const currentMetadata = record(org.public_metadata);
   const currentLightfast = record(currentMetadata.lightfast);
 
@@ -518,8 +516,10 @@ async function createActiveXConnectorConnection(input: {
     ),
     enabledForAutomations: true,
     lastToolRefreshAt: new Date(),
-    mcpEndpoint: new URL("/api/connectors/x/mcp", input.config.appOrigin)
-      .toString(),
+    mcpEndpoint: new URL(
+      "/api/connectors/x/mcp",
+      input.config.appOrigin
+    ).toString(),
     metadata: {
       smoke: "app-tanstack-auth-routes",
       username: input.orgSlug,
@@ -568,10 +568,7 @@ async function agentBrowser(
   ]);
 }
 
-async function agentEval(
-  config: AppTanstackAuthRouteSmokeConfig,
-  js: string
-) {
+async function agentEval(config: AppTanstackAuthRouteSmokeConfig, js: string) {
   return await agentBrowser(config, ["eval", js]);
 }
 


### PR DESCRIPTION
## Summary
- Gate the app-tanstack user menu, team switcher, and profile display on first client mount so SSR skeletons match the initial hydrated render.
- Add source coverage for the mount guards on the auth shell/account settings components.
- Treat read-triggered skills refresh enqueue failures as opportunistic so single-app dev does not surface local Inngest registration failures as route errors; setup-triggered enqueue failures still propagate.

## Verification
- `pnpm --filter @lightfast/app-tanstack test`
- `pnpm --filter @api/app test`
- `pnpm --filter @lightfast/app-tanstack typecheck`
- `pnpm --filter @api/app typecheck`
- `git diff --check`
- `pnpm --filter @lightfast/e2e app-tanstack:auth-routes`
- Log grep: no hydration mismatch lines and no `Inngest API Error` lines in `/tmp/app-tanstack-hydration-runtime.log`

## Notes
- The auth-route smoke still produced some browser-side network errors during rapid navigation, followed by successful tRPC responses. This PR targets the hydration mismatch and the server-side Inngest 404 noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill index refresh resilience: read-triggered failures no longer interrupt operations.
  * Fixed loading state handling in profile, team switcher, and user menu components to prevent premature content display during hydration.

* **Tests**
  * Added comprehensive test coverage for skill refresh error handling and component mount-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->