### PR TITLE
Add explicit public health API route

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -41,6 +41,10 @@
       "types": "./src/adapters/public/signals.ts",
       "default": "./src/adapters/public/signals.ts"
     },
+    "./public-api/system": {
+      "types": "./src/adapters/public/system.ts",
+      "default": "./src/adapters/public/system.ts"
+    },
     "./tanstack/signals": {
       "types": "./src/adapters/tanstack/signals.ts",
       "default": "./src/adapters/tanstack/signals.ts"

--- a/api/app/src/__tests__/public-system-api.test.ts
+++ b/api/app/src/__tests__/public-system-api.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getActiveOrgBinding: vi.fn(),
+  getCurrentOrgConnectorConnection: vi.fn(),
+  verifyKey: vi.fn(),
+}));
+
+vi.mock("@vendor/unkey/server", () => ({
+  getUnkeyClient: () => ({
+    keys: { verifyKey: mocks.verifyKey },
+  }),
+}));
+
+vi.mock("@db/app/client", () => ({ db: { kind: "mock-db" } }));
+vi.mock("@db/app", () => ({
+  getActiveOrgBinding: mocks.getActiveOrgBinding,
+  getCurrentOrgConnectorConnection: mocks.getCurrentOrgConnectorConnection,
+}));
+
+const { handlePublicApiOptionsRequest, handleSystemHealthPublicApiRequest } =
+  await import("../adapters/public/system");
+
+const validKey = `lf_${"a".repeat(40)}`;
+
+function verifyResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    data: {
+      code: "VALID",
+      identity: { externalId: "org_test", id: "identity_test" },
+      keyId: "key_test",
+      meta: { createdByUserId: "user_test" },
+      valid: true,
+      ...overrides,
+    },
+    meta: { requestId: "req_test" },
+  };
+}
+
+function publicApiRequest(input: { token?: string } = {}) {
+  const headers = new Headers();
+  if (input.token) {
+    headers.set("authorization", `Bearer ${input.token}`);
+  }
+
+  return new Request("https://lightfast.test/api/v1/system/health", {
+    headers,
+    method: "GET",
+  });
+}
+
+async function responseJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.verifyKey.mockResolvedValue(verifyResult());
+  mocks.getCurrentOrgConnectorConnection.mockResolvedValue({
+    status: "active",
+  });
+  mocks.getActiveOrgBinding.mockResolvedValue({
+    metadata: {
+      lightfastRepository: {
+        fullName: "acme/.lightfast",
+        id: "987",
+        installationId: "1001",
+        name: ".lightfast",
+        verifiedAt: "2026-05-30T10:00:00.000Z",
+      },
+    },
+    provider: "github",
+    providerAccountLogin: "acme",
+    providerInstallationId: "1001",
+  });
+});
+
+describe("public system API adapter", () => {
+  it("answers CORS preflight without touching auth", () => {
+    const response = handlePublicApiOptionsRequest();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(mocks.verifyKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects health requests without an API key", async () => {
+    const response = await handleSystemHealthPublicApiRequest(
+      publicApiRequest()
+    );
+
+    expect(response.status).toBe(401);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "auth_required",
+    });
+  });
+
+  it("returns health for a valid org API key", async () => {
+    const response = await handleSystemHealthPublicApiRequest(
+      publicApiRequest({ token: validKey })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+    const body = await responseJson(response);
+    expect(body).toMatchObject({
+      status: "ok",
+      version: expect.any(String),
+      timestamp: expect.any(String),
+    });
+    expect(Date.parse(String(body.timestamp))).not.toBeNaN();
+  });
+
+  it("does not require completed org setup for connectivity checks", async () => {
+    mocks.getActiveOrgBinding.mockResolvedValueOnce(undefined);
+
+    const response = await handleSystemHealthPublicApiRequest(
+      publicApiRequest({ token: validKey })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      status: "ok",
+    });
+  });
+});

