### PR TITLE
test: cover app tanstack automation list history

### DIFF
--- a/apps/app-tanstack/src/automations/automation-run-detail-sheet.tsx
+++ b/apps/app-tanstack/src/automations/automation-run-detail-sheet.tsx
@@ -45,6 +45,8 @@ export function AutomationRunDetailSheet({
 
   const run = hasInitial ? initialRun : query.data;
 
+  // Closing on query.isError asks the parent to clear the invalid run search
+  // param, which re-renders this sheet with publicId=null and stops recovery.
   useEffect(() => {
     if (publicId && query.isError) {
       onOpenChange(false);

--- a/apps/app-tanstack/src/automations/automation-run-detail-sheet.tsx
+++ b/apps/app-tanstack/src/automations/automation-run-detail-sheet.tsx
@@ -10,6 +10,7 @@ import {
 import { toast } from "@repo/ui/components/ui/sonner";
 import { skipToken, useQuery } from "@tanstack/react-query";
 import { X } from "lucide-react";
+import { useEffect } from "react";
 import { useTRPC } from "~/trpc/react";
 import { AutomationRunDetailContent } from "./automation-run-detail-content";
 
@@ -36,12 +37,19 @@ export function AutomationRunDetailSheet({
       {
         enabled: typeof window !== "undefined" && shouldFetchRun,
         refetchOnWindowFocus: true,
+        retry: false,
         staleTime: 5000,
       }
     )
   );
 
   const run = hasInitial ? initialRun : query.data;
+
+  useEffect(() => {
+    if (publicId && query.isError) {
+      onOpenChange(false);
+    }
+  }, [onOpenChange, publicId, query.isError]);
 
   function handleCopyLink() {
     if (typeof window === "undefined") {

--- a/apps/app-tanstack/src/automations/automations-client.tsx
+++ b/apps/app-tanstack/src/automations/automations-client.tsx
@@ -123,7 +123,7 @@ function AutomationRow({
     <Link
       className="flex items-center justify-between gap-4 rounded-xl px-3 py-3 transition-colors hover:bg-muted/40"
       params={{ automation: automation.publicId, slug }}
-      search={{ run: null }}
+      search={{ run: undefined }}
       to="/$slug/automations/$automation"
     >
       <div className="flex min-w-0 items-center gap-3">

--- a/apps/app-tanstack/src/routes/_authenticated/$slug/automations/$automation.tsx
+++ b/apps/app-tanstack/src/routes/_authenticated/$slug/automations/$automation.tsx
@@ -11,9 +11,9 @@ import {
 } from "~/trpc/route-prefetch";
 
 function validateAutomationDetailSearch(search: Record<string, unknown>) {
-  const run = typeof search.run === "string" ? search.run : null;
+  const run = typeof search.run === "string" ? search.run : undefined;
   return {
-    run: run && run.length > 0 ? run : null,
+    run: run && run !== "null" && run.length > 0 ? run : undefined,
   };
 }
 
@@ -74,7 +74,7 @@ function AutomationDetailPage() {
         replace: true,
         search: (previous) => ({
           ...previous,
-          run: publicId,
+          run: publicId ?? undefined,
         }),
       });
     },
@@ -85,7 +85,7 @@ function AutomationDetailPage() {
     <RoutePrefetchBoundary state={prefetchState}>
       <AutomationDetailClient
         automationId={automationId}
-        selectedRunId={run}
+        selectedRunId={run ?? null}
         setSelectedRunId={setSelectedRunId}
         slug={slug}
       />

--- a/e2e/src/app-tanstack/automation-run-smoke.test.ts
+++ b/e2e/src/app-tanstack/automation-run-smoke.test.ts
@@ -31,6 +31,20 @@ describe("app-tanstack automation run smoke helpers", () => {
     });
   });
 
+  it("builds automation detail path for invalid selected-run recovery", () => {
+    expect(
+      buildAppTanstackAutomationRunPaths({
+        automationId: "automation_123",
+        orgSlug: "lightfast",
+        runId: "missing run/id",
+      })
+    ).toEqual({
+      detailPath: "/lightfast/automations/automation_123",
+      runDetailPath:
+        "/lightfast/automations/automation_123?run=missing%20run%2Fid",
+    });
+  });
+
   it("returns null run detail path when run id is omitted", () => {
     expect(
       buildAppTanstackAutomationRunPaths({

--- a/e2e/src/app-tanstack/automation-run-smoke.ts
+++ b/e2e/src/app-tanstack/automation-run-smoke.ts
@@ -159,15 +159,36 @@ async function waitForManualRun(input: {
 
 async function assertSelectedRunSearchParam(
   config: AppTanstackAuthRouteSmokeConfig,
-  runId: string
+  runId: string | null
 ) {
   const href = await agentBrowser(config, ["get", "url"]);
   const selectedRunId = new URL(href).searchParams.get("run");
   if (selectedRunId !== runId) {
     throw new Error(
-      `Expected selected run query param ${runId}, received ${selectedRunId ?? "<missing>"} at ${href}`
+      `Expected selected run query param ${runId ?? "<missing>"}, received ${selectedRunId ?? "<missing>"} at ${href}`
     );
   }
+}
+
+async function waitForSelectedRunSearchParam(
+  config: AppTanstackAuthRouteSmokeConfig,
+  runId: string | null
+) {
+  const deadline = Date.now() + config.routeTimeoutMs;
+  let latestHref = "";
+
+  while (Date.now() < deadline) {
+    latestHref = await agentBrowser(config, ["get", "url"]);
+    const selectedRunId = new URL(latestHref).searchParams.get("run");
+    if (selectedRunId === runId) {
+      return;
+    }
+    await delay(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for selected run query param ${runId ?? "<missing>"}. Last URL: ${latestHref}`
+  );
 }
 
 export async function runAppTanstackAutomationRunSmoke(
@@ -244,6 +265,26 @@ export async function runAppTanstackAutomationRunSmoke(
       expectedText: ["manual run", "Status", "Trigger", "Run ID", run.publicId],
       name: "automation manual run detail",
       path: runPaths.detailPath,
+    });
+
+    const invalidRunPaths = buildAppTanstackAutomationRunPaths({
+      automationId: automation.publicId,
+      orgSlug: session.orgSlug,
+      runId: "automation_run_00000000-0000-4000-8000-000000000000",
+    });
+    if (!invalidRunPaths.runDetailPath) {
+      throw new Error("Invalid run detail path was not built.");
+    }
+
+    await agentBrowser(config, [
+      "open",
+      new URL(invalidRunPaths.runDetailPath, config.appOrigin).toString(),
+    ]);
+    await waitForSelectedRunSearchParam(config, null);
+    await waitForRouteText(config, {
+      expectedText: ["Previous runs", "manual"],
+      name: "automation invalid selected run recovery",
+      path: invalidRunPaths.detailPath,
     });
 
     console.log(`[smoke] completed automation manual run ${run.publicId}`);

--- a/e2e/src/app-tanstack/automation-schedule-smoke.test.ts
+++ b/e2e/src/app-tanstack/automation-schedule-smoke.test.ts
@@ -18,7 +18,7 @@ describe("app-tanstack automation schedule smoke helpers", () => {
     });
   });
 
-  it("builds the organization-scoped automation detail path", () => {
+  it("builds the organization-scoped automation detail and list paths", () => {
     expect(
       buildAppTanstackAutomationSchedulePaths({
         automationId: "automation_123",
@@ -26,6 +26,7 @@ describe("app-tanstack automation schedule smoke helpers", () => {
       })
     ).toEqual({
       detailPath: "/lightfast/automations/automation_123",
+      listPath: "/lightfast/automations",
     });
   });
 });

--- a/e2e/src/app-tanstack/automation-schedule-smoke.ts
+++ b/e2e/src/app-tanstack/automation-schedule-smoke.ts
@@ -27,6 +27,7 @@ export interface AppTanstackAutomationSchedulePathsInput {
 
 export interface AppTanstackAutomationSchedulePaths {
   detailPath: string;
+  listPath: string;
 }
 
 export function buildAppTanstackAutomationScheduleFixture(
@@ -45,6 +46,7 @@ export function buildAppTanstackAutomationSchedulePaths(
 ): AppTanstackAutomationSchedulePaths {
   return {
     detailPath: `/${input.orgSlug}/automations/${input.automationId}`,
+    listPath: `/${input.orgSlug}/automations`,
   };
 }
 
@@ -183,12 +185,22 @@ async function fillTimeInput(
           ),
         };
       }
+      input.focus();
       const valueSetter = Object.getOwnPropertyDescriptor(
         HTMLInputElement.prototype,
         "value"
       )?.set;
       valueSetter?.call(input, time);
-      input.dispatchEvent(new Event("input", { bubbles: true }));
+      const inputEvent =
+        typeof InputEvent === "function"
+          ? new InputEvent("input", {
+              bubbles: true,
+              cancelable: true,
+              data: time,
+              inputType: "insertReplacementText",
+            })
+          : new Event("input", { bubbles: true, cancelable: true });
+      input.dispatchEvent(inputEvent);
       input.dispatchEvent(new Event("change", { bubbles: true }));
       input.blur();
       return { filled: true, value: input.value };
@@ -370,6 +382,21 @@ export async function runAppTanstackAutomationScheduleSmoke(
       expectedText: ["Active", "Weekly on Friday at 2:30 PM", "UTC"],
       name: "automation detail after schedule edit reload",
       path: paths.detailPath,
+    });
+
+    await agentBrowser(config, [
+      "open",
+      new URL(paths.listPath, config.appOrigin).toString(),
+    ]);
+    await waitForRouteText(config, {
+      expectedText: [
+        "Automations",
+        "Current",
+        fixture.automationName,
+        "Weekly on Friday at 2:30 PM",
+      ],
+      name: "automation list after schedule edit",
+      path: paths.listPath,
     });
 
     console.log(


### PR DESCRIPTION
## Summary
- extend app-tanstack automation schedule smoke to verify list-row persistence after schedule edits
- extend run-history smoke to cover selected-run URL state and invalid-run recovery
- normalize automation run search state so clearing a selected run removes the query param instead of serializing run=null

## Verification
- pnpm --filter @lightfast/e2e exec vitest run src/app-tanstack/automation-schedule-smoke.test.ts src/app-tanstack/automation-run-smoke.test.ts
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm --filter @lightfast/e2e typecheck
- pnpm check
- LIGHTFAST_E2E_APP_TANSTACK_URL=https://app-tanstack-automation-list-history.app-tanstack.lightfast.localhost pnpm --filter @lightfast/e2e app-tanstack:automation-schedule
- LIGHTFAST_E2E_APP_TANSTACK_URL=https://app-tanstack-automation-list-history.app-tanstack.lightfast.localhost pnpm --filter @lightfast/e2e app-tanstack:automation-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sheet now automatically closes when a run fetch fails.
  * Improved handling and normalization of the selected run parameter (clearing uses undefined).
  * Better recovery for invalid run IDs, including correct URL-encoding behavior.

* **Tests**
  * Added E2E checks for invalid run recovery and run ID encoding.
  * Strengthened schedule tests with list-page verification and more reliable time-input interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->