### PR TITLE
fix: describe automation run sheet

### DIFF
--- a/apps/app-tanstack/src/__tests__/automations-run-detail-sheet.test.tsx
+++ b/apps/app-tanstack/src/__tests__/automations-run-detail-sheet.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+
+import type { AppRouterOutputs } from "@api/app";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AutomationRunDetailSheet } from "~/automations/automation-run-detail-sheet";
+
+type AutomationRun =
+  AppRouterOutputs["org"]["workspace"]["automations"]["listRuns"][number];
+
+vi.mock("@tanstack/react-query", () => ({
+  skipToken: Symbol("skipToken"),
+  useQuery: () => ({ data: undefined, isError: false }),
+}));
+
+vi.mock("~/trpc/react", () => ({
+  useTRPC: () => ({
+    org: {
+      workspace: {
+        automations: {
+          getRun: {
+            queryOptions: () => ({}),
+          },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("~/automations/automation-run-detail-content", () => ({
+  AutomationRunDetailContent: ({
+    closeSlot,
+    run,
+  }: {
+    closeSlot: ReactNode;
+    run: AutomationRun;
+  }) => (
+    <section>
+      <p>{run.publicId}</p>
+      {closeSlot}
+    </section>
+  ),
+}));
+
+vi.mock("@repo/ui/components/ui/sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@repo/ui/components/ui/sheet", () => ({
+  Sheet: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? children : null,
+  SheetClose: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SheetContent: ({
+    children,
+    ...props
+  }: ComponentProps<"div"> & { showCloseButton?: boolean; side?: string }) => (
+    <div
+      aria-describedby="automation-run-sheet-description"
+      aria-labelledby="automation-run-sheet-title"
+      role="dialog"
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  SheetDescription: ({ children }: { children: ReactNode }) => (
+    <p id="automation-run-sheet-description">{children}</p>
+  ),
+  SheetHeader: ({ children }: { children: ReactNode }) => (
+    <header>{children}</header>
+  ),
+  SheetTitle: ({ children }: { children: ReactNode }) => (
+    <h2 id="automation-run-sheet-title">{children}</h2>
+  ),
+}));
+
+vi.mock("@repo/ui/components/ui/button", () => ({
+  Button: ({ children, ...props }: ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AutomationRunDetailSheet", () => {
+  it("associates the run details dialog with an accessible description", () => {
+    render(
+      <AutomationRunDetailSheet
+        initialRun={run()}
+        onOpenChange={vi.fn()}
+        publicId="automation_run_123"
+      />
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const descriptionId = dialog.getAttribute("aria-describedby");
+
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId ?? "")?.textContent).toBe(
+      "Automation run details"
+    );
+  });
+});
+
+function run(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    automationId: 1,
+    automationPublicId: "automation_123",
+    clerkOrgId: "org_acme",
+    createdAt: new Date("2026-06-06T00:00:00.000Z"),
+    dueAt: new Date("2026-06-06T00:00:00.000Z"),
+    errorCode: null,
+    errorMessage: null,
+    finishedAt: new Date("2026-06-06T00:00:10.000Z"),
+    id: 1,
+    idempotencyKey: "manual:123",
+    output: null,
+    publicId: "automation_run_123",
+    scheduleVersion: 1,
+    startedAt: new Date("2026-06-06T00:00:00.000Z"),
+    status: "completed",
+    trigger: "manual",
+    updatedAt: new Date("2026-06-06T00:00:10.000Z"),
+    ...overrides,
+  } as AutomationRun;
+}

--- a/apps/app-tanstack/src/__tests__/workspace-actions-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/workspace-actions-source.test.ts
@@ -79,13 +79,4 @@ describe("workspace page-owned actions", () => {
     expect(newRouteSource).toContain("New automation -");
     expect(detailRouteSource).toContain("Automation -");
   });
-
-  it("keeps automation run sheets accessible for dialog descriptions", () => {
-    const runSheetSource = source(
-      "src/automations/automation-run-detail-sheet.tsx"
-    );
-
-    expect(runSheetSource).toContain("SheetDescription");
-    expect(runSheetSource).toContain("Automation run details");
-  });
 });

--- a/apps/app-tanstack/src/__tests__/workspace-actions-source.test.ts
+++ b/apps/app-tanstack/src/__tests__/workspace-actions-source.test.ts
@@ -79,4 +79,13 @@ describe("workspace page-owned actions", () => {
     expect(newRouteSource).toContain("New automation -");
     expect(detailRouteSource).toContain("Automation -");
   });
+
+  it("keeps automation run sheets accessible for dialog descriptions", () => {
+    const runSheetSource = source(
+      "src/automations/automation-run-detail-sheet.tsx"
+    );
+
+    expect(runSheetSource).toContain("SheetDescription");
+    expect(runSheetSource).toContain("Automation run details");
+  });
 });

--- a/apps/app-tanstack/src/automations/automation-run-detail-sheet.tsx
+++ b/apps/app-tanstack/src/automations/automation-run-detail-sheet.tsx
@@ -4,6 +4,7 @@ import {
   Sheet,
   SheetClose,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from "@repo/ui/components/ui/sheet";
@@ -83,6 +84,7 @@ export function AutomationRunDetailSheet({
       >
         <SheetHeader className="sr-only">
           <SheetTitle>Run details</SheetTitle>
+          <SheetDescription>Automation run details</SheetDescription>
         </SheetHeader>
 
         {run ? (


### PR DESCRIPTION
## Summary
- add a hidden SheetDescription to the automation run detail sheet
- add a source regression check so future sheet changes keep dialog descriptions wired

## Verification
- pnpm --filter @lightfast/app-tanstack exec vitest run src/__tests__/workspace-actions-source.test.ts
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm check
- LIGHTFAST_E2E_APP_TANSTACK_URL=https://app-tanstack-run-sheet-a11y.app-tanstack.lightfast.localhost pnpm --filter @lightfast/e2e app-tanstack:automation-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automation run details sheet now includes enhanced descriptive content for improved accessibility.

* **Tests**
  * Added test coverage validating automation run details sheet accessibility and description rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->