### PR TITLE
Add native RPC surfaces

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -33,6 +33,14 @@
       "types": "./src/native-auth/index.ts",
       "default": "./src/native-auth/index.ts"
     },
+    "./desktop-api": {
+      "types": "./src/adapters/desktop-api.ts",
+      "default": "./src/adapters/desktop-api.ts"
+    },
+    "./cli-api": {
+      "types": "./src/adapters/cli-api.ts",
+      "default": "./src/adapters/cli-api.ts"
+    },
     "./internal-api/mcp-signals": {
       "types": "./src/adapters/internal/mcp-signals.ts",
       "default": "./src/adapters/internal/mcp-signals.ts"

--- a/api/app/src/__tests__/native-rpc-adapter.test.ts
+++ b/api/app/src/__tests__/native-rpc-adapter.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class NativeAuthError extends Error {
+    readonly code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED";
+    readonly status: number;
+
+    constructor(input: {
+      code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED";
+      message: string;
+      status: number;
+    }) {
+      super(input.message);
+      this.name = "NativeAuthError";
+      this.code = input.code;
+      this.status = input.status;
+    }
+  }
+
+  return {
+    getNativeAuthSessionForRequest: vi.fn(),
+    NativeAuthError,
+  };
+});
+
+vi.mock("../native-auth", () => ({
+  getNativeAuthSessionForRequest: mocks.getNativeAuthSessionForRequest,
+  isNativeAuthError: (error: unknown) => error instanceof mocks.NativeAuthError,
+}));
+
+const { handleCliNativeRpcRequest } = await import("../adapters/cli-api");
+const { handleDesktopNativeRpcRequest } = await import(
+  "../adapters/desktop-api"
+);
+
+function rpcRequest(body: unknown) {
+  return new Request("https://app.lightfast.test/api/desktop/rpc", {
+    body: JSON.stringify(body),
+    headers: {
+      accept: "application/json",
+      authorization: "Bearer access_test",
+      "content-type": "application/json",
+      "x-lightfast-organization-id": "org_1",
+    },
+    method: "POST",
+  });
+}
+
+const session = {
+  client: "desktop" as const,
+  organization: { id: "org_1", name: "Acme", slug: "acme" },
+  user: {
+    email: "dev@example.com",
+    id: "user_1",
+    imageUrl: "https://img.example.com/user_1.png",
+    initials: "JP",
+    username: "jeevanpillay",
+  },
+};
+
+describe("native RPC adapters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getNativeAuthSessionForRequest.mockResolvedValue(session);
+  });
+
+  it("handles desktop auth.session through the desktop native OAuth source", async () => {
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({ command: "auth.session" })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      result: session,
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(mocks.getNativeAuthSessionForRequest).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      source: "desktop",
+    });
+    const [firstCall] = mocks.getNativeAuthSessionForRequest.mock.calls;
+    expect(firstCall).toBeDefined();
+    const { headers } = firstCall![0];
+    expect(headers.get("authorization")).toBe("Bearer access_test");
+  });
+
+  it("handles CLI auth.session through the CLI native OAuth source", async () => {
+    mocks.getNativeAuthSessionForRequest.mockResolvedValue({
+      ...session,
+      client: "cli",
+    });
+
+    const response = await handleCliNativeRpcRequest(
+      rpcRequest({ command: "auth.session" })
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: { client: "cli", organization: { id: "org_1" } },
+    });
+    expect(mocks.getNativeAuthSessionForRequest).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      source: "cli",
+    });
+  });
+
+  it("rejects command input that is not part of the explicit contract", async () => {
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({
+        command: "auth.session",
+        input: { organizationId: "org_1" },
+      })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "BAD_REQUEST",
+        message: "Native RPC request is invalid.",
+      },
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.getNativeAuthSessionForRequest).not.toHaveBeenCalled();
+  });
+
+  it("maps native OAuth errors to the native RPC error envelope", async () => {
+    mocks.getNativeAuthSessionForRequest.mockRejectedValue(
+      new mocks.NativeAuthError({
+        code: "UNAUTHORIZED",
+        message: "Lightfast native OAuth authentication required.",
+        status: 401,
+      })
+    );
+
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({ command: "auth.session" })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Lightfast native OAuth authentication required.",
+      },
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("treats invalid backend output as an internal native RPC error", async () => {
+    mocks.getNativeAuthSessionForRequest.mockResolvedValue({
+      organization: { id: "org_1", name: "Acme", slug: "acme" },
+      user: { email: "dev@example.com", id: "user_1" },
+    });
+
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({ command: "auth.session" })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unexpected native RPC error",
+      },
+    });
+    expect(response.status).toBe(500);
+  });
+});

