### PR TITLE
Remove empty tRPC routers

### DIFF
--- a/api/app/src/__tests__/connectors-router-source.test.ts
+++ b/api/app/src/__tests__/connectors-router-source.test.ts
@@ -1,25 +1,20 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const apiRoot = resolve(import.meta.dirname, "..");
 
 describe("connectors tRPC router", () => {
-  it("does not expose migrated connector procedures after the TanStack migration", () => {
-    const source = readFileSync(
-      resolve(apiRoot, "router/(pending-not-allowed)/connectors.ts"),
-      "utf8"
+  it("removes the empty connector router after the TanStack migration", () => {
+    const routerPath = resolve(
+      apiRoot,
+      "router/(pending-not-allowed)/connectors.ts"
     );
+    const rootSource = readFileSync(resolve(apiRoot, "root.ts"), "utf8");
 
-    expect(source).not.toContain("setupProcedure");
-    expect(source).not.toContain("orgAdminProcedure");
-    expect(source).not.toContain("boundOrgAdminProcedure");
-    expect(source).not.toContain("listConnectorsForOrg");
-    expect(source).not.toContain("listUserConnectorsForViewer");
-    expect(source).not.toContain("startConnectorOAuth");
-    expect(source).not.toContain("refreshConnectorTools");
-    expect(source).not.toContain("setConnectorAutomationEnabled");
-    expect(source).not.toContain("setConnectorAgentEnabled");
-    expect(source).not.toContain("disconnectConnector");
+    expect(existsSync(routerPath)).toBe(false);
+    expect(rootSource).not.toContain("connectorsRouter");
+    expect(rootSource).not.toContain("connectors:");
+    expect(rootSource).not.toContain("router/(pending-not-allowed)/connectors");
   });
 });

--- a/api/app/src/__tests__/developer-connections-router-source.test.ts
+++ b/api/app/src/__tests__/developer-connections-router-source.test.ts
@@ -1,23 +1,22 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const apiRoot = resolve(import.meta.dirname, "..");
 
 describe("developer-connections tRPC router", () => {
-  it("does not expose migrated developer-connection procedures after the TanStack migration", () => {
-    const source = readFileSync(
-      resolve(apiRoot, "router/(pending-not-allowed)/developer-connections.ts"),
-      "utf8"
+  it("removes the empty developer-connections router after the TanStack migration", () => {
+    const routerPath = resolve(
+      apiRoot,
+      "router/(pending-not-allowed)/developer-connections.ts"
     );
+    const rootSource = readFileSync(resolve(apiRoot, "root.ts"), "utf8");
 
-    expect(source).not.toContain("boundOrgProcedure");
-    expect(source).not.toContain("boundOrgAdminProcedure");
-    expect(source).not.toContain("listDeveloperConnectionsForOrg");
-    expect(source).not.toContain("connectDeveloperConnection");
-    expect(source).not.toContain("startSentryDeveloperConnectionAuth");
-    expect(source).not.toContain("completeSentryDeveloperConnectionAuth");
-    expect(source).not.toContain("setDeveloperConnectionSandboxEnabled");
-    expect(source).not.toContain("disconnectDeveloperConnection");
+    expect(existsSync(routerPath)).toBe(false);
+    expect(rootSource).not.toContain("developerConnectionsRouter");
+    expect(rootSource).not.toContain("developerConnections:");
+    expect(rootSource).not.toContain(
+      "router/(pending-not-allowed)/developer-connections"
+    );
   });
 });

--- a/api/app/src/__tests__/org-source-control-router-source.test.ts
+++ b/api/app/src/__tests__/org-source-control-router-source.test.ts
@@ -1,20 +1,22 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const apiRoot = resolve(import.meta.dirname, "..");
 
 describe("org source-control tRPC router", () => {
-  it("does not expose migrated source-control procedures after the TanStack migration", () => {
-    const source = readFileSync(
-      resolve(apiRoot, "router/(pending-not-allowed)/org-source-control.ts"),
-      "utf8"
+  it("removes the empty source-control router after the TanStack migration", () => {
+    const routerPath = resolve(
+      apiRoot,
+      "router/(pending-not-allowed)/org-source-control.ts"
     );
+    const rootSource = readFileSync(resolve(apiRoot, "root.ts"), "utf8");
 
-    expect(source).not.toContain("orgProcedure");
-    expect(source).not.toContain("orgAdminProcedure");
-    expect(source).not.toContain("getActiveOrgBinding");
-    expect(source).not.toContain("listRepositories");
-    expect(source).not.toContain("importRepository");
+    expect(existsSync(routerPath)).toBe(false);
+    expect(rootSource).not.toContain("orgSourceControlRouter");
+    expect(rootSource).not.toContain("sourceControl:");
+    expect(rootSource).not.toContain(
+      "router/(pending-not-allowed)/org-source-control"
+    );
   });
 });

--- a/api/app/src/root.ts
+++ b/api/app/src/root.ts
@@ -8,9 +8,6 @@
  * - `org.workspace`: bound-org product surface.
  */
 
-import { connectorsRouter } from "./router/(pending-not-allowed)/connectors";
-import { developerConnectionsRouter } from "./router/(pending-not-allowed)/developer-connections";
-import { orgSourceControlRouter } from "./router/(pending-not-allowed)/org-source-control";
 import { taskRouter } from "./router/(pending-not-allowed)/task";
 import { workspaceEntityGraphRouter } from "./router/(pending-not-allowed)/workspace-entity-graph";
 import { createTRPCRouter } from "./trpc";
@@ -20,12 +17,7 @@ export const appRouter = createTRPCRouter({
     setup: createTRPCRouter({
       task: taskRouter,
     }),
-    settings: createTRPCRouter({
-      sourceControl: orgSourceControlRouter,
-    }),
     workspace: createTRPCRouter({
-      connectors: connectorsRouter,
-      developerConnections: developerConnectionsRouter,
       entityGraph: workspaceEntityGraphRouter,
     }),
   }),

--- a/api/app/src/router/(pending-not-allowed)/connectors.ts
+++ b/api/app/src/router/(pending-not-allowed)/connectors.ts
@@ -1,3 +1,0 @@
-import type { TRPCRouterRecord } from "@trpc/server";
-
-export const connectorsRouter = {} satisfies TRPCRouterRecord;

--- a/api/app/src/router/(pending-not-allowed)/developer-connections.ts
+++ b/api/app/src/router/(pending-not-allowed)/developer-connections.ts
@@ -1,3 +1,0 @@
-import type { TRPCRouterRecord } from "@trpc/server";
-
-export const developerConnectionsRouter = {} satisfies TRPCRouterRecord;

--- a/api/app/src/router/(pending-not-allowed)/org-source-control.ts
+++ b/api/app/src/router/(pending-not-allowed)/org-source-control.ts
@@ -1,3 +1,0 @@
-import type { TRPCRouterRecord } from "@trpc/server";
-
-export const orgSourceControlRouter = {} satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary
- Remove empty connector, developer-connection, and org source-control tRPC placeholder routers.
- Drop those no-op registrations from the app tRPC root so the remaining tRPC surface is explicit.
- Update source guards to assert the migrated routers are gone instead of merely empty.

## Verification
- pnpm --filter @api/app test -- src/__tests__/connectors-router-source.test.ts src/__tests__/developer-connections-router-source.test.ts src/__tests__/org-source-control-router-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated router modules (connectors, developer-connections, org-source-control)
  * Simplified API root router configuration by removing stale references
  * Updated tests to reflect router cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->