--- a/api/app/src/adapters/public/system.ts
+++ b/api/app/src/adapters/public/system.ts
@@ -1,0 +1,75 @@
+import { db } from "@db/app/client";
+import { systemHealthOutput } from "@repo/api-contract";
+
+import { isApiKeyAuthError, resolveApiKeyAuth } from "../../auth/api-key";
+
+const SDK_VERSION = "0.1.0";
+
+type PublicApiStatus = 401 | 403 | 500;
+
+function withPublicApiCors(response: Response): Response {
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set(
+    "Access-Control-Allow-Methods",
+    "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+  );
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "authorization,content-type"
+  );
+  response.headers.set("Access-Control-Max-Age", "86400");
+  return response;
+}
+
+function jsonResponse(data: unknown, status: number): Response {
+  return withPublicApiCors(Response.json(data, { status }));
+}
+
+function jsonError(
+  error: string,
+  message: string,
+  status: PublicApiStatus,
+  extra?: Record<string, unknown>
+): Response {
+  return jsonResponse({ error, message, ...extra }, status);
+}
+
+function authErrorResponse(error: unknown): Response {
+  if (!isApiKeyAuthError(error)) {
+    return jsonError(
+      "internal_error",
+      "Failed to authenticate API request.",
+      500
+    );
+  }
+
+  return jsonError(
+    error.orpcCode === "FORBIDDEN" ? "forbidden" : "auth_required",
+    error.message,
+    error.orpcCode === "FORBIDDEN" ? 403 : 401,
+    { diagnostics: [error.diagnostic] }
+  );
+}
+
+export function handlePublicApiOptionsRequest(): Response {
+  return withPublicApiCors(new Response(null, { status: 204 }));
+}
+
+export async function handleSystemHealthPublicApiRequest(
+  request: Request
+): Promise<Response> {
+  try {
+    await resolveApiKeyAuth({ db, headers: request.headers });
+  } catch (error) {
+    return authErrorResponse(error);
+  }
+
+  return jsonResponse(
+    systemHealthOutput.parse({
+      status: "ok",
+      timestamp: new Date().toISOString(),
+      version: SDK_VERSION,
+    }),
+    200
+  );
+}

