### PR TITLE
test: add app-tanstack automation run smoke

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
     "app-tanstack:automation-interactions": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-interaction-smoke.ts",
+    "app-tanstack:automation-run": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-run-smoke.ts",
     "app-tanstack:auth-routes": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/auth-route-smoke.ts",
     "connectors:x:local": "pnpm with-env tsx src/connectors/x-local-agent-smoke.ts",
     "decisions:real-clerk": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/decisions/real-clerk-smoke.ts",

--- a/e2e/src/app-tanstack/automation-interaction-smoke.ts
+++ b/e2e/src/app-tanstack/automation-interaction-smoke.ts
@@ -59,7 +59,7 @@ export function buildAppTanstackAutomationInteractionPaths(
   };
 }
 
-async function waitForRouteText(
+export async function waitForRouteText(
   config: AppTanstackAuthRouteSmokeConfig,
   input: WaitForRouteTextInput
 ) {
@@ -152,7 +152,7 @@ async function clickAutomationLinkByName(
   );
 }
 
-async function clickButtonByText(
+export async function clickButtonByText(
   config: AppTanstackAuthRouteSmokeConfig,
   name: string
 ) {

--- a/e2e/src/app-tanstack/automation-run-smoke.test.ts
+++ b/e2e/src/app-tanstack/automation-run-smoke.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAppTanstackAutomationRunFixture,
+  buildAppTanstackAutomationRunPaths,
+  isObservedAutomationRunStatus,
+} from "./automation-run-smoke";
+
+describe("app-tanstack automation run smoke helpers", () => {
+  it("builds deterministic automation copy for manual run assertions", () => {
+    expect(
+      buildAppTanstackAutomationRunFixture({ nowMs: 1_780_876_800_000 })
+    ).toEqual({
+      automationName: "Manual run smoke automation 1780876800000",
+      automationPrompt:
+        "Verify the app-tanstack manual run history smoke can enqueue this automation.",
+    });
+  });
+
+  it("builds automation detail and selected-run paths", () => {
+    expect(
+      buildAppTanstackAutomationRunPaths({
+        automationId: "automation_123",
+        orgSlug: "lightfast",
+        runId: "automation_run_456",
+      })
+    ).toEqual({
+      detailPath: "/lightfast/automations/automation_123",
+      runDetailPath:
+        "/lightfast/automations/automation_123?run=automation_run_456",
+    });
+  });
+
+  it("recognizes run statuses that may be visible after enqueue", () => {
+    expect(isObservedAutomationRunStatus("pending")).toBe(true);
+    expect(isObservedAutomationRunStatus("running")).toBe(true);
+    expect(isObservedAutomationRunStatus("completed")).toBe(true);
+    expect(isObservedAutomationRunStatus("failed")).toBe(true);
+    expect(isObservedAutomationRunStatus("skipped")).toBe(true);
+    expect(isObservedAutomationRunStatus("deleted")).toBe(false);
+  });
+});

--- a/e2e/src/app-tanstack/automation-run-smoke.test.ts
+++ b/e2e/src/app-tanstack/automation-run-smoke.test.ts
@@ -31,6 +31,18 @@ describe("app-tanstack automation run smoke helpers", () => {
     });
   });
 
