### PR TITLE
Fix product navigation pending delay

### DIFF
--- a/apps/app/src/__tests__/route-boundaries-source.test.ts
+++ b/apps/app/src/__tests__/route-boundaries-source.test.ts
@@ -58,6 +58,10 @@ describe("app route boundaries", () => {
       expect(routeSource).toContain("pendingComponent:");
       expect(routeSource).toContain("errorComponent:");
       expect(routeSource).toContain("WorkspaceRouteErrorPanel");
+      expect(routeSource).toContain("pendingMs: 0");
+      expect(routeSource).toContain("pendingMinMs: 0");
+      expect(routeSource).not.toContain("pendingMs: 250");
+      expect(routeSource).not.toContain("pendingMinMs: 250");
       expect(routeSource).not.toContain("next/");
     }
   });

--- a/apps/app/src/routes/_authenticated/$slug/automations/index.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/automations/index.tsx
@@ -14,8 +14,8 @@ export const Route = createFileRoute("/_authenticated/$slug/automations/")({
   head: ({ params }) => ({
     meta: [{ title: `Automations - ${params.slug} - Lightfast` }],
   }),
-  pendingMs: 250,
-  pendingMinMs: 250,
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: AutomationsRoutePending,
   errorComponent: AutomationsRouteError,
   component: AutomationsPage,

--- a/apps/app/src/routes/_authenticated/$slug/decisions.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/decisions.tsx
@@ -25,8 +25,8 @@ export const Route = createFileRoute("/_authenticated/$slug/decisions")({
   head: ({ params }) => ({
     meta: [{ title: `Decisions - ${params.slug} - Lightfast` }],
   }),
-  pendingMs: 250,
-  pendingMinMs: 250,
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: DecisionsRoutePending,
   errorComponent: DecisionsRouteError,
   component: DecisionsPage,

--- a/apps/app/src/routes/_authenticated/$slug/people.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/people.tsx
@@ -25,8 +25,8 @@ export const Route = createFileRoute("/_authenticated/$slug/people")({
   head: ({ params }) => ({
     meta: [{ title: `People - ${params.slug} - Lightfast` }],
   }),
-  pendingMs: 250,
-  pendingMinMs: 250,
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: PeopleRoutePending,
   errorComponent: PeopleRouteError,
   component: PeoplePage,

--- a/apps/app/src/routes/_authenticated/$slug/signals.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/signals.tsx
@@ -19,8 +19,8 @@ export const Route = createFileRoute("/_authenticated/$slug/signals")({
   head: ({ params }) => ({
     meta: [{ title: `Signals - ${params.slug} - Lightfast` }],
   }),
-  pendingMs: 250,
-  pendingMinMs: 250,
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: SignalsRoutePending,
   errorComponent: SignalsRouteError,
   component: SignalsPage,


### PR DESCRIPTION
## Summary
- Remove the 250ms product-route pending delay for people, signals, decisions, and automations
- Make the route pending shells appear immediately so the sidebar and outlet no longer disagree during navigation
- Add a source regression assertion to keep these scoped routes at immediate pending behavior

## Test Plan
- [x] `pnpm --filter @lightfast/app test`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm check`
- [x] `DATABASE_HOST=localhost DATABASE_USERNAME=lightfast DATABASE_PASSWORD=lightfast KV_REST_API_URL=https://example.com KV_REST_API_TOKEN=placeholder pnpm --filter @lightfast/app build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted loading state timing across multiple workspace routes to display immediately rather than after a delay, improving responsiveness of pending UI indicators.

* **Tests**
  * Updated test assertions to verify correct pending timing configuration for workspace routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->