### PR TITLE
Fix product route loading states

### DIFF
--- a/apps/app/src/__tests__/product-loading-empty-states-source.test.ts
+++ b/apps/app/src/__tests__/product-loading-empty-states-source.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+describe("product loading and empty states", () => {
+  it("keeps initial pending states separate from empty states", () => {
+    const peopleClientSource = source("src/people/people-client.tsx");
+    const signalsClientSource = source("src/signals/signals-client.tsx");
+    const signalsDataSource = source(
+      "src/signals/use-signals-workspace-data.ts"
+    );
+
+    expect(peopleClientSource).toContain("PeopleLoading");
+    expect(peopleClientSource).toContain(
+      "peopleQuery.isPending && rows.length === 0"
+    );
+
+    expect(signalsDataSource).toContain("isInitialPending");
+    expect(signalsClientSource).toContain("SignalsLoading");
+    expect(signalsClientSource).toContain("isInitialPending");
+  });
+});

--- a/apps/app/src/__tests__/product-route-prefetch-source.test.ts
+++ b/apps/app/src/__tests__/product-route-prefetch-source.test.ts
@@ -185,4 +185,32 @@ describe("app product route data prefetch", () => {
     expect(formSource).toContain("connectorProvider");
     expect(formSource).toContain("No connector");
   });
+
+  it("hydrates people and decisions with the active route search params", () => {
+    const peopleRouteSource = source(
+      "src/routes/_authenticated/$slug/people.tsx"
+    );
+    const decisionsRouteSource = source(
+      "src/routes/_authenticated/$slug/decisions.tsx"
+    );
+    const prefetchSource = source("src/trpc/route-prefetch.tsx");
+
+    expect(peopleRouteSource).toContain("loaderDeps:");
+    expect(peopleRouteSource).toContain("peopleQuery: search.peopleQuery");
+    expect(peopleRouteSource).toContain("provider: search.provider");
+    expect(peopleRouteSource).toContain("type: search.type");
+    expect(peopleRouteSource).toContain("...deps");
+
+    expect(decisionsRouteSource).toContain("loaderDeps:");
+    expect(decisionsRouteSource).toContain("provider: search.provider");
+    expect(decisionsRouteSource).toContain("q: search.q");
+    expect(decisionsRouteSource).toContain("status: search.status");
+    expect(decisionsRouteSource).toContain("...deps");
+
+    expect(prefetchSource).toContain("peopleQuery?: string");
+    expect(prefetchSource).toContain("provider?: string");
+    expect(prefetchSource).toContain("status?: string");
+    expect(prefetchSource).toContain("prefetchPeopleRoute(prefetchContext,");
+    expect(prefetchSource).toContain("prefetchDecisionsRoute(prefetchContext,");
+  });
 });

--- a/apps/app/src/__tests__/route-boundaries-source.test.ts
+++ b/apps/app/src/__tests__/route-boundaries-source.test.ts
@@ -44,6 +44,24 @@ describe("app route boundaries", () => {
     }
   });
 
