### PR TITLE
Add Storybook to Portless dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ See `SPEC.md` for business goals and product vision.
 │                @lightfast/mcp · hosted OAuth MCP resource server                 │
 │      www       https://[<wt>.]www.lightfast.localhost                            │
 │                marketing + docs (fumadocs MDX) · marketing-group MFE             │
+│      storybook https://[<wt>.]storybook.lightfast.localhost                      │
+│                UI component workshop (@lightfast/storybook)                      │
 │      inngest   https://[<wt>.]inngest.lightfast.localhost                        │
 │      qstash    https://[<wt>.]qstash.lightfast.localhost                         │
 │      db        https://[<wt>.]db.lightfast.localhost                             │
@@ -71,7 +73,7 @@ Packages: @repo/* (ui, lib, ai)  |  @repo/app-* (23)  |  @vendor/* (18)
 ```bash
 # Dev servers (NEVER use global pnpm build).
 # Worktree-prefixed URLs: see Architecture diagram above.
-pnpm dev              # app + mcp + www + local Inngest + local QStash + MFE aggregate
+pnpm dev              # app + mcp + www + Storybook + local Inngest + local QStash + MFE aggregate
 
 # Local infrastructure setup
 # Load the lightfast-local-infra skill for PlanetScale DB / Upstash Redis setup.
@@ -99,7 +101,7 @@ pnpm db:migrate
 pnpm db:studio        # starts Drizzle Studio through Portless
 ```
 
-`pnpm dev` is the only root local-dev entrypoint. It starts app, mcp, www, local Inngest, local QStash, and the Portless-backed Vercel Microfrontends aggregate for `https://lightfast.localhost`. The hosted MCP resource is available at `https://[<wt>.]mcp.lightfast.localhost/mcp` and is intentionally not part of `apps/app/microfrontends.json`. Direct Portless routes are still used for service registration and project URL injection: `NEXT_PUBLIC_*`, `INNGEST_DEV`, `QSTASH_URL`, `MCP_RESOURCE_URL`, and `MCP_AUTH_ISSUER` values use the concrete service URLs. It does not start public tunnels automatically.
+`pnpm dev` is the only root local-dev entrypoint. It starts app, mcp, www, Storybook, local Inngest, local QStash, and the Portless-backed Vercel Microfrontends aggregate for `https://lightfast.localhost`. The hosted MCP resource is available at `https://[<wt>.]mcp.lightfast.localhost/mcp`; Storybook is available at `https://[<wt>.]storybook.lightfast.localhost`; and both are intentionally not part of `apps/app/microfrontends.json`. Direct Portless routes are still used for service registration and project URL injection: `NEXT_PUBLIC_*`, `INNGEST_DEV`, `QSTASH_URL`, `MCP_RESOURCE_URL`, and `MCP_AUTH_ISSUER` values use the concrete service URLs. It does not start public tunnels automatically.
 
 ## Next.js Agent Diagnostics
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -134,18 +134,18 @@ No Lightfast API keys or Clerk JWT templates are created for desktop login.
 ### Run the stack (two terminals)
 
 ```bash
-# Terminal 1 — app + www + mcp + local services + MFE aggregate
+# Terminal 1 — app + www + mcp + Storybook + local services + MFE aggregate
 pnpm dev
 
 # Terminal 2 — Electron app
 pnpm --filter @lightfast/desktop dev
 ```
 
-`pnpm dev` boots `apps/app`, `apps/www`, `apps/mcp`, local Inngest, local
-QStash, and the Portless-backed Microfrontends aggregate. The desktop package
-dev script passes `APP_URL=$(portless get lightfast)` to Electron so dev opens
-the aggregate URL. The direct app route remains `https://app.lightfast.localhost`
-for service wiring and `NEXT_PUBLIC_APP_URL`.
+`pnpm dev` boots `apps/app`, `apps/www`, `apps/mcp`, `apps/storybook`, local
+Inngest, local QStash, and the Portless-backed Microfrontends aggregate. The
+desktop package dev script passes `APP_URL=$(portless get lightfast)` to
+Electron so dev opens the aggregate URL. The direct app route remains
+`https://app.lightfast.localhost` for service wiring and `NEXT_PUBLIC_APP_URL`.
 
 ### Inspect the encrypted session store
 

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -4,6 +4,8 @@ import type { StorybookConfig } from "@storybook/react-vite";
 import { mergeConfig, searchForWorkspaceRoot } from "vite";
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const portlessUrl = process.env.PORTLESS_URL;
+const hmrHost = portlessUrl ? new URL(portlessUrl).hostname : undefined;
 
 const config: StorybookConfig = {
   stories: ["../stories/**/*.stories.@(ts|tsx|mdx)"],
