### PR TITLE
test: expand app-tanstack product route smoke

### DIFF
--- a/e2e/src/app-tanstack/auth-route-smoke.test.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.test.ts
@@ -65,14 +65,16 @@ describe("app-tanstack auth route smoke helpers", () => {
 
   it("builds route checks for account and org-authenticated pages", () => {
     const checks = buildRouteChecks("lf-tanstack");
+    const paths = checks.map((check) => check.path);
 
-    expect(checks.map((check) => check.path)).toContain(
-      "/account/settings/general"
-    );
-    expect(checks.map((check) => check.path)).toContain(
-      "/lf-tanstack/settings/source-control"
-    );
-    expect(checks.map((check) => check.path)).toContain("/lf-tanstack/signals");
+    expect(paths).toContain("/account/settings/general");
+    expect(paths).toContain("/lf-tanstack/settings/source-control");
+    expect(paths).toContain("/lf-tanstack/signals");
+    expect(paths).toContain("/lf-tanstack/chat");
+    expect(paths).toContain("/lf-tanstack/decisions");
+    expect(paths).toContain("/lf-tanstack/people");
+    expect(paths).toContain("/lf-tanstack/developer-connections");
+    expect(paths).toContain("/lf-tanstack/automations/new");
     expect(checks).toHaveLength(APP_TANSTACK_AUTH_ROUTE_SPECS.length);
     expect(checks.some((check) => check.path.includes("$slug"))).toBe(false);
   });

--- a/e2e/src/app-tanstack/auth-route-smoke.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.ts
@@ -129,9 +129,34 @@ export const APP_TANSTACK_AUTH_ROUTE_SPECS: RouteSpec[] = [
     pathTemplate: "/$slug/automations",
   },
   {
+    expectedText: ["New automation", "Name", "Instructions", "Schedule"],
+    name: "new automation",
+    pathTemplate: "/$slug/automations/new",
+  },
+  {
+    expectedText: ["Ready when you are."],
+    name: "chat",
+    pathTemplate: "/$slug/chat",
+  },
+  {
     expectedText: ["Connectors", "Team connectors"],
     name: "connectors",
     pathTemplate: "/$slug/connectors",
+  },
+  {
+    expectedText: ["Decisions", "No decisions yet"],
+    name: "decisions",
+    pathTemplate: "/$slug/decisions",
+  },
+  {
+    expectedText: ["Developer Connections", "Connect provider CLIs"],
+    name: "developer connections",
+    pathTemplate: "/$slug/developer-connections",
+  },
+  {
+    expectedText: ["People", "No people yet"],
+    name: "people",
+    pathTemplate: "/$slug/people",
   },
   {
     expectedText: ["General", "Profile"],


### PR DESCRIPTION
## Summary
- expand the app-tanstack auth route smoke to cover product surfaces: chat, decisions, people, developer connections, and new automation
- update the helper test so slug substitution coverage includes those routes

## Verification
- pnpm --filter @lightfast/e2e exec vitest run src/app-tanstack/auth-route-smoke.test.ts
- pnpm --filter @lightfast/e2e app-tanstack:auth-routes (21 routes)
- pnpm --filter @lightfast/e2e test
- pnpm --filter @lightfast/e2e typecheck
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test coverage for authentication routes across account and organization features, including automations, chat, decisions, developer connections, and people sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->