### PR TITLE
Move signals and people actions into topbar

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -231,13 +231,20 @@ describe("app authenticated route migration", () => {
     const viewsSource = source("src/signals/signals-view-switcher.tsx");
     const viewQuerySource = source("src/signals/use-signal-views-query.ts");
     const viewSwitcherSource = source("src/components/views/view-switcher.tsx");
+    const topbarActionsSource = source(
+      "src/workspace/workspace-topbar-actions.tsx"
+    );
 
     expect(routeSource).toContain("validateSignalsSearch");
     expect(routeSource).toContain("createFileRoute");
     expect(routeSource).toContain("setSearchParams");
+    expect(routeSource).toContain(
+      'staticData: { workspaceTopbarAction: "signals" }'
+    );
     expect(clientSource).toContain("SignalCreateDialog");
-    expect(clientSource).toContain("SignalsViewSwitcher");
+    expect(clientSource).not.toContain("SignalsViewSwitcher");
     expect(clientSource).toContain("signalDetailQueryOptions");
+    expect(topbarActionsSource).toContain("SignalsViewSwitcher");
     expect(createDialogSource).toContain("createSignalMutationOptions");
     expect(createDialogSource).toContain("listUserOrganizationsQueryOptions");
     expect(searchSource).toContain("validateSignalsSearch");
@@ -275,15 +282,22 @@ describe("app authenticated route migration", () => {
     const tableSource = source("src/people/people-table-view.tsx");
     const detailSource = source("src/people/people-detail-content.tsx");
     const emptySource = source("src/people/people-empty-state.tsx");
+    const topbarActionsSource = source(
+      "src/workspace/workspace-topbar-actions.tsx"
+    );
 
     expect(routeSource).toContain("validatePeopleSearch");
     expect(routeSource).toContain("createFileRoute");
     expect(routeSource).toContain("setSearchParams");
+    expect(routeSource).toContain(
+      'staticData: { workspaceTopbarAction: "people" }'
+    );
     expect(clientSource).toContain("PeopleToolbar");
-    expect(clientSource).toContain("PeopleViewSwitcher");
+    expect(clientSource).not.toContain("PeopleViewSwitcher");
     expect(clientSource).toContain("PeopleTableView");
     expect(clientSource).toContain("PeopleDetailSheet");
     expect(clientSource).toContain("usePeopleListQuery");
+    expect(topbarActionsSource).toContain("PeopleViewSwitcher");
     expect(searchSource).toContain("validatePeopleSearch");
     expect(searchSource).toContain("parsePersonProviders");
     expect(querySource).toContain("people.list.infiniteQueryOptions");
@@ -291,7 +305,7 @@ describe("app authenticated route migration", () => {
     expect(viewsSource).toContain("viewConfigToParamValues");
     expect(viewQuerySource).toContain('@api/app/tanstack/people-views"');
     expect(viewQuerySource).toContain("listPeopleViews");
-    expect(toolbarSource).toContain("viewsSlot");
+    expect(toolbarSource).not.toContain("viewsSlot");
     expect(tableSource).toContain("PeopleEmptyState");
     expect(detailSource).toContain('to="/$slug/signals"');
     expect(emptySource).toContain('href="/docs/get-started/overview"');

--- a/apps/app/src/__tests__/workspace-actions-source.test.ts
+++ b/apps/app/src/__tests__/workspace-actions-source.test.ts
@@ -70,31 +70,57 @@ describe("workspace page-owned actions", () => {
     const connectorsRouteSource = source(
       "src/routes/_authenticated/$slug/connectors.tsx"
     );
+    const peopleRouteSource = source(
+      "src/routes/_authenticated/$slug/people.tsx"
+    );
+    const signalsRouteSource = source(
+      "src/routes/_authenticated/$slug/signals.tsx"
+    );
     const skillsClientSource = source("src/skills/skills-client.tsx");
     const connectorsClientSource = source(
       "src/connectors/connectors-client.tsx"
     );
+    const peopleClientSource = source("src/people/people-client.tsx");
+    const peopleToolbarSource = source("src/people/people-toolbar.tsx");
+    const signalsClientSource = source("src/signals/signals-client.tsx");
+    const signalsToolbarSource = source("src/signals/signals-toolbar.tsx");
 
     expect(shellSource).toContain("useWorkspaceTopbarAction");
     expect(shellSource).toContain("actions={workspaceTopbarAction}");
     expect(topbarActionsSource).toContain("useMatches");
     expect(topbarActionsSource).toContain("workspaceTopbarAction");
     expect(topbarActionsSource).toContain("ConnectorsTopbarActions");
+    expect(topbarActionsSource).toContain("PeopleTopbarActions");
     expect(topbarActionsSource).toContain("SkillsTopbarActions");
+    expect(topbarActionsSource).toContain("SignalsTopbarActions");
     expect(topbarActionsSource).toContain(
       'getRouteApi("/_authenticated/$slug/connectors")'
     );
     expect(topbarActionsSource).toContain(
+      'getRouteApi("/_authenticated/$slug/people")'
+    );
+    expect(topbarActionsSource).toContain(
       'getRouteApi("/_authenticated/$slug/skills")'
     );
+    expect(topbarActionsSource).toContain(
+      'getRouteApi("/_authenticated/$slug/signals")'
+    );
     expect(topbarActionsSource).toContain("ConnectorOwnerScopeTabs");
+    expect(topbarActionsSource).toContain("PeopleViewSwitcher");
     expect(topbarActionsSource).toContain("SkillsActions");
+    expect(topbarActionsSource).toContain("SignalsViewSwitcher");
 
     expect(skillsRouteSource).toContain(
       'staticData: { workspaceTopbarAction: "skills" }'
     );
     expect(connectorsRouteSource).toContain(
       'staticData: { workspaceTopbarAction: "connectors" }'
+    );
+    expect(peopleRouteSource).toContain(
+      'staticData: { workspaceTopbarAction: "people" }'
+    );
+    expect(signalsRouteSource).toContain(
+      'staticData: { workspaceTopbarAction: "signals" }'
     );
 
     expect(skillsClientSource).not.toContain(
@@ -105,6 +131,12 @@ describe("workspace page-owned actions", () => {
       'data-testid="connectors-actions-row"'
     );
     expect(connectorsClientSource).not.toContain("<ConnectorOwnerScopeTabs");
+    expect(peopleClientSource).not.toContain("<PeopleViewSwitcher");
+    expect(peopleClientSource).not.toContain("viewsSlot=");
+    expect(peopleToolbarSource).not.toContain("viewsSlot");
+    expect(signalsClientSource).not.toContain("<SignalsViewSwitcher");
+    expect(signalsClientSource).not.toContain("viewsSlot=");
+    expect(signalsToolbarSource).not.toContain("viewsSlot");
   });
 
   it("lets automation child routes own document titles", () => {

--- a/apps/app/src/people/people-client.tsx
+++ b/apps/app/src/people/people-client.tsx
@@ -16,7 +16,6 @@ import {
 } from "./people-search-params";
 import { PeopleTableView } from "./people-table-view";
 import { PeopleToolbar } from "./people-toolbar";
-import { PeopleViewSwitcher } from "./people-view-switcher";
 import { usePeopleListQuery } from "./use-people-list-query";
 
 export function PeopleClient({
@@ -100,12 +99,6 @@ export function PeopleClient({
           });
         }}
         query={search.peopleQuery}
-        viewsSlot={
-          <PeopleViewSwitcher
-            search={search}
-            setSearchParams={setSearchParams}
-          />
-        }
       />
 
       <PeopleTableView

--- a/apps/app/src/people/people-toolbar.tsx
+++ b/apps/app/src/people/people-toolbar.tsx
@@ -12,7 +12,7 @@ import {
 } from "@repo/ui/components/ui/dropdown-menu";
 import { Input } from "@repo/ui/components/ui/input";
 import { AtSign, ListFilter, Search, Tag, X } from "lucide-react";
-import type { ComponentType, ReactNode } from "react";
+import type { ComponentType } from "react";
 import {
   getPersonProviderLabel,
   getPersonTypeLabel,
@@ -40,7 +40,6 @@ export function PeopleToolbar({
   onToggleProvider,
   onToggleType,
   query,
-  viewsSlot,
 }: {
   filters: PeopleClassificationFilters;
   onClearFilterGroup: (group: FilterGroupId) => void;
@@ -48,7 +47,6 @@ export function PeopleToolbar({
   onToggleProvider: (value: PersonProvider) => void;
   onToggleType: (value: PersonType) => void;
   query: string;
-  viewsSlot?: ReactNode;
 }) {
   const filterGroups: FilterGroup[] = [
     {
@@ -72,11 +70,6 @@ export function PeopleToolbar({
       data-testid="people-toolbar"
     >
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-        {viewsSlot ? (
-          <div className="flex min-w-[12rem] flex-1 basis-full items-center overflow-hidden lg:basis-auto">
-            {viewsSlot}
-          </div>
-        ) : null}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/apps/app/src/routes/_authenticated/$slug/people.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/people.tsx
@@ -11,6 +11,7 @@ import {
 
 export const Route = createFileRoute("/_authenticated/$slug/people")({
   validateSearch: validatePeopleSearch,
+  staticData: { workspaceTopbarAction: "people" },
   head: ({ params }) => ({
     meta: [{ title: `People - ${params.slug} - Lightfast` }],
   }),

--- a/apps/app/src/routes/_authenticated/$slug/signals.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/signals.tsx
@@ -11,6 +11,7 @@ import {
 
 export const Route = createFileRoute("/_authenticated/$slug/signals")({
   validateSearch: validateSignalsSearch,
+  staticData: { workspaceTopbarAction: "signals" },
   head: ({ params }) => ({
     meta: [{ title: `Signals - ${params.slug} - Lightfast` }],
   }),

--- a/apps/app/src/signals/signals-client.tsx
+++ b/apps/app/src/signals/signals-client.tsx
@@ -19,7 +19,6 @@ import {
 import { SignalsToolbar } from "./signals-toolbar";
 import { SignalsTruncationBanner } from "./signals-truncation-banner";
 import { useSignalsUiStore } from "./signals-ui-store";
-import { SignalsViewSwitcher } from "./signals-view-switcher";
 import { useSignalsWorkspaceData } from "./use-signals-workspace-data";
 
 export function SignalsClient({
@@ -152,12 +151,6 @@ export function SignalsClient({
             view: null,
           });
         }}
-        viewsSlot={
-          <SignalsViewSwitcher
-            search={search}
-            setSearchParams={setSearchParams}
-          />
-        }
       />
 
       <SignalsTruncationBanner

--- a/apps/app/src/signals/signals-toolbar.tsx
+++ b/apps/app/src/signals/signals-toolbar.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@repo/ui/components/ui/dropdown-menu";
 import { Flag, ListFilter, Tag, UserRoundCheck, X } from "lucide-react";
-import type { ComponentType, ReactNode } from "react";
+import type { ComponentType } from "react";
 import {
   getSignalDispositionLabel,
   getSignalKindLabel,
@@ -50,7 +50,6 @@ export function SignalsToolbar({
   onToggleDisposition,
   onToggleKind,
   onTogglePriority,
-  viewsSlot,
 }: {
   filters: SignalClassificationFilters;
   onAddSignal: () => void;
@@ -61,7 +60,6 @@ export function SignalsToolbar({
   onToggleDisposition: (value: SignalDisposition) => void;
   onToggleKind: (value: SignalKind) => void;
   onTogglePriority: (value: SignalPriority) => void;
-  viewsSlot?: ReactNode;
 }) {
   const filterGroups: FilterGroup[] = [
     {
@@ -101,11 +99,6 @@ export function SignalsToolbar({
       data-testid="signals-toolbar"
     >
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-        {viewsSlot ? (
-          <div className="flex min-w-[12rem] flex-1 basis-full items-center overflow-hidden lg:basis-auto">
-            {viewsSlot}
-          </div>
-        ) : null}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/apps/app/src/workspace/workspace-topbar-actions.tsx
+++ b/apps/app/src/workspace/workspace-topbar-actions.tsx
@@ -9,14 +9,26 @@ import {
   type ConnectorOwnerScope,
   normalizeConnectorsSearch,
 } from "~/connectors/connectors-search-params";
+import {
+  type NormalizedPeopleSearch,
+  normalizePeopleSearch,
+} from "~/people/people-search-params";
+import { PeopleViewSwitcher } from "~/people/people-view-switcher";
+import {
+  type NormalizedSignalsSearch,
+  normalizeSignalsSearch,
+} from "~/signals/signals-search-params";
+import { SignalsViewSwitcher } from "~/signals/signals-view-switcher";
 import { SkillsActions } from "~/skills/skills-actions";
 import { useSkillsListQuery } from "~/skills/use-skills-list-query";
 
-type WorkspaceTopbarAction = "connectors" | "skills";
+type WorkspaceTopbarAction = "connectors" | "people" | "signals" | "skills";
 
 const workspaceActionRoutes = {
   connectors: getRouteApi("/_authenticated/$slug/connectors"),
+  people: getRouteApi("/_authenticated/$slug/people"),
   skills: getRouteApi("/_authenticated/$slug/skills"),
+  signals: getRouteApi("/_authenticated/$slug/signals"),
 };
 
 function getWorkspaceTopbarActionKey(
@@ -27,7 +39,12 @@ function getWorkspaceTopbarActionKey(
   }
 
   const action = staticData.workspaceTopbarAction;
-  if (action === "connectors" || action === "skills") {
+  if (
+    action === "connectors" ||
+    action === "people" ||
+    action === "signals" ||
+    action === "skills"
+  ) {
     return action;
   }
 
@@ -53,6 +70,10 @@ export function useWorkspaceTopbarAction(): ReactNode {
   switch (action) {
     case "connectors":
       return <ConnectorsTopbarActions />;
+    case "people":
+      return <PeopleTopbarActions />;
+    case "signals":
+      return <SignalsTopbarActions />;
     case "skills":
       return <SkillsTopbarActions />;
     default:
@@ -88,6 +109,46 @@ function ConnectorsTopbarActions() {
   );
 }
 
+function PeopleTopbarActions() {
+  const routeSearch = workspaceActionRoutes.people.useSearch();
+  const navigate = workspaceActionRoutes.people.useNavigate();
+  const search = useMemo(
+    () => normalizePeopleSearch(routeSearch),
+    [routeSearch]
+  );
+  const setSearchParams = useCallback(
+    (updates: Partial<NormalizedPeopleSearch>) => {
+      void navigate({
+        replace: true,
+        search: (previous) => {
+          const next = { ...previous };
+          if ("peopleQuery" in updates) {
+            next.peopleQuery = updates.peopleQuery || undefined;
+          }
+          if ("provider" in updates) {
+            next.provider = updates.provider || undefined;
+          }
+          if ("type" in updates) {
+            next.type = updates.type || undefined;
+          }
+          if ("person" in updates) {
+            next.person = updates.person || undefined;
+          }
+          if ("view" in updates) {
+            next.view = updates.view || undefined;
+          }
+          return next;
+        },
+      });
+    },
+    [navigate]
+  );
+
+  return (
+    <PeopleViewSwitcher search={search} setSearchParams={setSearchParams} />
+  );
+}
+
 function SkillsTopbarActions() {
   const { query } = useSkillsListQuery();
   const data = query.data;
@@ -101,5 +162,49 @@ function SkillsTopbarActions() {
       freshness={data.freshness}
       repositoryUrl={data.repositoryUrl}
     />
+  );
+}
+
+function SignalsTopbarActions() {
+  const routeSearch = workspaceActionRoutes.signals.useSearch();
+  const navigate = workspaceActionRoutes.signals.useNavigate();
+  const search = useMemo(
+    () => normalizeSignalsSearch(routeSearch),
+    [routeSearch]
+  );
+  const setSearchParams = useCallback(
+    (updates: Partial<NormalizedSignalsSearch>) => {
+      void navigate({
+        replace: true,
+        search: (previous) => {
+          const next = { ...previous };
+          if ("disposition" in updates) {
+            next.disposition = updates.disposition || undefined;
+          }
+          if ("kind" in updates) {
+            next.kind = updates.kind || undefined;
+          }
+          if ("people" in updates) {
+            next.people =
+              updates.people === "routed" ? updates.people : undefined;
+          }
+          if ("priority" in updates) {
+            next.priority = updates.priority || undefined;
+          }
+          if ("signal" in updates) {
+            next.signal = updates.signal || undefined;
+          }
+          if ("view" in updates) {
+            next.view = updates.view || undefined;
+          }
+          return next;
+        },
+      });
+    },
+    [navigate]
+  );
+
+  return (
+    <SignalsViewSwitcher search={search} setSearchParams={setSearchParams} />
   );
 }


### PR DESCRIPTION
## Summary
- Move the Signals and People saved-view switchers into the authenticated topbar action slot.
- Mark the `/signals` and `/people` TanStack routes with `workspaceTopbarAction` static data.
- Remove the duplicate `viewsSlot` plumbing from the Signals and People page toolbars/clients.

## Test Plan
- `pnpm --filter @lightfast/app test src/__tests__/workspace-actions-source.test.ts src/__tests__/authenticated-routes-source.test.ts`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relocated view switcher controls for People and Signals sections from page-level toolbars to the workspace topbar for improved navigation consistency.

* **Tests**
  * Updated test coverage to verify correct placement of view switchers in the workspace topbar and confirm their removal from individual page components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->