### PR TITLE
Extract native OAuth auth boundary

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -29,9 +29,17 @@
       "types": "./src/domain/index.ts",
       "default": "./src/domain/index.ts"
     },
+    "./native-auth": {
+      "types": "./src/native-auth/index.ts",
+      "default": "./src/native-auth/index.ts"
+    },
     "./tanstack/signals": {
       "types": "./src/adapters/tanstack/signals.ts",
       "default": "./src/adapters/tanstack/signals.ts"
+    },
+    "./tanstack/native-auth": {
+      "types": "./src/adapters/tanstack/native-auth.ts",
+      "default": "./src/adapters/tanstack/native-auth.ts"
     },
     "./tanstack/org-api-keys": {
       "types": "./src/adapters/tanstack/org-api-keys.ts",

--- a/api/app/src/__tests__/native-auth-boundary-source.test.ts
+++ b/api/app/src/__tests__/native-auth-boundary-source.test.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("native auth boundary exports", () => {
+  it("exposes explicit native auth and TanStack adapter entrypoints", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
+
+    expect(packageJson.exports["./native-auth"]).toEqual({
+      default: "./src/native-auth/index.ts",
+      types: "./src/native-auth/index.ts",
+    });
+    expect(packageJson.exports["./tanstack/native-auth"]).toEqual({
+      default: "./src/adapters/tanstack/native-auth.ts",
+      types: "./src/adapters/tanstack/native-auth.ts",
+    });
+    expect(existsSync(resolve(apiRoot, "src/native-auth/index.ts"))).toBe(true);
+    expect(
+      existsSync(resolve(apiRoot, "src/adapters/tanstack/native-auth.ts"))
+    ).toBe(true);
+  });
+
+  it("keeps the tRPC native router as a compatibility wrapper", () => {
+    const routerSource = source("src/router/(pending-allowed)/native-auth.ts");
+
+    expect(routerSource).toContain('from "../../native-auth"');
+    expect(routerSource).not.toContain("buildClerkAuthorizeUrl");
+    expect(routerSource).not.toContain("issueNativeAuthAttempt");
+    expect(routerSource).not.toContain("consumeNativeAuthAttempt");
+  });
+});

--- a/api/app/src/__tests__/native-auth-boundary-source.test.ts
+++ b/api/app/src/__tests__/native-auth-boundary-source.test.ts
@@ -28,13 +28,6 @@ describe("native auth boundary exports", () => {
     ).toBe(true);
   });
 
-  it("preserves native auth statuses through TanStack server functions", () => {
-    const adapterSource = source("src/adapters/tanstack/native-auth.ts");
-
-    expect(adapterSource).toContain("setResponseStatus");
-    expect(adapterSource).toContain("setResponseStatus(error.status)");
-  });
-
   it("keeps the tRPC native router as a compatibility wrapper", () => {
     const routerSource = source("src/router/(pending-allowed)/native-auth.ts");
 

--- a/api/app/src/__tests__/native-auth-boundary-source.test.ts
+++ b/api/app/src/__tests__/native-auth-boundary-source.test.ts
@@ -28,6 +28,13 @@ describe("native auth boundary exports", () => {
     ).toBe(true);
   });
 
+  it("preserves native auth statuses through TanStack server functions", () => {
+    const adapterSource = source("src/adapters/tanstack/native-auth.ts");
+
+    expect(adapterSource).toContain("setResponseStatus");
+    expect(adapterSource).toContain("setResponseStatus(error.status)");
+  });
+
   it("keeps the tRPC native router as a compatibility wrapper", () => {
     const routerSource = source("src/router/(pending-allowed)/native-auth.ts");
 

--- a/api/app/src/__tests__/native-auth-tanstack-adapter.test.ts
+++ b/api/app/src/__tests__/native-auth-tanstack-adapter.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class NativeAuthError extends Error {
+    readonly code: "FORBIDDEN";
+    readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "NativeAuthError";
+      this.code = "FORBIDDEN";
+      this.status = status;
+    }
+  }
+
+  return {
+    createNativeAuthAttemptForAuthContext: vi.fn(),
+    getRequest: vi.fn(),
+    listNativeOrganizationsForAuthContext: vi.fn(),
+    NativeAuthError,
+    resolveAuthContextFromClerk: vi.fn(),
+    setResponseHeader: vi.fn(),
+    setResponseStatus: vi.fn(),
+  };
+});
+
+vi.mock("@db/app/client", () => ({ db: {} }));
+
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: () => ({
+    handler: (handler: (input?: unknown) => unknown) => (input?: unknown) =>
+      handler(input),
+    inputValidator: () => ({
+      handler:
+        (handler: (input: { data: unknown }) => unknown) =>
+        (input: { data: unknown }) =>
+          handler(input),
+    }),
+  }),
+}));
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequest: mocks.getRequest,
+  setResponseHeader: mocks.setResponseHeader,
+  setResponseStatus: mocks.setResponseStatus,
+}));
+
+vi.mock("../auth/identity", () => ({
+  resolveAuthContextFromClerk: mocks.resolveAuthContextFromClerk,
+}));
+
+vi.mock("../native-auth", () => ({
+  createNativeAuthAttemptForAuthContext:
+    mocks.createNativeAuthAttemptForAuthContext,
+  isNativeAuthError: (error: unknown) => error instanceof mocks.NativeAuthError,
+  listNativeOrganizationsForAuthContext:
+    mocks.listNativeOrganizationsForAuthContext,
+}));
+
+const { listNativeAuthOrganizations } = await import(
+  "../adapters/tanstack/native-auth"
+);
+
+describe("native auth TanStack adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getRequest.mockReturnValue(
+      new Request("https://lightfast.localhost/oauth/cli/start")
+    );
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      identity: { type: "pending", userId: "user_1" },
+    });
+  });
+
+  it("preserves native auth status codes on server function errors", async () => {
+    mocks.listNativeOrganizationsForAuthContext.mockRejectedValue(
+      new mocks.NativeAuthError(403, "User is not a member")
+    );
+
+    await expect(listNativeAuthOrganizations()).rejects.toThrow(
+      "User is not a member"
+    );
+
+    expect(mocks.setResponseStatus).toHaveBeenCalledWith(403);
+  });
+});

