### PR TITLE
Move MCP signal intake to internal API adapter

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -33,6 +33,10 @@
       "types": "./src/native-auth/index.ts",
       "default": "./src/native-auth/index.ts"
     },
+    "./internal-api/mcp-signals": {
+      "types": "./src/adapters/internal/mcp-signals.ts",
+      "default": "./src/adapters/internal/mcp-signals.ts"
+    },
     "./tanstack/signals": {
       "types": "./src/adapters/tanstack/signals.ts",
       "default": "./src/adapters/tanstack/signals.ts"

--- a/api/app/src/__tests__/mcp-signals-internal-adapter.test.ts
+++ b/api/app/src/__tests__/mcp-signals-internal-adapter.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signServiceJWT } from "../service-jwt";
+
+const mocks = vi.hoisted(() => ({
+  assertHostedMcpOrgAccess: vi.fn(),
+  createSignalForActor: vi.fn(),
+  getVisibleSignalByPublicId: vi.fn(),
+}));
+
+vi.mock("@db/app", () => ({
+  getVisibleSignalByPublicId: mocks.getVisibleSignalByPublicId,
+}));
+
+vi.mock("@db/app/client", () => ({
+  db: {},
+}));
+
+vi.mock("../mcp-oauth/resource-access", () => ({
+  assertHostedMcpOrgAccess: mocks.assertHostedMcpOrgAccess,
+}));
+
+vi.mock("../signals/service", () => ({
+  createSignalForActor: mocks.createSignalForActor,
+}));
+
+const {
+  handleCreateMcpSignalInternalRequest,
+  handleGetMcpSignalInternalRequest,
+} = await import("../adapters/internal/mcp-signals");
+
+const originalServiceJwtSecret = process.env.SERVICE_JWT_SECRET;
+const jwtSecret = "test-mcp-jwt-secret-test-mcp-jwt-secret";
+const invisibleSignalId = "signal_123e4567-e89b-12d3-a456-426614174000";
+const actor = {
+  clientId: "client_1",
+  grantId: "grant_1",
+  kind: "mcp" as const,
+  orgId: "org_1",
+  userId: "user_1",
+};
+
+async function serviceToken(
+  input: { caller?: "app" | "mcp"; ttlSeconds?: number } = {}
+) {
+  return signServiceJWT({
+    audience: "lightfast-app",
+    caller: input.caller ?? "mcp",
+    jwtSecret,
+    ttlSeconds: input.ttlSeconds,
+  });
+}
+
+function jsonRequest(input: { body: unknown; token?: string }) {
+  return new Request("https://lightfast.localhost/api/internal/mcp/signals", {
+    body: JSON.stringify(input.body),
+    headers: input.token
+      ? {
+          authorization: `Bearer ${input.token}`,
+          "content-type": "application/json",
+        }
+      : { "content-type": "application/json" },
+    method: "POST",
+  });
+}
+
+async function responseJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("MCP signal internal adapter", () => {
+  beforeEach(() => {
+    process.env.SERVICE_JWT_SECRET = jwtSecret;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalServiceJwtSecret === undefined) {
+      delete process.env.SERVICE_JWT_SECRET;
+      return;
+    }
+    process.env.SERVICE_JWT_SECRET = originalServiceJwtSecret;
+  });
+
+  it("rejects missing service JWTs before parsing create commands", async () => {
+    const response = await handleCreateMcpSignalInternalRequest(
+      jsonRequest({ body: { actor, input: "hello" } })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "missing_token",
+    });
+    expect(mocks.assertHostedMcpOrgAccess).not.toHaveBeenCalled();
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+  });
+
+  it("rejects expired service JWTs before org access checks", async () => {
+    const response = await handleCreateMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, input: "hello" },
+        token: await serviceToken({ ttlSeconds: -1 }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "invalid_token",
+    });
+    expect(mocks.assertHostedMcpOrgAccess).not.toHaveBeenCalled();
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+  });
+
+  it("rejects service JWTs from non-MCP callers", async () => {
+    const response = await handleCreateMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, input: "hello" },
+        token: await serviceToken({ caller: "app" }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "disallowed_caller",
+    });
+    expect(mocks.assertHostedMcpOrgAccess).not.toHaveBeenCalled();
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+  });
+
+  it("rejects create commands when hosted MCP org access is denied", async () => {
+    const denied = Object.assign(new Error("No access to this organization."), {
+      status: 403,
+    });
+    mocks.assertHostedMcpOrgAccess.mockRejectedValueOnce(denied);
+
+    const response = await handleCreateMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, input: "hello" },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "org_access_denied",
+      message: "No access to this organization.",
+    });
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+  });
+
+  it("rejects get commands when hosted MCP org access is denied", async () => {
+    const denied = Object.assign(new Error("No access to this organization."), {
+      status: 403,
+    });
+    mocks.assertHostedMcpOrgAccess.mockRejectedValueOnce(denied);
+
+    const response = await handleGetMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, id: invisibleSignalId },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "org_access_denied",
+      message: "No access to this organization.",
+    });
+    expect(mocks.getVisibleSignalByPublicId).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when a requested signal is outside actor visibility", async () => {
+    mocks.getVisibleSignalByPublicId.mockResolvedValueOnce(null);
+
+    const response = await handleGetMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, id: invisibleSignalId },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(404);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "not_found",
+    });
+    expect(mocks.getVisibleSignalByPublicId).toHaveBeenCalledWith(
+      {},
+      {
+        clerkOrgId: "org_1",
+        createdByUserId: "user_1",
+        publicId: invisibleSignalId,
+      }
+    );
+  });
+});

