### PR TITLE
Apply immediate route pending boundaries

### DIFF
--- a/apps/app/src/__tests__/route-boundaries-source.test.ts
+++ b/apps/app/src/__tests__/route-boundaries-source.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const appRoot = resolve(import.meta.dirname, "../..");
@@ -11,6 +11,30 @@ function source(path: string) {
 function expectSource(path: string) {
   expect(existsSync(resolve(appRoot, path)), `${path} should exist`).toBe(true);
   return source(path);
+}
+
+function routeFilesWithPendingComponents() {
+  const routesRoot = resolve(appRoot, "src/routes");
+  const routeFiles: string[] = [];
+  const visit = (directory: string) => {
+    for (const entry of readdirSync(directory)) {
+      const fullPath = join(directory, entry);
+      if (statSync(fullPath).isDirectory()) {
+        visit(fullPath);
+        continue;
+      }
+      if (!entry.endsWith(".tsx")) {
+        continue;
+      }
+      const routeFile = relative(appRoot, fullPath);
+      if (source(routeFile).includes("pendingComponent:")) {
+        routeFiles.push(routeFile);
+      }
+    }
+  };
+
+  visit(routesRoot);
+  return routeFiles.sort();
 }
 
 describe("app route boundaries", () => {
@@ -63,6 +87,26 @@ describe("app route boundaries", () => {
       expect(routeSource).not.toContain("pendingMs: 250");
       expect(routeSource).not.toContain("pendingMinMs: 250");
       expect(routeSource).not.toContain("next/");
+    }
+  });
+
+  it("shows every route pending boundary immediately", () => {
+    const routeFiles = routeFilesWithPendingComponents();
+
+    expect(routeFiles).toContain(
+      "src/routes/_authenticated/$slug/chat/index.tsx"
+    );
+    expect(routeFiles).toContain(
+      "src/routes/_authenticated/$slug/decisions.tsx"
+    );
+
+    for (const routeFile of routeFiles) {
+      const routeSource = expectSource(routeFile);
+
+      expect(routeSource, `${routeFile} pendingMs`).toContain("pendingMs: 0");
+      expect(routeSource, `${routeFile} pendingMinMs`).toContain(
+        "pendingMinMs: 0"
+      );
     }
   });
 

--- a/apps/app/src/routes/_authenticated/$slug/automations/$automation.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/automations/$automation.tsx
@@ -31,6 +31,8 @@ export const Route = createFileRoute(
   head: ({ params }) => ({
     meta: [{ title: `Automation - ${params.slug} - Lightfast` }],
   }),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: AutomationDetailRoutePending,
   errorComponent: AutomationDetailRouteError,
   component: AutomationDetailPage,

--- a/apps/app/src/routes/_authenticated/$slug/automations/new.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/automations/new.tsx
@@ -14,6 +14,8 @@ export const Route = createFileRoute("/_authenticated/$slug/automations/new")({
   head: ({ params }) => ({
     meta: [{ title: `New automation - ${params.slug} - Lightfast` }],
   }),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: AutomationFormRoutePending,
   errorComponent: NewAutomationRouteError,
   component: NewAutomationPage,

--- a/apps/app/src/routes/_authenticated/$slug/chat/$conversationId.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/chat/$conversationId.tsx
@@ -16,6 +16,8 @@ export const Route = createFileRoute(
       { title: `Chat ${params.conversationId} - ${params.slug} - Lightfast` },
     ],
   }),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: ChatRoutePending,
   errorComponent: ChatRouteError,
   component: WorkspaceConversationPage,

--- a/apps/app/src/routes/_authenticated/$slug/chat/index.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/chat/index.tsx
@@ -15,6 +15,8 @@ const createNewWorkspaceAssistantConversationId = createServerFn({
 
 export const Route = createFileRoute("/_authenticated/$slug/chat/")({
   loader: () => createNewWorkspaceAssistantConversationId(),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: ChatRoutePending,
   errorComponent: ChatRouteError,
   component: WorkspaceChatPage,

--- a/apps/app/src/routes/_authenticated/$slug/settings/api-keys.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/settings/api-keys.tsx
@@ -20,6 +20,8 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/api-keys")(
         },
       ],
     }),
+    pendingMs: 0,
+    pendingMinMs: 0,
     pendingComponent: ApiKeysRoutePending,
     component: ApiKeysSettingsPage,
   }

--- a/apps/app/src/routes/_authenticated/$slug/settings/billing.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/settings/billing.tsx
@@ -20,6 +20,8 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/billing")({
       },
     ],
   }),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: BillingRoutePending,
   errorComponent: BillingRouteError,
   component: BillingSettingsPage,

--- a/apps/app/src/routes/_authenticated/$slug/settings/members.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/settings/members.tsx
@@ -17,6 +17,8 @@ export const Route = createFileRoute("/_authenticated/$slug/settings/members")({
       },
     ],
   }),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: MembersRoutePending,
   component: MembersSettingsPage,
 });

--- a/apps/app/src/routes/_authenticated/$slug/settings/source-control.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/settings/source-control.tsx
@@ -20,6 +20,8 @@ export const Route = createFileRoute(
       },
     ],
   }),
+  pendingMs: 0,
+  pendingMinMs: 0,
   pendingComponent: SourceControlRoutePending,
   component: WorkspaceSourceControlSettingsPage,
 });


### PR DESCRIPTION
## Summary
- Add explicit `pendingMs: 0` and `pendingMinMs: 0` to every remaining app route with a `pendingComponent`
- Extend the route-boundary source test so future pending routes must opt into immediate pending display
- Preserve existing route pending/error shells while removing TanStack Router's default stale-outlet delay

## Test Plan
- [x] RED: `pnpm --filter @lightfast/app test src/__tests__/route-boundaries-source.test.ts` failed before route edits because pending routes lacked `pendingMs: 0`
- [x] `pnpm --filter @lightfast/app test src/__tests__/route-boundaries-source.test.ts`
- [x] `pnpm --filter @lightfast/app test`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm check`
- [x] `DATABASE_HOST=localhost DATABASE_USERNAME=lightfast DATABASE_PASSWORD=lightfast KV_REST_API_URL=https://example.com KV_REST_API_TOKEN=placeholder pnpm --filter @lightfast/app build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification to ensure all route pending states display loading screens immediately without delays.

* **Changes**
  * Updated chat, automations, and settings routes (API keys, billing, members, source control) to show loading states immediately during navigation without waiting periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->