### PR TITLE
feat: add app-tanstack workspace route boundaries

### DIFF
--- a/apps/app-tanstack/src/__tests__/route-boundaries-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/route-boundaries-source.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function expectSource(path: string) {
+  expect(existsSync(resolve(appRoot, path)), `${path} should exist`).toBe(true);
+  return source(path);
+}
+
+describe("app-tanstack route boundaries", () => {
+  it("defines reusable TanStack route pending and error shells", () => {
+    const boundarySource = expectSource("src/components/route-boundaries.tsx");
+
+    expect(boundarySource).toContain('from "@sentry/tanstackstart-react"');
+    expect(boundarySource).toContain("useRouter");
+    expect(boundarySource).toContain("router.invalidate");
+    expect(boundarySource).toContain("captureException");
+    expect(boundarySource).toContain('role="status"');
+    expect(boundarySource).toContain("aria-label={label}");
+  });
+
+  it("wires route-level pending and error boundaries where Next had segment shells", () => {
+    const routeFiles = [
+      "src/routes/_authenticated/$slug/chat/index.tsx",
+      "src/routes/_authenticated/$slug/chat/$conversationId.tsx",
+      "src/routes/_authenticated/$slug/automations/new.tsx",
+      "src/routes/_authenticated/$slug/automations/$automation.tsx",
+      "src/routes/_authenticated/$slug/settings/billing.tsx",
+    ];
+
+    for (const routeFile of routeFiles) {
+      const routeSource = expectSource(routeFile);
+
+      expect(routeSource).toContain("pendingComponent:");
+      expect(routeSource).toContain("errorComponent:");
+      expect(routeSource).toContain("RouteError");
+      expect(routeSource).not.toContain("next/");
+    }
+  });
+
+  it("wires loading shells for settings routes with async prefetch loaders", () => {
+    const routeFiles = [
+      "src/routes/_authenticated/$slug/settings/source-control.tsx",
+      "src/routes/_authenticated/$slug/settings/members.tsx",
+      "src/routes/_authenticated/$slug/settings/api-keys.tsx",
+    ];
+
+    for (const routeFile of routeFiles) {
+      const routeSource = expectSource(routeFile);
+
+      expect(routeSource).toContain("pendingComponent:");
+      expect(routeSource).toContain("WorkspaceRoutePending");
+      expect(routeSource).not.toContain("next/");
+    }
+  });
+});

