### PR TITLE
fix: port chat write mode

### DIFF
--- a/apps/app-tanstack/src/__tests__/chat-workspace-assistant-client.test.tsx
+++ b/apps/app-tanstack/src/__tests__/chat-workspace-assistant-client.test.tsx
@@ -1,8 +1,15 @@
 // @vitest-environment happy-dom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { AppRouterOutputs } from "@api/app";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clearErrorMock = vi.fn();
 const invalidateQueriesMock = vi.fn();
@@ -20,6 +27,8 @@ let chatMessages: Array<{
   parts: Array<{ text?: string; type: string }>;
   role: "assistant" | "user";
 }> = [];
+type WorkspaceAssistantConversationResult =
+  AppRouterOutputs["org"]["workspace"]["assistant"]["getConversation"];
 
 vi.mock("@ai-sdk/react", () => ({
   useChat: (options: { messages?: typeof chatMessages } = {}) => {
@@ -99,14 +108,18 @@ vi.mock("~/chat/chat-composer", () => ({
     error,
     onSubmit,
     onTextChange,
+    onWriteModeChange,
     status,
     text,
+    writeModeEnabled,
   }: {
     error?: Error;
     onSubmit: (message: { files: []; text: string }) => Promise<void>;
     onTextChange: (value: string) => void;
+    onWriteModeChange?: (enabled: boolean) => void;
     status: string;
     text: string;
+    writeModeEnabled?: boolean;
   }) => (
     <form
       onSubmit={(event) => {
@@ -119,6 +132,13 @@ vi.mock("~/chat/chat-composer", () => ({
         onChange={(event) => onTextChange(event.currentTarget.value)}
         value={text}
       />
+      <button
+        aria-pressed={writeModeEnabled ? "true" : "false"}
+        onClick={() => onWriteModeChange?.(!writeModeEnabled)}
+        type="button"
+      >
+        Write
+      </button>
       <button aria-label="Send message" data-status={status} type="submit">
         Send
       </button>
@@ -159,6 +179,10 @@ beforeEach(() => {
   vi.stubGlobal("crypto", {
     randomUUID: () => "ff83026e-ef0e-40db-ae59-544fbe4df209",
   });
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 describe("WorkspaceAssistantClient", () => {
@@ -232,4 +256,65 @@ describe("WorkspaceAssistantClient", () => {
     });
     expect(routerInvalidateMock).not.toHaveBeenCalled();
   });
+
+  it("sends one existing conversation turn with provider routine write mode enabled", async () => {
+    render(
+      <WorkspaceAssistantClient
+        conversationId="conv_existing"
+        initialConversation={conversationResult()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Write" }));
+    expect(
+      screen.getByRole("button", { name: "Write" }).getAttribute("aria-pressed")
+    ).toBe("true");
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "Update the Linear ticket" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        { text: "Update the Linear ticket" },
+        {
+          body: {
+            conversationId: "conv_existing",
+            idempotencyKey: "idem_ff83026e-ef0e-40db-ae59-544fbe4df209",
+            providerRoutineWriteMode: true,
+          },
+        }
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: "Write" })
+          .getAttribute("aria-pressed")
+      ).toBe("false");
+    });
+  });
 });
+
+function conversationResult(
+  overrides: Partial<WorkspaceAssistantConversationResult["conversation"]> = {}
+): WorkspaceAssistantConversationResult {
+  return {
+    conversation: {
+      activeStreamId: null,
+      clerkOrgId: "org_lightfast",
+      createdAt: new Date("2026-06-15T00:00:00.000Z"),
+      createdByUserId: "user_lightfast",
+      id: 1,
+      lastMessageAt: null,
+      lastMessageId: null,
+      metadata: {},
+      publicId: "conv_existing",
+      status: "active",
+      title: "Existing chat",
+      updatedAt: new Date("2026-06-15T00:00:00.000Z"),
+      ...overrides,
+    },
+    messages: [],
+  };
+}

--- a/apps/app-tanstack/src/chat/chat-composer.tsx
+++ b/apps/app-tanstack/src/chat/chat-composer.tsx
@@ -7,9 +7,15 @@ import {
   PromptInputTextarea,
   PromptInputTools,
 } from "@repo/ui/components/ai-elements/prompt-input";
+import { Toggle } from "@repo/ui/components/ui/toggle";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@repo/ui/components/ui/tooltip";
 import { cn } from "@repo/ui/lib/utils";
 import type { ChatStatus } from "@vendor/ai";
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, PencilLine } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 
 export const ChatComposer = memo(function ChatComposer({
@@ -17,17 +23,21 @@ export const ChatComposer = memo(function ChatComposer({
   error,
   onSubmit,
   onTextChange,
+  onWriteModeChange,
   status,
   stop,
   text,
+  writeModeEnabled,
 }: {
   compact: boolean;
   error: Error | undefined;
   onSubmit: (message: PromptInputMessage) => Promise<void>;
   onTextChange: (text: string) => void;
+  onWriteModeChange: (enabled: boolean) => void;
   status: ChatStatus;
   stop: () => void;
   text: string;
+  writeModeEnabled: boolean;
 }) {
   const [isSubmitPending, setIsSubmitPending] = useState(false);
 
@@ -71,13 +81,32 @@ export const ChatComposer = memo(function ChatComposer({
   const submit = (
     <PromptInputSubmit
       aria-label={isStreaming ? "Stop generating" : "Send message"}
-      className={cn("size-8 rounded-full", compact && "mr-2 mb-2 shrink-0")}
+      className="size-8 shrink-0 rounded-full"
       disabled={submitDisabled}
       onStop={stop}
       status={effectiveStatus}
     >
       {effectiveStatus === "ready" ? <ArrowUp className="size-4" /> : undefined}
     </PromptInputSubmit>
+  );
+  const writeModeToggle = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Toggle
+          aria-label="Write mode"
+          className="h-8 gap-1.5 rounded-full px-2 text-muted-foreground text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+          disabled={isBusy}
+          onPressedChange={onWriteModeChange}
+          pressed={writeModeEnabled}
+          size="sm"
+          type="button"
+        >
+          <PencilLine className="size-3.5" />
+          <span>Write mode</span>
+        </Toggle>
+      </TooltipTrigger>
+      <TooltipContent>Allow Linear writes for this turn</TooltipContent>
+    </Tooltip>
   );
 
   return (
@@ -105,14 +134,10 @@ export const ChatComposer = memo(function ChatComposer({
             value={text}
           />
         </PromptInputBody>
-        {compact ? (
-          submit
-        ) : (
-          <PromptInputFooter className="px-2.5 pb-2.5">
-            <PromptInputTools />
-            {submit}
-          </PromptInputFooter>
-        )}
+        <PromptInputFooter className={cn("px-2.5 pb-2.5", compact && "pt-1")}>
+          <PromptInputTools>{writeModeToggle}</PromptInputTools>
+          {submit}
+        </PromptInputFooter>
       </PromptInput>
     </div>
   );

--- a/apps/app-tanstack/src/chat/workspace-assistant-client.tsx
+++ b/apps/app-tanstack/src/chat/workspace-assistant-client.tsx
@@ -61,6 +61,8 @@ export function WorkspaceAssistantClient({
   const [creationError, setCreationError] = useState<Error | undefined>();
   const [optimisticFirstMessage, setOptimisticFirstMessage] =
     useState<UIMessage | null>(null);
+  const [providerRoutineWriteMode, setProviderRoutineWriteMode] =
+    useState(false);
   const conversationCreatedRef = useRef(Boolean(initialConversation));
 
   const transport = useMemo(
@@ -149,6 +151,7 @@ export function WorkspaceAssistantClient({
         }
       }
 
+      const writeModeForTurn = providerRoutineWriteMode;
       try {
         await sendMessage(
           { text: nextText },
@@ -156,11 +159,13 @@ export function WorkspaceAssistantClient({
             body: {
               idempotencyKey: createWorkspaceAssistantIdempotencyKey(),
               conversationId,
+              ...(writeModeForTurn ? { providerRoutineWriteMode: true } : {}),
             },
           }
         );
       } finally {
         setOptimisticFirstMessage(null);
+        setProviderRoutineWriteMode(false);
       }
       setText("");
       if (!initialConversation) {
@@ -185,6 +190,7 @@ export function WorkspaceAssistantClient({
       router,
       sendMessage,
       clearError,
+      providerRoutineWriteMode,
     ]
   );
 
@@ -194,9 +200,11 @@ export function WorkspaceAssistantClient({
       error={displayError}
       onSubmit={handleSubmit}
       onTextChange={setText}
+      onWriteModeChange={setProviderRoutineWriteMode}
       status={composerStatus}
       stop={stop}
       text={text}
+      writeModeEnabled={providerRoutineWriteMode}
     />
   );
 


### PR DESCRIPTION
## Summary
- port the workspace assistant Write mode toggle into app-tanstack chat composer
- send providerRoutineWriteMode for the selected turn and reset it after send
- add app-tanstack client coverage for existing-conversation write mode sends

## Verification
- pnpm --filter @lightfast/app-tanstack exec vitest run src/__tests__/chat-workspace-assistant-client.test.tsx
- pnpm --filter @lightfast/app-tanstack exec vitest run src/__tests__/chat-workspace-assistant-client.test.tsx src/__tests__/chat-conversation-id.test.ts src/__tests__/chat-api-source.test.ts src/__tests__/server-chat-workspace-assistant-route.test.ts src/__tests__/server-chat-workspace-assistant-stream-route.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm check
- pnpm --filter @lightfast/e2e exec vitest run src/app-tanstack/auth-route-smoke.test.ts
- LIGHTFAST_E2E_APP_TANSTACK_URL=https://app-tanstack-chat-shell.app-tanstack.lightfast.localhost pnpm --filter @lightfast/e2e app-tanstack:auth-routes

Note: broad live route smoke completed 22 routes including /$slug/chat. Dev logs showed transient tRPC network retries and a skills refresh Inngest enqueue warning, but the relevant route checks completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Write mode" toggle to the chat composer interface, allowing users to enable or disable write mode when sending messages. The toggle is conveniently located in the message input footer and remains disabled while composing is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->