### PR TITLE
fix: tighten source control tanstack migration

### DIFF
--- a/api/app/src/__tests__/org-source-control-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-source-control-domain-commands.test.ts
@@ -125,12 +125,11 @@ function createDeps() {
       id: "1001",
       targetType: "Organization",
     }),
-    getWatchedSourceControlRepository: vi.fn(),
-    insertWatchedSourceControlRepository: vi.fn(),
     listAllGitHubInstallationRepositories: vi
       .fn()
       .mockResolvedValue([liveRepository()]),
     listWatchedSourceControlRepositories: vi.fn(),
+    upsertWatchedSourceControlRepository: vi.fn(),
   };
 }
 
@@ -293,7 +292,7 @@ describe("listSourceControlRepositoriesCommand", () => {
     });
 
     expect(deps.createGitHubInstallationToken).not.toHaveBeenCalled();
-    expect(deps.insertWatchedSourceControlRepository).not.toHaveBeenCalled();
+    expect(deps.upsertWatchedSourceControlRepository).not.toHaveBeenCalled();
   });
 });
 
@@ -315,7 +314,6 @@ describe("importSourceControlRepositoryCommand", () => {
 
   it("registers one repository without watch globs", async () => {
     deps.getActiveOrgBinding.mockResolvedValue(activeBinding());
-    deps.getWatchedSourceControlRepository.mockResolvedValue(undefined);
     deps.listWatchedSourceControlRepositories.mockResolvedValueOnce([
       watchedRepository({
         fullName: "acme-live/app",
@@ -343,7 +341,7 @@ describe("importSourceControlRepositoryCommand", () => {
       status: "bound",
     });
 
-    expect(deps.insertWatchedSourceControlRepository).toHaveBeenCalledWith(
+    expect(deps.upsertWatchedSourceControlRepository).toHaveBeenCalledWith(
       expect.anything(),
       {
         fullName: "acme-live/app",
@@ -372,6 +370,6 @@ describe("importSourceControlRepositoryCommand", () => {
 
     expect(deps.createGitHubAppJwt).not.toHaveBeenCalled();
     expect(deps.listAllGitHubInstallationRepositories).not.toHaveBeenCalled();
-    expect(deps.insertWatchedSourceControlRepository).not.toHaveBeenCalled();
+    expect(deps.upsertWatchedSourceControlRepository).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/org-source-control-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-source-control-domain-commands.test.ts
@@ -129,7 +129,7 @@ function createDeps() {
       .fn()
       .mockResolvedValue([liveRepository()]),
     listWatchedSourceControlRepositories: vi.fn(),
-    upsertWatchedSourceControlRepository: vi.fn(),
+    insertWatchedSourceControlRepository: vi.fn(),
   };
 }
 
@@ -292,7 +292,7 @@ describe("listSourceControlRepositoriesCommand", () => {
     });
 
     expect(deps.createGitHubInstallationToken).not.toHaveBeenCalled();
-    expect(deps.upsertWatchedSourceControlRepository).not.toHaveBeenCalled();
+    expect(deps.insertWatchedSourceControlRepository).not.toHaveBeenCalled();
   });
 });
 
@@ -341,7 +341,7 @@ describe("importSourceControlRepositoryCommand", () => {
       status: "bound",
     });
 
-    expect(deps.upsertWatchedSourceControlRepository).toHaveBeenCalledWith(
+    expect(deps.insertWatchedSourceControlRepository).toHaveBeenCalledWith(
       expect.anything(),
       {
         fullName: "acme-live/app",
@@ -370,6 +370,6 @@ describe("importSourceControlRepositoryCommand", () => {
 
     expect(deps.createGitHubAppJwt).not.toHaveBeenCalled();
     expect(deps.listAllGitHubInstallationRepositories).not.toHaveBeenCalled();
-    expect(deps.upsertWatchedSourceControlRepository).not.toHaveBeenCalled();
+    expect(deps.insertWatchedSourceControlRepository).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/domain/source-control/commands.ts
+++ b/api/app/src/domain/source-control/commands.ts
@@ -1,9 +1,8 @@
 import type { Database, OrgSourceControlBinding } from "@db/app";
 import {
   getActiveOrgBinding,
-  getWatchedSourceControlRepository,
-  insertWatchedSourceControlRepository,
   listWatchedSourceControlRepositories,
+  upsertWatchedSourceControlRepository,
 } from "@db/app";
 import { LIGHTFAST_REPOSITORY_NAME } from "@repo/app-setup-contract";
 import {
@@ -12,6 +11,7 @@ import {
   createGitHubInstallationToken,
   getGitHubAppInstallation,
 } from "@repo/github-app-node";
+import { sourceControlRepositorySyncStatusSchema } from "@repo/source-control-contract";
 import { z } from "zod";
 
 import { getMatchingGitHubLightfastRepository } from "../../auth/org-setup-gate";
@@ -46,10 +46,9 @@ interface SourceControlCommandDeps {
   getActiveOrgBinding: typeof getActiveOrgBinding;
   getGitHubAppConfig: typeof getGitHubAppConfig;
   getGitHubAppInstallation: typeof getGitHubAppInstallation;
-  getWatchedSourceControlRepository: typeof getWatchedSourceControlRepository;
-  insertWatchedSourceControlRepository: typeof insertWatchedSourceControlRepository;
   listAllGitHubInstallationRepositories: typeof listAllGitHubInstallationRepositories;
   listWatchedSourceControlRepositories: typeof listWatchedSourceControlRepositories;
+  upsertWatchedSourceControlRepository: typeof upsertWatchedSourceControlRepository;
 }
 
 export function createDefaultSourceControlCommandDeps(input: {
@@ -59,10 +58,9 @@ export function createDefaultSourceControlCommandDeps(input: {
   getActiveOrgBinding?: typeof getActiveOrgBinding;
   getGitHubAppConfig?: typeof getGitHubAppConfig;
   getGitHubAppInstallation?: typeof getGitHubAppInstallation;
-  getWatchedSourceControlRepository?: typeof getWatchedSourceControlRepository;
-  insertWatchedSourceControlRepository?: typeof insertWatchedSourceControlRepository;
   listAllGitHubInstallationRepositories?: typeof listAllGitHubInstallationRepositories;
   listWatchedSourceControlRepositories?: typeof listWatchedSourceControlRepositories;
+  upsertWatchedSourceControlRepository?: typeof upsertWatchedSourceControlRepository;
 }): SourceControlCommandDeps {
   return {
     createGitHubAppJwt: input.createGitHubAppJwt ?? createGitHubAppJwt,
@@ -73,18 +71,15 @@ export function createDefaultSourceControlCommandDeps(input: {
     getGitHubAppConfig: input.getGitHubAppConfig ?? getGitHubAppConfig,
     getGitHubAppInstallation:
       input.getGitHubAppInstallation ?? getGitHubAppInstallation,
-    getWatchedSourceControlRepository:
-      input.getWatchedSourceControlRepository ??
-      getWatchedSourceControlRepository,
-    insertWatchedSourceControlRepository:
-      input.insertWatchedSourceControlRepository ??
-      insertWatchedSourceControlRepository,
     listAllGitHubInstallationRepositories:
       input.listAllGitHubInstallationRepositories ??
       listAllGitHubInstallationRepositories,
     listWatchedSourceControlRepositories:
       input.listWatchedSourceControlRepositories ??
       listWatchedSourceControlRepositories,
+    upsertWatchedSourceControlRepository:
+      input.upsertWatchedSourceControlRepository ??
+      upsertWatchedSourceControlRepository,
   };
 }
 
@@ -147,24 +142,98 @@ export type ListSourceControlRepositoriesResult =
     };
 
 const getSourceControlConnectionInput = z.object({}).strict();
-const getSourceControlConnectionOutput =
-  z.custom<SourceControlConnectionResult>(
-    (value) => typeof value === "object" && value !== null
-  );
+
+const lightfastRepositoryOutput = z.object({
+  fullName: z.string().min(1),
+  id: z.string().min(1),
+  verifiedAt: z.date(),
+});
+
+const sourceControlBindingSummaryOutput = z.object({
+  accountLogin: z.string().min(1),
+  connectedAt: z.date(),
+  importedRepositoryCount: z.number().int().nonnegative(),
+  lightfastRepository: lightfastRepositoryOutput.nullable(),
+  newLightfastRepositoryUrl: z.string().url(),
+  provider: z.string().min(1),
+  providerLabel: z.string().min(1),
+}) satisfies z.ZodType<SourceControlBindingSummary>;
+
+const getSourceControlConnectionOutput = z.discriminatedUnion("status", [
+  z.object({
+    binding: z.null(),
+    status: z.literal("unbound"),
+  }),
+  z.object({
+    binding: sourceControlBindingSummaryOutput,
+    status: z.literal("bound"),
+  }),
+]) satisfies z.ZodType<SourceControlConnectionResult>;
+
+const sourceControlOrganizationOutput = z.object({
+  id: z.string().min(1),
+  installationManageUrl: z.string().url(),
+  login: z.string().min(1),
+}) satisfies z.ZodType<SourceControlOrganization>;
+
+const sourceControlRepositoryErrorOutput = z.discriminatedUnion("code", [
+  z.object({
+    code: z.literal("github_installation_account_mismatch"),
+    message: z.string().min(1),
+  }),
+  z.object({
+    code: z.literal("github_repository_listing_failed"),
+    message: z.string().min(1),
+  }),
+]) satisfies z.ZodType<SourceControlRepositoryError>;
+
+const sourceControlRepositoryRowOutput = z.object({
+  fullName: z.string().min(1),
+  id: z.string().min(1),
+  imported: z.boolean(),
+  name: z.string().min(1),
+  owner: z.object({
+    id: z.string().min(1),
+    login: z.string().min(1),
+  }),
+  private: z.boolean(),
+  syncStatus: sourceControlRepositorySyncStatusSchema,
+  watchedPathGlobs: z.array(z.string().min(1)).nullable(),
+  webUrl: z.string().url(),
+}) satisfies z.ZodType<SourceControlRepositoryRow>;
 
 const listSourceControlRepositoriesInput = z.object({}).strict();
-const listSourceControlRepositoriesOutput =
-  z.custom<ListSourceControlRepositoriesResult>(
-    (value) => typeof value === "object" && value !== null
-  );
+const listSourceControlRepositoriesOutput = z.discriminatedUnion("status", [
+  z.object({
+    binding: z.null(),
+    lightfastRepository: z.null(),
+    organization: z.null(),
+    repositories: z.tuple([]),
+    repositoriesError: z.null(),
+    status: z.literal("unbound"),
+  }),
+  z.object({
+    binding: sourceControlBindingSummaryOutput,
+    lightfastRepository: lightfastRepositoryOutput.nullable(),
+    organization: sourceControlOrganizationOutput.nullable(),
+    repositories: z.array(sourceControlRepositoryRowOutput),
+    repositoriesError: sourceControlRepositoryErrorOutput.nullable(),
+    status: z.literal("bound"),
+  }),
+  z.object({
+    binding: sourceControlBindingSummaryOutput,
+    lightfastRepository: lightfastRepositoryOutput.nullable(),
+    organization: sourceControlOrganizationOutput.nullable(),
+    repositories: z.array(sourceControlRepositoryRowOutput),
+    repositoriesError: sourceControlRepositoryErrorOutput.nullable(),
+    status: z.literal("broken"),
+  }),
+]) satisfies z.ZodType<ListSourceControlRepositoriesResult>;
 
 const importSourceControlRepositoryInput = z.object({
   repositoryId: z.string().min(1),
 });
-const importSourceControlRepositoryOutput =
-  z.custom<ListSourceControlRepositoriesResult>(
-    (value) => typeof value === "object" && value !== null
-  );
+const importSourceControlRepositoryOutput = listSourceControlRepositoriesOutput;
 
 const GITHUB_INSTALLATION_METADATA_FAILED_MESSAGE =
   "GitHub installation metadata could not be refreshed.";
@@ -518,23 +587,13 @@ export const importSourceControlRepositoryCommand = defineCommand<
       );
     }
 
-    const existingWatch = await deps.getWatchedSourceControlRepository(
-      deps.db,
-      {
-        orgSourceControlBindingId: binding.id,
-        providerRepositoryId: selectedRepository.id,
-      }
-    );
-
-    if (!existingWatch) {
-      await deps.insertWatchedSourceControlRepository(deps.db, {
-        fullName: selectedRepository.fullName,
-        orgSourceControlBindingId: binding.id,
-        providerRepositoryId: selectedRepository.id,
-        syncStatus: "disabled",
-        watchedPathGlobs: null,
-      });
-    }
+    await deps.upsertWatchedSourceControlRepository(deps.db, {
+      fullName: selectedRepository.fullName,
+      orgSourceControlBindingId: binding.id,
+      providerRepositoryId: selectedRepository.id,
+      syncStatus: "disabled",
+      watchedPathGlobs: null,
+    });
 
     const watchedRepositories = await deps.listWatchedSourceControlRepositories(
       deps.db,

--- a/api/app/src/domain/source-control/commands.ts
+++ b/api/app/src/domain/source-control/commands.ts
@@ -1,8 +1,8 @@
 import type { Database, OrgSourceControlBinding } from "@db/app";
 import {
   getActiveOrgBinding,
+  insertWatchedSourceControlRepository,
   listWatchedSourceControlRepositories,
-  upsertWatchedSourceControlRepository,
 } from "@db/app";
 import { LIGHTFAST_REPOSITORY_NAME } from "@repo/app-setup-contract";
 import {
@@ -46,9 +46,9 @@ interface SourceControlCommandDeps {
   getActiveOrgBinding: typeof getActiveOrgBinding;
   getGitHubAppConfig: typeof getGitHubAppConfig;
   getGitHubAppInstallation: typeof getGitHubAppInstallation;
+  insertWatchedSourceControlRepository: typeof insertWatchedSourceControlRepository;
   listAllGitHubInstallationRepositories: typeof listAllGitHubInstallationRepositories;
   listWatchedSourceControlRepositories: typeof listWatchedSourceControlRepositories;
-  upsertWatchedSourceControlRepository: typeof upsertWatchedSourceControlRepository;
 }
 
 export function createDefaultSourceControlCommandDeps(input: {
@@ -58,9 +58,9 @@ export function createDefaultSourceControlCommandDeps(input: {
   getActiveOrgBinding?: typeof getActiveOrgBinding;
   getGitHubAppConfig?: typeof getGitHubAppConfig;
   getGitHubAppInstallation?: typeof getGitHubAppInstallation;
+  insertWatchedSourceControlRepository?: typeof insertWatchedSourceControlRepository;
   listAllGitHubInstallationRepositories?: typeof listAllGitHubInstallationRepositories;
   listWatchedSourceControlRepositories?: typeof listWatchedSourceControlRepositories;
-  upsertWatchedSourceControlRepository?: typeof upsertWatchedSourceControlRepository;
 }): SourceControlCommandDeps {
   return {
     createGitHubAppJwt: input.createGitHubAppJwt ?? createGitHubAppJwt,
@@ -71,15 +71,15 @@ export function createDefaultSourceControlCommandDeps(input: {
     getGitHubAppConfig: input.getGitHubAppConfig ?? getGitHubAppConfig,
     getGitHubAppInstallation:
       input.getGitHubAppInstallation ?? getGitHubAppInstallation,
+    insertWatchedSourceControlRepository:
+      input.insertWatchedSourceControlRepository ??
+      insertWatchedSourceControlRepository,
     listAllGitHubInstallationRepositories:
       input.listAllGitHubInstallationRepositories ??
       listAllGitHubInstallationRepositories,
     listWatchedSourceControlRepositories:
       input.listWatchedSourceControlRepositories ??
       listWatchedSourceControlRepositories,
-    upsertWatchedSourceControlRepository:
-      input.upsertWatchedSourceControlRepository ??
-      upsertWatchedSourceControlRepository,
   };
 }
 
@@ -587,7 +587,9 @@ export const importSourceControlRepositoryCommand = defineCommand<
       );
     }
 
-    await deps.upsertWatchedSourceControlRepository(deps.db, {
+    // The insert helper handles duplicate-key races without overwriting an
+    // existing watch's sync status or path policy.
+    await deps.insertWatchedSourceControlRepository(deps.db, {
       fullName: selectedRepository.fullName,
       orgSourceControlBindingId: binding.id,
       providerRepositoryId: selectedRepository.id,

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -777,7 +777,7 @@ describe("app authenticated route migration", () => {
     expect(sourceControlQueriesSource).toContain(
       '@api/app/tanstack/source-control"'
     );
-    expect(sourceControlQueriesSource).toContain(
+    expect(sourceControlQueriesSource).not.toContain(
       'enabled: typeof window !== "undefined"'
     );
     expect(settingsClientSource).toContain("SourceControlConnectionCard");

--- a/apps/app/src/__tests__/source-control-queries-source.test.ts
+++ b/apps/app/src/__tests__/source-control-queries-source.test.ts
@@ -26,6 +26,7 @@ describe("source-control app data access", () => {
     expect(source).toContain("queryOptions");
     expect(source).toContain("mutationOptions");
     expect(source).not.toContain("useTRPC");
+    expect(source).not.toContain('enabled: typeof window !== "undefined"');
   });
 
   it("removes source-control UI callers from tRPC", () => {

--- a/apps/app/src/org/settings/source-control/source-control-queries.ts
+++ b/apps/app/src/org/settings/source-control/source-control-queries.ts
@@ -24,9 +24,18 @@ export const sourceControlQueryKeys = {
   repositories: () => ["source-control", "repositories"] as const,
 };
 
+function connectionResultFromRepositoriesResult(
+  data: ListSourceControlRepositoriesResult
+): SourceControlConnectionResult {
+  if (!data.binding) {
+    return { binding: null, status: "unbound" };
+  }
+
+  return { binding: data.binding, status: "bound" };
+}
+
 export function sourceControlConnectionQueryOptions() {
   return queryOptions({
-    enabled: typeof window !== "undefined",
     queryFn: () => getSourceControlConnection(),
     queryKey: sourceControlQueryKeys.connection(),
     staleTime: 30_000,
@@ -35,7 +44,6 @@ export function sourceControlConnectionQueryOptions() {
 
 export function sourceControlRepositoriesQueryOptions() {
   return queryOptions({
-    enabled: typeof window !== "undefined",
     queryFn: () => listSourceControlRepositories(),
     queryKey: sourceControlQueryKeys.repositories(),
   });
@@ -56,15 +64,7 @@ export function importSourceControlRepositoryMutationOptions(input: {
       );
       input.queryClient.setQueryData(
         sourceControlQueryKeys.connection(),
-        data.binding
-          ? {
-              binding: data.binding,
-              status: "bound" as const,
-            }
-          : {
-              binding: null,
-              status: "unbound" as const,
-            }
+        connectionResultFromRepositoriesResult(data)
       );
       input.onImported?.();
     },


### PR DESCRIPTION
## Summary
- remove browser-only gates from migrated source-control TanStack query helpers
- make import repository idempotent through the existing watched-repository upsert helper
- tighten source-control command output validators to explicit result schemas

## Verification
- pnpm --filter @api/app test -- src/__tests__/org-source-control-domain-commands.test.ts src/__tests__/org-source-control-tanstack-adapter-source.test.ts src/__tests__/org-source-control-router-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/source-control-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm check
- pnpm turbo typecheck --affected --continue --summarize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when registering existing source control repositories.

* **Refactor**
  * Strengthened validation for source control operations.
  * Enhanced compatibility for source control queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->