--- a/apps/app/src/__tests__/migration-readiness.test.ts
+++ b/apps/app/src/__tests__/migration-readiness.test.ts
@@ -64,6 +64,7 @@ const migratedNextAppRoutes = [
   "/api/v1/$",
   "/api/v1/signals",
   "/api/v1/signals/$",
+  "/api/v1/system/health",
   "/oauth/$/start",
   "/oauth/authorize",
   "/oauth/jwks",
@@ -128,7 +129,7 @@ describe("app migration readiness", () => {
   it("declares TanStack routes for every migrated legacy Next route", () => {
     const tanstackRoutes = new Set(tanstackRouteDeclarations());
 
-    expect(migratedNextAppRoutes.length).toBe(68);
+    expect(migratedNextAppRoutes.length).toBe(69);
     expect(tanstackRoutes.size).toBeGreaterThan(0);
     expect(
       migratedNextAppRoutes.filter((route) => !tanstackRoutes.has(route))

--- a/apps/app/src/__tests__/public-api-routes-source.test.ts
+++ b/apps/app/src/__tests__/public-api-routes-source.test.ts
@@ -41,6 +41,23 @@ describe("public API route boundaries", () => {
     }
   });
 
+  it("mounts public system health as a thin app-owned route file", () => {
+    const healthPath = resolve(appRoot, "src/routes/api/v1/system/health.ts");
+
+    expect(existsSync(healthPath)).toBe(true);
+
+    const healthRoute = appSource("src/routes/api/v1/system/health.ts");
+
+    expect(healthRoute).toContain('createFileRoute("/api/v1/system/health")');
+    expect(healthRoute).toContain('@api/app/public-api/system"');
+    expect(healthRoute).toContain("handleSystemHealthPublicApiRequest");
+    expect(healthRoute).toContain("handlePublicApiOptionsRequest");
+    expect(healthRoute).not.toContain("OpenAPIHandler");
+    expect(healthRoute).not.toContain("orpcRouter");
+    expect(healthRoute).not.toContain("@db/app");
+    expect(healthRoute).not.toContain("resolveApiKeyAuth");
+  });
+
   it("keeps public signal behavior in an explicit api/app adapter", () => {
     const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
       exports?: Record<string, unknown>;
@@ -52,6 +69,20 @@ describe("public API route boundaries", () => {
     expect(adapter).toContain("createSignalInput");
     expect(adapter).toContain("getSignalOutput.parse");
     expect(adapter).toContain("createSignalForActor");
+    expect(adapter).not.toContain("ORPCError");
+    expect(adapter).not.toContain("@orpc/");
+    expect(adapter).not.toContain("OpenAPIHandler");
+  });
+
+  it("keeps public system health behavior in an explicit api/app adapter", () => {
+    const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports?: Record<string, unknown>;
+    };
+    const adapter = repoSource("api/app/src/adapters/public/system.ts");
+
+    expect(packageJson.exports).toHaveProperty("./public-api/system");
+    expect(adapter).toContain("resolveApiKeyAuth");
+    expect(adapter).toContain("systemHealthOutput.parse");
     expect(adapter).not.toContain("ORPCError");
     expect(adapter).not.toContain("@orpc/");
     expect(adapter).not.toContain("OpenAPIHandler");

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -51,6 +51,7 @@ import { Route as AuthenticatedSlugTasksIndexRouteImport } from './routes/_authe
 import { Route as AuthenticatedSlugSettingsIndexRouteImport } from './routes/_authenticated/$slug/settings/index'
 import { Route as AuthenticatedSlugChatIndexRouteImport } from './routes/_authenticated/$slug/chat/index'
 import { Route as AuthenticatedSlugAutomationsIndexRouteImport } from './routes/_authenticated/$slug/automations/index'
+import { Route as ApiV1SystemHealthRouteImport } from './routes/api/v1/system/health'
 import { Route as ApiV1SignalsIdRouteImport } from './routes/api/v1/signals/$id'
 import { Route as ApiSkillsIndexEventsRouteImport } from './routes/api/skills/index/events'
 import { Route as ApiOauthDesktopSessionRouteImport } from './routes/api/oauth/desktop/session'
@@ -315,6 +316,11 @@ const AuthenticatedSlugAutomationsIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedSlugAutomationsRoute,
   } as any)
+const ApiV1SystemHealthRoute = ApiV1SystemHealthRouteImport.update({
+  id: '/api/v1/system/health',
+  path: '/api/v1/system/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1SignalsIdRoute = ApiV1SignalsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -613,6 +619,7 @@ export interface FileRoutesByFullPath {
   '/api/oauth/desktop/session': typeof ApiOauthDesktopSessionRoute
   '/api/skills/index/events': typeof ApiSkillsIndexEventsRoute
   '/api/v1/signals/$id': typeof ApiV1SignalsIdRoute
+  '/api/v1/system/health': typeof ApiV1SystemHealthRoute
   '/$slug/automations/': typeof AuthenticatedSlugAutomationsIndexRoute
   '/$slug/chat/': typeof AuthenticatedSlugChatIndexRoute
   '/$slug/settings/': typeof AuthenticatedSlugSettingsIndexRoute
@@ -689,6 +696,7 @@ export interface FileRoutesByTo {
   '/api/oauth/desktop/session': typeof ApiOauthDesktopSessionRoute
   '/api/skills/index/events': typeof ApiSkillsIndexEventsRoute
   '/api/v1/signals/$id': typeof ApiV1SignalsIdRoute
+  '/api/v1/system/health': typeof ApiV1SystemHealthRoute
   '/$slug/automations': typeof AuthenticatedSlugAutomationsIndexRoute
   '/$slug/chat': typeof AuthenticatedSlugChatIndexRoute
   '/$slug/settings': typeof AuthenticatedSlugSettingsIndexRoute
@@ -774,6 +782,7 @@ export interface FileRoutesById {
   '/api/oauth/desktop/session': typeof ApiOauthDesktopSessionRoute
   '/api/skills/index/events': typeof ApiSkillsIndexEventsRoute
   '/api/v1/signals/$id': typeof ApiV1SignalsIdRoute
+  '/api/v1/system/health': typeof ApiV1SystemHealthRoute
   '/_authenticated/$slug/automations/': typeof AuthenticatedSlugAutomationsIndexRoute
   '/_authenticated/$slug/chat/': typeof AuthenticatedSlugChatIndexRoute
   '/_authenticated/$slug/settings/': typeof AuthenticatedSlugSettingsIndexRoute
@@ -860,6 +869,7 @@ export interface FileRouteTypes {
     | '/api/oauth/desktop/session'
     | '/api/skills/index/events'
     | '/api/v1/signals/$id'
+    | '/api/v1/system/health'
     | '/$slug/automations/'
     | '/$slug/chat/'
     | '/$slug/settings/'
@@ -936,6 +946,7 @@ export interface FileRouteTypes {
     | '/api/oauth/desktop/session'
     | '/api/skills/index/events'
     | '/api/v1/signals/$id'
+    | '/api/v1/system/health'
     | '/$slug/automations'
     | '/$slug/chat'
     | '/$slug/settings'
@@ -1020,6 +1031,7 @@ export interface FileRouteTypes {
     | '/api/oauth/desktop/session'
     | '/api/skills/index/events'
     | '/api/v1/signals/$id'
+    | '/api/v1/system/health'
     | '/_authenticated/$slug/automations/'
     | '/_authenticated/$slug/chat/'
     | '/_authenticated/$slug/settings/'
@@ -1072,6 +1084,7 @@ export interface RootRouteChildren {
   ApiOauthClientConfigRoute: typeof ApiOauthClientConfigRoute
   ApiOauthDesktopSessionRoute: typeof ApiOauthDesktopSessionRoute
   ApiSkillsIndexEventsRoute: typeof ApiSkillsIndexEventsRoute
+  ApiV1SystemHealthRoute: typeof ApiV1SystemHealthRoute
   ApiConnectorsGranolaOauthCallbackRoute: typeof ApiConnectorsGranolaOauthCallbackRoute
   ApiConnectorsLinearOauthCallbackRoute: typeof ApiConnectorsLinearOauthCallbackRoute
   ApiConnectorsXOauthCallbackRoute: typeof ApiConnectorsXOauthCallbackRoute
@@ -1375,6 +1388,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/$slug/automations/'
       preLoaderRoute: typeof AuthenticatedSlugAutomationsIndexRouteImport
       parentRoute: typeof AuthenticatedSlugAutomationsRoute
+    }
+    '/api/v1/system/health': {
+      id: '/api/v1/system/health'
+      path: '/api/v1/system/health'
+      fullPath: '/api/v1/system/health'
+      preLoaderRoute: typeof ApiV1SystemHealthRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/v1/signals/$id': {
       id: '/api/v1/signals/$id'
@@ -1980,6 +2000,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOauthClientConfigRoute: ApiOauthClientConfigRoute,
   ApiOauthDesktopSessionRoute: ApiOauthDesktopSessionRoute,
   ApiSkillsIndexEventsRoute: ApiSkillsIndexEventsRoute,
+  ApiV1SystemHealthRoute: ApiV1SystemHealthRoute,
   ApiConnectorsGranolaOauthCallbackRoute:
     ApiConnectorsGranolaOauthCallbackRoute,
   ApiConnectorsLinearOauthCallbackRoute: ApiConnectorsLinearOauthCallbackRoute,

--- a/apps/app/src/routes/api/v1/system/health.ts
+++ b/apps/app/src/routes/api/v1/system/health.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/v1/system/health")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { handleSystemHealthPublicApiRequest } = await import(
+          "@api/app/public-api/system"
+        );
+        return handleSystemHealthPublicApiRequest(request);
+      },
+      OPTIONS: async () => {
+        const { handlePublicApiOptionsRequest } = await import(
+          "@api/app/public-api/system"
+        );
+        return handlePublicApiOptionsRequest();
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds an explicit `@api/app/public-api/system` adapter for authenticated `/api/v1/system/health` responses.
- Mounts `/api/v1/system/health` as a thin TanStack route outside the oRPC catch-all.
- Adds boundary/readiness tests so the public health endpoint stays on the explicit public API path.

## Test Plan
- `pnpm --filter @api/app test -- src/__tests__/public-system-api.test.ts`
- `pnpm --filter @api/app test -- src/__tests__/public-system-api.test.ts src/orpc/__tests__/system-health.test.ts`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app test -- src/__tests__/public-api-routes-source.test.ts src/__tests__/migration-readiness.test.ts`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @lightfast/app build`
- `pnpm --filter lightfast test -- src/__tests__/client.test.ts`
- `pnpm check`
- `git diff --check`