--- a/api/app/src/__tests__/native-auth-tanstack-adapter.test.ts
+++ b/api/app/src/__tests__/native-auth-tanstack-adapter.test.ts
@@ -2,14 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   class NativeAuthError extends Error {
-    readonly code: "FORBIDDEN";
+    readonly code: "FORBIDDEN" | "UNAUTHORIZED";
     readonly status: number;
 
-    constructor(status: number, message: string) {
-      super(message);
+    constructor(input: {
+      code: "FORBIDDEN" | "UNAUTHORIZED";
+      message: string;
+      status: number;
+    }) {
+      super(input.message);
       this.name = "NativeAuthError";
-      this.code = "FORBIDDEN";
-      this.status = status;
+      this.code = input.code;
+      this.status = input.status;
     }
   }
 
@@ -72,15 +76,42 @@ describe("native auth TanStack adapter", () => {
     });
   });
 
-  it("preserves native auth status codes on server function errors", async () => {
+  it.each([
+    {
+      code: "UNAUTHORIZED" as const,
+      label: "expired token",
+      message: "Lightfast native OAuth authentication required.",
+      status: 401,
+    },
+    {
+      code: "FORBIDDEN" as const,
+      label: "missing organization",
+      message: "Native session organization required",
+      status: 403,
+    },
+    {
+      code: "FORBIDDEN" as const,
+      label: "wrong organization",
+      message: "User is not a member of the selected organization",
+      status: 403,
+    },
+    {
+      code: "FORBIDDEN" as const,
+      label: "membership mismatch",
+      message: "User is not a member",
+      status: 403,
+    },
+  ])("preserves native auth status codes on $label errors", async ({
+    code,
+    message,
+    status,
+  }) => {
     mocks.listNativeOrganizationsForAuthContext.mockRejectedValue(
-      new mocks.NativeAuthError(403, "User is not a member")
+      new mocks.NativeAuthError({ code, message, status })
     );
 
-    await expect(listNativeAuthOrganizations()).rejects.toThrow(
-      "User is not a member"
-    );
+    await expect(listNativeAuthOrganizations()).rejects.toThrow(message);
 
-    expect(mocks.setResponseStatus).toHaveBeenCalledWith(403);
+    expect(mocks.setResponseStatus).toHaveBeenCalledWith(status);
   });
 });

--- a/api/app/src/adapters/tanstack/native-auth.ts
+++ b/api/app/src/adapters/tanstack/native-auth.ts
@@ -1,7 +1,11 @@
 import { db } from "@db/app/client";
 import { nativeCreateAttemptInputSchema } from "@repo/native-auth-contract";
 import { createServerFn } from "@tanstack/react-start";
