### PR TITLE
Add explicit public signal API routes

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -37,6 +37,10 @@
       "types": "./src/adapters/internal/mcp-signals.ts",
       "default": "./src/adapters/internal/mcp-signals.ts"
     },
+    "./public-api/signals": {
+      "types": "./src/adapters/public/signals.ts",
+      "default": "./src/adapters/public/signals.ts"
+    },
     "./tanstack/signals": {
       "types": "./src/adapters/tanstack/signals.ts",
       "default": "./src/adapters/tanstack/signals.ts"

--- a/api/app/src/__tests__/public-signals-api.test.ts
+++ b/api/app/src/__tests__/public-signals-api.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createSignalForActor: vi.fn(),
+  getActiveOrgBinding: vi.fn(),
+  getCurrentOrgConnectorConnection: vi.fn(),
+  getVisibleSignalByPublicId: vi.fn(),
+  listSignalEntityLinksForSignal: vi.fn(),
+  verifyKey: vi.fn(),
+}));
+
+vi.mock("@vendor/unkey/server", () => ({
+  getUnkeyClient: () => ({
+    keys: { verifyKey: mocks.verifyKey },
+  }),
+}));
+
+vi.mock("@db/app/client", () => ({ db: { kind: "mock-db" } }));
+vi.mock("@db/app", () => ({
+  getActiveOrgBinding: mocks.getActiveOrgBinding,
+  getCurrentOrgConnectorConnection: mocks.getCurrentOrgConnectorConnection,
+  getVisibleSignalByPublicId: mocks.getVisibleSignalByPublicId,
+  listSignalEntityLinksForSignal: mocks.listSignalEntityLinksForSignal,
+}));
+
+vi.mock("../signals/service", () => ({
+  createSignalForActor: mocks.createSignalForActor,
+}));
+
+const {
+  handleCreateSignalPublicApiRequest,
+  handleGetSignalPublicApiRequest,
+  handlePublicApiOptionsRequest,
+} = await import("../adapters/public/signals");
+const { SignalCreateQueueError } = await import("../signals/create-signal");
+
+const validKey = `lf_${"a".repeat(40)}`;
+const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
+
+function verifyResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    data: {
+      code: "VALID",
+      identity: { externalId: "org_test", id: "identity_test" },
+      keyId: "key_test",
+      meta: { createdByUserId: "user_test" },
+      valid: true,
+      ...overrides,
+    },
+    meta: { requestId: "req_test" },
+  };
+}
+
+function publicApiRequest(input: {
+  body?: unknown;
+  method?: string;
+  token?: string;
+  url?: string;
+}) {
+  const headers = new Headers();
+  if (input.token) {
+    headers.set("authorization", `Bearer ${input.token}`);
+  }
+  if (input.body !== undefined) {
+    headers.set("content-type", "application/json");
+  }
+
+  return new Request(input.url ?? "https://lightfast.test/api/v1/signals", {
+    body: input.body === undefined ? undefined : JSON.stringify(input.body),
+    headers,
+    method: input.method ?? "POST",
+  });
+}
+
+async function responseJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.verifyKey.mockResolvedValue(verifyResult());
+  mocks.getCurrentOrgConnectorConnection.mockResolvedValue({
+    status: "active",
+  });
+  mocks.getActiveOrgBinding.mockResolvedValue({
+    metadata: {
+      lightfastRepository: {
+        fullName: "acme/.lightfast",
+        id: "987",
+        installationId: "1001",
+        name: ".lightfast",
+        verifiedAt: "2026-05-30T10:00:00.000Z",
+      },
+    },
+    provider: "github",
+    providerAccountLogin: "acme",
+    providerInstallationId: "1001",
+  });
+  mocks.listSignalEntityLinksForSignal.mockResolvedValue([]);
+  mocks.createSignalForActor.mockResolvedValue({
+    id: signalId,
+    status: "queued",
+    visibilityScope: "user",
+  });
+});
+
+describe("public signal API adapter", () => {
+  it("answers CORS preflight without touching auth", () => {
+    const response = handlePublicApiOptionsRequest();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(mocks.verifyKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects create requests without an API key", async () => {
+    const response = await handleCreateSignalPublicApiRequest(
+      publicApiRequest({ body: { input: "hello" } })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "auth_required",
+    });
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+  });
+
+  it("creates a queued signal with API-key attribution", async () => {
+    const response = await handleCreateSignalPublicApiRequest(
+      publicApiRequest({
+        body: { input: "  Reply to this relevant post  " },
+        token: validKey,
+      })
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    await expect(responseJson(response)).resolves.toEqual({
+      id: signalId,
+      status: "queued",
+      visibilityScope: "user",
+    });
+    expect(mocks.createSignalForActor).toHaveBeenCalledWith(expect.anything(), {
+      actor: {
+        apiKeyId: "key_test",
+        kind: "api_key",
+        orgId: "org_test",
+        userId: "user_test",
+      },
+      input: "Reply to this relevant post",
+    });
+  });
+
+  it("rejects signal creation for unbound organizations", async () => {
+    mocks.getActiveOrgBinding.mockResolvedValueOnce(undefined);
+
+    const response = await handleCreateSignalPublicApiRequest(
+      publicApiRequest({
+        body: { input: "Run the test plan" },
+        token: validKey,
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "org_setup_required",
+    });
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+  });
+
+  it("maps signal queue failures to a public internal error", async () => {
+    mocks.createSignalForActor.mockRejectedValueOnce(
+      new SignalCreateQueueError(new Error("inngest unavailable"))
+    );
+
+    const response = await handleCreateSignalPublicApiRequest(
+      publicApiRequest({
+        body: { input: "Run the test plan" },
+        token: validKey,
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "signal_enqueue_failed",
+      message: expect.stringContaining("Failed to queue signal"),
+    });
+  });
+
+  it("reads a visible signal by id", async () => {
+    mocks.getVisibleSignalByPublicId.mockResolvedValueOnce({
+      classification: null,
+      clerkOrgId: "org_test",
+      createdAt: new Date("2026-05-21T00:00:00.000Z"),
+      createdByApiKeyId: "key_test",
+      createdByMcpClientId: null,
+      createdByMcpGrantId: null,
+      createdByUserId: "user_test",
+      errorCode: null,
+      errorMessage: null,
+      id: 1,
+      input: "Run the test plan",
+      publicId: signalId,
+      status: "classified",
+      updatedAt: new Date("2026-05-21T00:01:00.000Z"),
+      visibilityScope: "team",
+    });
+
+    const response = await handleGetSignalPublicApiRequest(
+      publicApiRequest({
+        method: "GET",
+        token: validKey,
+        url: `https://lightfast.test/api/v1/signals/${signalId}`,
+      }),
+      { id: signalId }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      entityLinks: [],
+      id: signalId,
+      input: "Run the test plan",
+      status: "classified",
+      visibilityScope: "team",
+    });
+    expect(mocks.getVisibleSignalByPublicId).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_test",
+        createdByUserId: "user_test",
+        publicId: signalId,
+      }
+    );
+  });
+
+  it("returns not found for missing or wrong-org signals", async () => {
+    mocks.getVisibleSignalByPublicId.mockResolvedValueOnce(undefined);
+
+    const response = await handleGetSignalPublicApiRequest(
+      publicApiRequest({
+        method: "GET",
+        token: validKey,
+        url: `https://lightfast.test/api/v1/signals/${signalId}`,
+      }),
+      { id: signalId }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "not_found",
+    });
+  });
+
+  it("scopes signal reads to the requesting API key organization", async () => {
+    mocks.verifyKey.mockResolvedValueOnce(
+      verifyResult({
+        identity: { externalId: "org_other", id: "identity_other" },
+      })
+    );
+    mocks.getActiveOrgBinding.mockResolvedValueOnce({
+      metadata: {
+        lightfastRepository: {
+          fullName: "other/.lightfast",
+          id: "2002",
+          installationId: "2002",
+          name: ".lightfast",
+          verifiedAt: "2026-05-30T10:00:00.000Z",
+        },
+      },
+      provider: "github",
+      providerAccountLogin: "other",
+      providerInstallationId: "2002",
+    });
+    mocks.getVisibleSignalByPublicId.mockResolvedValueOnce(undefined);
+
+    const response = await handleGetSignalPublicApiRequest(
+      publicApiRequest({
+        method: "GET",
+        token: validKey,
+        url: `https://lightfast.test/api/v1/signals/${signalId}`,
+      }),
+      { id: signalId }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "not_found",
+    });
+    expect(mocks.getVisibleSignalByPublicId).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_other",
+        createdByUserId: "user_test",
+        publicId: signalId,
+      }
+    );
+  });
+});