+  it("returns null run detail path when run id is omitted", () => {
+    expect(
+      buildAppTanstackAutomationRunPaths({
+        automationId: "automation_123",
+        orgSlug: "lightfast",
+      })
+    ).toEqual({
+      detailPath: "/lightfast/automations/automation_123",
+      runDetailPath: null,
+    });
+  });
+
   it("recognizes run statuses that may be visible after enqueue", () => {
     expect(isObservedAutomationRunStatus("pending")).toBe(true);
     expect(isObservedAutomationRunStatus("running")).toBe(true);

--- a/e2e/src/app-tanstack/automation-run-smoke.ts
+++ b/e2e/src/app-tanstack/automation-run-smoke.ts
@@ -157,6 +157,19 @@ async function waitForManualRun(input: {
   );
 }
 
+async function assertSelectedRunSearchParam(
+  config: AppTanstackAuthRouteSmokeConfig,
+  runId: string
+) {
+  const href = await agentBrowser(config, ["get", "url"]);
+  const selectedRunId = new URL(href).searchParams.get("run");
+  if (selectedRunId !== runId) {
+    throw new Error(
+      `Expected selected run query param ${runId}, received ${selectedRunId ?? "<missing>"} at ${href}`
+    );
+  }
+}
+
 export async function runAppTanstackAutomationRunSmoke(
   input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
 ) {
@@ -226,6 +239,7 @@ export async function runAppTanstackAutomationRunSmoke(
       "open",
       new URL(runPaths.runDetailPath, config.appOrigin).toString(),
     ]);
+    await assertSelectedRunSearchParam(config, run.publicId);
     await waitForRouteText(config, {
       expectedText: ["manual run", "Status", "Trigger", "Run ID", run.publicId],
       name: "automation manual run detail",

--- a/e2e/src/app-tanstack/automation-run-smoke.ts
+++ b/e2e/src/app-tanstack/automation-run-smoke.ts
@@ -1,0 +1,258 @@
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import type {
+  AppTanstackAuthRouteSmokeConfig,
+  AppTanstackAuthSmokeSession,
+  BuildAppTanstackAuthRouteSmokeConfigInput,
+} from "./auth-route-smoke";
+import {
+  agentBrowser,
+  cleanupAppTanstackAuthSmokeSession,
+  createAppTanstackAuthSmokeSession,
+} from "./auth-route-smoke";
+import {
+  clickButtonByText,
+  waitForRouteText,
+} from "./automation-interaction-smoke";
+
+export interface AppTanstackAutomationRunFixture {
+  automationName: string;
+  automationPrompt: string;
+}
+
+export interface AppTanstackAutomationRunPathsInput {
+  automationId: string;
+  orgSlug: string;
+  runId?: string;
+}
+
+export interface AppTanstackAutomationRunPaths {
+  detailPath: string;
+  runDetailPath: string | null;
+}
+
+const OBSERVED_AUTOMATION_RUN_STATUSES = [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "skipped",
+] as const;
+
+type ObservedAutomationRunStatus =
+  (typeof OBSERVED_AUTOMATION_RUN_STATUSES)[number];
+
+interface AutomationRunRecord {
+  errorCode: string | null;
+  errorMessage: string | null;
+  publicId: string;
+  status: string;
+  trigger: string;
+}
+
+export function buildAppTanstackAutomationRunFixture(
+  input: { nowMs?: number } = {}
+): AppTanstackAutomationRunFixture {
+  const timestampMs = input.nowMs ?? Date.now();
+  return {
+    automationName: `Manual run smoke automation ${timestampMs}`,
+    automationPrompt:
+      "Verify the app-tanstack manual run history smoke can enqueue this automation.",
+  };
+}
+
+export function buildAppTanstackAutomationRunPaths(
+  input: AppTanstackAutomationRunPathsInput
+): AppTanstackAutomationRunPaths {
+  const detailPath = `/${input.orgSlug}/automations/${input.automationId}`;
+  return {
+    detailPath,
+    runDetailPath: input.runId
+      ? `${detailPath}?run=${encodeURIComponent(input.runId)}`
+      : null,
+  };
+}
+
+export function isObservedAutomationRunStatus(
+  value: string
+): value is ObservedAutomationRunStatus {
+  return OBSERVED_AUTOMATION_RUN_STATUSES.includes(
+    value as ObservedAutomationRunStatus
+  );
+}
+
+async function createManualRunSmokeAutomation(input: {
+  fixture: AppTanstackAutomationRunFixture;
+  session: AppTanstackAuthSmokeSession;
+}) {
+  const [{ db }, { createAutomation }] = await Promise.all([
+    import("@db/app/client"),
+    import("@db/app"),
+  ]);
+  return await createAutomation(db, {
+    clerkOrgId: input.session.orgId,
+    connectorProvider: null,
+    createdByUserId: input.session.userId,
+    name: input.fixture.automationName,
+    prompt: input.fixture.automationPrompt,
+    schedule: { kind: "manual", config: {} },
+    timezone: "UTC",
+  });
+}
+
+async function waitForManualRun(input: {
+  automationPublicId: string;
+  config: AppTanstackAuthRouteSmokeConfig;
+  orgId: string;
+}) {
+  const [{ db }, { listAutomationRuns }] = await Promise.all([
+    import("@db/app/client"),
+    import("@db/app"),
+  ]);
+  const deadline = Date.now() + input.config.routeTimeoutMs;
+  let latestRuns: AutomationRunRecord[] = [];
+
+  while (Date.now() < deadline) {
+    const runs = await listAutomationRuns(db, {
+      automationPublicId: input.automationPublicId,
+      clerkOrgId: input.orgId,
+      limit: 5,
+    });
+    latestRuns = runs.map((run) => ({
+      errorCode: run.errorCode,
+      errorMessage: run.errorMessage,
+      publicId: run.publicId,
+      status: run.status,
+      trigger: run.trigger,
+    }));
+    const manualRun = latestRuns.find((run) => run.trigger === "manual");
+    if (manualRun) {
+      if (manualRun.errorCode === "AUTOMATION_RUN_ENQUEUE_FAILED") {
+        throw new Error(
+          [
+            `Manual automation run ${manualRun.publicId} failed before enqueue.`,
+            manualRun.errorMessage,
+            "Start the local Inngest dev server or set a valid INNGEST_EVENT_KEY before running this smoke.",
+          ]
+            .filter(Boolean)
+            .join("\n")
+        );
+      }
+      if (!isObservedAutomationRunStatus(manualRun.status)) {
+        throw new Error(
+          `Manual automation run ${manualRun.publicId} has unexpected status ${manualRun.status}.`
+        );
+      }
+      return manualRun;
+    }
+    await delay(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for manual automation run. Latest runs: ${JSON.stringify(
+      latestRuns
+    )}`
+  );
+}
+
+export async function runAppTanstackAutomationRunSmoke(
+  input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
+) {
+  const nowMs = input.nowMs ?? Date.now();
+  const fixture = buildAppTanstackAutomationRunFixture({ nowMs });
+  let config: AppTanstackAuthRouteSmokeConfig | undefined;
+  let session: AppTanstackAuthSmokeSession | undefined;
+
+  try {
+    session = await createAppTanstackAuthSmokeSession({
+      ...input,
+      nowMs,
+    });
+    config = session.config;
+    const automation = await createManualRunSmokeAutomation({
+      fixture,
+      session,
+    });
+    const paths = buildAppTanstackAutomationRunPaths({
+      automationId: automation.publicId,
+      orgSlug: session.orgSlug,
+    });
+
+    console.log(`[smoke] app=${config.appOrigin}`);
+    console.log(`[smoke] org=${session.orgSlug}`);
+    console.log(`[smoke] automation=${automation.publicId}`);
+
+    await agentBrowser(config, [
+      "open",
+      new URL(paths.detailPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: [
+        fixture.automationName,
+        fixture.automationPrompt,
+        "Run now",
+        "Previous runs",
+        "No runs yet.",
+      ],
+      name: "automation detail before manual run",
+      path: paths.detailPath,
+    });
+
+    await clickButtonByText(config, "Run now");
+    const run = await waitForManualRun({
+      automationPublicId: automation.publicId,
+      config,
+      orgId: session.orgId,
+    });
+
+    await waitForRouteText(config, {
+      expectedText: ["Previous runs", "manual"],
+      name: "automation detail after manual run",
+      path: paths.detailPath,
+    });
+
+    const runPaths = buildAppTanstackAutomationRunPaths({
+      automationId: automation.publicId,
+      orgSlug: session.orgSlug,
+      runId: run.publicId,
+    });
+    if (!runPaths.runDetailPath) {
+      throw new Error("Run detail path was not built.");
+    }
+
+    await agentBrowser(config, [
+      "open",
+      new URL(runPaths.runDetailPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: ["manual run", "Status", "Trigger", "Run ID", run.publicId],
+      name: "automation manual run detail",
+      path: runPaths.detailPath,
+    });
+
+    console.log(`[smoke] completed automation manual run ${run.publicId}`);
+  } finally {
+    if (config) {
+      await agentBrowser(config, ["close"]).catch(() => undefined);
+    }
+    if (session) {
+      await cleanupAppTanstackAuthSmokeSession(session);
+    }
+  }
+}
+
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return Boolean(
+    entrypoint && path.resolve(entrypoint) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isMainModule()) {
+  runAppTanstackAutomationRunSmoke().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add an app-tanstack manual automation run smoke covering the Run now button, DB run creation, run-history UI, and selected run detail sheet
- reuse shared browser smoke helpers from the automation interaction smoke
- add deterministic helper tests and a package script for the run smoke

## Verification
- pnpm --filter @lightfast/e2e test
- pnpm --filter @lightfast/e2e typecheck
- pnpm check
- LIGHTFAST_E2E_APP_TANSTACK_URL=http://127.0.0.1:5123 pnpm --filter @lightfast/e2e app-tanstack:automation-run

## Local smoke setup used
- Vite app-tanstack: http://127.0.0.1:5123
- Inngest dev: http://127.0.0.1:8288 pointed at http://127.0.0.1:5123/api/inngest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end smoke tests for the automation manual-run feature, including validation of run creation, status updates, and UI interactions. Enhanced test helper functions for improved reusability across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->