+  it("wires product workspace list routes with pending and error boundaries", () => {
+    const routeFiles = [
+      "src/routes/_authenticated/$slug/people.tsx",
+      "src/routes/_authenticated/$slug/signals.tsx",
+      "src/routes/_authenticated/$slug/decisions.tsx",
+      "src/routes/_authenticated/$slug/automations/index.tsx",
+    ];
+
+    for (const routeFile of routeFiles) {
+      const routeSource = expectSource(routeFile);
+
+      expect(routeSource).toContain("pendingComponent:");
+      expect(routeSource).toContain("errorComponent:");
+      expect(routeSource).toContain("WorkspaceRouteErrorPanel");
+      expect(routeSource).not.toContain("next/");
+    }
+  });
+
   it("wires loading shells for settings routes with async prefetch loaders", () => {
     const routeFiles = [
       "src/routes/_authenticated/$slug/settings/source-control.tsx",

--- a/apps/app/src/decisions/decisions-route-prefetch.ts
+++ b/apps/app/src/decisions/decisions-route-prefetch.ts
@@ -1,14 +1,27 @@
 import { DECISIONS_PAGE_SIZE } from "~/decisions/decisions-model";
+import {
+  parseDecisionProviders,
+  parseDecisionStatuses,
+} from "~/decisions/decisions-search-params";
 import type { RoutePrefetchContext } from "~/trpc/route-prefetch-types";
 
-export async function prefetchDecisionsRoute({
-  queryClient,
-  trpc,
-}: RoutePrefetchContext) {
+export async function prefetchDecisionsRoute(
+  { queryClient, trpc }: RoutePrefetchContext,
+  search: { provider?: string; q?: string; status?: string } = {}
+) {
+  const providers = parseDecisionProviders(search.provider ?? "");
+  const statuses = parseDecisionStatuses(search.status ?? "");
+  const searchText = search.q?.trim() || undefined;
+
   await Promise.all([
     queryClient.fetchInfiniteQuery(
       trpc.org.workspace.decisions.list.infiniteQueryOptions(
-        { limit: DECISIONS_PAGE_SIZE },
+        {
+          limit: DECISIONS_PAGE_SIZE,
+          providers: providers.length ? providers : undefined,
+          search: searchText,
+          statuses: statuses.length ? statuses : undefined,
+        },
         {
           getNextPageParam: (lastPage) => lastPage.nextCursor,
           staleTime: 60_000,

--- a/apps/app/src/people/people-client.tsx
+++ b/apps/app/src/people/people-client.tsx
@@ -1,6 +1,7 @@
 import { useDeferredValue, useMemo } from "react";
 import { WorkspaceSurface } from "~/components/workspace-surface";
 import { PeopleDetailSheet } from "./people-detail-sheet";
+import { PeopleLoading } from "./people-loading";
 import {
   flattenPeoplePages,
   type PeopleClassificationFilters,
@@ -53,6 +54,18 @@ export function PeopleClient({
     }
     return map;
   }, [rows]);
+
+  if (peopleQuery.isPending && rows.length === 0) {
+    return (
+      <WorkspaceSurface
+        className="flex min-h-full flex-col bg-background"
+        variant="flush"
+      >
+        <h1 className="sr-only">People</h1>
+        <PeopleLoading />
+      </WorkspaceSurface>
+    );
+  }
 
   return (
     <WorkspaceSurface

--- a/apps/app/src/people/people-route-prefetch.ts
+++ b/apps/app/src/people/people-route-prefetch.ts
@@ -1,14 +1,27 @@
 import { PEOPLE_PAGE_SIZE } from "~/people/people-model";
+import {
+  parsePersonProviders,
+  parsePersonTypes,
+} from "~/people/people-search-params";
 import type { RoutePrefetchContext } from "~/trpc/route-prefetch-types";
 
-export async function prefetchPeopleRoute({
-  queryClient,
-  trpc,
-}: RoutePrefetchContext) {
+export async function prefetchPeopleRoute(
+  { queryClient, trpc }: RoutePrefetchContext,
+  search: { peopleQuery?: string; provider?: string; type?: string } = {}
+) {
+  const providers = parsePersonProviders(search.provider ?? "");
+  const types = parsePersonTypes(search.type ?? "");
+  const searchText = search.peopleQuery?.trim() || undefined;
+
   await Promise.all([
     queryClient.fetchInfiniteQuery(
       trpc.org.workspace.people.list.infiniteQueryOptions(
-        { limit: PEOPLE_PAGE_SIZE },
+        {
+          limit: PEOPLE_PAGE_SIZE,
+          providers: providers.length ? providers : undefined,
+          search: searchText,
+          types: types.length ? types : undefined,
+        },
         {
           getNextPageParam: (lastPage) => lastPage.nextCursor,
           staleTime: 60_000,

--- a/apps/app/src/routes/_authenticated/$slug/automations/index.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/automations/index.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AutomationsClient } from "~/automations/automations-client";
 import {
+  WorkspaceRouteErrorPanel,
+  WorkspaceRoutePending,
+} from "~/components/route-boundaries";
+import {
   loadRoutePrefetch,
   RoutePrefetchBoundary,
 } from "~/trpc/route-prefetch";
@@ -10,8 +14,36 @@ export const Route = createFileRoute("/_authenticated/$slug/automations/")({
   head: ({ params }) => ({
     meta: [{ title: `Automations - ${params.slug} - Lightfast` }],
   }),
+  pendingMs: 250,
+  pendingMinMs: 250,
+  pendingComponent: AutomationsRoutePending,
+  errorComponent: AutomationsRouteError,
   component: AutomationsPage,
 });
+
+function AutomationsRoutePending() {
+  return (
+    <WorkspaceRoutePending className="min-h-full" label="Loading automations" />
+  );
+}
+
+function AutomationsRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <WorkspaceRouteErrorPanel
+      description="We couldn't load automations for this workspace. Refresh the route to try again."
+      error={error}
+      reset={reset}
+      route="automations"
+      title="Couldn't load automations"
+    />
+  );
+}
 
 function AutomationsPage() {
   const { slug } = Route.useParams();

--- a/apps/app/src/routes/_authenticated/$slug/decisions.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/decisions.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
+import { WorkspaceRouteErrorPanel } from "~/components/route-boundaries";
 import { DecisionsClient } from "~/decisions/decisions-client";
+import { DecisionsLoading } from "~/decisions/decisions-loading";
 import {
   type NormalizedDecisionsSearch,
   normalizeDecisionsSearch,
@@ -13,12 +15,44 @@ import {
 
 export const Route = createFileRoute("/_authenticated/$slug/decisions")({
   validateSearch: validateDecisionsSearch,
-  loader: () => loadRoutePrefetch({ data: { route: "decisions" } }),
+  loaderDeps: ({ search }) => ({
+    provider: search.provider,
+    q: search.q,
+    status: search.status,
+  }),
+  loader: ({ deps }) =>
+    loadRoutePrefetch({ data: { route: "decisions", ...deps } }),
   head: ({ params }) => ({
     meta: [{ title: `Decisions - ${params.slug} - Lightfast` }],
   }),
+  pendingMs: 250,
+  pendingMinMs: 250,
+  pendingComponent: DecisionsRoutePending,
+  errorComponent: DecisionsRouteError,
   component: DecisionsPage,
 });
+
+function DecisionsRoutePending() {
+  return <DecisionsLoading />;
+}
+
+function DecisionsRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <WorkspaceRouteErrorPanel
+      description="We couldn't load decisions for this workspace. Refresh the route to try again."
+      error={error}
+      reset={reset}
+      route="decisions"
+      title="Couldn't load decisions"
+    />
+  );
+}
 
 function DecisionsPage() {
   const prefetchState = Route.useLoaderData();

--- a/apps/app/src/routes/_authenticated/$slug/people.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/people.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
+import { WorkspaceRouteErrorPanel } from "~/components/route-boundaries";
 import { PeopleClient } from "~/people/people-client";
+import { PeopleLoading } from "~/people/people-loading";
 import {
   type NormalizedPeopleSearch,
   normalizePeopleSearch,
@@ -13,12 +15,44 @@ import {
 
 export const Route = createFileRoute("/_authenticated/$slug/people")({
   validateSearch: validatePeopleSearch,
-  loader: () => loadRoutePrefetch({ data: { route: "people" } }),
+  loaderDeps: ({ search }) => ({
+    peopleQuery: search.peopleQuery,
+    provider: search.provider,
+    type: search.type,
+  }),
+  loader: ({ deps }) =>
+    loadRoutePrefetch({ data: { route: "people", ...deps } }),
   head: ({ params }) => ({
     meta: [{ title: `People - ${params.slug} - Lightfast` }],
   }),
+  pendingMs: 250,
+  pendingMinMs: 250,
+  pendingComponent: PeopleRoutePending,
+  errorComponent: PeopleRouteError,
   component: PeoplePage,
 });
+
+function PeopleRoutePending() {
+  return <PeopleLoading />;
+}
+
+function PeopleRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <WorkspaceRouteErrorPanel
+      description="We couldn't load people for this workspace. Refresh the route to try again."
+      error={error}
+      reset={reset}
+      route="people"
+      title="Couldn't load people"
+    />
+  );
+}
 
 function PeoplePage() {
   const prefetchState = Route.useLoaderData();

--- a/apps/app/src/routes/_authenticated/$slug/signals.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/signals.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
+import { WorkspaceRouteErrorPanel } from "~/components/route-boundaries";
 import { SignalsClient } from "~/signals/signals-client";
+import { SignalsLoading } from "~/signals/signals-loading";
 import {
   type NormalizedSignalsSearch,
   normalizeSignalsSearch,
@@ -17,8 +19,34 @@ export const Route = createFileRoute("/_authenticated/$slug/signals")({
   head: ({ params }) => ({
     meta: [{ title: `Signals - ${params.slug} - Lightfast` }],
   }),
+  pendingMs: 250,
+  pendingMinMs: 250,
+  pendingComponent: SignalsRoutePending,
+  errorComponent: SignalsRouteError,
   component: SignalsPage,
 });
+
+function SignalsRoutePending() {
+  return <SignalsLoading />;
+}
+
+function SignalsRouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <WorkspaceRouteErrorPanel
+      description="We couldn't load signals for this workspace. Refresh the route to try again."
+      error={error}
+      reset={reset}
+      route="signals"
+      title="Couldn't load signals"
+    />
+  );
+}
 
 function SignalsPage() {
   const prefetchState = Route.useLoaderData();

--- a/apps/app/src/signals/signals-client.tsx
+++ b/apps/app/src/signals/signals-client.tsx
@@ -6,6 +6,7 @@ import { useTRPC } from "~/trpc/react";
 import { SignalCreateDialog } from "./signal-create-dialog";
 import { SignalDetailSheet } from "./signal-detail-sheet";
 import { SignalsListView } from "./signals-list-view";
+import { SignalsLoading } from "./signals-loading";
 import type { SignalClassificationFilters } from "./signals-model";
 import {
   type NormalizedSignalsSearch,
@@ -60,6 +61,7 @@ export function SignalsClient({
 
   const {
     hasAnyRows,
+    isInitialPending,
     limit,
     signalsByPublicId,
     truncated,
@@ -91,6 +93,18 @@ export function SignalsClient({
       Add Signal
     </Button>
   );
+
+  if (isInitialPending) {
+    return (
+      <WorkspaceSurface
+        className="flex min-h-full flex-col bg-background"
+        variant="flush"
+      >
+        <h1 className="sr-only">Signals</h1>
+        <SignalsLoading />
+      </WorkspaceSurface>
+    );
+  }
 
   return (
     <WorkspaceSurface

--- a/apps/app/src/signals/use-signals-workspace-data.ts
+++ b/apps/app/src/signals/use-signals-workspace-data.ts
@@ -87,8 +87,12 @@ export function useSignalsWorkspaceData({
     return map;
   }, [classifiedRows, dedupedProcessingFullRows]);
 
+  const hasAnyRows = classifiedRows.length + processingRows.length > 0;
+
   return {
-    hasAnyRows: classifiedRows.length + processingRows.length > 0,
+    hasAnyRows,
+    isInitialPending:
+      !hasAnyRows && (workingSetQuery.isPending || processingQuery.isPending),
     limit: workingSetQuery.data?.limit ?? 2000,
     processingQueryKey,
     signalsByPublicId,

--- a/apps/app/src/trpc/route-prefetch.tsx
+++ b/apps/app/src/trpc/route-prefetch.tsx
@@ -13,7 +13,7 @@ type RoutePrefetchInput =
   | { route: "automations.list" }
   | { route: "automations.new" }
   | { route: "connectors" }
-  | { route: "decisions" }
+  | { provider?: string; q?: string; route: "decisions"; status?: string }
   | { route: "developerConnections" }
   | { route: "org.mcp" }
   | { route: "org.settings.apiKeys" }
@@ -21,7 +21,7 @@ type RoutePrefetchInput =
   | { route: "org.settings.general"; slug: string }
   | { route: "org.settings.members" }
   | { route: "org.settings.sourceControl" }
-  | { route: "people" }
+  | { peopleQuery?: string; provider?: string; route: "people"; type?: string }
   | { route: "signals" }
   | { route: "skills" }
   | { route: "tasks.bind"; slug: string }
@@ -219,7 +219,11 @@ export const loadRoutePrefetch = createServerFn({ method: "GET" })
           await connectorsPrefetch.prefetchConnectorsRoute(prefetchContext);
           break;
         case "decisions":
-          await decisionsPrefetch.prefetchDecisionsRoute(prefetchContext);
+          await decisionsPrefetch.prefetchDecisionsRoute(prefetchContext, {
+            provider: data.provider,
+            q: data.q,
+            status: data.status,
+          });
           break;
         case "developerConnections":
           await developerConnectionsPrefetch.prefetchDeveloperConnectionsRoute(
@@ -248,7 +252,11 @@ export const loadRoutePrefetch = createServerFn({ method: "GET" })
           await orgPrefetch.prefetchOrgSourceControlRoute(prefetchContext);
           break;
         case "people":
-          await peoplePrefetch.prefetchPeopleRoute(prefetchContext);
+          await peoplePrefetch.prefetchPeopleRoute(prefetchContext, {
+            peopleQuery: data.peopleQuery,
+            provider: data.provider,
+            type: data.type,
+          });
           break;
         case "signals":
           await signalsPrefetch.prefetchSignalsRoute(prefetchContext);


### PR DESCRIPTION
## Summary
- Add route-level pending and error boundaries for people, signals, decisions, and automations list routes.
- Hydrate people and decisions route prefetches from active URL search params so filtered direct links avoid default-cache/empty-state flashes.
- Keep initial client query pending separate from true empty states for people and signals.

## Validation
- pnpm check
- pnpm --filter @lightfast/app test
- pnpm --filter @lightfast/app typecheck
- DATABASE_HOST=localhost DATABASE_USERNAME=lightfast DATABASE_PASSWORD=lightfast KV_REST_API_URL=https://example.com KV_REST_API_TOKEN=placeholder pnpm --filter @lightfast/app build

Note: local build needed placeholder DB/Upstash env values because this worktree does not have those development env vars configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated loading screens for People, Decisions, Signals, and Automations product pages.
  * Integrated route search parameters into data prefetching for improved performance.

* **Bug Fixes**
  * Enhanced error handling with route-specific error panels across product pages.

* **Tests**
  * Added test coverage for loading/empty state handling and route prefetching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->