--- a/api/app/src/adapters/public/signals.ts
+++ b/api/app/src/adapters/public/signals.ts
@@ -1,0 +1,200 @@
+import {
+  getVisibleSignalByPublicId,
+  listSignalEntityLinksForSignal,
+} from "@db/app";
+import { db } from "@db/app/client";
+import {
+  createSignalInput,
+  createSignalOutput,
+  getSignalInput,
+  getSignalOutput,
+} from "@repo/api-contract";
+import { repairIdForSetupRequirement } from "@repo/app-setup-contract";
+
+import {
+  type ApiKeyAuthResult,
+  isApiKeyAuthError,
+  resolveApiKeyAuth,
+} from "../../auth/api-key";
+import { isSignalCreateQueueError } from "../../signals/create-signal";
+import { createSignalForActor } from "../../signals/service";
+
+type PublicApiStatus = 400 | 401 | 403 | 404 | 500;
+
+function withPublicApiCors(response: Response): Response {
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set(
+    "Access-Control-Allow-Methods",
+    "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+  );
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "authorization,content-type"
+  );
+  response.headers.set("Access-Control-Max-Age", "86400");
+  return response;
+}
+
+function jsonResponse(data: unknown, status: number): Response {
+  return withPublicApiCors(Response.json(data, { status }));
+}
+
+function jsonError(
+  error: string,
+  message: string,
+  status: PublicApiStatus,
+  extra?: Record<string, unknown>
+): Response {
+  return jsonResponse({ error, message, ...extra }, status);
+}
+
+function authErrorResponse(error: unknown): Response {
+  if (!isApiKeyAuthError(error)) {
+    return jsonError(
+      "internal_error",
+      "Failed to authenticate API request.",
+      500
+    );
+  }
+
+  return jsonError(
+    error.orpcCode === "FORBIDDEN" ? "forbidden" : "auth_required",
+    error.message,
+    error.orpcCode === "FORBIDDEN" ? 403 : 401,
+    { diagnostics: [error.diagnostic] }
+  );
+}
+
+function orgSetupErrorResponse(auth: ApiKeyAuthResult): Response {
+  const requirement = auth.identity.orgGate.nextSetupRequirement;
+  const message =
+    "This organization has not completed setup. Complete setup before using Lightfast API features.";
+  return jsonError("org_setup_required", message, 403, {
+    diagnostics: [
+      {
+        code: "ORG_SETUP_REQUIRED",
+        message,
+        repair: {
+          id: repairIdForSetupRequirement(requirement ?? "github_org"),
+        },
+      },
+    ],
+  });
+}
+
+function isResponse(value: unknown): value is Response {
+  return value instanceof Response;
+}
+
+async function requireBoundApiKeyAuth(
+  request: Request
+): Promise<ApiKeyAuthResult | Response> {
+  let auth: ApiKeyAuthResult;
+  try {
+    auth = await resolveApiKeyAuth({ db, headers: request.headers });
+  } catch (error) {
+    return authErrorResponse(error);
+  }
+
+  if (auth.identity.orgGate.bindingStatus !== "bound") {
+    return orgSetupErrorResponse(auth);
+  }
+
+  return auth;
+}
+
+export function handlePublicApiOptionsRequest(): Response {
+  return withPublicApiCors(new Response(null, { status: 204 }));
+}
+
+export async function handleCreateSignalPublicApiRequest(
+  request: Request
+): Promise<Response> {
+  const auth = await requireBoundApiKeyAuth(request);
+  if (isResponse(auth)) {
+    return auth;
+  }
+
+  const body = await request.json().catch(() => undefined);
+  const parsed = createSignalInput.safeParse(body);
+  if (!parsed.success) {
+    return jsonError(
+      "invalid_request",
+      "Signal request body is invalid.",
+      400,
+      {
+        diagnostics: parsed.error.issues,
+      }
+    );
+  }
+
+  try {
+    const result = await createSignalForActor(db, {
+      actor: {
+        apiKeyId: auth.apiKeyId,
+        kind: "api_key",
+        orgId: auth.identity.orgId,
+        userId: auth.identity.userId,
+      },
+      input: parsed.data.input,
+    });
+    return jsonResponse(createSignalOutput.parse(result), 202);
+  } catch (error) {
+    if (isSignalCreateQueueError(error)) {
+      return jsonError("signal_enqueue_failed", error.message, 500);
+    }
+    return jsonError("internal_error", "Failed to create signal.", 500);
+  }
+}
+
+export async function handleGetSignalPublicApiRequest(
+  request: Request,
+  params: { id: string }
+): Promise<Response> {
+  const auth = await requireBoundApiKeyAuth(request);
+  if (isResponse(auth)) {
+    return auth;
+  }
+
+  const parsed = getSignalInput.safeParse(params);
+  if (!parsed.success) {
+    return jsonError("invalid_request", "Signal id is invalid.", 400, {
+      diagnostics: parsed.error.issues,
+    });
+  }
+
+  try {
+    const signal = await getVisibleSignalByPublicId(db, {
+      clerkOrgId: auth.identity.orgId,
+      createdByUserId: auth.identity.userId,
+      publicId: parsed.data.id,
+    });
+
+    if (!signal) {
+      return jsonError("not_found", "Signal not found.", 404);
+    }
+
+    const entityLinks = await listSignalEntityLinksForSignal(db, {
+      clerkOrgId: auth.identity.orgId,
+      signalId: signal.publicId,
+    });
+
+    const output = getSignalOutput.parse({
+      id: signal.publicId,
+      input: signal.input,
+      status: signal.status,
+      classification: signal.classification,
+      entityLinks,
+      visibilityScope: signal.visibilityScope,
+      createdAt: signal.createdAt.toISOString(),
+      updatedAt: signal.updatedAt.toISOString(),
+    });
+
+    return jsonResponse(output, 200);
+  } catch (error) {
+    if (error instanceof Response) {
+      return withPublicApiCors(error);
+    }
+    return jsonError("internal_error", "Failed to get signal.", 500);
+  }
+}

