### PR TITLE
chore: rename dev task after app migration

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -9,7 +9,6 @@
     "build": "pnpm with-env vite build",
     "clean": "git clean -xdf .cache .output .tanstack .turbo .vercel dist node_modules src/routeTree.gen.ts",
     "dev": "portless run pnpm with-related-projects pnpm with-env vite dev",
-    "dev:next": "pnpm dev",
     "mfe:proxy": "portless run --name lightfast sh -c 'pnpm exec microfrontends proxy ./microfrontends.json --port \"$PORT\" --local-apps lightfast-app lightfast-www --local-app-url lightfast-app=$(portless get app.lightfast) --local-app-url lightfast-www=$(portless get www.lightfast)'",
     "preview": "pnpm with-env vite preview",
     "start": "pnpm preview",

--- a/apps/app/src/__tests__/workspace-wiring.test.ts
+++ b/apps/app/src/__tests__/workspace-wiring.test.ts
@@ -24,12 +24,23 @@ describe("app workspace wiring", () => {
       readFileSync(resolve(repoRoot, "package.json"), "utf8")
     ) as { scripts: Record<string, string> };
 
+    expect(rootPackageJson.scripts.dev).toContain("turbo run dev");
     expect(rootPackageJson.scripts.dev).toContain("-F @lightfast/app");
     expect(rootPackageJson.scripts.dev).toContain("@lightfast/app#mfe:proxy");
+    expect(rootPackageJson.scripts.dev).not.toContain("dev:next");
     expect(rootPackageJson.scripts.dev).not.toContain("-F @lightfast/app-next");
     expect(rootPackageJson.scripts.dev).not.toContain(
       "@lightfast/app-next#mfe:proxy"
     );
+  });
+
+  it("does not expose the canonical app through a Next-specific dev task", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(appRoot, "package.json"), "utf8")
+    ) as { scripts: Record<string, string | undefined> };
+
+    expect(packageJson.scripts.dev).toContain("vite dev");
+    expect(packageJson.scripts["dev:next"]).toBeUndefined();
   });
 
   it("carries the canonical MFE mesh and proxy dependency", () => {

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -66,10 +66,6 @@
       "persistent": true,
       "passThroughEnv": ["HOST", "PORT", "PORTLESS_URL"]
     },
-    "dev:next": {
-      "cache": false,
-      "persistent": true
-    },
     "mfe:proxy": {
       "cache": false,
       "persistent": true

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -9,7 +9,6 @@
     "build": "pnpm with-env vite build",
     "clean": "git clean -xdf .cache .output .tanstack .turbo .vercel dist node_modules src/routeTree.gen.ts",
     "dev": "portless run pnpm with-related-projects pnpm with-env vite dev",
-    "dev:next": "pnpm dev",
     "preview": "pnpm with-env vite preview",
     "start": "pnpm preview",
     "test": "vitest run",

--- a/apps/mcp/turbo.json
+++ b/apps/mcp/turbo.json
@@ -38,10 +38,6 @@
       "persistent": true,
       "passThroughEnv": ["HOST", "PORT", "PORTLESS_URL"]
     },
-    "dev:next": {
-      "cache": false,
-      "persistent": true
-    },
     "transit": {}
   }
 }

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -14,7 +14,7 @@
     "search:sync": "mxbai store sync $MXBAI_STORE_ID \"./src/content/**/*.mdx\" --api-key $MXBAI_API_KEY",
     "search:sync:ci": "mxbai store sync $MXBAI_STORE_ID \"./src/content/**/*.mdx\" --api-key $MXBAI_API_KEY -y",
     "clean": "git clean -xdf .cache .clerk .next .turbo .vercel node_modules",
-    "dev:next": "portless run pnpm with-related-projects pnpm with-env next dev --turbo",
+    "dev": "portless run pnpm with-related-projects pnpm with-env next dev --turbo",
     "start": "pnpm with-env next start -p 4101",
     "test": "vitest run",
     "typecheck": "pnpm with-env next typegen && tsc --noEmit",

--- a/apps/www/turbo.json
+++ b/apps/www/turbo.json
@@ -41,7 +41,7 @@
         "next-env.d.ts"
       ]
     },
-    "dev:next": {
+    "dev": {
       "persistent": true
     },
     "transit": {}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:mcp": "turbo run build -F @lightfast/mcp",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo run clean",
-    "dev": "portless proxy start && turbo run dev:next @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator //#_x_emulator //#_granola_emulator --concurrency=16 -F @lightfast/www -F @lightfast/app -F @lightfast/mcp --continue",
+    "dev": "portless proxy start && turbo run dev @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator //#_x_emulator //#_granola_emulator --concurrency=16 -F @lightfast/www -F @lightfast/app -F @lightfast/mcp --continue",
     "_inngest": "portless run --name inngest.lightfast sh -c 'npx inngest-cli@latest dev --no-discovery --host \"$HOST\" --port \"$PORT\" -u \"$(portless get lightfast)/api/inngest\"'",
     "_github_emulator": "portless run --name github.lightfast sh -c 'CALLBACK_URL=\"$(portless get lightfast)/api/github/setup\" PUBLIC_ORIGIN=\"$(portless get github.lightfast)\" pnpm --filter @repo/github-emulator dev'",
     "_granola_emulator": "portless run --name granola.lightfast sh -c 'PUBLIC_ORIGIN=\"$(portless get granola.lightfast)\" pnpm --filter @repo/granola-emulator dev'",

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,7 @@
         "VERCEL_ENV"
       ]
     },
-    "dev:next": {
+    "dev": {
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary
- renames the root local-dev Turbo task from `dev:next` to generic `dev`
- removes `dev:next` compatibility aliases from TanStack app and MCP packages
- exposes the existing `www` Next dev command as `dev` so root `pnpm dev` preserves behavior
- adds app workspace guard coverage to keep the canonical app off Next-specific dev task naming

## Test Plan
- [x] `pnpm --filter @lightfast/app exec vitest run src/__tests__/workspace-wiring.test.ts`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm check`
- [x] `pnpm lint:ws` (passes with existing platform package warnings)
- [x] `pnpm exec turbo run dev @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator //#_x_emulator //#_granola_emulator --concurrency=16 -F @lightfast/www -F @lightfast/app -F @lightfast/mcp --continue --dry=json`