### PR TITLE
feat: Port app-tanstack chat message primitives

### DIFF
--- a/apps/app-tanstack/src/__tests__/chat-message.test.tsx
+++ b/apps/app-tanstack/src/__tests__/chat-message.test.tsx
@@ -1,0 +1,338 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useReducer, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+let messageRenderCount = 0;
+let messageResponseRenderCount = 0;
+
+vi.mock("@repo/ui/components/ai-elements/message", () => ({
+  Message: ({
+    children,
+    className,
+    from,
+  }: {
+    children?: ReactNode;
+    className?: string;
+    from?: string;
+  }) => {
+    messageRenderCount += 1;
+    return (
+      <article className={className} data-from={from} data-testid="message">
+        {children}
+      </article>
+    );
+  },
+  MessageActions: ({
+    children,
+    className,
+  }: {
+    children?: ReactNode;
+    className?: string;
+  }) => (
+    <div className={className} data-testid="message-actions">
+      {children}
+    </div>
+  ),
+  MessageContent: ({
+    children,
+    className,
+  }: {
+    children?: ReactNode;
+    className?: string;
+  }) => (
+    <section className={className} data-testid="message-content">
+      {children}
+    </section>
+  ),
+  MessageResponse: ({ children }: { children?: ReactNode }) => {
+    messageResponseRenderCount += 1;
+    return <div data-testid="message-response">{children}</div>;
+  },
+}));
+
+vi.mock("@repo/ui/components/ai-elements/reasoning", () => ({
+  Reasoning: ({
+    children,
+    defaultOpen,
+    isStreaming,
+  }: {
+    children?: ReactNode;
+    defaultOpen?: boolean;
+    isStreaming?: boolean;
+  }) => (
+    <div
+      data-default-open={String(defaultOpen)}
+      data-streaming={String(isStreaming)}
+      data-testid="reasoning"
+    >
+      {children}
+    </div>
+  ),
+  ReasoningContent: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="reasoning-content">{children}</div>
+  ),
+  ReasoningTrigger: () => <button type="button">Reasoning</button>,
+}));
+
+vi.mock("@repo/ui/components/ai-elements/tool", () => ({
+  Tool: ({
+    children,
+    defaultOpen,
+  }: {
+    children?: ReactNode;
+    defaultOpen?: boolean;
+  }) => {
+    const [open] = useState(defaultOpen);
+    return (
+      <div data-default-open={String(open)} data-testid="tool">
+        {children}
+      </div>
+    );
+  },
+  ToolContent: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="tool-content">{children}</div>
+  ),
+  ToolHeader: ({
+    state,
+    toolName,
+    type,
+  }: {
+    state?: string;
+    toolName?: string;
+    type?: string;
+  }) => (
+    <button data-state={state} data-tool-name={toolName} type="button">
+      {type}
+    </button>
+  ),
+  ToolInput: ({ input }: { input?: unknown }) => (
+    <div data-testid="tool-input">{JSON.stringify(input)}</div>
+  ),
+  ToolOutput: ({
+    errorText,
+    output,
+  }: {
+    errorText?: string;
+    output?: unknown;
+  }) => (
+    <div data-testid="tool-output">{errorText ?? JSON.stringify(output)}</div>
+  ),
+}));
+
+vi.mock("@repo/ui/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    className,
+  }: {
+    children?: ReactNode;
+    className?: string;
+  }) => <span className={className}>{children}</span>,
+}));
+
+vi.mock("~/chat/message-copy-button", () => ({
+  extractMessageText: (message: {
+    parts: Array<{ text?: string; type: string }>;
+  }) =>
+    message.parts
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n\n")
+      .trim(),
+  MessageCopyButton: ({ text }: { text: string }) => (
+    <button aria-label="Copy" type="button">
+      {text}
+    </button>
+  ),
+}));
+
+const { ChatMessage } = await import("~/chat/chat-message");
+
+afterEach(() => {
+  cleanup();
+});
+
+function Harness({
+  message,
+}: {
+  message: Parameters<typeof ChatMessage>[0]["message"];
+}) {
+  const [, force] = useReducer((x: number) => x + 1, 0);
+  return (
+    <>
+      <button onClick={() => force()} type="button">
+        force
+      </button>
+      <ChatMessage isStreaming={false} message={message} />
+    </>
+  );
+}
+
+describe("ChatMessage", () => {
+  it("renders through ai-elements message primitives", () => {
+    render(
+      <ChatMessage
+        isStreaming={false}
+        message={{
+          id: "msg_user",
+          parts: [{ text: "Hello", type: "text" }],
+          role: "user",
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("message").getAttribute("data-from")).toBe(
+      "user"
+    );
+    expect(screen.getByTestId("message-content").textContent).toContain(
+      "Hello"
+    );
+    expect(screen.getByTestId("message-response").textContent).toBe("Hello");
+    expect(screen.getByTestId("message-actions")).toBeTruthy();
+  });
+
+  it("does not re-render a completed message when the parent re-renders", () => {
+    messageRenderCount = 0;
+    messageResponseRenderCount = 0;
+    const message = {
+      id: "msg_assistant",
+      parts: [{ text: "Stable answer", type: "text" as const }],
+      role: "assistant" as const,
+    };
+
+    render(<Harness message={message} />);
+    expect(messageRenderCount).toBe(1);
+    expect(messageResponseRenderCount).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "force" }));
+    fireEvent.click(screen.getByRole("button", { name: "force" }));
+
+    expect(messageRenderCount).toBe(1);
+    expect(messageResponseRenderCount).toBe(1);
+  });
+
+  it("renders reasoning and generic tool parts through ai-elements primitives", () => {
+    render(
+      <ChatMessage
+        isStreaming={true}
+        message={{
+          id: "msg_assistant",
+          parts: [
+            { text: "Thinking", type: "reasoning" },
+            {
+              input: { query: "roadmap" },
+              output: { count: 2 },
+              state: "output-available",
+              toolCallId: "tool_1",
+              toolName: "searchDocs",
+              type: "dynamic-tool",
+            },
+          ],
+          role: "assistant",
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId("reasoning").getAttribute("data-default-open")
+    ).toBe("true");
+    expect(screen.getByTestId("reasoning").getAttribute("data-streaming")).toBe(
+      "true"
+    );
+    expect(screen.getByTestId("reasoning-content").textContent).toContain(
+      "Thinking"
+    );
+    expect(screen.getByTestId("tool").getAttribute("data-default-open")).toBe(
+      "false"
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "dynamic-tool" })
+        .getAttribute("data-tool-name")
+    ).toBe("searchDocs");
+    expect(screen.getByTestId("tool-input").textContent).toContain("roadmap");
+    expect(screen.getByTestId("tool-output").textContent).toContain("count");
+  });
+
+  it("collapses a streaming tool part when output becomes available", () => {
+    const message = {
+      id: "msg_assistant",
+      parts: [
+        {
+          input: { query: "roadmap" },
+          output: undefined,
+          state: "input-available" as const,
+          toolCallId: "tool_1",
+          toolName: "searchDocs",
+          type: "dynamic-tool" as const,
+        },
+      ],
+      role: "assistant" as const,
+    };
+    const { rerender } = render(
+      <ChatMessage isStreaming={true} message={message} />
+    );
+
+    expect(screen.getByTestId("tool").getAttribute("data-default-open")).toBe(
+      "true"
+    );
+
+    rerender(
+      <ChatMessage
+        isStreaming={true}
+        message={{
+          ...message,
+          parts: [
+            {
+              input: { query: "roadmap" },
+              output: { count: 2 },
+              state: "output-available" as const,
+              toolCallId: "tool_1",
+              toolName: "searchDocs",
+              type: "dynamic-tool" as const,
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("tool").getAttribute("data-default-open")).toBe(
+      "false"
+    );
+  });
+
+  it("renders a quiet Granola usage indicator for user connector tool output", () => {
+    render(
+      <ChatMessage
+        isStreaming={false}
+        message={{
+          id: "msg_1",
+          role: "assistant",
+          parts: [
+            {
+              input: {
+                input: { query: "SOC2" },
+                routineId: "granola__search_notes",
+              },
+              output: {
+                provider: "granola",
+                providerToolName: "search_notes",
+                result: { content: [{ text: "result", type: "text" }] },
+                routineId: "granola__search_notes",
+                status: "succeeded",
+              },
+              state: "output-available",
+              toolCallId: "tool_1",
+              type: "tool-callUserConnectorTool",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Used Granola")).toBeTruthy();
+    expect(screen.queryByTestId("tool")).toBeNull();
+  });
+});

--- a/apps/app-tanstack/src/chat/chat-message.tsx
+++ b/apps/app-tanstack/src/chat/chat-message.tsx
@@ -1,3 +1,8 @@
+import {
+  Message,
+  MessageActions,
+  MessageContent,
+} from "@repo/ui/components/ai-elements/message";
 import { cn } from "@repo/ui/lib/utils";
 import type { UIMessage } from "@vendor/ai";
 import { memo } from "react";
@@ -13,13 +18,8 @@ export const ChatMessage = memo(function ChatMessage({
 }) {
   const copyText = extractMessageText(message);
   return (
-    <article
-      className={cn(
-        "group relative flex w-full",
-        message.role === "user" ? "justify-end" : "justify-start"
-      )}
-    >
-      <div
+    <Message className="relative" from={message.role}>
+      <MessageContent
         className={cn(
           message.role === "user" &&
             "max-w-[80%] rounded-3xl bg-muted px-5 py-2 text-base leading-6",
@@ -34,17 +34,17 @@ export const ChatMessage = memo(function ChatMessage({
             part={part}
           />
         ))}
-      </div>
+      </MessageContent>
       {copyText ? (
-        <div
+        <MessageActions
           className={cn(
             "absolute top-full mt-2 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100",
             message.role === "user" ? "right-0" : "left-0"
           )}
         >
           <MessageCopyButton text={copyText} />
-        </div>
+        </MessageActions>
       ) : null}
-    </article>
+    </Message>
   );
 });

--- a/apps/app-tanstack/src/chat/message-part.tsx
+++ b/apps/app-tanstack/src/chat/message-part.tsx
@@ -1,16 +1,28 @@
-import { Badge } from "@repo/ui/components/ui/badge";
-import { cn } from "@repo/ui/lib/utils";
-import type { UIMessage } from "@vendor/ai";
-import { ChevronDown, Wrench } from "lucide-react";
+import { MessageResponse } from "@repo/ui/components/ai-elements/message";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "@repo/ui/components/ai-elements/reasoning";
+import {
+  type ToolPart as AiElementsToolPart,
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
+} from "@repo/ui/components/ai-elements/tool";
+import type { DynamicToolUIPart, ToolUIPart, UIMessage } from "@vendor/ai";
 import { memo } from "react";
 
-type ToolPart = UIMessage["parts"][number] & {
-  errorText?: string;
-  input?: unknown;
-  output?: unknown;
-  state: string;
+interface WorkspaceToolPart {
+  errorText?: AiElementsToolPart["errorText"];
+  input?: AiElementsToolPart["input"];
+  output?: AiElementsToolPart["output"];
+  state: AiElementsToolPart["state"];
   toolName?: string;
-};
+  type: "dynamic-tool" | `tool-${string}`;
+}
 
 export const WorkspaceAssistantMessagePart = memo(
   function WorkspaceAssistantMessagePart({
@@ -21,58 +33,53 @@ export const WorkspaceAssistantMessagePart = memo(
     part: UIMessage["parts"][number];
   }) {
     if (part.type === "text") {
-      return <div className="whitespace-pre-wrap">{part.text}</div>;
+      return <MessageResponse>{part.text}</MessageResponse>;
     }
 
     if (part.type === "reasoning") {
       return (
-        <details
-          className="rounded-sm border border-border/60 bg-muted/20 p-3 text-sm"
-          open={isStreaming}
-        >
-          <summary className="cursor-pointer font-medium text-muted-foreground">
-            Reasoning
-          </summary>
-          <div className="mt-3 whitespace-pre-wrap text-muted-foreground">
-            {part.text}
-          </div>
-        </details>
+        <Reasoning defaultOpen={isStreaming} isStreaming={isStreaming}>
+          <ReasoningTrigger />
+          <ReasoningContent>{part.text}</ReasoningContent>
+        </Reasoning>
+      );
+    }
+
+    if (isGranolaUserConnectorToolPart(part)) {
+      return (
+        <div className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1 text-muted-foreground text-xs">
+          Used Granola
+        </div>
       );
     }
 
     if (isToolPart(part)) {
-      const toolName =
-        part.type === "dynamic-tool"
-          ? part.toolName
-          : part.type.split("-").slice(1).join("-");
+      const toolPart = part as unknown as WorkspaceToolPart;
       return (
-        <details
-          className="rounded-sm border border-border/60 bg-muted/20 text-sm"
-          open={part.state !== "output-available"}
+        <Tool
+          defaultOpen={toolPart.state !== "output-available"}
+          key={toolPart.state}
         >
-          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-3">
-            <span className="flex min-w-0 items-center gap-2">
-              <Wrench className="size-3.5 shrink-0 text-muted-foreground" />
-              <span className="truncate font-medium">{toolName}</span>
-            </span>
-            <span className="flex shrink-0 items-center gap-2">
-              <Badge className="rounded-full text-xs" variant="secondary">
-                {formatPartLabel(part.state)}
-              </Badge>
-              <ChevronDown className="size-3.5 text-muted-foreground" />
-            </span>
-          </summary>
-          <div className="space-y-3 border-border/60 border-t p-3">
-            <ToolPayload label="Input" value={part.input} />
-            {part.errorText ? (
-              <div className="rounded-sm border border-destructive/30 bg-destructive/10 p-3 text-destructive">
-                {part.errorText}
-              </div>
-            ) : (
-              <ToolPayload label="Output" value={part.output} />
-            )}
-          </div>
-        </details>
+          {toolPart.type === "dynamic-tool" ? (
+            <ToolHeader
+              state={toolPart.state as DynamicToolUIPart["state"]}
+              toolName={toolPart.toolName ?? ""}
+              type="dynamic-tool"
+            />
+          ) : (
+            <ToolHeader
+              state={toolPart.state as ToolUIPart["state"]}
+              type={toolPart.type as ToolUIPart["type"]}
+            />
+          )}
+          <ToolContent>
+            <ToolInput input={toolPart.input} />
+            <ToolOutput
+              errorText={toolPart.errorText}
+              output={toolPart.output}
+            />
+          </ToolContent>
+        </Tool>
       );
     }
 
@@ -144,42 +151,31 @@ export const WorkspaceAssistantMessagePart = memo(
   }
 );
 
-function isToolPart(part: UIMessage["parts"][number]): part is ToolPart {
+function isToolPart(part: UIMessage["parts"][number]) {
   return (
     "state" in part &&
     (part.type === "dynamic-tool" || part.type.startsWith("tool-"))
   );
 }
 
-function ToolPayload({ label, value }: { label: string; value: unknown }) {
-  if (value === undefined || value === null) {
-    return null;
+function isGranolaUserConnectorToolPart(
+  part: UIMessage["parts"][number]
+): boolean {
+  if (
+    !("state" in part) ||
+    part.type !== "tool-callUserConnectorTool" ||
+    part.state !== "output-available"
+  ) {
+    return false;
   }
 
+  const output = part.output;
   return (
-    <div className="space-y-1.5">
-      <div className="font-medium text-muted-foreground text-xs">{label}</div>
-      <pre
-        className={cn(
-          "max-h-72 overflow-auto rounded-sm bg-background/80 p-3 text-xs",
-          "whitespace-pre-wrap break-words"
-        )}
-      >
-        {formatPayload(value)}
-      </pre>
-    </div>
+    typeof output === "object" &&
+    output !== null &&
+    "provider" in output &&
+    output.provider === "granola"
   );
-}
-
-function formatPayload(value: unknown) {
-  if (typeof value === "string") {
-    return value;
-  }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 }
 
 function formatPartLabel(value: string) {

--- a/packages/ui/src/components/ai-elements/tool.test.tsx
+++ b/packages/ui/src/components/ai-elements/tool.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ToolInput, ToolOutput } from "./tool";
+
+describe("Tool payload rendering", () => {
+  it("renders BigInt payloads without throwing", () => {
+    expect(() => render(<ToolInput input={1n} />)).not.toThrow();
+
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("renders circular output payloads without throwing", () => {
+    const value: { self?: unknown } = {};
+    value.self = value;
+
+    expect(() =>
+      render(<ToolOutput errorText={undefined} output={value} />)
+    ).not.toThrow();
+
+    expect(screen.getByText("[object Object]")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/ai-elements/tool.tsx
+++ b/packages/ui/src/components/ai-elements/tool.tsx
@@ -19,8 +19,6 @@ import {
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement } from "react";
 
-import { CodeBlock } from "./code-block";
-
 export type ToolProps = ComponentProps<typeof Collapsible>;
 
 export const Tool = ({ className, ...props }: ToolProps) => (
@@ -121,12 +119,7 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
     <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
       Parameters
     </h4>
-    <div className="rounded-md bg-muted/50">
-      <CodeBlock
-        code={JSON.stringify(input ?? null, null, 2)}
-        language="json"
-      />
-    </div>
+    <JsonBlock value={input ?? null} />
   </div>
 );
 
@@ -151,11 +144,9 @@ export const ToolOutput = ({
     output === null ||
     (typeof output === "object" && !isValidElement(output))
   ) {
-    Output = (
-      <CodeBlock code={JSON.stringify(output, null, 2)} language="json" />
-    );
+    Output = <JsonBlock value={output} />;
   } else if (typeof output === "string") {
-    Output = <CodeBlock code={output} language="json" />;
+    Output = <JsonBlock value={output} />;
   }
 
   return (
@@ -177,3 +168,25 @@ export const ToolOutput = ({
     </div>
   );
 };
+
+function JsonBlock({ value }: { value: unknown }) {
+  const code = serializeForCode(value);
+
+  return (
+    <pre className="overflow-x-auto rounded-md bg-muted/50 p-3 text-xs">
+      <code>{code}</code>
+    </pre>
+  );
+}
+
+function serializeForCode(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
## Summary
- port app-tanstack chat messages to the shared ai-elements Message/Reasoning/Tool primitives
- add TanStack chat message parity coverage for memoization, reasoning/tool rendering, and Granola connector compaction
- make ai-elements tool payload rendering avoid the heavier CodeBlock dependency for TanStack chat SSR paths

## Validation
- pnpm --filter @lightfast/app-tanstack test
- pnpm --filter @lightfast/app-tanstack typecheck
- pnpm --filter @repo/ui test
- pnpm --filter @repo/ui typecheck
- pnpm check

## Known issue
- pnpm --filter @lightfast/app-tanstack build still fails in the broader SSR build graph on Shiki onig.wasm loading from shiki@3.13.0. This remains after removing the chat tool CodeBlock dependency and appears outside this slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expand/collapse and streaming behavior for chat reasoning.
  * Updated chat tool rendering to show structured inputs/outputs more clearly.
  * Added a “Used Granola” indicator for a specific connector tool output.
* **Style**
  * Improved JSON display for tool payloads using consistent pre/code rendering.
  * Refined chat message layout, including where the copy action appears.
* **Tests**
  * Added React Testing Library + Vitest coverage to prevent unnecessary re-renders in chat messages.
  * Added tool rendering tests for `bigint` and circular-reference payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->