--- a/apps/app-tanstack/src/components/route-boundaries.tsx
+++ b/apps/app-tanstack/src/components/route-boundaries.tsx
@@ -1,0 +1,148 @@
+import { Button } from "@repo/ui/components/ui/button";
+import { Skeleton } from "@repo/ui/components/ui/skeleton";
+import { cn } from "@repo/ui/lib/utils";
+import * as Sentry from "@sentry/tanstackstart-react";
+import { useRouter } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+
+export function WorkspaceRoutePending({
+  className,
+  label,
+}: {
+  className?: string;
+  label: string;
+}) {
+  return (
+    <div
+      aria-label={label}
+      className={cn(
+        "flex min-h-40 items-center justify-center bg-background",
+        className
+      )}
+      role="status"
+    >
+      <Loader2
+        aria-hidden="true"
+        className="size-6 animate-spin text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+export function AutomationFormRoutePending() {
+  return (
+    <div className="min-h-full bg-background text-foreground">
+      <div
+        aria-label="Loading new automation form"
+        className="mx-auto w-full max-w-2xl px-6 py-10"
+        role="status"
+      >
+        <Skeleton className="mb-8 h-8 w-20" />
+
+        <div className="space-y-8">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-48 w-full" />
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-20" />
+              <div className="flex gap-2">
+                <Skeleton className="h-9 w-16" />
+                <Skeleton className="h-9 w-16" />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-4">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-20" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceRouteErrorPanel({
+  backHref,
+  backLabel,
+  description,
+  error,
+  maxWidth = "max-w-xl",
+  reset,
+  route,
+  title,
+}: {
+  backHref?: string;
+  backLabel?: string;
+  description: string;
+  error: Error & { digest?: string };
+  maxWidth?: string;
+  reset?: () => void;
+  route: string;
+  title: string;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    Sentry.captureException(error, {
+      extra: {
+        errorDigest: error.digest,
+      },
+      tags: {
+        route,
+      },
+    });
+  }, [error, route]);
+
+  return (
+    <main className="flex min-h-full w-full items-center justify-center bg-background px-6 py-10">
+      <section
+        className={cn(
+          "w-full space-y-4 rounded-sm border border-border/60 px-5 py-6",
+          maxWidth
+        )}
+      >
+        <div>
+          <h2 className="font-medium text-foreground text-lg">{title}</h2>
+          <p className="mt-2 text-muted-foreground text-sm">{description}</p>
+          {error.digest ? (
+            <p className="mt-3 text-muted-foreground text-xs">
+              Error ID: {error.digest}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            onClick={() => {
+              reset?.();
+              void router.invalidate();
+            }}
+            size="sm"
+            type="button"
+          >
+            Try again
+          </Button>
+          {backHref && backLabel ? (
+            <Button asChild size="sm" type="button" variant="outline">
+              <a href={backHref}>{backLabel}</a>
+            </Button>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/automations/$automation.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/automations/$automation.tsx
@@ -2,6 +2,10 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { AutomationDetailClient } from "~/automations/automation-detail-client";
 import {
+  WorkspaceRouteErrorPanel,
+  WorkspaceRoutePending,
+} from "~/components/route-boundaries";
+import {
   loadRoutePrefetch,
   RoutePrefetchBoundary,
 } from "~/trpc/route-prefetch";
@@ -27,8 +31,37 @@ export const Route = createFileRoute(
   head: ({ params }) => ({
     meta: [{ title: `Automation - ${params.slug} - Lightfast` }],
   }),
+  pendingComponent: AutomationDetailRoutePending,
+  errorComponent: AutomationDetailRouteError,
   component: AutomationDetailPage,
 });
+
+function AutomationDetailRoutePending() {
+  return <WorkspaceRoutePending label="Loading automation" />;
+}
+
+function AutomationDetailRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { slug } = Route.useParams();
+
+  return (
+    <WorkspaceRouteErrorPanel
+      backHref={`/${slug}/automations`}
+      backLabel="Back to automations"
+      description="It may have been deleted, or there was a transient error."
+      error={error}
+      maxWidth="max-w-5xl"
+      reset={reset}
+      route="automations/[automationId]"
+      title="Couldn't load automation"
+    />
+  );
+}
 
 function AutomationDetailPage() {
   const { automation: automationId, slug } = Route.useParams();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/automations/new.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/automations/new.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AutomationCreateForm } from "~/automations/automation-create-form";
 import {
+  AutomationFormRoutePending,
+  WorkspaceRouteErrorPanel,
+} from "~/components/route-boundaries";
+import {
   loadRoutePrefetch,
   RoutePrefetchBoundary,
 } from "~/trpc/route-prefetch";
@@ -10,8 +14,33 @@ export const Route = createFileRoute("/_authenticated/$slug/automations/new")({
   head: ({ params }) => ({
     meta: [{ title: `New automation - ${params.slug} - Lightfast` }],
   }),
+  pendingComponent: AutomationFormRoutePending,
+  errorComponent: NewAutomationRouteError,
   component: NewAutomationPage,
 });
+
+function NewAutomationRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { slug } = Route.useParams();
+
+  return (
+    <WorkspaceRouteErrorPanel
+      backHref={`/${slug}/automations`}
+      backLabel="Back to automations"
+      description="There was a transient error while preparing the automation form."
+      error={error}
+      maxWidth="max-w-2xl"
+      reset={reset}
+      route="automations/new"
+      title="Couldn't load new automation"
+    />
+  );
+}
 
 function NewAutomationPage() {
   const { slug } = Route.useParams();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/chat/$conversationId.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/chat/$conversationId.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { ChatLoading } from "~/chat/chat-loading";
 import { isPreallocatedConversationId } from "~/chat/conversation-id";
 import { WorkspaceAssistantClient } from "~/chat/workspace-assistant-client";
+import { WorkspaceRouteErrorPanel } from "~/components/route-boundaries";
 import { useTRPC } from "~/trpc/react";
 
 export const Route = createFileRoute(
@@ -15,8 +16,36 @@ export const Route = createFileRoute(
       { title: `Chat ${params.conversationId} - ${params.slug} - Lightfast` },
     ],
   }),
+  pendingComponent: ChatRoutePending,
+  errorComponent: ChatRouteError,
   component: WorkspaceConversationPage,
 });
+
+function ChatRoutePending() {
+  return <ChatLoading />;
+}
+
+function ChatRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { slug } = Route.useParams();
+
+  return (
+    <WorkspaceRouteErrorPanel
+      backHref={`/${slug}/chat`}
+      backLabel="New chat"
+      description="There was a transient error while loading the conversation."
+      error={error}
+      reset={reset}
+      route="workspace-chat"
+      title="Couldn't load this chat"
+    />
+  );
+}
 
 function WorkspaceConversationPage() {
   const { conversationId } = Route.useParams();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/chat/index.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/chat/index.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { WorkspaceAssistantClient } from "~/chat/workspace-assistant-client";
+import {
+  WorkspaceRouteErrorPanel,
+  WorkspaceRoutePending,
+} from "~/components/route-boundaries";
 
 const createNewWorkspaceAssistantConversationId = createServerFn({
   method: "GET",
@@ -11,8 +15,38 @@ const createNewWorkspaceAssistantConversationId = createServerFn({
 
 export const Route = createFileRoute("/_authenticated/$slug/chat/")({
   loader: () => createNewWorkspaceAssistantConversationId(),
+  pendingComponent: ChatRoutePending,
+  errorComponent: ChatRouteError,
   component: WorkspaceChatPage,
 });
+
+function ChatRoutePending() {
+  return (
+    <WorkspaceRoutePending className="h-full min-h-0" label="Loading chat" />
+  );
+}
+
+function ChatRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { slug } = Route.useParams();
+
+  return (
+    <WorkspaceRouteErrorPanel
+      backHref={`/${slug}/chat`}
+      backLabel="New chat"
+      description="There was a transient error while preparing a new conversation."
+      error={error}
+      reset={reset}
+      route="workspace-chat"
+      title="Couldn't load this chat"
+    />
+  );
+}
 
 function WorkspaceChatPage() {
   const conversationId = Route.useLoaderData();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/api-keys.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/api-keys.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { WorkspaceRoutePending } from "~/components/route-boundaries";
 import { OrgApiKeyCreate } from "~/org/settings/api-keys/org-api-key-create";
 import { OrgApiKeyList } from "~/org/settings/api-keys/org-api-key-list";
 import {
@@ -19,9 +20,14 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/api-keys")(
         },
       ],
     }),
+    pendingComponent: ApiKeysRoutePending,
     component: ApiKeysSettingsPage,
   }
 );
+
+function ApiKeysRoutePending() {
+  return <WorkspaceRoutePending label="Loading API keys" />;
+}
 
 function ApiKeysSettingsPage() {
   const prefetchState = Route.useLoaderData();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/billing.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/billing.tsx
@@ -1,4 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import {
+  WorkspaceRouteErrorPanel,
+  WorkspaceRoutePending,
+} from "~/components/route-boundaries";
 import { BillingSettingsClient } from "~/org/settings/billing/billing-settings-client";
 import {
   loadRoutePrefetch,
@@ -16,8 +20,32 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/billing")({
       },
     ],
   }),
