### PR TITLE
test: add app tanstack automation delete smoke

### DIFF
--- a/api/app/src/__tests__/automations-router.test.ts
+++ b/api/app/src/__tests__/automations-router.test.ts
@@ -5,6 +5,7 @@ import type { AuthIdentity } from "../auth/identity";
 
 const createAutomationMock = vi.fn();
 const createAutomationRunMock = vi.fn();
+const deleteAutomationMock = vi.fn();
 const getAutomationByPublicIdMock = vi.fn();
 const getAutomationRunByPublicIdMock = vi.fn();
 const listAutomationRunsMock = vi.fn();
@@ -17,6 +18,7 @@ vi.mock("@db/app/client", () => ({ db: {} }));
 vi.mock("@db/app", () => ({
   createAutomation: createAutomationMock,
   createAutomationRun: createAutomationRunMock,
+  deleteAutomation: deleteAutomationMock,
   getAutomationByPublicId: getAutomationByPublicIdMock,
   getAutomationRunByPublicId: getAutomationRunByPublicIdMock,
   listAutomationRuns: listAutomationRunsMock,
@@ -166,6 +168,7 @@ const run = {
 beforeEach(() => {
   createAutomationMock.mockReset();
   createAutomationRunMock.mockReset();
+  deleteAutomationMock.mockReset();
   getAutomationByPublicIdMock.mockReset();
   getAutomationRunByPublicIdMock.mockReset();
   listAutomationRunsMock.mockReset();
@@ -176,6 +179,7 @@ beforeEach(() => {
 
   createAutomationMock.mockResolvedValue(automation);
   createAutomationRunMock.mockResolvedValue(run);
+  deleteAutomationMock.mockResolvedValue(true);
   getAutomationByPublicIdMock.mockResolvedValue(automation);
   getAutomationRunByPublicIdMock.mockResolvedValue(run);
   listAutomationRunsMock.mockResolvedValue([run]);
@@ -367,6 +371,33 @@ describe("automationsRouter", () => {
     expect(getAutomationByPublicIdMock).not.toHaveBeenCalled();
     expect(createAutomationRunMock).not.toHaveBeenCalled();
     expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("deletes an automation for org admins", async () => {
+    await expect(
+      caller().automations.delete({ id: automation.publicId })
+    ).resolves.toEqual({ deleted: true });
+
+    expect(deleteAutomationMock).toHaveBeenCalledWith(expect.anything(), {
+      clerkOrgId: "org_acme",
+      publicId: automation.publicId,
+    });
+  });
+
+  it("returns NOT_FOUND when deleting a missing automation", async () => {
+    deleteAutomationMock.mockResolvedValueOnce(false);
+
+    await expect(
+      caller().automations.delete({ id: automation.publicId })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("rejects delete for non-admin org members", async () => {
+    await expect(
+      caller(nonAdminAccess()).automations.delete({ id: automation.publicId })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(deleteAutomationMock).not.toHaveBeenCalled();
   });
 
   it("gets a single run scoped to the active organization", async () => {

--- a/api/app/src/router/(pending-not-allowed)/automations.ts
+++ b/api/app/src/router/(pending-not-allowed)/automations.ts
@@ -1,6 +1,7 @@
 import {
   createAutomation,
   createAutomationRun,
+  deleteAutomation,
   getAutomationByPublicId,
   getAutomationRunByPublicId,
   listAutomationRuns,
@@ -103,6 +104,19 @@ export const automationsRouter = {
         status: "active",
       });
       return automation ?? notFound();
+    }),
+
+  delete: boundOrgAdminProcedure
+    .input(getAutomationSchema)
+    .mutation(async ({ ctx, input }) => {
+      const deleted = await deleteAutomation(ctx.db, {
+        clerkOrgId: ctx.auth.identity.orgId,
+        publicId: input.id,
+      });
+      if (!deleted) {
+        notFound();
+      }
+      return { deleted: true };
     }),
 
   runNow: boundOrgAdminProcedure

--- a/apps/app-tanstack/src/automations/automation-actions.tsx
+++ b/apps/app-tanstack/src/automations/automation-actions.tsx
@@ -1,20 +1,37 @@
 import type { AppRouterOutputs } from "@api/app";
 import { useAuth } from "@clerk/tanstack-react-start";
-import { Button } from "@repo/ui/components/ui/button";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@repo/ui/components/ui/tooltip";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@repo/ui/components/ui/alert-dialog";
+import { Button } from "@repo/ui/components/ui/button";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { Loader2, Play, Trash } from "lucide-react";
+import { useState } from "react";
 import { useTRPC } from "~/trpc/react";
-import { AUTOMATION_RUNS_PAGE_LIMIT, upsertRun } from "./automations-cache";
+import {
+  AUTOMATION_RUNS_PAGE_LIMIT,
+  removeFromList,
+  upsertRun,
+} from "./automations-cache";
 import { RailSection } from "./detail-sections";
 
 type Automation = AppRouterOutputs["org"]["workspace"]["automations"]["get"];
 
-export function AutomationActions({ automation }: { automation: Automation }) {
+export function AutomationActions({
+  automation,
+  slug,
+}: {
+  automation: Automation;
+  slug: string;
+}) {
   const { has, isLoaded } = useAuth();
   const canManage = isLoaded && !!has?.({ role: "org:admin" });
 
@@ -22,14 +39,26 @@ export function AutomationActions({ automation }: { automation: Automation }) {
     return null;
   }
 
-  return <AutomationActionsInner automation={automation} />;
+  return <AutomationActionsInner automation={automation} slug={slug} />;
 }
 
-function AutomationActionsInner({ automation }: { automation: Automation }) {
+function AutomationActionsInner({
+  automation,
+  slug,
+}: {
+  automation: Automation;
+  slug: string;
+}) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const qc = useQueryClient();
+  const navigate = useNavigate();
   const trpc = useTRPC();
   const id = automation.publicId;
 
+  const getKey = trpc.org.workspace.automations.get.queryOptions({
+    id,
+  }).queryKey;
+  const listKey = trpc.org.workspace.automations.list.queryOptions().queryKey;
   const listRunsKey = trpc.org.workspace.automations.listRuns.queryOptions({
     id,
     limit: AUTOMATION_RUNS_PAGE_LIMIT,
@@ -41,6 +70,39 @@ function AutomationActionsInner({ automation }: { automation: Automation }) {
       onSuccess: (run) => {
         upsertRun(qc, trpc, id, run);
         void qc.invalidateQueries({ queryKey: listRunsKey });
+      },
+    })
+  );
+
+  const deleteMutation = useMutation(
+    trpc.org.workspace.automations.delete.mutationOptions({
+      meta: { errorTitle: "Failed to delete automation" },
+      onMutate: async () => {
+        await Promise.all([
+          qc.cancelQueries({ queryKey: getKey }),
+          qc.cancelQueries({ queryKey: listKey }),
+        ]);
+        const prevGet = qc.getQueryData(getKey);
+        const prevList = qc.getQueryData(listKey);
+        removeFromList(qc, trpc, id);
+        return { prevGet, prevList };
+      },
+      onError: (_error, _variables, ctx) => {
+        if (ctx?.prevGet) {
+          qc.setQueryData(getKey, ctx.prevGet);
+        }
+        if (ctx?.prevList) {
+          qc.setQueryData(listKey, ctx.prevList);
+        }
+      },
+      onSuccess: async () => {
+        setDeleteDialogOpen(false);
+        await navigate({
+          params: { slug },
+          to: "/$slug/automations",
+        });
+        qc.removeQueries({ queryKey: getKey });
+        void qc.invalidateQueries({ queryKey: listKey });
       },
     })
   );
@@ -62,23 +124,49 @@ function AutomationActionsInner({ automation }: { automation: Automation }) {
           )}
           Run now
         </Button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              aria-disabled
-              className="w-full cursor-not-allowed justify-start gap-2 opacity-50"
-              size="lf"
-              type="button"
-              variant="secondary"
-            >
+        <AlertDialog onOpenChange={setDeleteDialogOpen} open={deleteDialogOpen}>
+          <Button
+            className="w-full justify-start gap-2"
+            disabled={deleteMutation.isPending}
+            onClick={() => setDeleteDialogOpen(true)}
+            size="lf"
+            type="button"
+            variant="secondary"
+          >
+            {deleteMutation.isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
               <Trash className="size-4" />
-              Delete
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            Delete is not available yet - pause the automation instead.
-          </TooltipContent>
-        </Tooltip>
+            )}
+            Delete
+          </Button>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete automation?</AlertDialogTitle>
+              <AlertDialogDescription>
+                "{automation.name}" will be removed from this workspace. This
+                action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={deleteMutation.isPending}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                disabled={deleteMutation.isPending}
+                onClick={() => {
+                  deleteMutation.mutate({ id });
+                }}
+              >
+                {deleteMutation.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </RailSection>
   );

--- a/apps/app-tanstack/src/automations/automation-detail-client.tsx
+++ b/apps/app-tanstack/src/automations/automation-detail-client.tsx
@@ -146,7 +146,7 @@ export function AutomationDetailClient({
           <AutomationScheduleEditor automation={automation} />
         </RailSection>
 
-        <AutomationActions automation={automation} />
+        <AutomationActions automation={automation} slug={slug} />
 
         <RailSection title="Previous runs">
           <AutomationRunsSection

--- a/apps/app-tanstack/src/automations/automations-cache.ts
+++ b/apps/app-tanstack/src/automations/automations-cache.ts
@@ -34,6 +34,17 @@ export function upsertInList(
   });
 }
 
+export function removeFromList(
+  qc: QueryClient,
+  trpc: TRPCClient,
+  id: string
+): void {
+  const key = trpc.org.workspace.automations.list.queryOptions().queryKey;
+  qc.setQueryData(key, (old: Automation[] | undefined) =>
+    (old ?? []).filter((automation) => automation.publicId !== id)
+  );
+}
+
 export function setOne(
   qc: QueryClient,
   trpc: TRPCClient,

--- a/db/app/src/__tests__/automations.test.ts
+++ b/db/app/src/__tests__/automations.test.ts
@@ -6,6 +6,7 @@ import type { Database } from "../client";
 import {
   calculateNextRunAt,
   createAutomation,
+  deleteAutomation,
   markAutomationRunFailed,
 } from "../utils/automations";
 
@@ -243,6 +244,58 @@ describe("createAutomation", () => {
         connectorProvider: null,
       })
     );
+  });
+});
+
+describe("deleteAutomation", () => {
+  it("soft deletes active automations scoped to the organization", async () => {
+    const whereMock = vi.fn((_: SQL) => ({ affectedRows: 1 }));
+    const setMock = vi.fn(() => ({ where: whereMock }));
+    const db = {
+      update: vi.fn(() => ({ set: setMock })),
+    } as unknown as Database;
+
+    await expect(
+      deleteAutomation(db, {
+        clerkOrgId: "org_test",
+        publicId: "automation_123e4567-e89b-12d3-a456-426614174000",
+      })
+    ).resolves.toBe(true);
+
+    expect(setMock).toHaveBeenCalledWith({ status: "deleted" });
+
+    const condition = whereMock.mock.calls[0]?.[0];
+    expect(condition).toBeDefined();
+    if (!condition) {
+      throw new Error("expected update where condition");
+    }
+    const query = new MySqlDialect().sqlToQuery(condition);
+
+    expect(query.sql).toContain("`clerk_org_id` = ?");
+    expect(query.sql).toContain("`public_id` = ?");
+    expect(query.sql).toContain("`status` <> ?");
+    expect(query.params).toEqual(
+      expect.arrayContaining([
+        "org_test",
+        "automation_123e4567-e89b-12d3-a456-426614174000",
+        "deleted",
+      ])
+    );
+  });
+
+  it("returns false when no automation row was deleted", async () => {
+    const whereMock = vi.fn((_: SQL) => ({ rowsAffected: 0 }));
+    const setMock = vi.fn(() => ({ where: whereMock }));
+    const db = {
+      update: vi.fn(() => ({ set: setMock })),
+    } as unknown as Database;
+
+    await expect(
+      deleteAutomation(db, {
+        clerkOrgId: "org_test",
+        publicId: "automation_123e4567-e89b-12d3-a456-426614174000",
+      })
+    ).resolves.toBe(false);
   });
 });
 

--- a/db/app/src/index.ts
+++ b/db/app/src/index.ts
@@ -193,6 +193,7 @@ export {
   claimDueAutomationRuns,
   createAutomation,
   createAutomationRun,
+  deleteAutomation,
   type GetAutomationByPublicIdInput,
   getAutomationByPublicId,
   getAutomationRunByIdempotencyKey,

--- a/db/app/src/utils/automations.ts
+++ b/db/app/src/utils/automations.ts
@@ -332,6 +332,28 @@ export async function setAutomationStatus(
   return getAutomationByPublicId(db, input);
 }
 
+export async function deleteAutomation(
+  db: Database,
+  input: {
+    clerkOrgId: string;
+    publicId: string;
+  }
+): Promise<boolean> {
+  const result = await db
+    .update(automations)
+    .set({
+      status: "deleted",
+    })
+    .where(
+      and(
+        eq(automations.clerkOrgId, input.clerkOrgId),
+        eq(automations.publicId, input.publicId),
+        ne(automations.status, "deleted")
+      )
+    );
+  return getRowsAffected(result) > 0;
+}
+
 export async function listAutomationRuns(
   db: Database,
   input: { automationPublicId: string; clerkOrgId: string; limit?: number }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
+    "app-tanstack:automation-delete": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-delete-smoke.ts",
     "app-tanstack:automation-interactions": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-interaction-smoke.ts",
     "app-tanstack:automation-run": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-run-smoke.ts",
     "app-tanstack:automation-schedule": "NODE_OPTIONS=\"--conditions=react-server ${NODE_OPTIONS:-}\" pnpm with-env tsx src/app-tanstack/automation-schedule-smoke.ts",

--- a/e2e/src/app-tanstack/automation-delete-smoke.test.ts
+++ b/e2e/src/app-tanstack/automation-delete-smoke.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAppTanstackAutomationDeleteFixture,
+  buildAppTanstackAutomationDeletePaths,
+} from "./automation-delete-smoke";
+
+describe("app-tanstack automation delete smoke helpers", () => {
+  it("builds deterministic automation copy for delete assertions", () => {
+    expect(
+      buildAppTanstackAutomationDeleteFixture({
+        nowMs: 1_780_876_800_000,
+      })
+    ).toEqual({
+      automationName: "Delete smoke automation 1780876800000",
+      automationPrompt:
+        "Verify the app-tanstack automation delete smoke can remove this automation from the workspace list.",
+    });
+  });
+
+  it("builds organization-scoped automation list and detail paths", () => {
+    expect(
+      buildAppTanstackAutomationDeletePaths({
+        automationId: "automation_123",
+        orgSlug: "lightfast",
+      })
+    ).toEqual({
+      detailPath: "/lightfast/automations/automation_123",
+      listPath: "/lightfast/automations",
+    });
+  });
+});

--- a/e2e/src/app-tanstack/automation-delete-smoke.ts
+++ b/e2e/src/app-tanstack/automation-delete-smoke.ts
@@ -1,0 +1,281 @@
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import type {
+  AppTanstackAuthRouteSmokeConfig,
+  AppTanstackAuthSmokeSession,
+  BuildAppTanstackAuthRouteSmokeConfigInput,
+} from "./auth-route-smoke";
+import {
+  agentBrowser,
+  agentEval,
+  cleanupAppTanstackAuthSmokeSession,
+  createAppTanstackAuthSmokeSession,
+} from "./auth-route-smoke";
+import { waitForRouteText } from "./automation-interaction-smoke";
+
+export interface AppTanstackAutomationDeleteFixture {
+  automationName: string;
+  automationPrompt: string;
+}
+
+export interface AppTanstackAutomationDeletePathsInput {
+  automationId: string;
+  orgSlug: string;
+}
+
+export interface AppTanstackAutomationDeletePaths {
+  detailPath: string;
+  listPath: string;
+}
+
+export function buildAppTanstackAutomationDeleteFixture(
+  input: { nowMs?: number } = {}
+): AppTanstackAutomationDeleteFixture {
+  const timestampMs = input.nowMs ?? Date.now();
+  return {
+    automationName: `Delete smoke automation ${timestampMs}`,
+    automationPrompt:
+      "Verify the app-tanstack automation delete smoke can remove this automation from the workspace list.",
+  };
+}
+
+export function buildAppTanstackAutomationDeletePaths(
+  input: AppTanstackAutomationDeletePathsInput
+): AppTanstackAutomationDeletePaths {
+  return {
+    detailPath: `/${input.orgSlug}/automations/${input.automationId}`,
+    listPath: `/${input.orgSlug}/automations`,
+  };
+}
+
+async function createDeleteSmokeAutomation(input: {
+  fixture: AppTanstackAutomationDeleteFixture;
+  session: AppTanstackAuthSmokeSession;
+}) {
+  const [{ db }, { createAutomation }] = await Promise.all([
+    import("@db/app/client"),
+    import("@db/app"),
+  ]);
+  return await createAutomation(db, {
+    clerkOrgId: input.session.orgId,
+    connectorProvider: null,
+    createdByUserId: input.session.userId,
+    name: input.fixture.automationName,
+    prompt: input.fixture.automationPrompt,
+    schedule: { kind: "manual", config: {} },
+    timezone: "UTC",
+  });
+}
+
+async function clickButtonByExactText(
+  config: AppTanstackAuthRouteSmokeConfig,
+  input: { preferLast?: boolean; text: string }
+) {
+  const deadline = Date.now() + config.routeTimeoutMs;
+  let latestButtons: string[] = [];
+
+  while (Date.now() < deadline) {
+    const raw = await agentEval(
+      config,
+      `(() => {
+        const expected = ${JSON.stringify(input.text)};
+        const buttons = Array.from(document.querySelectorAll("button"));
+        const matches = buttons.filter(
+          (element) =>
+            element instanceof HTMLButtonElement &&
+            element.textContent?.trim() === expected
+        );
+        const button = ${input.preferLast ? "matches.at(-1)" : "matches.at(0)"};
+        if (!(button instanceof HTMLButtonElement)) {
+          return {
+            clicked: false,
+            buttons: buttons.map((element) => element.textContent?.trim() ?? ""),
+          };
+        }
+        if (button.disabled) {
+          return {
+            clicked: false,
+            buttons: buttons.map((element) => element.textContent?.trim() ?? ""),
+          };
+        }
+        button.scrollIntoView({ block: "center", inline: "center" });
+        const pointerInit = {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          button: 0,
+          buttons: 1,
+          pointerType: "mouse",
+          isPrimary: true,
+        };
+        const mouseInit = {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          button: 0,
+          buttons: 1,
+          view: window,
+        };
+        const PointerCtor = typeof PointerEvent === "function" ? PointerEvent : MouseEvent;
+        button.dispatchEvent(new PointerCtor("pointerdown", pointerInit));
+        button.dispatchEvent(new MouseEvent("mousedown", mouseInit));
+        button.dispatchEvent(new PointerCtor("pointerup", {
+          ...pointerInit,
+          buttons: 0,
+        }));
+        button.dispatchEvent(new MouseEvent("mouseup", {
+          ...mouseInit,
+          buttons: 0,
+        }));
+        button.dispatchEvent(new MouseEvent("click", {
+          ...mouseInit,
+          buttons: 0,
+        }));
+        return { clicked: true };
+      })()`
+    );
+    const result = JSON.parse(raw) as
+      | { buttons: string[]; clicked: false }
+      | { clicked: true };
+    if (result.clicked) {
+      return;
+    }
+    latestButtons = result.buttons;
+    await delay(250);
+  }
+
+  throw new Error(
+    `Could not click "${input.text}" button. Buttons: ${JSON.stringify(
+      latestButtons
+    )}`
+  );
+}
+
+async function waitForDeletedAutomation(input: {
+  automationPublicId: string;
+  config: AppTanstackAuthRouteSmokeConfig;
+  orgId: string;
+}) {
+  const [{ db }, { getAutomationByPublicId }] = await Promise.all([
+    import("@db/app/client"),
+    import("@db/app"),
+  ]);
+  const deadline = Date.now() + input.config.routeTimeoutMs;
+  let found = true;
+
+  while (Date.now() < deadline) {
+    const automation = await getAutomationByPublicId(db, {
+      clerkOrgId: input.orgId,
+      publicId: input.automationPublicId,
+    });
+    found = Boolean(automation);
+    if (!found) {
+      return;
+    }
+    await delay(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for deleted automation ${input.automationPublicId}. Found=${found}`
+  );
+}
+
+export async function runAppTanstackAutomationDeleteSmoke(
+  input: BuildAppTanstackAuthRouteSmokeConfigInput = {}
+) {
+  const nowMs = input.nowMs ?? Date.now();
+  const fixture = buildAppTanstackAutomationDeleteFixture({ nowMs });
+  let config: AppTanstackAuthRouteSmokeConfig | undefined;
+  let session: AppTanstackAuthSmokeSession | undefined;
+
+  try {
+    session = await createAppTanstackAuthSmokeSession({
+      ...input,
+      nowMs,
+    });
+    config = session.config;
+    const automation = await createDeleteSmokeAutomation({
+      fixture,
+      session,
+    });
+    const paths = buildAppTanstackAutomationDeletePaths({
+      automationId: automation.publicId,
+      orgSlug: session.orgSlug,
+    });
+
+    console.log(`[smoke] app=${config.appOrigin}`);
+    console.log(`[smoke] org=${session.orgSlug}`);
+    console.log(`[smoke] automation=${automation.publicId}`);
+
+    await agentBrowser(config, [
+      "open",
+      new URL(paths.detailPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: [
+        fixture.automationName,
+        fixture.automationPrompt,
+        "Manual",
+        "Delete",
+      ],
+      name: "automation detail before delete",
+      path: paths.detailPath,
+    });
+
+    await clickButtonByExactText(config, { text: "Delete" });
+    await waitForRouteText(config, {
+      expectedText: ["Delete automation?", fixture.automationName],
+      name: "automation delete confirmation",
+      path: paths.detailPath,
+    });
+    await clickButtonByExactText(config, {
+      preferLast: true,
+      text: "Delete",
+    });
+    await waitForDeletedAutomation({
+      automationPublicId: automation.publicId,
+      config,
+      orgId: session.orgId,
+    });
+    await waitForRouteText(config, {
+      expectedText: ["Automations", "No automations yet"],
+      name: "automation list after delete",
+      path: paths.listPath,
+    });
+
+    await agentBrowser(config, [
+      "open",
+      new URL(paths.detailPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: ["Couldn't load automation"],
+      name: "deleted automation detail",
+      path: paths.detailPath,
+    });
+
+    console.log(`[smoke] completed automation delete ${automation.publicId}`);
+  } finally {
+    if (config) {
+      await agentBrowser(config, ["close"]).catch(() => undefined);
+    }
+    if (session) {
+      await cleanupAppTanstackAuthSmokeSession(session);
+    }
+  }
+}
+
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return Boolean(
+    entrypoint && path.resolve(entrypoint) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isMainModule()) {
+  runAppTanstackAutomationDeleteSmoke().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a soft-delete automation helper and org-admin tRPC delete mutation
- replace the disabled TanStack automation detail Delete action with a confirmation flow that returns to the list and updates caches
- add an app-tanstack delete smoke covering detail delete, DB disappearance, list empty state, and deleted detail not-found behavior

## Verification
- pnpm --filter @db/app exec vitest run src/__tests__/automations.test.ts
- pnpm --filter @api/app exec vitest run src/__tests__/automations-router.test.ts
- pnpm --filter @lightfast/e2e exec vitest run src/app-tanstack/automation-delete-smoke.test.ts
- pnpm --filter @db/app typecheck
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm --filter @lightfast/e2e typecheck
- pnpm check
- LIGHTFAST_E2E_APP_TANSTACK_URL=http://127.0.0.1:5123 pnpm --filter @lightfast/e2e app-tanstack:automation-delete
- pnpm --filter @db/app test
- pnpm --filter @api/app test
- pnpm --filter @lightfast/e2e test
- Clerk cleanup check: recent generated smoke users: 0

## Notes
- Live smoke was run against apps/app-tanstack on http://127.0.0.1:5123.
- Local dev server, generated .output, and headless browser sessions were cleaned up after verification.