--- a/apps/app/src/__tests__/migration-readiness.test.ts
+++ b/apps/app/src/__tests__/migration-readiness.test.ts
@@ -62,6 +62,8 @@ const migratedNextAppRoutes = [
   "/api/skills/index/events",
   "/api/trpc/$",
   "/api/v1/$",
+  "/api/v1/signals",
+  "/api/v1/signals/$",
   "/oauth/$/start",
   "/oauth/authorize",
   "/oauth/jwks",
@@ -126,7 +128,7 @@ describe("app migration readiness", () => {
   it("declares TanStack routes for every migrated legacy Next route", () => {
     const tanstackRoutes = new Set(tanstackRouteDeclarations());
 
-    expect(migratedNextAppRoutes.length).toBe(66);
+    expect(migratedNextAppRoutes.length).toBe(68);
     expect(tanstackRoutes.size).toBeGreaterThan(0);
     expect(
       migratedNextAppRoutes.filter((route) => !tanstackRoutes.has(route))

--- a/apps/app/src/__tests__/public-api-routes-source.test.ts
+++ b/apps/app/src/__tests__/public-api-routes-source.test.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const appRoot = resolve(repoRoot, "apps/app");
+
+function appSource(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("public API route boundaries", () => {
+  it("mounts public signal routes as thin app-owned route files", () => {
+    const createPath = resolve(appRoot, "src/routes/api/v1/signals.ts");
+    const getPath = resolve(appRoot, "src/routes/api/v1/signals/$id.ts");
+
+    expect(existsSync(createPath)).toBe(true);
+    expect(existsSync(getPath)).toBe(true);
+
+    const createRoute = appSource("src/routes/api/v1/signals.ts");
+    const getRoute = appSource("src/routes/api/v1/signals/$id.ts");
+
+    expect(createRoute).toContain('createFileRoute("/api/v1/signals")');
+    expect(createRoute).toContain('@api/app/public-api/signals"');
+    expect(createRoute).toContain("handleCreateSignalPublicApiRequest");
+    expect(createRoute).toContain("handlePublicApiOptionsRequest");
+    expect(getRoute).toContain('createFileRoute("/api/v1/signals/$id")');
+    expect(getRoute).toContain('@api/app/public-api/signals"');
+    expect(getRoute).toContain("handleGetSignalPublicApiRequest");
+    expect(getRoute).toContain("params.id");
+
+    for (const source of [createRoute, getRoute]) {
+      expect(source).not.toContain("OpenAPIHandler");
+      expect(source).not.toContain("orpcRouter");
+      expect(source).not.toContain("@db/app");
+      expect(source).not.toContain("resolveApiKeyAuth");
+    }
+  });
+
+  it("keeps public signal behavior in an explicit api/app adapter", () => {
+    const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports?: Record<string, unknown>;
+    };
+    const adapter = repoSource("api/app/src/adapters/public/signals.ts");
+
+    expect(packageJson.exports).toHaveProperty("./public-api/signals");
+    expect(adapter).toContain("resolveApiKeyAuth");
+    expect(adapter).toContain("createSignalInput");
+    expect(adapter).toContain("getSignalOutput.parse");
+    expect(adapter).toContain("createSignalForActor");
+    expect(adapter).not.toContain("ORPCError");
+    expect(adapter).not.toContain("@orpc/");
+    expect(adapter).not.toContain("OpenAPIHandler");
+  });
+
+  it("keeps the oRPC catch-all only as the temporary public fallback", () => {
+    const fallback = appSource("src/routes/api/v1/$.ts");
+
+    expect(fallback).toContain('createFileRoute("/api/v1/$")');
+    expect(fallback).toContain("OpenAPIHandler");
+    expect(fallback).toContain("orpcRouter");
+  });
+});

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as DotwellKnownOauthAuthorizationServerRouteImport } from './rout
 import { Route as AuthenticatedSlugIndexRouteImport } from './routes/_authenticated/$slug/index'
 import { Route as OauthRegisterClientIdRouteImport } from './routes/oauth/register/$clientId'
 import { Route as OauthClientStartRouteImport } from './routes/oauth/$client/start'
+import { Route as ApiV1SignalsRouteImport } from './routes/api/v1/signals'
 import { Route as ApiV1SplatRouteImport } from './routes/api/v1/$'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc.$'
 import { Route as ApiOauthFinalizeRouteImport } from './routes/api/oauth/finalize'
@@ -50,6 +51,7 @@ import { Route as AuthenticatedSlugTasksIndexRouteImport } from './routes/_authe
 import { Route as AuthenticatedSlugSettingsIndexRouteImport } from './routes/_authenticated/$slug/settings/index'
 import { Route as AuthenticatedSlugChatIndexRouteImport } from './routes/_authenticated/$slug/chat/index'
 import { Route as AuthenticatedSlugAutomationsIndexRouteImport } from './routes/_authenticated/$slug/automations/index'
+import { Route as ApiV1SignalsIdRouteImport } from './routes/api/v1/signals/$id'
 import { Route as ApiSkillsIndexEventsRouteImport } from './routes/api/skills/index/events'
 import { Route as ApiOauthDesktopSessionRouteImport } from './routes/api/oauth/desktop/session'
 import { Route as ApiOauthClientConfigRouteImport } from './routes/api/oauth/$client/config'
@@ -186,6 +188,11 @@ const OauthClientStartRoute = OauthClientStartRouteImport.update({
   path: '/oauth/$client/start',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1SignalsRoute = ApiV1SignalsRouteImport.update({
+  id: '/api/v1/signals',
+  path: '/api/v1/signals',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1SplatRoute = ApiV1SplatRouteImport.update({
   id: '/api/v1/$',
   path: '/api/v1/$',
@@ -308,6 +315,11 @@ const AuthenticatedSlugAutomationsIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedSlugAutomationsRoute,
   } as any)
+const ApiV1SignalsIdRoute = ApiV1SignalsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ApiV1SignalsRoute,
+} as any)
 const ApiSkillsIndexEventsRoute = ApiSkillsIndexEventsRouteImport.update({
   id: '/api/skills/index/events',
   path: '/api/skills/index/events',
@@ -571,6 +583,7 @@ export interface FileRoutesByFullPath {
   '/api/oauth/finalize': typeof ApiOauthFinalizeRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
+  '/api/v1/signals': typeof ApiV1SignalsRouteWithChildren
   '/oauth/$client/start': typeof OauthClientStartRoute
   '/oauth/register/$clientId': typeof OauthRegisterClientIdRoute
   '/$slug/': typeof AuthenticatedSlugIndexRoute
@@ -599,6 +612,7 @@ export interface FileRoutesByFullPath {
   '/api/oauth/$client/config': typeof ApiOauthClientConfigRoute
   '/api/oauth/desktop/session': typeof ApiOauthDesktopSessionRoute
   '/api/skills/index/events': typeof ApiSkillsIndexEventsRoute
+  '/api/v1/signals/$id': typeof ApiV1SignalsIdRoute
   '/$slug/automations/': typeof AuthenticatedSlugAutomationsIndexRoute
   '/$slug/chat/': typeof AuthenticatedSlugChatIndexRoute
   '/$slug/settings/': typeof AuthenticatedSlugSettingsIndexRoute
@@ -647,6 +661,7 @@ export interface FileRoutesByTo {
   '/api/oauth/finalize': typeof ApiOauthFinalizeRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
+  '/api/v1/signals': typeof ApiV1SignalsRouteWithChildren
   '/oauth/$client/start': typeof OauthClientStartRoute
   '/oauth/register/$clientId': typeof OauthRegisterClientIdRoute
   '/$slug': typeof AuthenticatedSlugIndexRoute
@@ -673,6 +688,7 @@ export interface FileRoutesByTo {
   '/api/oauth/$client/config': typeof ApiOauthClientConfigRoute
   '/api/oauth/desktop/session': typeof ApiOauthDesktopSessionRoute
   '/api/skills/index/events': typeof ApiSkillsIndexEventsRoute
+  '/api/v1/signals/$id': typeof ApiV1SignalsIdRoute
   '/$slug/automations': typeof AuthenticatedSlugAutomationsIndexRoute
   '/$slug/chat': typeof AuthenticatedSlugChatIndexRoute
   '/$slug/settings': typeof AuthenticatedSlugSettingsIndexRoute
@@ -728,6 +744,7 @@ export interface FileRoutesById {
   '/api/oauth/finalize': typeof ApiOauthFinalizeRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
+  '/api/v1/signals': typeof ApiV1SignalsRouteWithChildren
   '/oauth/$client/start': typeof OauthClientStartRoute
   '/oauth/register/$clientId': typeof OauthRegisterClientIdRoute
   '/_authenticated/$slug/': typeof AuthenticatedSlugIndexRoute
@@ -756,6 +773,7 @@ export interface FileRoutesById {
   '/api/oauth/$client/config': typeof ApiOauthClientConfigRoute
   '/api/oauth/desktop/session': typeof ApiOauthDesktopSessionRoute
   '/api/skills/index/events': typeof ApiSkillsIndexEventsRoute
+  '/api/v1/signals/$id': typeof ApiV1SignalsIdRoute
   '/_authenticated/$slug/automations/': typeof AuthenticatedSlugAutomationsIndexRoute
   '/_authenticated/$slug/chat/': typeof AuthenticatedSlugChatIndexRoute
   '/_authenticated/$slug/settings/': typeof AuthenticatedSlugSettingsIndexRoute
@@ -812,6 +830,7 @@ export interface FileRouteTypes {
     | '/api/oauth/finalize'
     | '/api/trpc/$'
     | '/api/v1/$'
+    | '/api/v1/signals'
     | '/oauth/$client/start'
     | '/oauth/register/$clientId'
     | '/$slug/'
@@ -840,6 +859,7 @@ export interface FileRouteTypes {
     | '/api/oauth/$client/config'
     | '/api/oauth/desktop/session'
     | '/api/skills/index/events'
+    | '/api/v1/signals/$id'
     | '/$slug/automations/'
     | '/$slug/chat/'
     | '/$slug/settings/'
@@ -888,6 +908,7 @@ export interface FileRouteTypes {
     | '/api/oauth/finalize'
     | '/api/trpc/$'
     | '/api/v1/$'
+    | '/api/v1/signals'
     | '/oauth/$client/start'
     | '/oauth/register/$clientId'
     | '/$slug'
@@ -914,6 +935,7 @@ export interface FileRouteTypes {
     | '/api/oauth/$client/config'
     | '/api/oauth/desktop/session'
     | '/api/skills/index/events'
+    | '/api/v1/signals/$id'
     | '/$slug/automations'
     | '/$slug/chat'
     | '/$slug/settings'
@@ -968,6 +990,7 @@ export interface FileRouteTypes {
     | '/api/oauth/finalize'
     | '/api/trpc/$'
     | '/api/v1/$'
+    | '/api/v1/signals'
     | '/oauth/$client/start'
     | '/oauth/register/$clientId'
     | '/_authenticated/$slug/'
@@ -996,6 +1019,7 @@ export interface FileRouteTypes {
     | '/api/oauth/$client/config'
     | '/api/oauth/desktop/session'
     | '/api/skills/index/events'
+    | '/api/v1/signals/$id'
     | '/_authenticated/$slug/automations/'
     | '/_authenticated/$slug/chat/'
     | '/_authenticated/$slug/settings/'
@@ -1038,6 +1062,7 @@ export interface RootRouteChildren {
   ApiOauthFinalizeRoute: typeof ApiOauthFinalizeRoute
   ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute
   ApiV1SplatRoute: typeof ApiV1SplatRoute
+  ApiV1SignalsRoute: typeof ApiV1SignalsRouteWithChildren
   OauthClientStartRoute: typeof OauthClientStartRoute
   ApiConnectorsXMcpRoute: typeof ApiConnectorsXMcpRoute
   ApiGithubOauthCallbackRoute: typeof ApiGithubOauthCallbackRoute
@@ -1188,6 +1213,13 @@ declare module '@tanstack/react-router' {
       path: '/oauth/$client/start'
       fullPath: '/oauth/$client/start'
       preLoaderRoute: typeof OauthClientStartRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/signals': {
+      id: '/api/v1/signals'
+      path: '/api/v1/signals'
+      fullPath: '/api/v1/signals'
+      preLoaderRoute: typeof ApiV1SignalsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/$': {
@@ -1343,6 +1375,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/$slug/automations/'
       preLoaderRoute: typeof AuthenticatedSlugAutomationsIndexRouteImport
       parentRoute: typeof AuthenticatedSlugAutomationsRoute
+    }
+    '/api/v1/signals/$id': {
+      id: '/api/v1/signals/$id'
+      path: '/$id'
+      fullPath: '/api/v1/signals/$id'
+      preLoaderRoute: typeof ApiV1SignalsIdRouteImport
+      parentRoute: typeof ApiV1SignalsRoute
     }
     '/api/skills/index/events': {
       id: '/api/skills/index/events'
@@ -1885,6 +1924,18 @@ const OauthRegisterRouteWithChildren = OauthRegisterRoute._addFileChildren(
   OauthRegisterRouteChildren,
 )
 
+interface ApiV1SignalsRouteChildren {
+  ApiV1SignalsIdRoute: typeof ApiV1SignalsIdRoute
+}
+
+const ApiV1SignalsRouteChildren: ApiV1SignalsRouteChildren = {
+  ApiV1SignalsIdRoute: ApiV1SignalsIdRoute,
+}
+
+const ApiV1SignalsRouteWithChildren = ApiV1SignalsRoute._addFileChildren(
+  ApiV1SignalsRouteChildren,
+)
+
 interface ApiInternalMcpSignalsRouteChildren {
   ApiInternalMcpSignalsGetRoute: typeof ApiInternalMcpSignalsGetRoute
 }
@@ -1919,6 +1970,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOauthFinalizeRoute: ApiOauthFinalizeRoute,
   ApiTrpcSplatRoute: ApiTrpcSplatRoute,
   ApiV1SplatRoute: ApiV1SplatRoute,
+  ApiV1SignalsRoute: ApiV1SignalsRouteWithChildren,
   OauthClientStartRoute: OauthClientStartRoute,
   ApiConnectorsXMcpRoute: ApiConnectorsXMcpRoute,
   ApiGithubOauthCallbackRoute: ApiGithubOauthCallbackRoute,

--- a/apps/app/src/routes/api/v1/signals.ts
+++ b/apps/app/src/routes/api/v1/signals.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/v1/signals")({
+  server: {
+    handlers: {
+      OPTIONS: async () => {
+        const { handlePublicApiOptionsRequest } = await import(
+          "@api/app/public-api/signals"
+        );
+        return handlePublicApiOptionsRequest();
+      },
+      POST: async ({ request }) => {
+        const { handleCreateSignalPublicApiRequest } = await import(
+          "@api/app/public-api/signals"
+        );
+        return handleCreateSignalPublicApiRequest(request);
+      },
+    },
+  },
+});

--- a/apps/app/src/routes/api/v1/signals/$id.ts
+++ b/apps/app/src/routes/api/v1/signals/$id.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/v1/signals/$id")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { handleGetSignalPublicApiRequest } = await import(
+          "@api/app/public-api/signals"
+        );
+        return handleGetSignalPublicApiRequest(request, { id: params.id });
+      },
+      OPTIONS: async () => {
+        const { handlePublicApiOptionsRequest } = await import(
+          "@api/app/public-api/signals"
+        );
+        return handlePublicApiOptionsRequest();
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add explicit @api/app public signal API handlers for POST /api/v1/signals and GET /api/v1/signals/:id with API-key auth and org setup gating.
- Mount thin TanStack Start route files in apps/app that delegate to @api/app/public-api/signals while keeping the oRPC catch-all as a temporary fallback.
- Add public API boundary/source tests and handler behavior coverage, plus regenerate the app route tree.

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/public-signals-api.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/public-api-routes-source.test.ts src/__tests__/migration-readiness.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm --filter lightfast test -- src/__tests__/client.test.ts
- pnpm --filter @lightfast/app build
- pnpm check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public API endpoints to create and retrieve signals via HTTP requests.
  * Implemented CORS support for cross-origin signal API access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->