--- a/api/app/src/adapters/internal/mcp-signals.ts
+++ b/api/app/src/adapters/internal/mcp-signals.ts
@@ -1,0 +1,182 @@
+import { getVisibleSignalByPublicId } from "@db/app";
+import { db } from "@db/app/client";
+import {
+  createMcpSignalCommandInput,
+  getMcpSignalCommandInput,
+  getSignalOutput,
+} from "@repo/api-contract";
+
+import { assertHostedMcpOrgAccess } from "../../mcp-oauth/resource-access";
+import { verifyServiceJWT } from "../../service-jwt";
+import { createSignalForActor } from "../../signals/service";
+
+function bearerToken(request: Request): string | undefined {
+  const authorization = request.headers.get("authorization");
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+function jsonError(error: string, message: string, status: number): Response {
+  return Response.json({ error, message }, { status });
+}
+
+function serviceJwtSecret(): string | undefined {
+  const secret = process.env.SERVICE_JWT_SECRET;
+  return secret && secret.length >= 32 ? secret : undefined;
+}
+
+async function verifyMcpServiceRequest(
+  request: Request
+): Promise<Response | null> {
+  const token = bearerToken(request);
+  if (!token) {
+    return jsonError("missing_token", "Service bearer token is required.", 401);
+  }
+  const jwtSecret = serviceJwtSecret();
+  if (!jwtSecret) {
+    return jsonError(
+      "service_not_configured",
+      "Service JWT verification is not configured.",
+      500
+    );
+  }
+
+  try {
+    await verifyServiceJWT({
+      allowedCallers: ["mcp"],
+      audience: "lightfast-app",
+      jwtSecret,
+      token,
+    });
+    return null;
+  } catch (error) {
+    const status =
+      error instanceof Error && "status" in error
+        ? Number((error as { status: unknown }).status)
+        : 401;
+    return jsonError(
+      status === 403 ? "disallowed_caller" : "invalid_token",
+      status === 403
+        ? "Service caller is not allowed for this command."
+        : "Service token is invalid.",
+      status === 403 ? 403 : 401
+    );
+  }
+}
+
+function isMcpOrgAccessDenied(error: unknown): error is {
+  message?: unknown;
+  status: 403;
+} {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "status" in error &&
+    (error as { status: unknown }).status === 403
+  );
+}
+
+function mcpOrgAccessDeniedMessage(error: { message?: unknown }): string {
+  return typeof error.message === "string"
+    ? error.message
+    : "MCP organization access denied.";
+}
+
+function isSignalCreateQueueErrorLike(error: unknown): error is Error {
+  return error instanceof Error && error.name === "SignalCreateQueueError";
+}
+
+export async function handleCreateMcpSignalInternalRequest(
+  request: Request
+): Promise<Response> {
+  const authError = await verifyMcpServiceRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const body = await request.json().catch(() => undefined);
+  const parsed = createMcpSignalCommandInput.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(
+      "invalid_request",
+      "MCP signal command request is invalid.",
+      400
+    );
+  }
+
+  try {
+    await assertHostedMcpOrgAccess(db, {
+      orgId: parsed.data.actor.orgId,
+      userId: parsed.data.actor.userId,
+    });
+    const result = await createSignalForActor(db, parsed.data);
+    return Response.json(result, { status: 200 });
+  } catch (error) {
+    if (isMcpOrgAccessDenied(error)) {
+      return jsonError(
+        "org_access_denied",
+        mcpOrgAccessDeniedMessage(error),
+        403
+      );
+    }
+    if (isSignalCreateQueueErrorLike(error)) {
+      return jsonError("signal_enqueue_failed", error.message, 500);
+    }
+    return jsonError("internal_error", "Failed to create signal.", 500);
+  }
+}
+
+export async function handleGetMcpSignalInternalRequest(
+  request: Request
+): Promise<Response> {
+  const authError = await verifyMcpServiceRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const body = await request.json().catch(() => undefined);
+  const parsed = getMcpSignalCommandInput.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(
+      "invalid_request",
+      "MCP signal get request is invalid.",
+      400
+    );
+  }
+
+  try {
+    await assertHostedMcpOrgAccess(db, {
+      orgId: parsed.data.actor.orgId,
+      userId: parsed.data.actor.userId,
+    });
+    const signal = await getVisibleSignalByPublicId(db, {
+      publicId: parsed.data.id,
+      clerkOrgId: parsed.data.actor.orgId,
+      createdByUserId: parsed.data.actor.userId,
+    });
+
+    if (!signal) {
+      return jsonError("not_found", "Signal not found.", 404);
+    }
+
+    const output = getSignalOutput.parse({
+      id: signal.publicId,
+      input: signal.input,
+      status: signal.status,
+      classification: signal.classification,
+      visibilityScope: signal.visibilityScope,
+      createdAt: signal.createdAt.toISOString(),
+      updatedAt: signal.updatedAt.toISOString(),
+    });
+    return Response.json(output, { status: 200 });
+  } catch (error) {
+    if (isMcpOrgAccessDenied(error)) {
+      return jsonError(
+        "org_access_denied",
+        mcpOrgAccessDeniedMessage(error),
+        403
+      );
+    }
+    return jsonError("internal_error", "Failed to get signal.", 500);
+  }
+}

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1356,11 +1356,15 @@ describe("app authenticated route migration", () => {
     expect(mcpSignalsRouteSource).toContain(
       'createFileRoute("/api/internal/mcp/signals")'
     );
-    expect(mcpSignalsRouteSource).toContain("createSignalForActor");
+    expect(mcpSignalsRouteSource).toContain(
+      "handleCreateMcpSignalInternalRequest"
+    );
     expect(mcpSignalsGetRouteSource).toContain(
       'createFileRoute("/api/internal/mcp/signals/get")'
     );
-    expect(mcpSignalsGetRouteSource).toContain("getVisibleSignalByPublicId");
+    expect(mcpSignalsGetRouteSource).toContain(
+      "handleGetMcpSignalInternalRequest"
+    );
 
     for (const startupSensitiveFile of [
       openApiRouteSource,

--- a/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
+++ b/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../../");
+const repoRoot = resolve(appRoot, "../..");
+
+function appSource(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("internal MCP app routes", () => {
+  it("mounts MCP signal intake through explicit api/app internal handlers", () => {
+    const createRoute = appSource("src/routes/api/internal/mcp/signals.ts");
+    const getRoute = appSource("src/routes/api/internal/mcp/signals/get.ts");
+    const adapter = repoSource("api/app/src/adapters/internal/mcp-signals.ts");
+    const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, unknown>;
+    };
+
+    expect(packageJson.exports).toHaveProperty("./internal-api/mcp-signals");
+
+    expect(createRoute).toContain('@api/app/internal-api/mcp-signals"');
+    expect(createRoute).toContain("handleCreateMcpSignalInternalRequest");
+    expect(getRoute).toContain('@api/app/internal-api/mcp-signals"');
+    expect(getRoute).toContain("handleGetMcpSignalInternalRequest");
+
+    for (const source of [createRoute, getRoute]) {
+      expect(source).not.toContain("@db/app");
+      expect(source).not.toContain("@repo/api-contract");
+      expect(source).not.toContain("~/server/mcp-service-auth");
+      expect(source).not.toContain("verifyMcpServiceRequest");
+      expect(source).not.toContain("jsonError");
+      expect(source).not.toContain("@api/app/mcp-oauth/resource-access");
+      expect(source).not.toContain("@api/app/signals/service");
+    }
+
+    expect(adapter).toContain("process.env.SERVICE_JWT_SECRET");
+    expect(adapter).not.toContain('from "../../env"');
+  });
+});

--- a/apps/app/src/routes/api/internal/mcp/signals.ts
+++ b/apps/app/src/routes/api/internal/mcp/signals.ts
@@ -1,63 +1,13 @@
-import { db } from "@db/app/client";
-import { createMcpSignalCommandInput } from "@repo/api-contract";
 import { createFileRoute } from "@tanstack/react-router";
-import { jsonError, verifyMcpServiceRequest } from "~/server/mcp-service-auth";
-
-function isSignalCreateQueueErrorLike(error: unknown): error is Error {
-  return error instanceof Error && error.name === "SignalCreateQueueError";
-}
 
 export const Route = createFileRoute("/api/internal/mcp/signals")({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        const authError = await verifyMcpServiceRequest(request);
-        if (authError) {
-          return authError;
-        }
-
-        const body = await request.json().catch(() => undefined);
-        const parsed = createMcpSignalCommandInput.safeParse(body);
-        if (!parsed.success) {
-          return jsonError(
-            "invalid_request",
-            "MCP signal command request is invalid.",
-            400
-          );
-        }
-
-        try {
-          const [{ assertHostedMcpOrgAccess }, { createSignalForActor }] =
-            await Promise.all([
-              import("@api/app/mcp-oauth/resource-access"),
-              import("@api/app/signals/service"),
-            ]);
-          await assertHostedMcpOrgAccess(db, {
-            orgId: parsed.data.actor.orgId,
-            userId: parsed.data.actor.userId,
-          });
-          const result = await createSignalForActor(db, parsed.data);
-          return Response.json(result, { status: 200 });
-        } catch (error) {
-          if (
-            error &&
-            typeof error === "object" &&
-            "status" in error &&
-            (error as { status: unknown }).status === 403
-          ) {
-            return jsonError(
-              "org_access_denied",
-              error instanceof Error
-                ? error.message
-                : "MCP organization access denied.",
-              403
-            );
-          }
-          if (isSignalCreateQueueErrorLike(error)) {
-            return jsonError("signal_enqueue_failed", error.message, 500);
-          }
-          return jsonError("internal_error", "Failed to create signal.", 500);
-        }
+        const { handleCreateMcpSignalInternalRequest } = await import(
+          "@api/app/internal-api/mcp-signals"
+        );
+        return handleCreateMcpSignalInternalRequest(request);
       },
     },
   },

--- a/apps/app/src/routes/api/internal/mcp/signals/get.ts
+++ b/apps/app/src/routes/api/internal/mcp/signals/get.ts
@@ -1,73 +1,13 @@
-import { getVisibleSignalByPublicId } from "@db/app";
-import { db } from "@db/app/client";
-import { getMcpSignalCommandInput, getSignalOutput } from "@repo/api-contract";
 import { createFileRoute } from "@tanstack/react-router";
-import { jsonError, verifyMcpServiceRequest } from "~/server/mcp-service-auth";
 
 export const Route = createFileRoute("/api/internal/mcp/signals/get")({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        const authError = await verifyMcpServiceRequest(request);
-        if (authError) {
-          return authError;
-        }
-
-        const body = await request.json().catch(() => undefined);
-        const parsed = getMcpSignalCommandInput.safeParse(body);
-        if (!parsed.success) {
-          return jsonError(
-            "invalid_request",
-            "MCP signal get request is invalid.",
-            400
-          );
-        }
-
-        try {
-          const { assertHostedMcpOrgAccess } = await import(
-            "@api/app/mcp-oauth/resource-access"
-          );
-          await assertHostedMcpOrgAccess(db, {
-            orgId: parsed.data.actor.orgId,
-            userId: parsed.data.actor.userId,
-          });
-          const signal = await getVisibleSignalByPublicId(db, {
-            publicId: parsed.data.id,
-            clerkOrgId: parsed.data.actor.orgId,
-            createdByUserId: parsed.data.actor.userId,
-          });
-
-          if (!signal) {
-            return jsonError("not_found", "Signal not found.", 404);
-          }
-
-          const output = getSignalOutput.parse({
-            id: signal.publicId,
-            input: signal.input,
-            status: signal.status,
-            classification: signal.classification,
-            visibilityScope: signal.visibilityScope,
-            createdAt: signal.createdAt.toISOString(),
-            updatedAt: signal.updatedAt.toISOString(),
-          });
-          return Response.json(output, { status: 200 });
-        } catch (error) {
-          if (
-            error &&
-            typeof error === "object" &&
-            "status" in error &&
-            (error as { status: unknown }).status === 403
-          ) {
-            return jsonError(
-              "org_access_denied",
-              error instanceof Error
-                ? error.message
-                : "MCP organization access denied.",
-              403
-            );
-          }
-          return jsonError("internal_error", "Failed to get signal.", 500);
-        }
+        const { handleGetMcpSignalInternalRequest } = await import(
+          "@api/app/internal-api/mcp-signals"
+        );
+        return handleGetMcpSignalInternalRequest(request);
       },
     },
   },


### PR DESCRIPTION
## Summary
- move hosted MCP signal create/get request handling behind `@api/app/internal-api/mcp-signals`
- keep `apps/app` internal MCP signal routes as thin dynamic mounts
- add a source ratchet for the new route boundary and let `api/app` own service JWT verification for this adapter

## Test Plan
- `pnpm --filter @lightfast/app test -- src/__tests__/internal-mcp-routes-source.test.ts src/__tests__/authenticated-routes-source.test.ts`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @api/app test -- src/__tests__/env.test.ts src/__tests__/service-jwt.test.ts`
- `pnpm check`
- `pnpm --filter @lightfast/mcp test -- src/__tests__/app-signal-intake.test.ts`
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal MCP signal handling logic into a centralized adapter for improved code maintainability and reusability.

* **Tests**
  * Updated tests to verify proper integration of refactored internal MCP signal handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->