### PR TITLE
fix: port chat connector tools

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -37,6 +37,10 @@
       "types": "./src/services/connectors/index.ts",
       "default": "./src/services/connectors/index.ts"
     },
+    "./services/connectors/chat-routines": {
+      "types": "./src/services/connectors/chat-routines.ts",
+      "default": "./src/services/connectors/chat-routines.ts"
+    },
     "./services/connectors/runtime": {
       "types": "./src/services/connectors/runtime.ts",
       "default": "./src/services/connectors/runtime.ts"

--- a/apps/app-tanstack/package.json
+++ b/apps/app-tanstack/package.json
@@ -37,6 +37,7 @@
     "@repo/provider-routine-contract": "workspace:*",
     "@repo/provider-routines": "workspace:*",
     "@repo/ui": "workspace:*",
+    "@repo/user-connector-contract": "workspace:*",
     "@sentry/tanstackstart-react": "catalog:",
     "@t3-oss/env-core": "catalog:",
     "@tanstack/react-query": "catalog:",

--- a/apps/app-tanstack/src/__tests__/server-chat-workspace-assistant-route.test.ts
+++ b/apps/app-tanstack/src/__tests__/server-chat-workspace-assistant-route.test.ts
@@ -8,12 +8,16 @@ const getSkillIndexSnapshotMock = vi.fn();
 const getVerifiedLightfastSkillSourceRepositoryIdMock = vi.fn();
 const gatewayMock = vi.fn();
 const getWorkspaceAssistantConversationByPublicIdMock = vi.fn();
+const callUserConnectorToolMock = vi.fn();
+const findUserConnectorToolsMock = vi.fn();
 const isDuplicateKeyErrorMock = vi.fn();
 const listWorkspaceAssistantMessagesMock = vi.fn();
 const markWorkspaceAssistantGenerationCompletedMock = vi.fn();
 const markWorkspaceAssistantGenerationFailedMock = vi.fn();
 const markWorkspaceAssistantMessageCompletedMock = vi.fn();
 const markWorkspaceAssistantMessageFailedMock = vi.fn();
+const callProviderRoutineMock = vi.fn();
+const findProviderRoutinesMock = vi.fn();
 const resolveWorkspaceAssistantAuthContextMock = vi.fn();
 const safeValidateUIMessagesMock = vi.fn();
 const setWorkspaceAssistantConversationActiveStreamMock = vi.fn();
@@ -78,9 +82,21 @@ vi.mock("@repo/provider-routine-contract", () => ({
   providerRoutineFindOutputSchema: { kind: "provider-find-output" },
 }));
 
-vi.mock("@repo/provider-routines", () => ({
-  callProviderRoutine: vi.fn(),
-  findProviderRoutines: vi.fn(),
+vi.mock("@api/app/services/connectors", () => ({
+  callChatProviderRoutine: callProviderRoutineMock,
+  findChatProviderRoutines: findProviderRoutinesMock,
+}));
+
+vi.mock("@repo/user-connector-contract", () => ({
+  userConnectorCallInputSchema: { kind: "user-connector-call-input" },
+  userConnectorCallSuccessSchema: { kind: "user-connector-call-success" },
+  userConnectorFindInputSchema: { kind: "user-connector-find-input" },
+  userConnectorFindOutputSchema: { kind: "user-connector-find-output" },
+}));
+
+vi.mock("@api/app/services/user-connectors/runtime", () => ({
+  callUserConnectorTool: callUserConnectorToolMock,
+  findUserConnectorTools: findUserConnectorToolsMock,
 }));
 
 vi.mock("@vendor/ai", () => ({
@@ -124,12 +140,16 @@ beforeEach(() => {
   getVerifiedLightfastSkillSourceRepositoryIdMock.mockReset();
   gatewayMock.mockReset();
   getWorkspaceAssistantConversationByPublicIdMock.mockReset();
+  callUserConnectorToolMock.mockReset();
+  findUserConnectorToolsMock.mockReset();
   isDuplicateKeyErrorMock.mockReset();
   listWorkspaceAssistantMessagesMock.mockReset();
   markWorkspaceAssistantGenerationCompletedMock.mockReset();
   markWorkspaceAssistantGenerationFailedMock.mockReset();
   markWorkspaceAssistantMessageCompletedMock.mockReset();
   markWorkspaceAssistantMessageFailedMock.mockReset();
+  callProviderRoutineMock.mockReset();
+  findProviderRoutinesMock.mockReset();
   resolveWorkspaceAssistantAuthContextMock.mockReset();
   safeValidateUIMessagesMock.mockReset();
   setWorkspaceAssistantConversationActiveStreamMock.mockReset();
@@ -328,6 +348,71 @@ describe("workspace assistant chat server route", () => {
         requestedByUserId: "user_123",
         usage: { inputTokens: 10, outputTokens: 12, totalTokens: 22 },
       })
+    );
+  });
+
+  it("passes write mode through provider routine tools and exposes user connector tools", async () => {
+    const uiMessages = [
+      {
+        id: "client-message-1",
+        parts: [
+          { text: "Create a Linear issue from my meeting", type: "text" },
+        ],
+        role: "user",
+      },
+    ];
+
+    const response = await handleWorkspaceAssistantChatRequest(
+      createJsonRequest({
+        conversationId: "conv_123",
+        messages: uiMessages,
+        providerRoutineWriteMode: true,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const streamOptions = streamTextMock.mock.calls.at(-1)?.[0] as
+      | {
+          tools?: Record<
+            string,
+            { execute?: (input: Record<string, unknown>) => Promise<unknown> }
+          >;
+        }
+      | undefined;
+    expect(streamOptions?.tools).toEqual(
+      expect.objectContaining({
+        callProviderRoutine: expect.any(Object),
+        findProviderRoutines: expect.any(Object),
+        callUserConnectorTool: expect.any(Object),
+        findUserConnectorTools: expect.any(Object),
+      })
+    );
+
+    await streamOptions?.tools?.findProviderRoutines?.execute?.({
+      query: "linear",
+    });
+    expect(findProviderRoutinesMock).toHaveBeenCalledWith(
+      {
+        clerkOrgId: "org_123",
+        conversationId: "conv_123",
+        userId: "user_123",
+        writeMode: true,
+      },
+      { query: "linear" }
+    );
+
+    await streamOptions?.tools?.findUserConnectorTools?.execute?.({
+      query: "granola",
+    });
+    expect(findUserConnectorToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { orgId: "org_123", userId: "user_123" },
+        source: {
+          conversationId: "conv_123",
+          surface: "interactive_chat",
+        },
+      }),
+      { query: "granola" }
     );
   });
 });

--- a/apps/app-tanstack/src/__tests__/server-chat-workspace-assistant-route.test.ts
+++ b/apps/app-tanstack/src/__tests__/server-chat-workspace-assistant-route.test.ts
@@ -82,7 +82,7 @@ vi.mock("@repo/provider-routine-contract", () => ({
   providerRoutineFindOutputSchema: { kind: "provider-find-output" },
 }));
 
-vi.mock("@api/app/services/connectors", () => ({
+vi.mock("@api/app/services/connectors/chat-routines", () => ({
   callChatProviderRoutine: callProviderRoutineMock,
   findChatProviderRoutines: findProviderRoutinesMock,
 }));
@@ -177,6 +177,7 @@ beforeEach(() => {
   getWorkspaceAssistantConversationByPublicIdMock.mockResolvedValue(
     makeConversation()
   );
+  isDuplicateKeyErrorMock.mockReturnValue(false);
   listWorkspaceAssistantMessagesMock.mockResolvedValue([]);
   appendWorkspaceAssistantMessageMock
     .mockResolvedValueOnce(
@@ -260,6 +261,76 @@ describe("workspace assistant chat server route", () => {
 
     expect(response.status).toBe(401);
     expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects write-mode chat requests with an unauthenticated identity (expired token)", async () => {
+    resolveWorkspaceAssistantAuthContextMock.mockResolvedValueOnce({
+      identity: { type: "unauthenticated" },
+    });
+
+    const response = await handleWorkspaceAssistantChatRequest(
+      createWriteModeRequest()
+    );
+
+    expect(response.status).toBe(401);
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(findProviderRoutinesMock).not.toHaveBeenCalled();
+    expect(findUserConnectorToolsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects write-mode chat requests without an active organization", async () => {
+    resolveWorkspaceAssistantAuthContextMock.mockResolvedValueOnce({
+      identity: { type: "pending", userId: "user_123" },
+    });
+
+    const response = await handleWorkspaceAssistantChatRequest(
+      createWriteModeRequest()
+    );
+
+    expect(response.status).toBe(403);
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(findProviderRoutinesMock).not.toHaveBeenCalled();
+    expect(findUserConnectorToolsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects write-mode chat requests when the active organization is not bound", async () => {
+    resolveWorkspaceAssistantAuthContextMock.mockResolvedValueOnce({
+      identity: {
+        orgGate: { bindingStatus: "unbound", nextSetupRequirement: "bind" },
+        orgId: "org_123",
+        type: "active",
+        userId: "user_123",
+      },
+    });
+
+    const response = await handleWorkspaceAssistantChatRequest(
+      createWriteModeRequest()
+    );
+
+    expect(response.status).toBe(403);
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(findProviderRoutinesMock).not.toHaveBeenCalled();
+    expect(findUserConnectorToolsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects write-mode chat requests when the conversation belongs to another organization", async () => {
+    const duplicatePublicId = new Error("duplicate public id");
+    getWorkspaceAssistantConversationByPublicIdMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    createWorkspaceAssistantConversationMock.mockRejectedValueOnce(
+      duplicatePublicId
+    );
+    isDuplicateKeyErrorMock.mockReturnValueOnce(true);
+
+    const response = await handleWorkspaceAssistantChatRequest(
+      createWriteModeRequest()
+    );
+
+    expect(response.status).toBe(404);
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(findProviderRoutinesMock).not.toHaveBeenCalled();
+    expect(findUserConnectorToolsMock).not.toHaveBeenCalled();
   });
 
   it("persists an idempotent turn and streams through the AI Gateway model", async () => {
@@ -422,6 +493,20 @@ function createJsonRequest(body: unknown) {
     body: JSON.stringify(body),
     headers: { "Content-Type": "application/json" },
     method: "POST",
+  });
+}
+
+function createWriteModeRequest() {
+  return createJsonRequest({
+    conversationId: "conv_123",
+    messages: [
+      {
+        id: "client-message-1",
+        parts: [{ text: "Create a Linear issue", type: "text" }],
+        role: "user",
+      },
+    ],
+    providerRoutineWriteMode: true,
   });
 }
 

--- a/apps/app-tanstack/src/server/chat/workspace-assistant-route.ts
+++ b/apps/app-tanstack/src/server/chat/workspace-assistant-route.ts
@@ -1,15 +1,5 @@
 import { createHash } from "node:crypto";
 import {
-  type ChatProviderRoutineContext,
-  callChatProviderRoutine,
-  findChatProviderRoutines,
-} from "@api/app/services/connectors";
-import {
-  callUserConnectorTool,
-  findUserConnectorTools,
-  type UserConnectorChatContext,
-} from "@api/app/services/user-connectors/runtime";
-import {
   appendWorkspaceAssistantMessage,
   createWorkspaceAssistantConversation,
   createWorkspaceAssistantGeneration,
@@ -70,6 +60,26 @@ const WORKSPACE_ASSISTANT_STREAM_SMOOTHING = {
   chunking: "word",
   delayInMs: 20,
 } as const;
+
+interface ChatProviderRoutineContext {
+  clerkOrgId: string;
+  conversationId: string;
+  userId: string;
+  writeMode: boolean;
+}
+
+interface UserConnectorChatContext {
+  actor: {
+    orgId: string;
+    userId: string;
+  };
+  db: typeof db;
+  now: () => Date;
+  source: {
+    conversationId: string;
+    surface: "interactive_chat";
+  };
+}
 
 const chatRequestSchema = z
   .object({
@@ -509,16 +519,24 @@ function createWorkspaceAssistantTools(input: {
         "Call one private user connector tool by routineId for the current user. Use routineIds returned by findUserConnectorTools.",
       inputSchema: userConnectorCallInputSchema,
       outputSchema: userConnectorCallSuccessSchema,
-      execute: async (toolInput) =>
-        callUserConnectorTool(userConnectorContext(input), toolInput),
+      execute: async (toolInput) => {
+        const { callUserConnectorTool } = await import(
+          "@api/app/services/user-connectors/runtime"
+        );
+        return callUserConnectorTool(userConnectorContext(input), toolInput);
+      },
     }),
     findUserConnectorTools: tool({
       description:
         "Find private user connector tools available to the current user, such as Granola meeting note tools. Use this before calling callUserConnectorTool.",
       inputSchema: userConnectorFindInputSchema,
       outputSchema: userConnectorFindOutputSchema,
-      execute: async (toolInput) =>
-        findUserConnectorTools(userConnectorContext(input), toolInput),
+      execute: async (toolInput) => {
+        const { findUserConnectorTools } = await import(
+          "@api/app/services/user-connectors/runtime"
+        );
+        return findUserConnectorTools(userConnectorContext(input), toolInput);
+      },
     }),
   };
 }
@@ -535,16 +553,30 @@ function createWorkspaceAssistantProviderRoutineTools(input: {
         "Call one connected provider routine by routineId using this workspace's enabled connector. Write routines require write mode for this turn.",
       inputSchema: providerRoutineCallInputSchema,
       outputSchema: providerRoutineCallSuccessSchema,
-      execute: async (toolInput) =>
-        callChatProviderRoutine(providerRoutineContext(input), toolInput),
+      execute: async (toolInput) => {
+        const { callChatProviderRoutine } = await import(
+          "@api/app/services/connectors/chat-routines"
+        );
+        return callChatProviderRoutine(
+          providerRoutineContext(input),
+          toolInput
+        );
+      },
     }),
     findProviderRoutines: tool({
       description:
         "Find connected provider routines available to this workspace through enabled connectors. Returns read routines, and write routines only when write mode is enabled for this turn.",
       inputSchema: providerRoutineFindInputSchema,
       outputSchema: providerRoutineFindOutputSchema,
-      execute: async (toolInput) =>
-        findChatProviderRoutines(providerRoutineContext(input), toolInput),
+      execute: async (toolInput) => {
+        const { findChatProviderRoutines } = await import(
+          "@api/app/services/connectors/chat-routines"
+        );
+        return findChatProviderRoutines(
+          providerRoutineContext(input),
+          toolInput
+        );
+      },
     }),
   };
 }

--- a/apps/app-tanstack/src/server/chat/workspace-assistant-route.ts
+++ b/apps/app-tanstack/src/server/chat/workspace-assistant-route.ts
@@ -1,5 +1,15 @@
 import { createHash } from "node:crypto";
 import {
+  type ChatProviderRoutineContext,
+  callChatProviderRoutine,
+  findChatProviderRoutines,
+} from "@api/app/services/connectors";
+import {
+  callUserConnectorTool,
+  findUserConnectorTools,
+  type UserConnectorChatContext,
+} from "@api/app/services/user-connectors/runtime";
+import {
   appendWorkspaceAssistantMessage,
   createWorkspaceAssistantConversation,
   createWorkspaceAssistantGeneration,
@@ -33,10 +43,11 @@ import {
   providerRoutineFindOutputSchema,
 } from "@repo/provider-routine-contract";
 import {
-  callProviderRoutine,
-  findProviderRoutines,
-  type ProviderRoutineServiceContext,
-} from "@repo/provider-routines";
+  userConnectorCallInputSchema,
+  userConnectorCallSuccessSchema,
+  userConnectorFindInputSchema,
+  userConnectorFindOutputSchema,
+} from "@repo/user-connector-contract";
 import {
   convertToModelMessages,
   gateway,
@@ -77,6 +88,7 @@ const chatRequestSchema = z
       .max(80)
       .regex(/^conv_[A-Za-z0-9_-]+$/)
       .optional(),
+    providerRoutineWriteMode: z.boolean().optional(),
   })
   .passthrough();
 
@@ -86,7 +98,9 @@ const baseSystemPrompt = [
   "When asked about skills, explain what the listed skills can do and suggest the next concrete action.",
   "When connector tools are useful, first find connected provider routines, then call the selected routine by routineId.",
   "Only call provider routines for the active workspace.",
-  "Connected provider routines in chat are read-only; do not use them to create, update, delete, post, assign, archive, or move external records.",
+  "Connected provider routines in chat can read from enabled Linear and X connectors. Write routines are available only for a turn where write mode is enabled. If write access is unavailable, tell the user to reconnect the connector to enable write access.",
+  "When private user connectors such as Granola are useful, first find user connector tools, then call the selected routine by routineId.",
+  "Granola is private meeting context for the current user. Never describe Granola results as workspace or team knowledge.",
 ].join(" ");
 
 export async function handleWorkspaceAssistantChatRequest(request: Request) {
@@ -134,6 +148,8 @@ export async function handleWorkspaceAssistantChatRequest(request: Request) {
       { status: 400 }
     );
   }
+  const providerRoutineWriteMode =
+    parsed.data.providerRoutineWriteMode === true;
 
   const conversation = await resolveConversation({
     createdByUserId: identity.userId,
@@ -232,6 +248,7 @@ export async function handleWorkspaceAssistantChatRequest(request: Request) {
     model: WORKSPACE_ASSISTANT_MODEL,
     streamId,
     conversationId: conversation.publicId,
+    providerRoutineWriteMode,
     userId: identity.userId,
   };
 
@@ -316,10 +333,11 @@ export async function handleWorkspaceAssistantChatRequest(request: Request) {
     },
     stopWhen: stepCountIs(WORKSPACE_ASSISTANT_MAX_TOOL_STEPS),
     system,
-    tools: createWorkspaceAssistantProviderRoutineTools({
+    tools: createWorkspaceAssistantTools({
       conversation,
       orgId: identity.orgId,
       userId: identity.userId,
+      writeMode: providerRoutineWriteMode,
     }),
   });
 
@@ -478,31 +496,75 @@ export async function handleWorkspaceAssistantChatRequest(request: Request) {
   });
 }
 
+function createWorkspaceAssistantTools(input: {
+  conversation: WorkspaceAssistantConversation;
+  orgId: string;
+  userId: string;
+  writeMode: boolean;
+}) {
+  return {
+    ...createWorkspaceAssistantProviderRoutineTools(input),
+    callUserConnectorTool: tool({
+      description:
+        "Call one private user connector tool by routineId for the current user. Use routineIds returned by findUserConnectorTools.",
+      inputSchema: userConnectorCallInputSchema,
+      outputSchema: userConnectorCallSuccessSchema,
+      execute: async (toolInput) =>
+        callUserConnectorTool(userConnectorContext(input), toolInput),
+    }),
+    findUserConnectorTools: tool({
+      description:
+        "Find private user connector tools available to the current user, such as Granola meeting note tools. Use this before calling callUserConnectorTool.",
+      inputSchema: userConnectorFindInputSchema,
+      outputSchema: userConnectorFindOutputSchema,
+      execute: async (toolInput) =>
+        findUserConnectorTools(userConnectorContext(input), toolInput),
+    }),
+  };
+}
+
 function createWorkspaceAssistantProviderRoutineTools(input: {
   conversation: WorkspaceAssistantConversation;
   orgId: string;
   userId: string;
+  writeMode: boolean;
 }) {
   return {
     callProviderRoutine: tool({
       description:
-        "Call one read-only connected provider routine by routineId using this workspace's enabled connector. Use routineIds returned by findProviderRoutines.",
+        "Call one connected provider routine by routineId using this workspace's enabled connector. Write routines require write mode for this turn.",
       inputSchema: providerRoutineCallInputSchema,
       outputSchema: providerRoutineCallSuccessSchema,
       execute: async (toolInput) =>
-        callProviderRoutine(providerRoutineContext(input), toolInput),
+        callChatProviderRoutine(providerRoutineContext(input), toolInput),
     }),
     findProviderRoutines: tool({
       description:
-        "Find read-only connected provider routines available to this workspace through enabled connectors. Use this before calling callProviderRoutine.",
+        "Find connected provider routines available to this workspace through enabled connectors. Returns read routines, and write routines only when write mode is enabled for this turn.",
       inputSchema: providerRoutineFindInputSchema,
       outputSchema: providerRoutineFindOutputSchema,
       execute: async (toolInput) =>
-        findProviderRoutines(providerRoutineContext(input), {
-          ...toolInput,
-          readOnly: true,
-        }),
+        findChatProviderRoutines(providerRoutineContext(input), toolInput),
     }),
+  };
+}
+
+function userConnectorContext(input: {
+  conversation: WorkspaceAssistantConversation;
+  orgId: string;
+  userId: string;
+}): UserConnectorChatContext {
+  return {
+    actor: {
+      orgId: input.orgId,
+      userId: input.userId,
+    },
+    db,
+    now: () => new Date(),
+    source: {
+      conversationId: input.conversation.publicId,
+      surface: "interactive_chat",
+    },
   };
 }
 
@@ -510,24 +572,13 @@ function providerRoutineContext(input: {
   conversation: WorkspaceAssistantConversation;
   orgId: string;
   userId: string;
-}): ProviderRoutineServiceContext {
+  writeMode: boolean;
+}): ChatProviderRoutineContext {
   return {
-    actor: {
-      orgId: input.orgId,
-      userId: input.userId,
-    },
-    db,
-    log,
-    now: () => new Date(),
-    scopes: {
-      providerRoutineRead: true,
-      providerRoutineWrite: false,
-    },
-    source: {
-      clientId: null,
-      ref: input.conversation.publicId,
-      surface: "chat",
-    },
+    clerkOrgId: input.orgId,
+    conversationId: input.conversation.publicId,
+    userId: input.userId,
+    writeMode: input.writeMode,
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,9 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@repo/user-connector-contract':
+        specifier: workspace:*
+        version: link:../../packages/user-connector-contract
       '@sentry/tanstackstart-react':
         specifier: 'catalog:'
         version: 10.56.0(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(react@19.2.6)


### PR DESCRIPTION
## Summary
- port app-tanstack chat API write-mode parsing and provider routine tool wiring
- expose private user connector tools, including Granola, from the TanStack chat server route
- add server-route coverage for write-mode context and user connector tool registration

## Verification
- pnpm --filter @lightfast/app-tanstack exec vitest run src/__tests__/server-chat-workspace-assistant-route.test.ts
- pnpm --filter @lightfast/app-tanstack exec vitest run src/__tests__/server-chat-workspace-assistant-route.test.ts src/__tests__/server-chat-workspace-assistant-stream-route.test.ts src/__tests__/chat-workspace-assistant-client.test.tsx src/__tests__/chat-conversation-id.test.ts src/__tests__/chat-api-source.test.ts
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm check
- pnpm --filter @lightfast/app-tanstack build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace assistant chat now supports write operations for connected provider routines when write mode is enabled.
  * User connector tools are now available during workspace assistant chat interactions.
  * Updated assistant guidance clarifies how provider routines and connector results are handled based on the session settings.

* **Bug Fixes**
  * Added stricter handling for write mode requests so unauthorized or mismatched context no longer triggers streaming or routine/tool execution.

* **Tests**
  * Expanded automated coverage for both write-mode success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->