### PR TITLE
test: add app-tanstack automation interaction smoke

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
+    "app-tanstack:automation-interactions": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-interaction-smoke.ts",
     "app-tanstack:auth-routes": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/auth-route-smoke.ts",
     "connectors:x:local": "pnpm with-env tsx src/connectors/x-local-agent-smoke.ts",
     "decisions:real-clerk": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/decisions/real-clerk-smoke.ts",

--- a/e2e/src/app-tanstack/auth-route-smoke.ts
+++ b/e2e/src/app-tanstack/auth-route-smoke.ts
@@ -43,6 +43,13 @@ export interface BuildAppTanstackAuthRouteSmokeConfigInput {
   nowMs?: number;
 }
 
+export interface AppTanstackAuthSmokeSession {
+  config: AppTanstackAuthRouteSmokeConfig;
+  orgId: string;
+  orgSlug: string;
+  userId: string;
+}
+
 interface ClerkUser {
   id: string;
 }
@@ -529,6 +536,46 @@ async function createClerkSignInToken(
   return body.token;
 }
 
+async function deleteClerkOrganization(
+  config: AppTanstackAuthRouteSmokeConfig,
+  orgId: string
+) {
+  await fetchClerkJson(config, `/organizations/${orgId}`, {
+    method: "DELETE",
+  });
+}
+
+async function deleteClerkUser(
+  config: AppTanstackAuthRouteSmokeConfig,
+  userId: string
+) {
+  await fetchClerkJson(config, `/users/${userId}`, {
+    method: "DELETE",
+  });
+}
+
+async function cleanupClerkSmokeIdentity(
+  config: AppTanstackAuthRouteSmokeConfig,
+  input: { orgId?: string; userId?: string }
+) {
+  const errors: string[] = [];
+  if (input.orgId) {
+    await deleteClerkOrganization(config, input.orgId).catch(
+      (error: unknown) => {
+        errors.push(error instanceof Error ? error.message : String(error));
+      }
+    );
+  }
+  if (input.userId) {
+    await deleteClerkUser(config, input.userId).catch((error: unknown) => {
+      errors.push(error instanceof Error ? error.message : String(error));
+    });
+  }
+  if (errors.length > 0) {
+    console.warn(`[smoke] Clerk cleanup warning: ${errors.join(" | ")}`);
+  }
+}
+
 export function readAppTanstackAuthEncryptionKey(env: Env = process.env) {
   const value = env.ENCRYPTION_KEY?.trim();
   if (!value) {
@@ -662,7 +709,7 @@ function record(value: unknown): Record<string, unknown> {
     : {};
 }
 
-async function agentBrowser(
+export async function agentBrowser(
   config: AppTanstackAuthRouteSmokeConfig,
   args: string[]
 ) {
@@ -673,7 +720,10 @@ async function agentBrowser(
   ]);
 }
 
-async function agentEval(config: AppTanstackAuthRouteSmokeConfig, js: string) {
+export async function agentEval(
+  config: AppTanstackAuthRouteSmokeConfig,
+  js: string
+) {
   return await agentBrowser(config, ["eval", js]);
 }
 
@@ -717,7 +767,7 @@ async function signInWithClerkTicket(
   );
 }
 
-async function readPageState(config: AppTanstackAuthRouteSmokeConfig) {
+export async function readPageState(config: AppTanstackAuthRouteSmokeConfig) {
   const raw = await agentEval(
     config,
     `({
@@ -822,6 +872,69 @@ function readPortlessUrl(name: string): string {
       stdio: ["ignore", "pipe", "pipe"],
     }).trim()
   );
+}
+
+export async function createAppTanstackAuthSmokeSession(
+  input: BuildAppTanstackAuthRouteSmokeConfigInput & {
+    destinationPath?: string;
+  } = {}
+): Promise<AppTanstackAuthSmokeSession> {
+  const env = input.env ?? process.env;
+  const config = buildAppTanstackAuthRouteSmokeConfig(input);
+  allowLocalhostTls(config.appOrigin);
+
+  let user: ClerkUser | undefined;
+  let org: ClerkOrganization | undefined;
+  try {
+    user = await createClerkUser(config);
+    org = await createClerkOrganization(config, user.id);
+    await updateClerkUserLastActiveOrg(config, {
+      orgId: org.id,
+      userId: user.id,
+    });
+    await createBoundSourceControlBinding({
+      orgId: org.id,
+      orgSlug: config.orgSlug,
+      userId: user.id,
+    });
+    await createActiveXConnectorConnection({
+      config,
+      env,
+      orgId: org.id,
+      orgSlug: config.orgSlug,
+      userId: user.id,
+    });
+    await updateClerkOrgBoundMetadata(config, org.id);
+
+    const ticket = await createClerkSignInToken(config, user.id);
+    await signInWithClerkTicket(config, {
+      destinationPath: input.destinationPath ?? "/account/settings/general",
+      orgId: org.id,
+      ticket,
+    });
+
+    return {
+      config,
+      orgId: org.id,
+      orgSlug: config.orgSlug,
+      userId: user.id,
+    };
+  } catch (error) {
+    await cleanupClerkSmokeIdentity(config, {
+      orgId: org?.id,
+      userId: user?.id,
+    });
+    throw error;
+  }
+}
+
+export async function cleanupAppTanstackAuthSmokeSession(
+  session: AppTanstackAuthSmokeSession
+) {
+  await cleanupClerkSmokeIdentity(session.config, {
+    orgId: session.orgId,
+    userId: session.userId,
+  });
 }
 
 export async function runAppTanstackAuthRouteSmoke(

--- a/e2e/src/app-tanstack/automation-interaction-smoke.test.ts
+++ b/e2e/src/app-tanstack/automation-interaction-smoke.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAppTanstackAutomationInteractionFixture,
+  buildAppTanstackAutomationInteractionPaths,
+} from "./automation-interaction-smoke";
+
+describe("app-tanstack automation interaction smoke helpers", () => {
+  it("builds deterministic automation copy for browser assertions", () => {
+    const fixture = buildAppTanstackAutomationInteractionFixture({
+      nowMs: 1_780_876_800_000,
+    });
+
+    expect(fixture).toEqual({
+      createName: "UI smoke automation 1780876800000",
+      createPrompt:
+        "Created through app-tanstack automation interaction smoke.",
+      updateName: "Updated UI smoke automation 1780876800000",
+      updatePrompt:
+        "Updated through app-tanstack automation interaction smoke.",
+    });
+  });
+
+  it("builds organization-scoped automation paths", () => {
+    expect(buildAppTanstackAutomationInteractionPaths("lightfast")).toEqual({
+      listPath: "/lightfast/automations",
+      newPath: "/lightfast/automations/new",
+    });
+  });
+});

--- a/e2e/src/app-tanstack/automation-interaction-smoke.ts
+++ b/e2e/src/app-tanstack/automation-interaction-smoke.ts
@@ -1,0 +1,442 @@
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import type {
+  AppTanstackAuthRouteSmokeConfig,
+  AppTanstackAuthSmokeSession,
+  BuildAppTanstackAuthRouteSmokeConfigInput,
+} from "./auth-route-smoke";
+import {
+  agentBrowser,
+  agentEval,
+  cleanupAppTanstackAuthSmokeSession,
+  collectRouteBodyProblems,
+  createAppTanstackAuthSmokeSession,
+  readPageState,
+} from "./auth-route-smoke";
+
+export interface AppTanstackAutomationInteractionFixture {
+  createName: string;
+  createPrompt: string;
+  updateName: string;
+  updatePrompt: string;
+}
+
+export interface AppTanstackAutomationInteractionPaths {
+  listPath: string;
+  newPath: string;
+}
+
+interface WaitForRouteTextInput {
+  expectedText: string[];
+  name: string;
+  path: string;
+}
+
+interface ClickAutomationLinkResult {
+  href: string;
+}
+
+export function buildAppTanstackAutomationInteractionFixture(
+  input: { nowMs?: number } = {}
+): AppTanstackAutomationInteractionFixture {
+  const timestampMs = input.nowMs ?? Date.now();
+  return {
+    createName: `UI smoke automation ${timestampMs}`,
+    createPrompt: "Created through app-tanstack automation interaction smoke.",
+    updateName: `Updated UI smoke automation ${timestampMs}`,
+    updatePrompt: "Updated through app-tanstack automation interaction smoke.",
+  };
+}
+
+export function buildAppTanstackAutomationInteractionPaths(
+  orgSlug: string
+): AppTanstackAutomationInteractionPaths {
+  return {
+    listPath: `/${orgSlug}/automations`,
+    newPath: `/${orgSlug}/automations/new`,
+  };
+}
+
+async function waitForRouteText(
+  config: AppTanstackAuthRouteSmokeConfig,
+  input: WaitForRouteTextInput
+) {
+  const deadline = Date.now() + config.routeTimeoutMs;
+  let latestState:
+    | {
+        bodyText: string;
+        href: string;
+        pathname: string;
+      }
+    | undefined;
+  let latestProblems: string[] = [];
+
+  while (Date.now() < deadline) {
+    latestState = await readPageState(config);
+    latestProblems = collectRouteBodyProblems({
+      bodyText: latestState.bodyText,
+      expectedText: input.expectedText,
+      finalPathname: latestState.pathname,
+      routeName: input.name,
+      routePath: input.path,
+    });
+    if (latestProblems.length === 0) {
+      return latestState;
+    }
+    await delay(500);
+  }
+
+  const snapshot = await agentBrowser(config, ["snapshot", "-i", "-u"]).catch(
+    (error) => String(error)
+  );
+  throw new Error(
+    [
+      `Automation interaction smoke failed for ${input.name} (${input.path}).`,
+      ...latestProblems,
+      latestState ? `Last URL: ${latestState.href}` : "Last URL: <unknown>",
+      snapshot,
+    ].join("\n")
+  );
+}
+
+async function clickAutomationLinkByName(
+  config: AppTanstackAuthRouteSmokeConfig,
+  name: string
+): Promise<ClickAutomationLinkResult> {
+  const deadline = Date.now() + config.routeTimeoutMs;
+  let latestLinks: Array<{ href: string; text: string }> = [];
+
+  while (Date.now() < deadline) {
+    const raw = await agentEval(
+      config,
+      `(() => {
+        const name = ${JSON.stringify(name)};
+        const links = Array.from(document.querySelectorAll("a"));
+        const link = links.find(
+          (element) =>
+            element instanceof HTMLAnchorElement &&
+            element.href.includes("/automations/") &&
+            element.textContent?.includes(name)
+        );
+        if (!(link instanceof HTMLAnchorElement)) {
+          return {
+            clicked: false,
+            links: links
+              .map((element) => ({
+                href: element instanceof HTMLAnchorElement ? element.href : "",
+                text: element.textContent?.trim() ?? "",
+              }))
+              .slice(0, 20),
+          };
+        }
+        link.click();
+        return { clicked: true, href: link.href };
+      })()`
+    );
+    const result = JSON.parse(raw) as
+      | { clicked: false; links: Array<{ href: string; text: string }> }
+      | { clicked: true; href: string };
+    if (result.clicked) {
+      return { href: result.href };
+    }
+    latestLinks = result.links;
+    await delay(500);
+  }
+
+  throw new Error(
+    `Could not find automation link for "${name}". Links: ${JSON.stringify(
+      latestLinks
+    )}`
+  );
+}
+
+async function clickButtonByText(
+  config: AppTanstackAuthRouteSmokeConfig,
+  name: string
+) {
+  const raw = await agentEval(
+    config,
+    `(() => {
+      const name = ${JSON.stringify(name)};
+      const button = Array.from(document.querySelectorAll("button")).find(
+        (element) =>
+          element instanceof HTMLButtonElement &&
+          element.textContent?.trim() === name
+      );
+      if (!(button instanceof HTMLButtonElement)) {
+        return { clicked: false, reason: "missing" };
+      }
+      if (button.disabled) {
+        return { clicked: false, reason: "disabled" };
+      }
+      button.click();
+      return { clicked: true };
+    })()`
+  );
+  const result = JSON.parse(raw) as
+    | { clicked: false; reason: string }
+    | { clicked: true };
+  if (!result.clicked) {
+    throw new Error(`Could not click "${name}" button: ${result.reason}`);
+  }
+}
+
+function extractAutomationPublicId(href: string): string {
+  const url = new URL(href);
+  const segments = url.pathname.split("/").filter(Boolean);
+  const automationsIndex = segments.indexOf("automations");
+  const publicId =
+    automationsIndex >= 0 ? segments[automationsIndex + 1] : undefined;
+  if (!publicId || publicId === "new") {
+    throw new Error(`Could not extract automation public id from ${href}`);
+  }
+  return publicId;
+}
+
+async function blurActiveElement(config: AppTanstackAuthRouteSmokeConfig) {
+  await agentEval(
+    config,
+    `(() => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+      return { activeElement: document.activeElement?.tagName ?? null };
+    })()`
+  );
+}
+
+async function waitForTextareaByAriaLabel(
+  config: AppTanstackAuthRouteSmokeConfig,
+  label: string
+) {
+  const deadline = Date.now() + config.routeTimeoutMs;
+  let latestLabels: string[] = [];
+
+  while (Date.now() < deadline) {
+    const raw = await agentEval(
+      config,
+      `(() => {
+        const label = ${JSON.stringify(label)};
+        const textareas = Array.from(document.querySelectorAll("textarea"));
+        return {
+          exists: textareas.some(
+            (element) => element.getAttribute("aria-label") === label
+          ),
+          labels: textareas.map(
+            (element) => element.getAttribute("aria-label") ?? ""
+          ),
+        };
+      })()`
+    );
+    const result = JSON.parse(raw) as {
+      exists: boolean;
+      labels: string[];
+    };
+    if (result.exists) {
+      return;
+    }
+    latestLabels = result.labels;
+    await delay(500);
+  }
+
+  throw new Error(
+    `Textarea "${label}" did not render. Latest textarea labels: ${JSON.stringify(
+      latestLabels
+    )}`
+  );
+}
+
+async function waitForAutomationPersisted(input: {
+  config: AppTanstackAuthRouteSmokeConfig;
+  expectedName: string;
+  expectedPrompt: string;
+  orgId: string;
+  publicId: string;
+}) {
+  const [{ db }, { getAutomationByPublicId }] = await Promise.all([
+    import("@db/app/client"),
+    import("@db/app"),
+  ]);
+  const deadline = Date.now() + input.config.routeTimeoutMs;
+  let latest:
+    | {
+        name: string;
+        prompt: string;
+      }
+    | undefined;
+
+  while (Date.now() < deadline) {
+    const automation = await getAutomationByPublicId(db, {
+      clerkOrgId: input.orgId,
+      publicId: input.publicId,
+    });
+    latest = automation
+      ? { name: automation.name, prompt: automation.prompt }
+      : undefined;
+    if (
+      automation?.name === input.expectedName &&
+      automation.prompt === input.expectedPrompt
+    ) {
+      return automation;
+    }
+    await delay(500);
+  }
+
+  throw new Error(
+    `Automation ${input.publicId} did not persist expected edits. Last row: ${JSON.stringify(
+      latest
+    )}`
+  );
+}
+
+export async function runAppTanstackAutomationInteractionSmoke(
+  input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
+) {
+  const nowMs = input.nowMs ?? Date.now();
+  const fixture = buildAppTanstackAutomationInteractionFixture({ nowMs });
+  let config: AppTanstackAuthRouteSmokeConfig | undefined;
+  let session: AppTanstackAuthSmokeSession | undefined;
+
+  try {
+    session = await createAppTanstackAuthSmokeSession({
+      ...input,
+      nowMs,
+    });
+    config = session.config;
+    const paths = buildAppTanstackAutomationInteractionPaths(session.orgSlug);
+
+    console.log(`[smoke] app=${config.appOrigin}`);
+    console.log(`[smoke] org=${session.orgSlug}`);
+    console.log(`[smoke] create=${fixture.createName}`);
+
+    await agentBrowser(config, [
+      "open",
+      new URL(paths.newPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: ["New automation", "Name", "Instructions", "Schedule"],
+      name: "new automation form",
+      path: paths.newPath,
+    });
+
+    await agentBrowser(config, [
+      "find",
+      "placeholder",
+      "Daily code review",
+      "fill",
+      fixture.createName,
+    ]);
+    await agentBrowser(config, [
+      "find",
+      "placeholder",
+      "Describe what the agent should do in each run.",
+      "fill",
+      fixture.createPrompt,
+    ]);
+    await waitForRouteText(config, {
+      expectedText: [
+        "New automation",
+        fixture.createName,
+        fixture.createPrompt,
+      ],
+      name: "new automation form after fill",
+      path: paths.newPath,
+    });
+    await clickButtonByText(config, "Create");
+
+    await waitForRouteText(config, {
+      expectedText: ["Automations", fixture.createName],
+      name: "automation list after create",
+      path: paths.listPath,
+    });
+
+    const clicked = await clickAutomationLinkByName(config, fixture.createName);
+    const automationPublicId = extractAutomationPublicId(clicked.href);
+    const detailPath = new URL(clicked.href).pathname;
+
+    await waitForRouteText(config, {
+      expectedText: [
+        fixture.createName,
+        fixture.createPrompt,
+        "Status",
+        "Actions",
+        "Previous runs",
+      ],
+      name: "automation detail after create",
+      path: detailPath,
+    });
+
+    await waitForTextareaByAriaLabel(config, "Automation name");
+    await agentBrowser(config, [
+      "fill",
+      'textarea[aria-label="Automation name"]',
+      fixture.updateName,
+    ]);
+    await agentBrowser(config, [
+      "fill",
+      'textarea[aria-label="Instructions"]',
+      fixture.updatePrompt,
+    ]);
+    await blurActiveElement(config);
+    await waitForAutomationPersisted({
+      config,
+      expectedName: fixture.updateName,
+      expectedPrompt: fixture.updatePrompt,
+      orgId: session.orgId,
+      publicId: automationPublicId,
+    });
+
+    await agentBrowser(config, [
+      "open",
+      new URL(detailPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: [
+        fixture.updateName,
+        fixture.updatePrompt,
+        "Status",
+        "Actions",
+        "Previous runs",
+      ],
+      name: "automation detail after edit reload",
+      path: detailPath,
+    });
+
+    await agentBrowser(config, [
+      "open",
+      new URL(paths.listPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: ["Automations", fixture.updateName],
+      name: "automation list after edit",
+      path: paths.listPath,
+    });
+
+    console.log(
+      `[smoke] completed automation interaction ${automationPublicId}`
+    );
+  } finally {
+    if (config) {
+      await agentBrowser(config, ["close"]).catch(() => undefined);
+    }
+    if (session) {
+      await cleanupAppTanstackAuthSmokeSession(session);
+    }
+  }
+}
+
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return Boolean(
+    entrypoint && path.resolve(entrypoint) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isMainModule()) {
+  runAppTanstackAutomationInteractionSmoke().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a browser-backed app-tanstack automation interaction smoke covering create, list, detail, autosave edit, persisted DB verification, reload, and list verification
- share the app-tanstack auth smoke Clerk/org/binding setup for interaction tests
- clean up generated Clerk smoke orgs/users so repeated runs do not exhaust the dev instance user quota

## Verification
- pnpm --filter @lightfast/e2e test
- pnpm --filter @lightfast/e2e typecheck
- pnpm check
- LIGHTFAST_E2E_APP_TANSTACK_URL=http://127.0.0.1:5123 pnpm --filter @lightfast/e2e app-tanstack:automation-interactions
