### PR TITLE
[codex] restore workspace views in tanstack

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -33,6 +33,14 @@
       "types": "./src/adapters/tanstack/signals.ts",
       "default": "./src/adapters/tanstack/signals.ts"
     },
+    "./tanstack/signal-views": {
+      "types": "./src/adapters/tanstack/signal-views.ts",
+      "default": "./src/adapters/tanstack/signal-views.ts"
+    },
+    "./tanstack/people-views": {
+      "types": "./src/adapters/tanstack/people-views.ts",
+      "default": "./src/adapters/tanstack/people-views.ts"
+    },
     "./services/github": {
       "types": "./src/services/github/index.ts",
       "default": "./src/services/github/index.ts"

--- a/api/app/src/adapters/tanstack/people-views.ts
+++ b/api/app/src/adapters/tanstack/people-views.ts
@@ -1,0 +1,124 @@
+import {
+  createPeopleView as createPeopleViewInDb,
+  deletePeopleView as deletePeopleViewInDb,
+  listPeopleViews as listPeopleViewsFromDb,
+} from "@db/app";
+import { db } from "@db/app/client";
+import {
+  peopleIdentityProviderSchema,
+  peopleIdentityTypeSchema,
+  personMemberStatusSchema,
+  personSourceSchema,
+} from "@repo/app-validation/schemas";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { z } from "zod";
+import { resolveAuthContextFromClerk } from "../../auth/identity";
+import {
+  actorFromAuthIdentity,
+  isDomainError,
+  NotFoundError,
+} from "../../domain";
+import { requireBoundClerkOrgActor } from "../../domain/gates";
+
+const peopleViewConfigSchema = z.object({
+  filters: z.object({
+    providers: z.array(peopleIdentityProviderSchema).max(5),
+    sources: z.array(personSourceSchema).max(3).default([]),
+    memberStatuses: z.array(personMemberStatusSchema).max(2).default([]),
+    types: z.array(peopleIdentityTypeSchema).max(3),
+  }),
+});
+
+const createPeopleViewInput = z.object({
+  name: z.string().trim().min(1).max(120),
+  config: peopleViewConfigSchema,
+});
+
+const deletePeopleViewInput = z.object({
+  publicId: z.string().min(1).max(64),
+});
+
+function requestId() {
+  return crypto.randomUUID();
+}
+
+async function getBoundActor() {
+  const request = getRequest();
+  const auth = await resolveAuthContextFromClerk({
+    db,
+    headers: new Headers(request.headers),
+  });
+  return requireBoundClerkOrgActor({
+    actor: actorFromAuthIdentity(auth.identity, "web"),
+    request: { id: requestId(), source: "tanstack" },
+  });
+}
+
+function mapTanStackError(error: unknown): never {
+  if (isDomainError(error)) {
+    throw new Error(error.message, { cause: error });
+  }
+  throw error;
+}
+
+function noStore() {
+  setResponseHeader("cache-control", "private, no-store");
+}
+
+export const listPeopleViews = createServerFn({ method: "GET" }).handler(
+  async () => {
+    noStore();
+    try {
+      const actor = await getBoundActor();
+      return await listPeopleViewsFromDb(db, {
+        clerkOrgId: actor.orgId,
+        createdByUserId: actor.userId,
+      });
+    } catch (error) {
+      mapTanStackError(error);
+    }
+  }
+);
+
+export const createPeopleView = createServerFn({ method: "POST" })
+  .inputValidator(createPeopleViewInput)
+  .handler(async ({ data }) => {
+    noStore();
+    try {
+      const actor = await getBoundActor();
+      return await createPeopleViewInDb(db, {
+        clerkOrgId: actor.orgId,
+        createdByUserId: actor.userId,
+        name: data.name,
+        config: data.config,
+      });
+    } catch (error) {
+      mapTanStackError(error);
+    }
+  });
+
+export const deletePeopleView = createServerFn({ method: "POST" })
+  .inputValidator(deletePeopleViewInput)
+  .handler(async ({ data }) => {
+    noStore();
+    try {
+      const actor = await getBoundActor();
+      const deleted = await deletePeopleViewInDb(db, {
+        clerkOrgId: actor.orgId,
+        createdByUserId: actor.userId,
+        publicId: data.publicId,
+      });
+      if (!deleted) {
+        throw new NotFoundError("VIEW_NOT_FOUND", "View not found");
+      }
+      return { success: true };
+    } catch (error) {
+      mapTanStackError(error);
+    }
+  });
+
+export type ListPeopleViewsResult = Awaited<ReturnType<typeof listPeopleViews>>;
+export type CreatePeopleViewResult = Awaited<
+  ReturnType<typeof createPeopleView>
+>;

--- a/api/app/src/adapters/tanstack/signal-views.ts
+++ b/api/app/src/adapters/tanstack/signal-views.ts
@@ -1,0 +1,123 @@
+import {
+  createSignalView as createSignalViewInDb,
+  deleteSignalView as deleteSignalViewInDb,
+  listSignalViews as listSignalViewsFromDb,
+} from "@db/app";
+import { db } from "@db/app/client";
+import {
+  signalDispositionSchema,
+  signalKindSchema,
+  signalPrioritySchema,
+} from "@repo/api-contract";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { z } from "zod";
+import { resolveAuthContextFromClerk } from "../../auth/identity";
+import {
+  actorFromAuthIdentity,
+  isDomainError,
+  NotFoundError,
+} from "../../domain";
+import { requireBoundClerkOrgActor } from "../../domain/gates";
+
+const signalViewConfigSchema = z.object({
+  filters: z.object({
+    kinds: z.array(signalKindSchema).max(7),
+    priorities: z.array(signalPrioritySchema).max(4),
+    dispositions: z.array(signalDispositionSchema).max(3),
+    peopleRouted: z.boolean(),
+  }),
+});
+
+const createSignalViewInput = z.object({
+  name: z.string().trim().min(1).max(120),
+  config: signalViewConfigSchema,
+});
+
+const deleteSignalViewInput = z.object({
+  publicId: z.string().min(1).max(64),
+});
+
+function requestId() {
+  return crypto.randomUUID();
+}
+
+async function getBoundActor() {
+  const request = getRequest();
+  const auth = await resolveAuthContextFromClerk({
+    db,
+    headers: new Headers(request.headers),
+  });
+  return requireBoundClerkOrgActor({
+    actor: actorFromAuthIdentity(auth.identity, "web"),
+    request: { id: requestId(), source: "tanstack" },
+  });
+}
+
+function mapTanStackError(error: unknown): never {
+  if (isDomainError(error)) {
+    throw new Error(error.message, { cause: error });
+  }
+  throw error;
+}
+
+function noStore() {
+  setResponseHeader("cache-control", "private, no-store");
+}
+
+export const listSignalViews = createServerFn({ method: "GET" }).handler(
+  async () => {
+    noStore();
+    try {
+      const actor = await getBoundActor();
+      return await listSignalViewsFromDb(db, {
+        clerkOrgId: actor.orgId,
+        createdByUserId: actor.userId,
+      });
+    } catch (error) {
+      mapTanStackError(error);
+    }
+  }
+);
+
+export const createSignalView = createServerFn({ method: "POST" })
+  .inputValidator(createSignalViewInput)
+  .handler(async ({ data }) => {
+    noStore();
+    try {
+      const actor = await getBoundActor();
+      return await createSignalViewInDb(db, {
+        clerkOrgId: actor.orgId,
+        createdByUserId: actor.userId,
+        name: data.name,
+        config: data.config,
+      });
+    } catch (error) {
+      mapTanStackError(error);
+    }
+  });
+
+export const deleteSignalView = createServerFn({ method: "POST" })
+  .inputValidator(deleteSignalViewInput)
+  .handler(async ({ data }) => {
+    noStore();
+    try {
+      const actor = await getBoundActor();
+      const deleted = await deleteSignalViewInDb(db, {
+        clerkOrgId: actor.orgId,
+        createdByUserId: actor.userId,
+        publicId: data.publicId,
+      });
+      if (!deleted) {
+        throw new NotFoundError("VIEW_NOT_FOUND", "View not found");
+      }
+      return { success: true };
+    } catch (error) {
+      mapTanStackError(error);
+    }
+  });
+
+export type ListSignalViewsResult = Awaited<ReturnType<typeof listSignalViews>>;
+export type CreateSignalViewResult = Awaited<
+  ReturnType<typeof createSignalView>
+>;

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -239,7 +239,8 @@ describe("app authenticated route migration", () => {
     expect(searchSource).toContain("parseSignalDispositions");
     expect(querySource).toContain("workingSetSignalsQueryOptions");
     expect(querySource).toContain("processingSignalsQueryOptions");
-    expect(viewQuerySource).toContain("signals.views.list.queryOptions");
+    expect(viewQuerySource).toContain('@api/app/tanstack/signal-views"');
+    expect(viewQuerySource).toContain("listSignalViews");
     expect(viewQuerySource).toContain('enabled: typeof window !== "undefined"');
     expect(viewsSource).toContain("viewConfigToParamValues");
     expect(viewSwitcherSource).toContain("partitionViews");
@@ -283,7 +284,8 @@ describe("app authenticated route migration", () => {
     expect(querySource).toContain("people.list.infiniteQueryOptions");
     expect(querySource).toContain('enabled: typeof window !== "undefined"');
     expect(viewsSource).toContain("viewConfigToParamValues");
-    expect(viewQuerySource).toContain("people.views.list.queryOptions");
+    expect(viewQuerySource).toContain('@api/app/tanstack/people-views"');
+    expect(viewQuerySource).toContain("listPeopleViews");
     expect(toolbarSource).toContain("viewsSlot");
     expect(tableSource).toContain("PeopleEmptyState");
     expect(detailSource).toContain('to="/$slug/signals"');

--- a/apps/app/src/__tests__/people-views-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/people-views-no-trpc-source.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+
+describe("migrated people views data access", () => {
+  it("uses TanStack server functions instead of tRPC", () => {
+    const source = readFileSync(
+      resolve(appRoot, "src/people/use-people-views-query.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain('@api/app/tanstack/people-views"');
+    expect(source).not.toContain("useTRPC");
+    expect(source).not.toContain("trpc.org.workspace.people.views");
+  });
+});

--- a/apps/app/src/__tests__/signals-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/signals-no-trpc-source.test.ts
@@ -7,6 +7,7 @@ const appRoot = resolve(import.meta.dirname, "../..");
 const migratedFiles = [
   "src/signals/signals-client.tsx",
   "src/signals/use-classified-signals-query.ts",
+  "src/signals/use-signal-views-query.ts",
   "src/signals/signal-detail-sheet.tsx",
   "src/signals/signal-create-dialog.tsx",
 ] as const;
@@ -30,12 +31,13 @@ describe("migrated signal UI data access", () => {
     }
   });
 
-  it("allows signal views to stay on tRPC in this slice", () => {
+  it("uses TanStack server functions for signal views", () => {
     const source = readFileSync(
       resolve(appRoot, "src/signals/use-signal-views-query.ts"),
       "utf8"
     );
-    expect(source).toContain("useTRPC");
-    expect(source).toContain("trpc.org.workspace.signals.views");
+    expect(source).toContain('@api/app/tanstack/signal-views"');
+    expect(source).not.toContain("useTRPC");
+    expect(source).not.toContain("trpc.org.workspace.signals.views");
   });
 });

--- a/apps/app/src/__tests__/signals-tanstack-adapter-source.test.ts
+++ b/apps/app/src/__tests__/signals-tanstack-adapter-source.test.ts
@@ -11,6 +11,8 @@ describe("signals TanStack adapter boundary", () => {
     ) as { exports?: Record<string, unknown> };
 
     expect(packageJson.exports).toHaveProperty("./tanstack/signals");
+    expect(packageJson.exports).toHaveProperty("./tanstack/signal-views");
+    expect(packageJson.exports).toHaveProperty("./tanstack/people-views");
   });
 
   it("defines signal server functions in the api/app adapter layer", () => {
@@ -24,5 +26,26 @@ describe("signals TanStack adapter boundary", () => {
     expect(source).toContain("createSignalCommand");
     expect(source).not.toContain("TRPCError");
     expect(source).not.toContain("ORPCError");
+  });
+
+  it("defines view server functions in the api/app adapter layer", () => {
+    const signalViewsSource = readFileSync(
+      resolve(repoRoot, "api/app/src/adapters/tanstack/signal-views.ts"),
+      "utf8"
+    );
+    const peopleViewsSource = readFileSync(
+      resolve(repoRoot, "api/app/src/adapters/tanstack/people-views.ts"),
+      "utf8"
+    );
+
+    expect(signalViewsSource).toContain('from "@tanstack/react-start"');
+    expect(signalViewsSource).toContain("createServerFn");
+    expect(signalViewsSource).toContain("listSignalViews");
+    expect(signalViewsSource).not.toContain("TRPCError");
+
+    expect(peopleViewsSource).toContain('from "@tanstack/react-start"');
+    expect(peopleViewsSource).toContain("createServerFn");
+    expect(peopleViewsSource).toContain("listPeopleViews");
+    expect(peopleViewsSource).not.toContain("TRPCError");
   });
 });

--- a/apps/app/src/__tests__/workspace-actions-source.test.ts
+++ b/apps/app/src/__tests__/workspace-actions-source.test.ts
@@ -59,6 +59,37 @@ describe("workspace page-owned actions", () => {
     );
   });
 
+  it("keeps secondary workspace page actions at the top-left", () => {
+    const skillsClientSource = source("src/skills/skills-client.tsx");
+    const skillsActionsSource = source("src/skills/skills-actions.tsx");
+    const connectorsClientSource = source(
+      "src/connectors/connectors-client.tsx"
+    );
+
+    const skillsActionsIndex = skillsClientSource.indexOf(
+      'data-testid="skills-actions-row"'
+    );
+    const skillsHeaderIndex = skillsClientSource.indexOf(
+      "Make Lightfast work your way"
+    );
+    const connectorsActionsIndex = connectorsClientSource.indexOf(
+      'data-testid="connectors-actions-row"'
+    );
+    const connectorsHeaderIndex =
+      connectorsClientSource.indexOf("<h1") >= 0
+        ? connectorsClientSource.indexOf("<h1")
+        : connectorsClientSource.indexOf("Connectors");
+
+    expect(skillsActionsIndex).toBeGreaterThanOrEqual(0);
+    expect(skillsActionsIndex).toBeLessThan(skillsHeaderIndex);
+    expect(skillsClientSource).not.toContain("pt-6 text-center");
+    expect(skillsActionsSource).toContain("justify-start");
+
+    expect(connectorsActionsIndex).toBeGreaterThanOrEqual(0);
+    expect(connectorsActionsIndex).toBeLessThan(connectorsHeaderIndex);
+    expect(connectorsClientSource).toContain("ConnectorOwnerScopeTabs");
+  });
+
   it("lets automation child routes own document titles", () => {
     const layoutRouteSource = source(
       "src/routes/_authenticated/$slug/automations.tsx"

--- a/apps/app/src/connectors/connectors-client.tsx
+++ b/apps/app/src/connectors/connectors-client.tsx
@@ -250,7 +250,17 @@ export function ConnectorsClient({
 
   return (
     <WorkspaceSurface className="max-w-3xl px-6 py-10">
-      <header>
+      <div
+        className="flex min-w-0 items-center justify-start"
+        data-testid="connectors-actions-row"
+      >
+        <ConnectorOwnerScopeTabs
+          onOwnerScopeChange={(scope) => setSearchParams({ scope })}
+          ownerScope={ownerView}
+        />
+      </div>
+
+      <header className="mt-8">
         <h1 className="font-semibold text-2xl text-foreground tracking-[-0.02em]">
           Connectors
         </h1>
@@ -296,13 +306,6 @@ export function ConnectorsClient({
             { label: "Needs reconnect", value: "needs_reconnect" },
           ]}
           value={statusFilter}
-        />
-      </div>
-
-      <div className="mt-4">
-        <ConnectorOwnerScopeTabs
-          onOwnerScopeChange={(scope) => setSearchParams({ scope })}
-          ownerScope={ownerView}
         />
       </div>
 

--- a/apps/app/src/people/people-views-model.ts
+++ b/apps/app/src/people/people-views-model.ts
@@ -1,9 +1,8 @@
-import type { AppRouterOutputs } from "@api/app";
+import type { ListPeopleViewsResult } from "@api/app/tanstack/people-views";
 import type { PeopleClassificationFilters } from "./people-model";
 import { serializePersonValues } from "./people-search-params";
 
-export type PeopleViewList =
-  AppRouterOutputs["org"]["workspace"]["people"]["views"]["list"];
+export type PeopleViewList = ListPeopleViewsResult;
 export type PeopleViewRow = PeopleViewList[number];
 export type PeopleViewConfig = PeopleViewRow["config"];
 

--- a/apps/app/src/people/use-people-views-query.ts
+++ b/apps/app/src/people/use-people-views-query.ts
@@ -1,37 +1,43 @@
+import {
+  createPeopleView,
+  deletePeopleView,
+  listPeopleViews,
+} from "@api/app/tanstack/people-views";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useTRPC } from "~/trpc/react";
+import type { PeopleViewConfig } from "./people-views-model";
+
+const peopleViewQueryKeys = {
+  list: () => ["people", "views"] as const,
+};
 
 export function usePeopleViewsQuery() {
-  const trpc = useTRPC();
   return useQuery({
-    ...trpc.org.workspace.people.views.list.queryOptions(),
     enabled: typeof window !== "undefined",
+    queryFn: () => listPeopleViews(),
+    queryKey: peopleViewQueryKeys.list(),
     staleTime: 60_000,
   });
 }
 
 export function useCreatePeopleView() {
-  const trpc = useTRPC();
   const queryClient = useQueryClient();
-  return useMutation(
-    trpc.org.workspace.people.views.create.mutationOptions({
-      onSuccess: () =>
-        queryClient.invalidateQueries({
-          queryKey: trpc.org.workspace.people.views.list.queryKey(),
-        }),
-    })
-  );
+  return useMutation({
+    mutationFn: (data: { config: PeopleViewConfig; name: string }) =>
+      createPeopleView({ data }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: peopleViewQueryKeys.list(),
+      }),
+  });
 }
 
 export function useDeletePeopleView() {
-  const trpc = useTRPC();
   const queryClient = useQueryClient();
-  return useMutation(
-    trpc.org.workspace.people.views.delete.mutationOptions({
-      onSuccess: () =>
-        queryClient.invalidateQueries({
-          queryKey: trpc.org.workspace.people.views.list.queryKey(),
-        }),
-    })
-  );
+  return useMutation({
+    mutationFn: (data: { publicId: string }) => deletePeopleView({ data }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: peopleViewQueryKeys.list(),
+      }),
+  });
 }

--- a/apps/app/src/signals/signals-views-model.ts
+++ b/apps/app/src/signals/signals-views-model.ts
@@ -1,9 +1,8 @@
-import type { AppRouterOutputs } from "@api/app";
+import type { ListSignalViewsResult } from "@api/app/tanstack/signal-views";
 import type { SignalClassificationFilters } from "./signals-model";
 import { serializeSignalValues } from "./signals-search-params";
 
-export type SignalViewList =
-  AppRouterOutputs["org"]["workspace"]["signals"]["views"]["list"];
+export type SignalViewList = ListSignalViewsResult;
 export type SignalViewRow = SignalViewList[number];
 export type SignalViewConfig = SignalViewRow["config"];
 

--- a/apps/app/src/signals/use-signal-views-query.ts
+++ b/apps/app/src/signals/use-signal-views-query.ts
@@ -1,39 +1,45 @@
+import {
+  createSignalView,
+  deleteSignalView,
+  listSignalViews,
+} from "@api/app/tanstack/signal-views";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useTRPC } from "~/trpc/react";
+import type { SignalViewConfig } from "./signals-views-model";
+
+const signalViewQueryKeys = {
+  list: () => ["signals", "views"] as const,
+};
 
 export function useSignalViewsQuery() {
-  const trpc = useTRPC();
   return useQuery({
-    ...trpc.org.workspace.signals.views.list.queryOptions(),
     enabled: typeof window !== "undefined",
+    queryFn: () => listSignalViews(),
+    queryKey: signalViewQueryKeys.list(),
     staleTime: 60_000,
   });
 }
 
 export function useCreateSignalView() {
-  const trpc = useTRPC();
   const queryClient = useQueryClient();
-  return useMutation(
-    trpc.org.workspace.signals.views.create.mutationOptions({
-      meta: { errorTitle: "Failed to save view" },
-      onSuccess: () =>
-        queryClient.invalidateQueries({
-          queryKey: trpc.org.workspace.signals.views.list.queryKey(),
-        }),
-    })
-  );
+  return useMutation({
+    meta: { errorTitle: "Failed to save view" },
+    mutationFn: (data: { config: SignalViewConfig; name: string }) =>
+      createSignalView({ data }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: signalViewQueryKeys.list(),
+      }),
+  });
 }
 
 export function useDeleteSignalView() {
-  const trpc = useTRPC();
   const queryClient = useQueryClient();
-  return useMutation(
-    trpc.org.workspace.signals.views.delete.mutationOptions({
-      meta: { errorTitle: "Failed to delete view" },
-      onSuccess: () =>
-        queryClient.invalidateQueries({
-          queryKey: trpc.org.workspace.signals.views.list.queryKey(),
-        }),
-    })
-  );
+  return useMutation({
+    meta: { errorTitle: "Failed to delete view" },
+    mutationFn: (data: { publicId: string }) => deleteSignalView({ data }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: signalViewQueryKeys.list(),
+      }),
+  });
 }

--- a/apps/app/src/skills/skills-actions.tsx
+++ b/apps/app/src/skills/skills-actions.tsx
@@ -11,7 +11,7 @@ export function SkillsActions({
   repositoryUrl: string;
 }) {
   return (
-    <div className="flex min-w-0 flex-wrap items-center justify-center gap-3">
+    <div className="flex min-w-0 flex-wrap items-center justify-start gap-3">
       <SkillStatus freshness={freshness} />
       {repositoryUrl && (
         <Button

--- a/apps/app/src/skills/skills-client.tsx
+++ b/apps/app/src/skills/skills-client.tsx
@@ -105,23 +105,27 @@ function SkillsClientContent({
   return (
     <WorkspaceSurface className="overflow-y-auto bg-background" variant="flush">
       <div className="mx-auto w-full max-w-3xl px-6 py-10">
-        <div className="pt-6 text-center">
+        <div
+          className="flex min-w-0 items-center justify-start"
+          data-testid="skills-actions-row"
+        >
+          <SkillsActions
+            freshness={data.freshness}
+            repositoryUrl={data.repositoryUrl}
+          />
+        </div>
+
+        <header className="mt-8">
           <h1 className="font-semibold text-3xl text-foreground tracking-[-0.02em]">
             Make Lightfast work your way
           </h1>
-          <p className="mx-auto mt-3 max-w-[30rem] text-muted-foreground text-sm">
+          <p className="mt-3 max-w-[30rem] text-muted-foreground text-sm">
             Reusable instructions your agents load on demand, indexed from your
             team&apos;s connected GitHub repository.
           </p>
-          <div className="mt-4">
-            <SkillsActions
-              freshness={data.freshness}
-              repositoryUrl={data.repositoryUrl}
-            />
-          </div>
-        </div>
+        </header>
 
-        <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="relative min-w-0 flex-1">
             <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input


### PR DESCRIPTION
## Summary
- Add TanStack Start server-function adapters for People and Signal saved views.
- Rewire People and Signal view hooks/models away from browser tRPC usage.
- Move Skills and Connectors page actions to top-left rows and add source regression coverage.

## Why
People and Signal saved views disappeared after the TanStack migration because their UI hooks still depended on the old tRPC action path instead of the migrated TanStack server-function boundary.

## Validation
- `pnpm --filter @lightfast/app test src/__tests__/workspace-actions-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/signals-no-trpc-source.test.ts src/__tests__/signals-tanstack-adapter-source.test.ts src/__tests__/people-views-no-trpc-source.test.ts`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @api/app typecheck`
- `git diff --check`
- `DATABASE_HOST=localhost DATABASE_USERNAME=test DATABASE_PASSWORD=test KV_REST_API_URL=https://example.test KV_REST_API_TOKEN=test pnpm --filter @lightfast/app build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Signal views and people views management now accessible through optimized API endpoints with improved performance and reliability.
  * UI layout enhancements: connector ownership tabs repositioned to dedicated top actions row for better accessibility; skills page actions moved to dedicated top row with improved left alignment for cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->