+  pendingComponent: BillingRoutePending,
+  errorComponent: BillingRouteError,
   component: BillingSettingsPage,
 });
+
+function BillingRoutePending() {
+  return <WorkspaceRoutePending label="Loading billing" />;
+}
+
+function BillingRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <WorkspaceRouteErrorPanel
+      description="We couldn't load billing details for this organization. This is usually a temporary issue with the billing provider."
+      error={error}
+      reset={reset}
+      route="org-billing-settings"
+      title="Billing is temporarily unavailable"
+    />
+  );
+}
 
 function BillingSettingsPage() {
   const prefetchState = Route.useLoaderData();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/members.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/members.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { WorkspaceRoutePending } from "~/components/route-boundaries";
 import { OrgMembersClient } from "~/org/settings/members/org-members-client";
 import {
   loadRoutePrefetch,
@@ -16,8 +17,13 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/members")({
       },
     ],
   }),
+  pendingComponent: MembersRoutePending,
   component: MembersSettingsPage,
 });
+
+function MembersRoutePending() {
+  return <WorkspaceRoutePending label="Loading members" />;
+}
 
 function MembersSettingsPage() {
   const prefetchState = Route.useLoaderData();

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/settings/source-control.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/settings/source-control.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { WorkspaceRoutePending } from "~/components/route-boundaries";
 import { SourceControlSettingsClient } from "~/org/settings/source-control/source-control-settings-client";
 import {
   loadRoutePrefetch,
@@ -19,8 +20,13 @@ export const Route = createFileRoute(
       },
     ],
   }),
+  pendingComponent: SourceControlRoutePending,
   component: WorkspaceSourceControlSettingsPage,
 });
+
+function SourceControlRoutePending() {
+  return <WorkspaceRoutePending label="Loading source control" />;
+}
 
 function WorkspaceSourceControlSettingsPage() {
   const prefetchState = Route.useLoaderData();


### PR DESCRIPTION
## Summary
- Add reusable TanStack route pending/error shells for app-tanstack workspace pages.
- Wire pending/error components into chat and automation routes that had Next segment loading/error boundaries.
- Wire loading shells into async workspace settings prefetch routes, with billing retaining a scoped error boundary.

## Verification
- `pnpm --filter @lightfast/app-tanstack exec vitest run src/__tests__/route-boundaries-source.test.ts`
- `pnpm --filter @lightfast/app-tanstack test`
- `pnpm --filter @lightfast/app-tanstack typecheck`
- `pnpm turbo //#check --summarize`
- `git diff --check`