### PR TITLE
Restore sidebar chat history on settings

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -196,8 +196,12 @@ describe("app authenticated route migration", () => {
       'orgAccess.bindingStatus === "bound"'
     );
     expect(workspaceShellSource).not.toContain("showChatHistory");
-    expect(workspaceShellSource).not.toContain("shouldShowWorkspaceChatHistory");
-    expect(workspaceModelSource).not.toContain("shouldShowWorkspaceChatHistory");
+    expect(workspaceShellSource).not.toContain(
+      "shouldShowWorkspaceChatHistory"
+    );
+    expect(workspaceModelSource).not.toContain(
+      "shouldShowWorkspaceChatHistory"
+    );
     expect(workspaceModelSource).toContain("isOrgSettingsPath");
     expect(workspaceShellSource).toContain("Team not found");
     expect(workspaceShellSource).not.toContain("organization?.name ?? slug");

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -181,8 +181,7 @@ describe("app authenticated route migration", () => {
     expect(teamSwitcherSource).not.toContain("next/link");
     expect(appSidebarSource).toContain("listConversations.queryOptions");
     expect(appSidebarSource).toContain('to="/$slug/chat/$conversationId"');
-    expect(appSidebarSource).toContain("showChatHistory = true");
-    expect(appSidebarSource).toContain("showChatHistory ? (");
+    expect(appSidebarSource).not.toContain("showChatHistory");
     expect(orgRouteSource).toContain("WorkspaceRouteShell");
     expect(workspaceShellSource).toContain("getBySlug.queryOptions({ slug })");
     expect(workspaceShellSource).toContain("useAuth");
@@ -193,11 +192,12 @@ describe("app authenticated route migration", () => {
     );
     expect(workspaceShellSource).toContain("isOrgSetupExemptPath");
     expect(workspaceShellSource).toContain("SetupRequirementNavigate");
-    expect(workspaceShellSource).toContain("showChatHistory={");
     expect(workspaceShellSource).toContain(
       'orgAccess.bindingStatus === "bound"'
     );
-    expect(workspaceShellSource).toContain("shouldShowWorkspaceChatHistory");
+    expect(workspaceShellSource).not.toContain("showChatHistory");
+    expect(workspaceShellSource).not.toContain("shouldShowWorkspaceChatHistory");
+    expect(workspaceModelSource).not.toContain("shouldShowWorkspaceChatHistory");
     expect(workspaceModelSource).toContain("isOrgSettingsPath");
     expect(workspaceShellSource).toContain("Team not found");
     expect(workspaceShellSource).not.toContain("organization?.name ?? slug");

--- a/apps/app/src/__tests__/workspace-route-model.test.ts
+++ b/apps/app/src/__tests__/workspace-route-model.test.ts
@@ -5,7 +5,6 @@ import {
   isOrgSetupCompletePath,
   isOrgSetupExemptPath,
   isOrgSetupPath,
-  shouldShowWorkspaceChatHistory,
 } from "../workspace/workspace-route-model";
 
 describe("workspace route model", () => {
@@ -51,29 +50,5 @@ describe("workspace route model", () => {
       params: { slug: "acme" },
       to: "/$slug/tasks/bind",
     });
-  });
-
-  it("shows chat history only for bound non-settings workspace routes", () => {
-    expect(
-      shouldShowWorkspaceChatHistory({
-        bindingStatus: "bound",
-        pathname: "/acme/automations",
-        slug: "acme",
-      })
-    ).toBe(true);
-    expect(
-      shouldShowWorkspaceChatHistory({
-        bindingStatus: "pending",
-        pathname: "/acme/automations",
-        slug: "acme",
-      })
-    ).toBe(false);
-    expect(
-      shouldShowWorkspaceChatHistory({
-        bindingStatus: "bound",
-        pathname: "/acme/settings/general",
-        slug: "acme",
-      })
-    ).toBe(false);
   });
 });

--- a/apps/app/src/components/app-sidebar.tsx
+++ b/apps/app/src/components/app-sidebar.tsx
@@ -67,13 +67,7 @@ const navIcons: Record<
   Skills: Scroll,
 };
 
-export function AppSidebar({
-  orgSlug,
-  showChatHistory = true,
-}: {
-  orgSlug: string;
-  showChatHistory?: boolean;
-}) {
+export function AppSidebar({ orgSlug }: { orgSlug: string }) {
   const { pathname } = useLocation();
   const { isMobile, setOpenMobile } = useSidebar();
   const navSections = getWorkspaceNavSections(orgSlug);
@@ -141,9 +135,7 @@ export function AppSidebar({
             </SidebarGroupContent>
           </SidebarGroup>
         ))}
-        {showChatHistory ? (
-          <ChatHistory orgSlug={orgSlug} pathname={pathname} />
-        ) : null}
+        <ChatHistory orgSlug={orgSlug} pathname={pathname} />
       </SidebarContent>
       <SidebarFooter>
         <DropdownMenu>

--- a/apps/app/src/workspace/workspace-route-model.ts
+++ b/apps/app/src/workspace/workspace-route-model.ts
@@ -46,15 +46,3 @@ export function getSetupRequirementRedirect(
       };
   }
 }
-
-export function shouldShowWorkspaceChatHistory({
-  bindingStatus,
-  pathname,
-  slug,
-}: {
-  bindingStatus: string;
-  pathname: string;
-  slug: string;
-}) {
-  return bindingStatus === "bound" && !isOrgSettingsPath(slug, pathname);
-}

--- a/apps/app/src/workspace/workspace-route-shell.tsx
+++ b/apps/app/src/workspace/workspace-route-shell.tsx
@@ -19,7 +19,6 @@ import {
   isOrgSetupCompletePath,
   isOrgSetupExemptPath,
   isOrgSetupPath,
-  shouldShowWorkspaceChatHistory,
 } from "./workspace-route-model";
 
 function SetupRequirementNavigate({
@@ -147,14 +146,7 @@ export function WorkspaceRouteShell({ slug }: { slug: string }) {
 
   return (
     <SidebarProvider className="!h-full !min-h-0 overflow-hidden bg-background">
-      <AppSidebar
-        orgSlug={slug}
-        showChatHistory={shouldShowWorkspaceChatHistory({
-          bindingStatus: orgAccess.bindingStatus,
-          pathname: location.pathname,
-          slug,
-        })}
-      />
+      <AppSidebar orgSlug={slug} />
       <SidebarInset className="min-h-0 overflow-hidden">
         <AuthenticatedTopbar
           left={<SidebarTrigger className="size-11 rounded-xl lg:hidden" />}


### PR DESCRIPTION
## Summary
- Remove the route-level `showChatHistory` suppression from the TanStack workspace shell.
- Keep org settings setup-exempt behavior while letting `AppSidebar` always mount chat history, matching the pre-migration Next.js behavior.
- Update source/model tests so `shouldShowWorkspaceChatHistory` does not come back.

## Validation
- `pnpm --filter @lightfast/app test`
- `pnpm --filter @lightfast/app typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chat history is now always visible in the application sidebar. The previous route- and binding-based visibility logic has been removed, and the sidebar no longer relies on a separate prop to control chat history display.

* **Tests**
  * Updated route and sidebar assertions to match the new always-visible chat history behavior, and removed the test coverage for conditional chat history visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->