-import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import {
+  getRequest,
+  setResponseHeader,
+  setResponseStatus,
+} from "@tanstack/react-start/server";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import {
@@ -20,6 +24,7 @@ async function createTanStackNativeAuthContext() {
 
 function mapTanStackNativeAuthError(error: unknown): never {
   if (isNativeAuthError(error)) {
+    setResponseStatus(error.status);
     throw new Error(error.message, { cause: error });
   }
   throw error;

--- a/api/app/src/adapters/tanstack/native-auth.ts
+++ b/api/app/src/adapters/tanstack/native-auth.ts
@@ -1,0 +1,67 @@
+import { db } from "@db/app/client";
+import { nativeCreateAttemptInputSchema } from "@repo/native-auth-contract";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+
+import { resolveAuthContextFromClerk } from "../../auth/identity";
+import {
+  createNativeAuthAttemptForAuthContext,
+  isNativeAuthError,
+  listNativeOrganizationsForAuthContext,
+} from "../../native-auth";
+
+async function createTanStackNativeAuthContext() {
+  const request = getRequest();
+  return resolveAuthContextFromClerk({
+    db,
+    headers: new Headers(request.headers),
+  });
+}
+
+function mapTanStackNativeAuthError(error: unknown): never {
+  if (isNativeAuthError(error)) {
+    throw new Error(error.message, { cause: error });
+  }
+  throw error;
+}
+
+function noStore() {
+  setResponseHeader("cache-control", "private, no-store");
+  setResponseHeader("vary", "Cookie, Authorization");
+}
+
+export const listNativeAuthOrganizations = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  noStore();
+  try {
+    return await listNativeOrganizationsForAuthContext({
+      auth: await createTanStackNativeAuthContext(),
+      db,
+    });
+  } catch (error) {
+    mapTanStackNativeAuthError(error);
+  }
+});
+
+export const createNativeAuthAttempt = createServerFn({ method: "POST" })
+  .inputValidator(nativeCreateAttemptInputSchema)
+  .handler(async ({ data }) => {
+    noStore();
+    try {
+      return await createNativeAuthAttemptForAuthContext({
+        auth: await createTanStackNativeAuthContext(),
+        data,
+        db,
+      });
+    } catch (error) {
+      mapTanStackNativeAuthError(error);
+    }
+  });
+
+export type ListNativeAuthOrganizationsResult = Awaited<
+  ReturnType<typeof listNativeAuthOrganizations>
+>;
+export type CreateNativeAuthAttemptResult = Awaited<
+  ReturnType<typeof createNativeAuthAttempt>
+>;

--- a/api/app/src/native-auth/index.ts
+++ b/api/app/src/native-auth/index.ts
@@ -1,0 +1,319 @@
+import type { Database } from "@db/app";
+import { db as defaultDb } from "@db/app/client";
+import {
+  NATIVE_AUTH_HEADERS,
+  type NativeClient,
+  type NativeCreateAttemptInput,
+  type NativeOAuthConfig,
+  type NativeOrganization,
+  type NativeSessionMetadata,
+  type nativeFinalizeRequestSchema,
+  nativeSessionMetadataSchema,
+} from "@repo/native-auth-contract";
+import { clerkClient } from "@vendor/clerk/server";
+import type { z } from "zod";
+
+import {
+  findUserOrganizationMembership,
+  listUserOrganizationMemberships,
+} from "../auth/clerk-org-membership";
+import type { AuthIdentity, ResolvedAuthContext } from "../auth/identity";
+import { resolveAuthContextFromClerk } from "../auth/identity";
+import {
+  consumeNativeAuthAttempt,
+  issueNativeAuthAttempt,
+} from "../auth/native-auth-attempts";
+import {
+  buildClerkAuthorizeUrl,
+  getNativeOAuthConfig,
+} from "../auth/native-oauth";
+import { resolveOrgSetupGate } from "../auth/org-setup-gate";
+import { toAccountProfile } from "../domain/account";
+
+export type NativeFinalizeRequest = z.infer<typeof nativeFinalizeRequestSchema>;
+
+export type NativeAuthErrorCode =
+  | "FORBIDDEN"
+  | "INTERNAL_SERVER_ERROR"
+  | "UNAUTHORIZED";
+
+const nativeAuthErrorStatuses = {
+  FORBIDDEN: 403,
+  INTERNAL_SERVER_ERROR: 500,
+  UNAUTHORIZED: 401,
+} satisfies Record<NativeAuthErrorCode, number>;
+
+export class NativeAuthError extends Error {
+  readonly code: NativeAuthErrorCode;
+  readonly status: number;
+
+  constructor(code: NativeAuthErrorCode, message: string) {
+    super(message);
+    this.name = "NativeAuthError";
+    this.code = code;
+    this.status = nativeAuthErrorStatuses[code];
+  }
+}
+
+export function isNativeAuthError(error: unknown): error is NativeAuthError {
+  return error instanceof NativeAuthError;
+}
+
+export function getNativeOAuthClientConfig(input: {
+  client: NativeClient;
+}): NativeOAuthConfig {
+  const config = getNativeOAuthConfig(input.client);
+  if (!config) {
+    throw new NativeAuthError(
+      "INTERNAL_SERVER_ERROR",
+      `${input.client} OAuth is not configured`
+    );
+  }
+  return config;
+}
+
+async function listMembershipsForUser(userId: string) {
+  return listUserOrganizationMemberships({ userId });
+}
+
+export async function listNativeOrganizationsForUser(input: {
+  db: Database;
+  userId: string;
+}): Promise<NativeOrganization[]> {
+  const memberships = await listMembershipsForUser(input.userId);
+  return Promise.all(
+    memberships.map(async (membership) => {
+      const gate = await resolveOrgSetupGate({
+        db: input.db,
+        clerkOrgId: membership.organization.id,
+      });
+      return {
+        bindingStatus: gate.bindingStatus,
+        id: membership.organization.id,
+        name: membership.organization.name,
+        role: membership.role,
+        slug: membership.organization.slug,
+      };
+    })
+  );
+}
+
+function requireSignedInIdentity(
+  auth: ResolvedAuthContext
+): Extract<AuthIdentity, { type: "active" | "pending" }> {
+  if (auth.identity.type === "unauthenticated") {
+    throw new NativeAuthError(
+      "UNAUTHORIZED",
+      "Authentication required. Please sign in."
+    );
+  }
+  return auth.identity;
+}
+
+function requireNativeOAuthContext(auth: ResolvedAuthContext) {
+  if (
+    auth.identity.type === "unauthenticated" ||
+    auth.access?.kind !== "clerk-oauth"
+  ) {
+    throw new NativeAuthError(
+      "UNAUTHORIZED",
+      "Lightfast native OAuth authentication required."
+    );
+  }
+
+  return {
+    access: auth.access,
+    identity: auth.identity,
+  };
+}
+
+async function assertNativeOrgMembership(input: {
+  organizationId: string;
+  userId: string;
+}): Promise<void> {
+  const membership = await findUserOrganizationMembership({
+    organizationId: input.organizationId,
+    userId: input.userId,
+  });
+  if (!membership) {
+    throw new NativeAuthError(
+      "FORBIDDEN",
+      "User is not a member of the selected organization"
+    );
+  }
+}
+
+async function createNativeSessionMetadata(input: {
+  client: NativeClient;
+  db: Database;
+  organizationId: string;
+  userId: string;
+}): Promise<NativeSessionMetadata> {
+  const clerk = await clerkClient();
+  const [user, organizations] = await Promise.all([
+    clerk.users.getUser(input.userId),
+    listNativeOrganizationsForUser({
+      db: input.db,
+      userId: input.userId,
+    }),
+  ]);
+  const organization = organizations.find(
+    (entry) => entry.id === input.organizationId
+  );
+  if (!organization) {
+    throw new NativeAuthError(
+      "FORBIDDEN",
+      "User is not a member of the selected organization"
+    );
+  }
+  const profile = toAccountProfile(user);
+
+  return nativeSessionMetadataSchema.parse({
+    client: input.client,
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      slug: organization.slug,
+    },
+    user: {
+      email: profile.primaryEmailAddress,
+      id: profile.id,
+      imageUrl: profile.imageUrl,
+      initials: profile.initials,
+      username: profile.username,
+    },
+  });
+}
+
+export async function listNativeOrganizationsForAuthContext(input: {
+  auth: ResolvedAuthContext;
+  db: Database;
+}): Promise<NativeOrganization[]> {
+  const identity = requireSignedInIdentity(input.auth);
+  return listNativeOrganizationsForUser({
+    db: input.db,
+    userId: identity.userId,
+  });
+}
+
+export async function createNativeAuthAttemptForUser(input: {
+  db: Database;
+  data: NativeCreateAttemptInput;
+  userId: string;
+}) {
+  await assertNativeOrgMembership({
+    organizationId: input.data.organizationId,
+    userId: input.userId,
+  });
+  const config = getNativeOAuthClientConfig({ client: input.data.client });
+  const issued = await issueNativeAuthAttempt({
+    ...input.data,
+    userId: input.userId,
+  });
+  return {
+    authorizationUrl: buildClerkAuthorizeUrl({
+      codeChallenge: input.data.codeChallenge,
+      config,
+      redirectUri: input.data.redirectUri,
+      state: issued.state,
+    }),
+    attemptId: issued.attemptId,
+  };
+}
+
+export async function createNativeAuthAttemptForAuthContext(input: {
+  auth: ResolvedAuthContext;
+  data: NativeCreateAttemptInput;
+  db: Database;
+}) {
+  const identity = requireSignedInIdentity(input.auth);
+  return createNativeAuthAttemptForUser({
+    data: input.data,
+    db: input.db,
+    userId: identity.userId,
+  });
+}
+
+export async function getNativeAuthSessionForAuthContext(input: {
+  auth: ResolvedAuthContext;
+  db: Database;
+}) {
+  const { access, identity } = requireNativeOAuthContext(input.auth);
+  if (identity.type !== "active") {
+    throw new NativeAuthError(
+      "FORBIDDEN",
+      "Native session organization required"
+    );
+  }
+
+  return createNativeSessionMetadata({
+    db: input.db,
+    client: access.client,
+    organizationId: identity.orgId,
+    userId: identity.userId,
+  });
+}
+
+export async function finalizeNativeAuthAttemptForAuthContext(input: {
+  auth: ResolvedAuthContext;
+  data: NativeFinalizeRequest;
+  db: Database;
+}) {
+  const { access } = requireNativeOAuthContext(input.auth);
+  const attempt = await consumeNativeAuthAttempt({
+    attemptId: input.data.attemptId,
+    state: input.data.state,
+  });
+  if (!attempt || attempt.client !== input.data.client) {
+    throw new NativeAuthError("UNAUTHORIZED", "Invalid native auth attempt");
+  }
+  if (access.userId !== attempt.userId) {
+    throw new NativeAuthError("FORBIDDEN", "Native auth user mismatch");
+  }
+  return createNativeSessionMetadata({
+    db: input.db,
+    client: input.data.client,
+    organizationId: attempt.organizationId,
+    userId: attempt.userId,
+  });
+}
+
+async function resolveNativeOAuthRequestAuth(input: {
+  db?: Database;
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const headers = new Headers(input.headers);
+  headers.set(NATIVE_AUTH_HEADERS.client, input.source);
+
+  return resolveAuthContextFromClerk({
+    db: input.db ?? defaultDb,
+    headers,
+  });
+}
+
+export async function getNativeAuthSessionForRequest(input: {
+  db?: Database;
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const auth = await resolveNativeOAuthRequestAuth(input);
+  return getNativeAuthSessionForAuthContext({
+    auth,
+    db: input.db ?? defaultDb,
+  });
+}
+
+export async function finalizeNativeAuthAttemptForRequest(input: {
+  data: NativeFinalizeRequest;
+  db?: Database;
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const auth = await resolveNativeOAuthRequestAuth(input);
+  return finalizeNativeAuthAttemptForAuthContext({
+    auth,
+    data: input.data,
+    db: input.db ?? defaultDb,
+  });
+}

--- a/api/app/src/router/(pending-allowed)/native-auth.ts
+++ b/api/app/src/router/(pending-allowed)/native-auth.ts
@@ -1,208 +1,94 @@
-import type { Database } from "@db/app";
 import {
-  type NativeClient,
-  type NativeOrganization,
-  type NativeSessionMetadata,
   nativeClientSchema,
   nativeCreateAttemptInputSchema,
   nativeFinalizeRequestSchema,
-  nativeSessionMetadataSchema,
 } from "@repo/native-auth-contract";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
-import { clerkClient } from "@vendor/clerk/server";
 import { z } from "zod";
 
 import {
-  findUserOrganizationMembership,
-  listUserOrganizationMemberships,
-} from "../../auth/clerk-org-membership";
-import {
-  consumeNativeAuthAttempt,
-  issueNativeAuthAttempt,
-} from "../../auth/native-auth-attempts";
-import {
-  buildClerkAuthorizeUrl,
-  getNativeOAuthConfig,
-} from "../../auth/native-oauth";
-import { resolveOrgSetupGate } from "../../auth/org-setup-gate";
-import { toAccountProfile } from "../../domain/account";
+  createNativeAuthAttemptForAuthContext,
+  finalizeNativeAuthAttemptForAuthContext,
+  getNativeAuthSessionForAuthContext,
+  getNativeOAuthClientConfig,
+  isNativeAuthError,
+  listNativeOrganizationsForAuthContext,
+} from "../../native-auth";
 import {
   nativeOAuthProcedure,
   publicProcedure,
   viewerProcedure,
 } from "../../trpc";
 
-function requireNativeOAuthConfig(client: NativeClient) {
-  const config = getNativeOAuthConfig(client);
-  if (!config) {
+function mapNativeAuthTRPCError(error: unknown): never {
+  if (isNativeAuthError(error)) {
     throw new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
-      message: `${client} OAuth is not configured`,
+      code: error.code,
+      message: error.message,
     });
   }
-  return config;
-}
-
-async function listMembershipsForUser(userId: string) {
-  return listUserOrganizationMemberships({ userId });
-}
-
-export async function listNativeOrganizationsForUser(input: {
-  db: Database;
-  userId: string;
-}): Promise<NativeOrganization[]> {
-  const memberships = await listMembershipsForUser(input.userId);
-  return Promise.all(
-    memberships.map(async (membership) => {
-      const gate = await resolveOrgSetupGate({
-        db: input.db,
-        clerkOrgId: membership.organization.id,
-      });
-      return {
-        bindingStatus: gate.bindingStatus,
-        id: membership.organization.id,
-        name: membership.organization.name,
-        role: membership.role,
-        slug: membership.organization.slug,
-      };
-    })
-  );
-}
-
-async function assertNativeOrgMembership(input: {
-  organizationId: string;
-  userId: string;
-}): Promise<void> {
-  const membership = await findUserOrganizationMembership({
-    organizationId: input.organizationId,
-    userId: input.userId,
-  });
-  if (!membership) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "User is not a member of the selected organization",
-    });
-  }
-}
-
-async function createNativeSessionMetadata(input: {
-  client: NativeClient;
-  db: Database;
-  organizationId: string;
-  userId: string;
-}): Promise<NativeSessionMetadata> {
-  const clerk = await clerkClient();
-  const [user, organizations] = await Promise.all([
-    clerk.users.getUser(input.userId),
-    listNativeOrganizationsForUser({
-      db: input.db,
-      userId: input.userId,
-    }),
-  ]);
-  const organization = organizations.find(
-    (entry) => entry.id === input.organizationId
-  );
-  if (!organization) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "User is not a member of the selected organization",
-    });
-  }
-  const profile = toAccountProfile(user);
-
-  return nativeSessionMetadataSchema.parse({
-    client: input.client,
-    organization: {
-      id: organization.id,
-      name: organization.name,
-      slug: organization.slug,
-    },
-    user: {
-      email: profile.primaryEmailAddress,
-      id: profile.id,
-      imageUrl: profile.imageUrl,
-      initials: profile.initials,
-      username: profile.username,
-    },
-  });
+  throw error;
 }
 
 export const nativeAuthRouter = {
   oauthConfig: publicProcedure
     .input(z.object({ client: nativeClientSchema }))
-    .query(({ input }) => requireNativeOAuthConfig(input.client)),
+    .query(({ input }) => {
+      try {
+        return getNativeOAuthClientConfig({ client: input.client });
+      } catch (error) {
+        mapNativeAuthTRPCError(error);
+      }
+    }),
 
-  listOrganizations: viewerProcedure.query(async ({ ctx }) =>
-    listNativeOrganizationsForUser({
-      db: ctx.db,
-      userId: ctx.auth.identity.userId,
-    })
-  ),
-
-  session: nativeOAuthProcedure.query(({ ctx }) => {
-    if (ctx.auth.identity.type !== "active") {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message: "Native session organization required",
+  listOrganizations: viewerProcedure.query(async ({ ctx }) => {
+    try {
+      return await listNativeOrganizationsForAuthContext({
+        auth: ctx.auth,
+        db: ctx.db,
       });
+    } catch (error) {
+      mapNativeAuthTRPCError(error);
     }
+  }),
 
-    return createNativeSessionMetadata({
-      db: ctx.db,
-      client: ctx.auth.access.client,
-      organizationId: ctx.auth.identity.orgId,
-      userId: ctx.auth.identity.userId,
-    });
+  session: nativeOAuthProcedure.query(async ({ ctx }) => {
+    try {
+      return await getNativeAuthSessionForAuthContext({
+        auth: ctx.auth,
+        db: ctx.db,
+      });
+    } catch (error) {
+      mapNativeAuthTRPCError(error);
+    }
   }),
 
   createAttempt: viewerProcedure
     .input(nativeCreateAttemptInputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertNativeOrgMembership({
-        organizationId: input.organizationId,
-        userId: ctx.auth.identity.userId,
-      });
-      const config = requireNativeOAuthConfig(input.client);
-      const issued = await issueNativeAuthAttempt({
-        ...input,
-        userId: ctx.auth.identity.userId,
-      });
-      return {
-        authorizationUrl: buildClerkAuthorizeUrl({
-          codeChallenge: input.codeChallenge,
-          config,
-          redirectUri: input.redirectUri,
-          state: issued.state,
-        }),
-        attemptId: issued.attemptId,
-      };
+      try {
+        return await createNativeAuthAttemptForAuthContext({
+          auth: ctx.auth,
+          data: input,
+          db: ctx.db,
+        });
+      } catch (error) {
+        mapNativeAuthTRPCError(error);
+      }
     }),
 
   finalize: nativeOAuthProcedure
     .input(nativeFinalizeRequestSchema)
     .mutation(async ({ ctx, input }) => {
-      const attempt = await consumeNativeAuthAttempt({
-        attemptId: input.attemptId,
-        state: input.state,
-      });
-      if (!attempt || attempt.client !== input.client) {
-        throw new TRPCError({
-          code: "UNAUTHORIZED",
-          message: "Invalid native auth attempt",
+      try {
+        return await finalizeNativeAuthAttemptForAuthContext({
+          auth: ctx.auth,
+          data: input,
+          db: ctx.db,
         });
+      } catch (error) {
+        mapNativeAuthTRPCError(error);
       }
-      if (ctx.auth.access.userId !== attempt.userId) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "Native auth user mismatch",
-        });
-      }
-      return createNativeSessionMetadata({
-        db: ctx.db,
-        client: input.client,
-        organizationId: attempt.organizationId,
-        userId: attempt.userId,
-      });
     }),
 } satisfies TRPCRouterRecord;

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -124,14 +124,17 @@ describe("app authenticated route migration", () => {
     expect(nativeRouteSource).toContain("validateNativeAuthStartSearch");
     expect(nativeRouteSource).toContain("loadNativeAuthOrganizations");
     expect(nativeRouteSource).toContain("NativeAuthOrgSelect");
-    expect(nativeOrgSelectSource).toContain(
-      "native.auth.createAttempt.mutationOptions"
-    );
+    expect(nativeOrgSelectSource).toContain('@api/app/tanstack/native-auth"');
+    expect(nativeOrgSelectSource).toContain("createNativeAuthAttempt");
+    expect(nativeOrgSelectSource).not.toContain("useTRPC");
+    expect(nativeOrgSelectSource).not.toContain("native.auth");
     expect(nativeOrgSelectSource).toContain("withClerkDevBrowserContext");
-    expect(nativeFunctionsSource).toContain(
-      "trpc.native.auth.listOrganizations.queryOptions()"
-    );
+    expect(nativeFunctionsSource).toContain('@api/app/tanstack/native-auth"');
+    expect(nativeFunctionsSource).toContain("listNativeAuthOrganizations");
     expect(nativeFunctionsSource).toContain("redirectToSignInForOAuth");
+    expect(nativeFunctionsSource).not.toContain("createTRPCOptionsProxy");
+    expect(nativeFunctionsSource).not.toContain("appRouter");
+    expect(nativeFunctionsSource).not.toContain("trpc.native");
     expect(nativeValidatorsSource).toContain("isLoopbackRedirectUri");
 
     for (const routeFile of [

--- a/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
+++ b/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
@@ -67,7 +67,7 @@ describe("app OAuth protocol route migration", () => {
     }
   });
 
-  it("ports native OAuth facade endpoints through request-aware tRPC callers", () => {
+  it("ports native OAuth facade endpoints through explicit api/app handlers", () => {
     const configSource = source("src/routes/api/oauth/$client/config.ts");
     const finalizeSource = source("src/routes/api/oauth/finalize.ts");
     const sessionSource = source("src/routes/api/oauth/desktop/session.ts");
@@ -78,24 +78,26 @@ describe("app OAuth protocol route migration", () => {
     );
     expect(configSource).toContain("nativeClientSchema");
     expect(configSource).toContain("nativeOAuthConfigSchema");
-    expect(configSource).toContain("createNativeOAuthFacadeCaller");
+    expect(configSource).toContain("getNativeOAuthClientConfig");
     expect(configSource).toContain("params.client");
-    expect(configSource).toContain("oauthConfig");
+    expect(configSource).not.toContain("caller.native.auth");
     expect(finalizeSource).toContain('createFileRoute("/api/oauth/finalize")');
     expect(finalizeSource).toContain("nativeFinalizeRequestSchema");
     expect(finalizeSource).toContain("nativeSessionMetadataSchema");
-    expect(finalizeSource).toContain("finalize");
+    expect(finalizeSource).toContain("finalizeNativeAuthAttemptForRequest");
+    expect(finalizeSource).not.toContain("caller.native.auth");
     expect(sessionSource).toContain(
       'createFileRoute("/api/oauth/desktop/session")'
     );
     expect(sessionSource).toContain("nativeSessionMetadataSchema");
-    expect(sessionSource).toContain("createNativeOAuthFacadeCaller");
+    expect(sessionSource).toContain("getNativeAuthSessionForRequest");
     expect(sessionSource).toContain('source: "desktop"');
-    expect(sessionSource).toContain("native.auth.session");
-    expect(nativeServerSource).toContain("createCallerFactory(appRouter)");
-    expect(nativeServerSource).toContain("createTRPCContext");
-    expect(nativeServerSource).toContain("NATIVE_AUTH_HEADERS.client");
-    expect(nativeServerSource).toContain("getHTTPStatusCodeFromError");
+    expect(sessionSource).not.toContain("caller.native.auth");
+    expect(nativeServerSource).toContain("@api/app/native-auth");
+    expect(nativeServerSource).not.toContain("appRouter");
+    expect(nativeServerSource).not.toContain("createTRPCContext");
+    expect(nativeServerSource).not.toContain("TRPCError");
+    expect(nativeServerSource).not.toContain("getHTTPStatusCodeFromError");
     expect(nativeServerSource).toContain("Unexpected auth error");
 
     for (const routeSource of [

--- a/apps/app/src/oauth/native-auth-functions.ts
+++ b/apps/app/src/oauth/native-auth-functions.ts
@@ -1,3 +1,4 @@
+import { listNativeAuthOrganizations } from "@api/app/tanstack/native-auth";
 import {
   type NativeOrganization,
   nativeClientSchema,
@@ -15,16 +16,10 @@ export const loadNativeAuthOrganizations = createServerFn({ method: "GET" })
     const [
       { getRequest, setResponseHeader },
       { auth },
-      { appRouter, createTRPCContext },
-      { createTRPCOptionsProxy },
-      { createQueryClient },
       { redirectToSignInForOAuth },
     ] = await Promise.all([
       import("@tanstack/react-start/server"),
       import("@vendor/clerk/server"),
-      import("@api/app"),
-      import("@trpc/tanstack-react-query"),
-      import("~/trpc/query-client"),
       import("./oauth-auth-redirect"),
     ]);
 
@@ -34,19 +29,7 @@ export const loadNativeAuthOrganizations = createServerFn({ method: "GET" })
       redirectToSignInForOAuth(request.url);
     }
 
-    const headers = new Headers(request.headers);
-    headers.set("x-trpc-source", "tanstack-native-auth-start");
-
     setResponseHeader("cache-control", "private, no-store");
 
-    const queryClient = createQueryClient();
-    const trpc = createTRPCOptionsProxy({
-      router: appRouter,
-      ctx: () => createTRPCContext({ headers }),
-      queryClient: () => queryClient,
-    });
-
-    return queryClient.fetchQuery(
-      trpc.native.auth.listOrganizations.queryOptions()
-    ) as Promise<NativeOrganization[]>;
+    return listNativeAuthOrganizations() as Promise<NativeOrganization[]>;
   });

--- a/apps/app/src/oauth/native-auth-org-select.tsx
+++ b/apps/app/src/oauth/native-auth-org-select.tsx
@@ -1,12 +1,13 @@
+import { createNativeAuthAttempt } from "@api/app/tanstack/native-auth";
 import type {
   NativeClient,
+  NativeCreateAttemptInput,
   NativeOrganization,
 } from "@repo/native-auth-contract";
 import { Icons } from "@repo/ui/components/icons";
 import { Button } from "@repo/ui/components/ui/button";
-import { useMutation } from "@tanstack/react-query";
+import { mutationOptions, useMutation } from "@tanstack/react-query";
 import { ArrowRight, Loader2 } from "lucide-react";
-import { useTRPC } from "~/trpc/react";
 
 const clientLabels = {
   cli: "Lightfast CLI",
@@ -75,9 +76,11 @@ export function NativeAuthOrgSelect({
   redirectUri: string;
   state: string;
 }) {
-  const trpc = useTRPC();
   const createAttemptMutation = useMutation(
-    trpc.native.auth.createAttempt.mutationOptions({
+    mutationOptions({
+      meta: { errorTitle: "Failed to continue native authorization" },
+      mutationFn: (data: NativeCreateAttemptInput) =>
+        createNativeAuthAttempt({ data }),
       onSuccess: (result) => {
         window.location.assign(
           withClerkDevBrowserContext(result.authorizationUrl)

--- a/apps/app/src/routes/api/oauth/$client/config.ts
+++ b/apps/app/src/routes/api/oauth/$client/config.ts
@@ -4,22 +4,18 @@ import {
 } from "@repo/native-auth-contract";
 import { createFileRoute } from "@tanstack/react-router";
 import {
-  createNativeOAuthFacadeCaller,
   errorResponse,
+  getNativeOAuthClientConfig,
   jsonResponse,
 } from "~/server/oauth/native-auth";
 
 export const Route = createFileRoute("/api/oauth/$client/config")({
   server: {
     handlers: {
-      GET: async ({ params, request }) => {
+      GET: async ({ params }) => {
         try {
           const parsedClient = nativeClientSchema.parse(params.client);
-          const caller = await createNativeOAuthFacadeCaller({
-            headers: request.headers,
-            source: parsedClient,
-          });
-          const config = await caller.native.auth.oauthConfig({
+          const config = getNativeOAuthClientConfig({
             client: parsedClient,
           });
           return jsonResponse(nativeOAuthConfigSchema.parse(config));

--- a/apps/app/src/routes/api/oauth/desktop/session.ts
+++ b/apps/app/src/routes/api/oauth/desktop/session.ts
@@ -1,8 +1,8 @@
 import { nativeSessionMetadataSchema } from "@repo/native-auth-contract";
 import { createFileRoute } from "@tanstack/react-router";
 import {
-  createNativeOAuthFacadeCaller,
   errorResponse,
+  getNativeAuthSessionForRequest,
   jsonResponse,
 } from "~/server/oauth/native-auth";
 
@@ -11,11 +11,10 @@ export const Route = createFileRoute("/api/oauth/desktop/session")({
     handlers: {
       GET: async ({ request }) => {
         try {
-          const caller = await createNativeOAuthFacadeCaller({
+          const session = await getNativeAuthSessionForRequest({
             headers: request.headers,
             source: "desktop",
           });
-          const session = await caller.native.auth.session();
           return jsonResponse(nativeSessionMetadataSchema.parse(session));
         } catch (error) {
           return errorResponse(error);

--- a/apps/app/src/routes/api/oauth/finalize.ts
+++ b/apps/app/src/routes/api/oauth/finalize.ts
@@ -4,8 +4,8 @@ import {
 } from "@repo/native-auth-contract";
 import { createFileRoute } from "@tanstack/react-router";
 import {
-  createNativeOAuthFacadeCaller,
   errorResponse,
+  finalizeNativeAuthAttemptForRequest,
   jsonResponse,
 } from "~/server/oauth/native-auth";
 
@@ -17,11 +17,11 @@ export const Route = createFileRoute("/api/oauth/finalize")({
           const body = nativeFinalizeRequestSchema.parse(
             await request.json().catch(() => null)
           );
-          const caller = await createNativeOAuthFacadeCaller({
+          const session = await finalizeNativeAuthAttemptForRequest({
+            data: body,
             headers: request.headers,
             source: body.client,
           });
-          const session = await caller.native.auth.finalize(body);
           return jsonResponse(nativeSessionMetadataSchema.parse(session));
         } catch (error) {
           return errorResponse(error);

--- a/apps/app/src/server/oauth/native-auth.ts
+++ b/apps/app/src/server/oauth/native-auth.ts
@@ -1,23 +1,15 @@
-import { appRouter, createCallerFactory, createTRPCContext } from "@api/app";
 import {
-  NATIVE_AUTH_HEADERS,
-  type NativeClient,
-} from "@repo/native-auth-contract";
-import { TRPCError } from "@trpc/server";
-import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+  finalizeNativeAuthAttemptForRequest,
+  getNativeAuthSessionForRequest,
+  getNativeOAuthClientConfig,
+  isNativeAuthError,
+} from "@api/app/native-auth";
 
-const createCaller = createCallerFactory(appRouter);
-
-export async function createNativeOAuthFacadeCaller(input: {
-  headers: Headers;
-  source: NativeClient;
-}) {
-  const headers = new Headers(input.headers);
-  headers.set("x-trpc-source", input.source);
-  headers.set(NATIVE_AUTH_HEADERS.client, input.source);
-
-  return createCaller(await createTRPCContext({ headers }));
-}
+export {
+  finalizeNativeAuthAttemptForRequest,
+  getNativeAuthSessionForRequest,
+  getNativeOAuthClientConfig,
+};
 
 export function jsonResponse(data: unknown, init: ResponseInit = {}) {
   const headers = new Headers(init.headers);
@@ -28,16 +20,16 @@ export function jsonResponse(data: unknown, init: ResponseInit = {}) {
 }
 
 export function errorResponse(error: unknown) {
-  if (error instanceof TRPCError) {
-    const status = getHTTPStatusCodeFromError(error);
+  if (isNativeAuthError(error)) {
     return jsonResponse(
       {
         error: {
           code: error.code,
-          message: status >= 500 ? "Unexpected auth error" : error.message,
+          message:
+            error.status >= 500 ? "Unexpected auth error" : error.message,
         },
       },
-      { status }
+      { status: error.status }
     );
   }
 


### PR DESCRIPTION
## Summary
- Extract native OAuth config, organization listing, attempt creation, finalize, and session refresh into an explicit `@api/app/native-auth` service boundary.
- Add `@api/app/tanstack/native-auth` server-function adapters and move the app OAuth start UI off `native.auth.*` tRPC usage.
- Replace the app `/api/oauth/*` facade's generated tRPC caller with named native auth handler imports, keeping the existing tRPC router as a compatibility wrapper.

## Test Plan
- `pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts src/__tests__/oauth-protocol-routes-source.test.ts`
- `pnpm --filter @api/app test -- src/__tests__/native-auth-boundary-source.test.ts src/__tests__/native-auth-router.test.ts src/__tests__/native-auth-attempts.test.ts`
- `pnpm check`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm exec turbo run typecheck --filter=@api/app --filter=@lightfast/app --summarize`
- `pnpm typecheck`
- agent-browser: opened `/api/oauth/cli/config` and verified OAuth config JSON; opened signed-out `/oauth/cli/start?...` and verified redirect to `/sign-in` with OAuth redirect preserved.

## Notes
- Local `pnpm dev` continued with app serving, but unrelated already-running dev services reported port conflicts for the MFE proxy/granola emulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TanStack native-auth adapter endpoints to list native auth organizations and create native auth attempts.

* **Refactor**
  * Updated native auth OAuth routes (config, desktop session, finalize) to call direct native-auth handlers instead of request-aware tRPC flows.
  * Updated native auth org select to create attempts via React Query.

* **Improvements**
  * Improved native-auth error handling by preserving native-auth HTTP status codes and messages.

* **Tests**
  * Added/updated coverage to validate new native-auth export entry points and adapter status mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->