--- a/api/app/src/__tests__/native-rpc-adapter.test.ts
+++ b/api/app/src/__tests__/native-rpc-adapter.test.ts
@@ -125,13 +125,48 @@ describe("native RPC adapters", () => {
     expect(mocks.getNativeAuthSessionForRequest).not.toHaveBeenCalled();
   });
 
-  it("maps native OAuth errors to the native RPC error envelope", async () => {
+  it("rejects explicit null command input", async () => {
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({ command: "auth.session", input: null })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "BAD_REQUEST",
+        message: "Native RPC request is invalid.",
+      },
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.getNativeAuthSessionForRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      code: "FORBIDDEN" as const,
+      label: "missing organization",
+      message: "Native session organization required",
+      status: 403,
+    },
+    {
+      code: "FORBIDDEN" as const,
+      label: "wrong organization",
+      message: "User is not a member of the selected organization",
+      status: 403,
+    },
+    {
+      code: "UNAUTHORIZED" as const,
+      label: "expired token",
+      message: "Lightfast native OAuth authentication required.",
+      status: 401,
+    },
+  ])("maps native OAuth $label errors to the native RPC error envelope", async ({
+    code,
+    message,
+    status,
+  }) => {
     mocks.getNativeAuthSessionForRequest.mockRejectedValue(
-      new mocks.NativeAuthError({
-        code: "UNAUTHORIZED",
-        message: "Lightfast native OAuth authentication required.",
-        status: 401,
-      })
+      new mocks.NativeAuthError({ code, message, status })
     );
 
     const response = await handleDesktopNativeRpcRequest(
@@ -141,11 +176,11 @@ describe("native RPC adapters", () => {
     await expect(response.json()).resolves.toEqual({
       ok: false,
       error: {
-        code: "UNAUTHORIZED",
-        message: "Lightfast native OAuth authentication required.",
+        code,
+        message,
       },
     });
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(status);
   });
 
   it("treats invalid backend output as an internal native RPC error", async () => {

--- a/api/app/src/adapters/cli-api.ts
+++ b/api/app/src/adapters/cli-api.ts
@@ -1,0 +1,10 @@
+import { handleNativeRpcRequest } from "./native-rpc";
+
+const cliNativeRpcCommands = ["auth.session"] as const;
+
+export function handleCliNativeRpcRequest(request: Request) {
+  return handleNativeRpcRequest(request, {
+    allowedCommands: cliNativeRpcCommands,
+    source: "cli",
+  });
+}

--- a/api/app/src/adapters/desktop-api.ts
+++ b/api/app/src/adapters/desktop-api.ts
@@ -1,0 +1,10 @@
+import { handleNativeRpcRequest } from "./native-rpc";
+
+const desktopNativeRpcCommands = ["auth.session"] as const;
+
+export function handleDesktopNativeRpcRequest(request: Request) {
+  return handleNativeRpcRequest(request, {
+    allowedCommands: desktopNativeRpcCommands,
+    source: "desktop",
+  });
+}

--- a/api/app/src/adapters/native-rpc.ts
+++ b/api/app/src/adapters/native-rpc.ts
@@ -86,9 +86,9 @@ export async function handleNativeRpcRequest(
   try {
     switch (parsedRequest.data.command) {
       case "auth.session": {
-        const parsedInput = nativeRpcAuthSessionInputSchema.safeParse(
-          parsedRequest.data.input ?? {}
-        );
+        const input =
+          "input" in parsedRequest.data ? parsedRequest.data.input : {};
+        const parsedInput = nativeRpcAuthSessionInputSchema.safeParse(input);
         if (!parsedInput.success) {
           return invalidRequestResponse();
         }

--- a/api/app/src/adapters/native-rpc.ts
+++ b/api/app/src/adapters/native-rpc.ts
@@ -1,0 +1,117 @@
+import {
+  type NativeClient,
+  type NativeRpcCommand,
+  type NativeRpcErrorCode,
+  nativeRpcAuthSessionInputSchema,
+  nativeRpcAuthSessionSuccessResponseSchema,
+  nativeRpcErrorResponseSchema,
+  nativeRpcRequestSchema,
+} from "@repo/native-auth-contract";
+
+import {
+  getNativeAuthSessionForRequest,
+  isNativeAuthError,
+} from "../native-auth";
+
+type NativeRpcStatus = 400 | 401 | 403 | 404 | 500;
+
+interface NativeRpcSurface {
+  allowedCommands: readonly NativeRpcCommand[];
+  source: NativeClient;
+}
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("cache-control", "no-store");
+  headers.set("content-type", "application/json");
+  headers.set("vary", "Authorization");
+
+  return Response.json(data, { ...init, headers });
+}
+
+function errorResponse(
+  code: NativeRpcErrorCode,
+  message: string,
+  status: NativeRpcStatus
+) {
+  return jsonResponse(
+    nativeRpcErrorResponseSchema.parse({
+      ok: false,
+      error: { code, message },
+    }),
+    { status }
+  );
+}
+
+function invalidRequestResponse() {
+  return errorResponse("BAD_REQUEST", "Native RPC request is invalid.", 400);
+}
+
+function normalizeErrorResponse(error: unknown) {
+  if (isNativeAuthError(error)) {
+    return errorResponse(
+      error.code,
+      error.status >= 500 ? "Unexpected native RPC error" : error.message,
+      error.status as NativeRpcStatus
+    );
+  }
+
+  console.error("[native-rpc] Unexpected route error", error);
+  return errorResponse(
+    "INTERNAL_SERVER_ERROR",
+    "Unexpected native RPC error",
+    500
+  );
+}
+
+export async function handleNativeRpcRequest(
+  request: Request,
+  surface: NativeRpcSurface
+): Promise<Response> {
+  const parsedRequest = nativeRpcRequestSchema.safeParse(
+    await request.json().catch(() => undefined)
+  );
+  if (!parsedRequest.success) {
+    return invalidRequestResponse();
+  }
+
+  if (!surface.allowedCommands.includes(parsedRequest.data.command)) {
+    return errorResponse(
+      "COMMAND_NOT_FOUND",
+      "Native RPC command was not found.",
+      404
+    );
+  }
+
+  try {
+    switch (parsedRequest.data.command) {
+      case "auth.session": {
+        const parsedInput = nativeRpcAuthSessionInputSchema.safeParse(
+          parsedRequest.data.input ?? {}
+        );
+        if (!parsedInput.success) {
+          return invalidRequestResponse();
+        }
+
+        const result = await getNativeAuthSessionForRequest({
+          headers: request.headers,
+          source: surface.source,
+        });
+        return jsonResponse(
+          nativeRpcAuthSessionSuccessResponseSchema.parse({
+            ok: true,
+            result,
+          })
+        );
+      }
+      default:
+        return errorResponse(
+          "COMMAND_NOT_FOUND",
+          "Native RPC command was not found.",
+          404
+        );
+    }
+  } catch (error) {
+    return normalizeErrorResponse(error);
+  }
+}

--- a/apps/app/src/__tests__/migration-readiness.test.ts
+++ b/apps/app/src/__tests__/migration-readiness.test.ts
@@ -41,10 +41,12 @@ const migratedNextAppRoutes = [
   "/account/teams/new",
   "/api/chat",
   "/api/chat/$/stream",
+  "/api/cli/rpc",
   "/api/connectors/granola/oauth/callback",
   "/api/connectors/linear/oauth/callback",
   "/api/connectors/x/mcp",
   "/api/connectors/x/oauth/callback",
+  "/api/desktop/rpc",
   "/api/github/oauth/callback",
   "/api/github/setup",
   "/api/github/user/oauth/callback",
@@ -128,7 +130,7 @@ describe("app migration readiness", () => {
   it("declares TanStack routes for every migrated legacy Next route", () => {
     const tanstackRoutes = new Set(tanstackRouteDeclarations());
 
-    expect(migratedNextAppRoutes.length).toBe(68);
+    expect(migratedNextAppRoutes.length).toBe(70);
     expect(tanstackRoutes.size).toBeGreaterThan(0);
     expect(
       migratedNextAppRoutes.filter((route) => !tanstackRoutes.has(route))

--- a/apps/app/src/__tests__/native-rpc-routes-source.test.ts
+++ b/apps/app/src/__tests__/native-rpc-routes-source.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const appRoot = resolve(repoRoot, "apps/app");
+
+function appSource(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("native RPC route boundaries", () => {
+  it("mounts desktop and CLI RPC endpoints as thin app-owned route files", () => {
+    const desktopPath = resolve(appRoot, "src/routes/api/desktop/rpc.ts");
+    const cliPath = resolve(appRoot, "src/routes/api/cli/rpc.ts");
+
+    expect(existsSync(desktopPath)).toBe(true);
+    expect(existsSync(cliPath)).toBe(true);
+
+    const desktopRoute = appSource("src/routes/api/desktop/rpc.ts");
+    const cliRoute = appSource("src/routes/api/cli/rpc.ts");
+
+    expect(desktopRoute).toContain('createFileRoute("/api/desktop/rpc")');
+    expect(desktopRoute).toContain('@api/app/desktop-api"');
+    expect(desktopRoute).toContain("handleDesktopNativeRpcRequest");
+    expect(cliRoute).toContain('createFileRoute("/api/cli/rpc")');
+    expect(cliRoute).toContain('@api/app/cli-api"');
+    expect(cliRoute).toContain("handleCliNativeRpcRequest");
+
+    for (const source of [desktopRoute, cliRoute]) {
+      expect(source).not.toContain("getNativeAuthSessionForRequest");
+      expect(source).not.toContain("@db/app");
+      expect(source).not.toContain("@repo/provider-routine");
+      expect(source).not.toContain("resolveAuthContextFromClerk");
+    }
+  });
+
+  it("keeps native RPC behavior in explicit api/app adapter entrypoints", () => {
+    const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports?: Record<string, unknown>;
+    };
+    const desktopAdapter = repoSource("api/app/src/adapters/desktop-api.ts");
+    const cliAdapter = repoSource("api/app/src/adapters/cli-api.ts");
+    const sharedAdapter = repoSource("api/app/src/adapters/native-rpc.ts");
+
+    expect(packageJson.exports).toHaveProperty("./desktop-api");
+    expect(packageJson.exports).toHaveProperty("./cli-api");
+    expect(desktopAdapter).toContain("desktopNativeRpcCommands");
+    expect(desktopAdapter).toContain('"auth.session"');
+    expect(desktopAdapter).toContain('source: "desktop"');
+    expect(cliAdapter).toContain("cliNativeRpcCommands");
+    expect(cliAdapter).toContain('"auth.session"');
+    expect(cliAdapter).toContain('source: "cli"');
+    expect(sharedAdapter).toContain("getNativeAuthSessionForRequest");
+    expect(sharedAdapter).toContain("nativeRpcRequestSchema");
+    expect(sharedAdapter).toContain("nativeRpcAuthSessionInputSchema");
+    expect(sharedAdapter).not.toContain("/api/v1/rpc");
+  });
+
+  it("leaves native provider proxy routes as separate CLI plumbing", () => {
+    expect(
+      existsSync(resolve(appRoot, "src/routes/api/native/proxy/call.ts"))
+    ).toBe(true);
+    expect(
+      existsSync(resolve(appRoot, "src/routes/api/native/proxy/routines.ts"))
+    ).toBe(true);
+
+    const proxyCallRoute = appSource("src/routes/api/native/proxy/call.ts");
+    const proxyFindRoute = appSource("src/routes/api/native/proxy/routines.ts");
+
+    expect(proxyCallRoute).toContain("@repo/provider-routine-contract");
+    expect(proxyFindRoute).toContain("@repo/provider-routine-contract");
+    expect(proxyCallRoute).not.toContain('@api/app/cli-api"');
+    expect(proxyFindRoute).not.toContain('@api/app/cli-api"');
+  });
+});

--- a/apps/app/src/__tests__/start-middleware.test.ts
+++ b/apps/app/src/__tests__/start-middleware.test.ts
@@ -23,10 +23,8 @@ describe("app start middleware", () => {
   });
 
   it("classifies app-owned API routes that handle their own auth", () => {
-    expect(isAppOwnedApiRoute("/api/cli/rpc")).toBe(true);
     expect(isAppOwnedApiRoute("/api/connectors/x/mcp")).toBe(true);
     expect(isAppOwnedApiRoute("/api/connectors/x/mcp/messages")).toBe(true);
-    expect(isAppOwnedApiRoute("/api/desktop/rpc")).toBe(true);
     expect(isAppOwnedApiRoute("/api/inngest")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/proxy/call")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/proxy/find")).toBe(true);
@@ -40,10 +38,12 @@ describe("app start middleware", () => {
     expect(isAppOwnedApiRoute("/api/trpc/org.workspace.connectors.list")).toBe(
       false
     );
+    expect(isAppOwnedApiRoute("/api/cli/rpc")).toBe(false);
     expect(isAppOwnedApiRoute("/api/connectors/x/oauth/callback")).toBe(false);
     expect(isAppOwnedApiRoute("/api/connectors/linear/oauth/callback")).toBe(
       false
     );
+    expect(isAppOwnedApiRoute("/api/desktop/rpc")).toBe(false);
     expect(isAppOwnedApiRoute("/api/github/oauth/callback")).toBe(false);
     expect(isAppOwnedApiRoute("/api/github/webhook")).toBe(false);
     expect(isAppOwnedApiRoute("/api/native/proxy/routines")).toBe(false);

--- a/apps/app/src/__tests__/start-middleware.test.ts
+++ b/apps/app/src/__tests__/start-middleware.test.ts
@@ -23,8 +23,10 @@ describe("app start middleware", () => {
   });
 
   it("classifies app-owned API routes that handle their own auth", () => {
+    expect(isAppOwnedApiRoute("/api/cli/rpc")).toBe(true);
     expect(isAppOwnedApiRoute("/api/connectors/x/mcp")).toBe(true);
     expect(isAppOwnedApiRoute("/api/connectors/x/mcp/messages")).toBe(true);
+    expect(isAppOwnedApiRoute("/api/desktop/rpc")).toBe(true);
     expect(isAppOwnedApiRoute("/api/inngest")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/proxy/call")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/proxy/find")).toBe(true);

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -33,6 +33,8 @@ import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc.$'
 import { Route as ApiOauthFinalizeRouteImport } from './routes/api/oauth/finalize'
 import { Route as ApiGithubWebhookRouteImport } from './routes/api/github/webhook'
 import { Route as ApiGithubSetupRouteImport } from './routes/api/github/setup'
+import { Route as ApiDesktopRpcRouteImport } from './routes/api/desktop/rpc'
+import { Route as ApiCliRpcRouteImport } from './routes/api/cli/rpc'
 import { Route as AuthenticatedAccountSettingsRouteImport } from './routes/_authenticated/account/settings'
 import { Route as AuthenticatedAccountMcpRouteImport } from './routes/_authenticated/account/mcp'
 import { Route as AuthenticatedSlugTasksRouteImport } from './routes/_authenticated/$slug/tasks'
@@ -211,6 +213,16 @@ const ApiGithubWebhookRoute = ApiGithubWebhookRouteImport.update({
 const ApiGithubSetupRoute = ApiGithubSetupRouteImport.update({
   id: '/api/github/setup',
   path: '/api/github/setup',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDesktopRpcRoute = ApiDesktopRpcRouteImport.update({
+  id: '/api/desktop/rpc',
+  path: '/api/desktop/rpc',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiCliRpcRoute = ApiCliRpcRouteImport.update({
+  id: '/api/cli/rpc',
+  path: '/api/cli/rpc',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedAccountSettingsRoute =
@@ -578,6 +590,8 @@ export interface FileRoutesByFullPath {
   '/$slug/tasks': typeof AuthenticatedSlugTasksRouteWithChildren
   '/account/mcp': typeof AuthenticatedAccountMcpRoute
   '/account/settings': typeof AuthenticatedAccountSettingsRouteWithChildren
+  '/api/cli/rpc': typeof ApiCliRpcRoute
+  '/api/desktop/rpc': typeof ApiDesktopRpcRoute
   '/api/github/setup': typeof ApiGithubSetupRoute
   '/api/github/webhook': typeof ApiGithubWebhookRoute
   '/api/oauth/finalize': typeof ApiOauthFinalizeRoute
@@ -656,6 +670,8 @@ export interface FileRoutesByTo {
   '/$slug/signals': typeof AuthenticatedSlugSignalsRoute
   '/$slug/skills': typeof AuthenticatedSlugSkillsRoute
   '/account/mcp': typeof AuthenticatedAccountMcpRoute
+  '/api/cli/rpc': typeof ApiCliRpcRoute
+  '/api/desktop/rpc': typeof ApiDesktopRpcRoute
   '/api/github/setup': typeof ApiGithubSetupRoute
   '/api/github/webhook': typeof ApiGithubWebhookRoute
   '/api/oauth/finalize': typeof ApiOauthFinalizeRoute
@@ -739,6 +755,8 @@ export interface FileRoutesById {
   '/_authenticated/$slug/tasks': typeof AuthenticatedSlugTasksRouteWithChildren
   '/_authenticated/account/mcp': typeof AuthenticatedAccountMcpRoute
   '/_authenticated/account/settings': typeof AuthenticatedAccountSettingsRouteWithChildren
+  '/api/cli/rpc': typeof ApiCliRpcRoute
+  '/api/desktop/rpc': typeof ApiDesktopRpcRoute
   '/api/github/setup': typeof ApiGithubSetupRoute
   '/api/github/webhook': typeof ApiGithubWebhookRoute
   '/api/oauth/finalize': typeof ApiOauthFinalizeRoute
@@ -825,6 +843,8 @@ export interface FileRouteTypes {
     | '/$slug/tasks'
     | '/account/mcp'
     | '/account/settings'
+    | '/api/cli/rpc'
+    | '/api/desktop/rpc'
     | '/api/github/setup'
     | '/api/github/webhook'
     | '/api/oauth/finalize'
@@ -903,6 +923,8 @@ export interface FileRouteTypes {
     | '/$slug/signals'
     | '/$slug/skills'
     | '/account/mcp'
+    | '/api/cli/rpc'
+    | '/api/desktop/rpc'
     | '/api/github/setup'
     | '/api/github/webhook'
     | '/api/oauth/finalize'
@@ -985,6 +1007,8 @@ export interface FileRouteTypes {
     | '/_authenticated/$slug/tasks'
     | '/_authenticated/account/mcp'
     | '/_authenticated/account/settings'
+    | '/api/cli/rpc'
+    | '/api/desktop/rpc'
     | '/api/github/setup'
     | '/api/github/webhook'
     | '/api/oauth/finalize'
@@ -1057,6 +1081,8 @@ export interface RootRouteChildren {
   OauthRevokeRoute: typeof OauthRevokeRoute
   OauthTokenRoute: typeof OauthTokenRoute
   SignUpAcceptInvitationRoute: typeof SignUpAcceptInvitationRoute
+  ApiCliRpcRoute: typeof ApiCliRpcRoute
+  ApiDesktopRpcRoute: typeof ApiDesktopRpcRoute
   ApiGithubSetupRoute: typeof ApiGithubSetupRoute
   ApiGithubWebhookRoute: typeof ApiGithubWebhookRoute
   ApiOauthFinalizeRoute: typeof ApiOauthFinalizeRoute
@@ -1248,6 +1274,20 @@ declare module '@tanstack/react-router' {
       path: '/api/github/setup'
       fullPath: '/api/github/setup'
       preLoaderRoute: typeof ApiGithubSetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/desktop/rpc': {
+      id: '/api/desktop/rpc'
+      path: '/api/desktop/rpc'
+      fullPath: '/api/desktop/rpc'
+      preLoaderRoute: typeof ApiDesktopRpcRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/cli/rpc': {
+      id: '/api/cli/rpc'
+      path: '/api/cli/rpc'
+      fullPath: '/api/cli/rpc'
+      preLoaderRoute: typeof ApiCliRpcRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/account/settings': {
@@ -1965,6 +2005,8 @@ const rootRouteChildren: RootRouteChildren = {
   OauthRevokeRoute: OauthRevokeRoute,
   OauthTokenRoute: OauthTokenRoute,
   SignUpAcceptInvitationRoute: SignUpAcceptInvitationRoute,
+  ApiCliRpcRoute: ApiCliRpcRoute,
+  ApiDesktopRpcRoute: ApiDesktopRpcRoute,
   ApiGithubSetupRoute: ApiGithubSetupRoute,
   ApiGithubWebhookRoute: ApiGithubWebhookRoute,
   ApiOauthFinalizeRoute: ApiOauthFinalizeRoute,

--- a/apps/app/src/routes/api/cli/rpc.ts
+++ b/apps/app/src/routes/api/cli/rpc.ts
@@ -1,0 +1,10 @@
+import { handleCliNativeRpcRequest } from "@api/app/cli-api";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/cli/rpc")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handleCliNativeRpcRequest(request),
+    },
+  },
+});

--- a/apps/app/src/routes/api/desktop/rpc.ts
+++ b/apps/app/src/routes/api/desktop/rpc.ts
@@ -1,0 +1,10 @@
+import { handleDesktopNativeRpcRequest } from "@api/app/desktop-api";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/desktop/rpc")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handleDesktopNativeRpcRequest(request),
+    },
+  },
+});

--- a/apps/app/src/start.ts
+++ b/apps/app/src/start.ts
@@ -11,9 +11,7 @@ import {
 import { applySecurityHeaders } from "~/security/headers";
 
 export const APP_OWNED_API_PREFIXES = [
-  "/api/cli/rpc",
   "/api/connectors/x/mcp",
-  "/api/desktop/rpc",
   "/api/inngest",
   "/api/internal/mcp/proxy",
   "/api/internal/mcp/signals",

--- a/apps/app/src/start.ts
+++ b/apps/app/src/start.ts
@@ -11,7 +11,9 @@ import {
 import { applySecurityHeaders } from "~/security/headers";
 
 export const APP_OWNED_API_PREFIXES = [
+  "/api/cli/rpc",
   "/api/connectors/x/mcp",
+  "/api/desktop/rpc",
   "/api/inngest",
   "/api/internal/mcp/proxy",
   "/api/internal/mcp/signals",

--- a/apps/desktop/src/main/native-auth/__tests__/app-client.test.ts
+++ b/apps/desktop/src/main/native-auth/__tests__/app-client.test.ts
@@ -105,6 +105,52 @@ describe("createDesktopNativeAuthClient", () => {
     );
   });
 
+  it.each([
+    {
+      code: "FORBIDDEN",
+      label: "missing organization",
+      message: "Native session organization required",
+      status: 403,
+    },
+    {
+      code: "FORBIDDEN",
+      label: "wrong organization",
+      message: "User is not a member of the selected organization",
+      status: 403,
+    },
+    {
+      code: "UNAUTHORIZED",
+      label: "expired token",
+      message: "Lightfast native OAuth authentication required.",
+      status: 401,
+    },
+  ])("surfaces desktop RPC session $label errors", async ({
+    code,
+    message,
+    status,
+  }) => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      Response.json(
+        {
+          ok: false,
+          error: { code, message },
+        },
+        { status }
+      )
+    );
+
+    const client = createDesktopNativeAuthClient({ fetchImpl });
+
+    await expect(
+      client.session({
+        accessToken: "access",
+        organizationId: "org_1",
+      })
+    ).rejects.toThrow(message);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(netFetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects finalize responses without organization metadata", async () => {
     const fetchImpl = vi.fn().mockResolvedValueOnce(
       Response.json({

--- a/apps/desktop/src/main/native-auth/__tests__/app-client.test.ts
+++ b/apps/desktop/src/main/native-auth/__tests__/app-client.test.ts
@@ -61,17 +61,20 @@ describe("createDesktopNativeAuthClient", () => {
     expect(netFetchMock).not.toHaveBeenCalled();
   });
 
-  it("fetches current desktop session metadata with native auth headers", async () => {
+  it("fetches current desktop session metadata through desktop RPC", async () => {
     const fetchImpl = vi.fn().mockResolvedValueOnce(
       Response.json({
-        client: "desktop",
-        organization: { id: "org_1", name: "Acme", slug: "acme" },
-        user: {
-          email: "dev@example.com",
-          id: "user_1",
-          imageUrl: "https://img.example.com/user_1.png",
-          initials: "JP",
-          username: "jeevanpillay",
+        ok: true,
+        result: {
+          client: "desktop",
+          organization: { id: "org_1", name: "Acme", slug: "acme" },
+          user: {
+            email: "dev@example.com",
+            id: "user_1",
+            imageUrl: "https://img.example.com/user_1.png",
+            initials: "JP",
+            username: "jeevanpillay",
+          },
         },
       })
     );
@@ -87,14 +90,17 @@ describe("createDesktopNativeAuthClient", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      "https://lightfast.localhost/api/oauth/desktop/session",
+      "https://lightfast.localhost/api/desktop/rpc",
       {
+        body: JSON.stringify({ command: "auth.session" }),
         headers: {
           accept: "application/json",
           authorization: "Bearer access",
+          "content-type": "application/json",
           "x-lightfast-native-client": "desktop",
           "x-lightfast-organization-id": "org_1",
         },
+        method: "POST",
       }
     );
   });

--- a/apps/desktop/src/main/native-auth/app-client.ts
+++ b/apps/desktop/src/main/native-auth/app-client.ts
@@ -1,6 +1,7 @@
 import {
   NATIVE_AUTH_HEADERS,
   nativeOAuthConfigSchema,
+  nativeRpcAuthSessionSuccessResponseSchema,
   nativeSessionMetadataSchema,
 } from "@repo/native-auth-contract";
 import { electronNetFetch } from "@vendor/electron/net";
@@ -75,17 +76,24 @@ export function createDesktopNativeAuthClient(
     },
     async session(input: { accessToken: string; organizationId: string }) {
       const response = await fetchImpl(
-        createAppUrl("/api/oauth/desktop/session").toString(),
+        createAppUrl("/api/desktop/rpc").toString(),
         {
+          method: "POST",
           headers: {
             accept: "application/json",
             authorization: `Bearer ${input.accessToken}`,
+            "content-type": "application/json",
             [NATIVE_AUTH_HEADERS.client]: "desktop",
             [NATIVE_AUTH_HEADERS.organizationId]: input.organizationId,
           },
+          body: JSON.stringify({ command: "auth.session" }),
         }
       );
-      return readJson(response, nativeSessionMetadataSchema);
+      const envelope = await readJson(
+        response,
+        nativeRpcAuthSessionSuccessResponseSchema
+      );
+      return envelope.result;
     },
   };
 }

--- a/packages/native-auth-contract/src/__tests__/native-rpc.test.ts
+++ b/packages/native-auth-contract/src/__tests__/native-rpc.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  nativeRpcAuthSessionInputSchema,
+  nativeRpcAuthSessionSuccessResponseSchema,
+  nativeRpcCommandNames,
+  nativeRpcErrorResponseSchema,
+  nativeRpcRequestSchema,
+} from "../native-rpc";
+
+describe("@repo/native-auth-contract native RPC", () => {
+  it("defines a small first-party native command vocabulary", () => {
+    expect(nativeRpcCommandNames).toEqual(["auth.session"]);
+    expect(nativeRpcRequestSchema.parse({ command: "auth.session" })).toEqual({
+      command: "auth.session",
+    });
+    expect(() =>
+      nativeRpcRequestSchema.parse({ command: "signals.list" })
+    ).toThrow();
+  });
+
+  it("keeps auth.session input empty and explicit", () => {
+    expect(nativeRpcAuthSessionInputSchema.parse({})).toEqual({});
+    expect(() =>
+      nativeRpcAuthSessionInputSchema.parse({ organizationId: "org_1" })
+    ).toThrow();
+  });
+
+  it("validates native RPC success and error envelopes", () => {
+    expect(
+      nativeRpcAuthSessionSuccessResponseSchema.parse({
+        ok: true,
+        result: {
+          client: "desktop",
+          organization: { id: "org_1", name: "Acme", slug: "acme" },
+          user: { email: "dev@example.com", id: "user_1" },
+        },
+      })
+    ).toMatchObject({
+      ok: true,
+      result: { client: "desktop", organization: { id: "org_1" } },
+    });
+
+    expect(
+      nativeRpcErrorResponseSchema.parse({
+        ok: false,
+        error: {
+          code: "UNAUTHORIZED",
+          message: "Lightfast native OAuth authentication required.",
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Lightfast native OAuth authentication required.",
+      },
+    });
+  });
+});

--- a/packages/native-auth-contract/src/index.ts
+++ b/packages/native-auth-contract/src/index.ts
@@ -24,3 +24,19 @@ export {
   type TokenSet,
   tokenSetSchema,
 } from "./native-auth";
+
+export {
+  type NativeRpcCommand,
+  type NativeRpcErrorCode,
+  type NativeRpcErrorResponse,
+  type NativeRpcRequest,
+  type NativeRpcSuccessResponse,
+  nativeRpcAuthSessionInputSchema,
+  nativeRpcAuthSessionSuccessResponseSchema,
+  nativeRpcCommandNames,
+  nativeRpcCommandSchema,
+  nativeRpcErrorCodeSchema,
+  nativeRpcErrorResponseSchema,
+  nativeRpcRequestSchema,
+  nativeRpcSuccessResponseSchema,
+} from "./native-rpc";

--- a/packages/native-auth-contract/src/native-rpc.ts
+++ b/packages/native-auth-contract/src/native-rpc.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+import { nativeSessionMetadataSchema } from "./native-auth";
+
+export const nativeRpcCommandNames = ["auth.session"] as const;
+export const nativeRpcCommandSchema = z.enum(nativeRpcCommandNames);
+
+export const nativeRpcRequestSchema = z
+  .object({
+    command: nativeRpcCommandSchema,
+    input: z.unknown().optional(),
+  })
+  .strict();
+
+export const nativeRpcAuthSessionInputSchema = z.object({}).strict();
+
+export const nativeRpcErrorCodeSchema = z.enum([
+  "BAD_REQUEST",
+  "COMMAND_NOT_FOUND",
+  "FORBIDDEN",
+  "INTERNAL_SERVER_ERROR",
+  "UNAUTHORIZED",
+]);
+
+export const nativeRpcErrorResponseSchema = z
+  .object({
+    ok: z.literal(false),
+    error: z
+      .object({
+        code: nativeRpcErrorCodeSchema,
+        message: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const nativeRpcSuccessResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    result: z.unknown(),
+  })
+  .strict();
+
+export const nativeRpcAuthSessionSuccessResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    result: nativeSessionMetadataSchema,
+  })
+  .strict();
+
+export type NativeRpcCommand = z.infer<typeof nativeRpcCommandSchema>;
+export type NativeRpcRequest = z.infer<typeof nativeRpcRequestSchema>;
+export type NativeRpcErrorCode = z.infer<typeof nativeRpcErrorCodeSchema>;
+export type NativeRpcErrorResponse = z.infer<
+  typeof nativeRpcErrorResponseSchema
+>;
+export type NativeRpcSuccessResponse = z.infer<
+  typeof nativeRpcSuccessResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add a small `@repo/native-auth-contract` native RPC protocol with explicit `auth.session` request/success/error schemas.
- Add explicit `@api/app/desktop-api` and `@api/app/cli-api` adapters mounted at `/api/desktop/rpc` and `/api/cli/rpc` through thin TanStack route files.
- Move desktop main session refresh to `/api/desktop/rpc` while preserving renderer credential blindness and leaving `/api/native/proxy/*` intact.

## Test Plan
- `pnpm --filter @repo/native-auth-contract test -- src/__tests__/native-rpc.test.ts && pnpm --filter @repo/native-auth-contract typecheck`
- `pnpm --filter @api/app test -- src/__tests__/native-rpc-adapter.test.ts && pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app test -- src/__tests__/native-rpc-routes-source.test.ts src/__tests__/migration-readiness.test.ts src/__tests__/start-middleware.test.ts && pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @lightfast/desktop test -- src/main/native-auth/__tests__/app-client.test.ts src/renderer/__tests__/desktop-auth-boundary-source.test.ts && pnpm --filter @lightfast/desktop typecheck`
- `pnpm check`
- `SKIP_ENV_VALIDATION=true pnpm typecheck`
- `git diff --check`
- Agent-browser live smoke against local TanStack app: POST `/api/desktop/rpc` and `/api/cli/rpc` invalid `auth.session` input both returned `{ ok: false, error: { code: "BAD_REQUEST", message: "Native RPC request is invalid." } }` with status 400.

## Notes
- `SKIP_ENV_VALIDATION=true pnpm knip` still exits non-zero due existing repository-wide unused-file/dependency/export drift; filtered output for `nativeRpc|cliNativeRpc|desktopNativeRpc|native-rpc|desktop-api|cli-api` is empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native RPC protocol support for authentication sessions via dedicated API endpoints
  * Desktop and CLI applications now use native authentication endpoints for session management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->