@@ -27,6 +29,15 @@ const config: StorybookConfig = {
         fs: {
           allow: [appRoot, searchForWorkspaceRoot(appRoot)],
         },
+        ...(hmrHost
+          ? {
+              hmr: {
+                clientPort: 443,
+                host: hmrHost,
+                protocol: "wss" as const,
+              },
+            }
+          : {}),
       },
       optimizeDeps: {
         include: ["@hugeicons/core-free-icons", "@hugeicons/react"],

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "portless": "storybook.lightfast",
   "scripts": {
-    "dev": "storybook dev -p 6006",
+    "dev": "portless run pnpm storybook:dev",
+    "storybook:dev": "storybook dev --host ${HOST:-127.0.0.1} --port ${PORT:-6006} --no-open",
     "build": "storybook build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/apps/storybook/portless.json
+++ b/apps/storybook/portless.json
@@ -1,0 +1,3 @@
+{
+  "name": "storybook.lightfast"
+}

--- a/apps/storybook/turbo.json
+++ b/apps/storybook/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tags": ["app"],
+  "tasks": {
+    "dev": {
+      "cache": false,
+      "persistent": true,
+      "passThroughEnv": ["HOST", "PORT", "PORTLESS_URL"]
+    },
+    "transit": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:mcp": "turbo run build -F @lightfast/mcp",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo run clean",
-    "dev": "portless proxy start && turbo run dev @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator //#_x_emulator //#_granola_emulator --concurrency=16 -F @lightfast/www -F @lightfast/app -F @lightfast/mcp --continue",
+    "dev": "portless proxy start && turbo run dev @lightfast/app#mfe:proxy //#_inngest //#_qstash //#_github_emulator //#_linear_emulator //#_x_emulator //#_granola_emulator --concurrency=16 -F @lightfast/www -F @lightfast/app -F @lightfast/mcp -F @lightfast/storybook --continue",
     "_inngest": "portless run --name inngest.lightfast sh -c 'npx inngest-cli@latest dev --no-discovery --host \"$HOST\" --port \"$PORT\" -u \"$(portless get lightfast)/api/inngest\"'",
     "_github_emulator": "portless run --name github.lightfast sh -c 'CALLBACK_URL=\"$(portless get lightfast)/api/github/setup\" PUBLIC_ORIGIN=\"$(portless get github.lightfast)\" pnpm --filter @repo/github-emulator dev'",
     "_granola_emulator": "portless run --name granola.lightfast sh -c 'PUBLIC_ORIGIN=\"$(portless get granola.lightfast)\" pnpm --filter @repo/granola-emulator dev'",


### PR DESCRIPTION
## Summary
- Add `@lightfast/storybook` to the root `pnpm dev` Turbo flow.
- Register Storybook with Portless at `storybook.lightfast` and add package-level Turbo dev metadata.
- Configure Storybook Vite HMR from `PORTLESS_URL` so worktree-prefixed hosts use the right websocket origin.
- Document the new Storybook route in local dev docs.

## Validation
- `pnpm --filter @lightfast/storybook dev --smoke-test`
- `pnpm --filter @lightfast/storybook typecheck`
- `pnpm check`
- `agent-browser` loaded the default Button story through Storybook.
- `agent-browser` loaded two worktree-prefixed Storybook URLs and verified the isolated iframe rendered the Button story.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Storybook development environment to use portless for dynamic port and host management
  * Enhanced development setup with environment variable support for customizable host and port configuration
  * Optimized Hot Module Replacement configuration and development scripts for improved development workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->