### PR TITLE
Use domain errors for connector dispatch

### DIFF
--- a/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("connector service domain errors", () => {
+  it("keeps connector dispatch and config errors framework-neutral", () => {
+    for (const file of [
+      "services/connectors/index.ts",
+      "services/connectors/config.ts",
+      "services/user-connectors/index.ts",
+    ]) {
+      const fileSource = source(file);
+
+      expect(fileSource, file).toContain("../../domain/errors");
+      expect(fileSource, file).not.toContain("@trpc/server");
+      expect(fileSource, file).not.toContain("TRPCError");
+    }
+  });
+});

--- a/api/app/src/__tests__/connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/connectors-domain-commands.test.ts
@@ -13,6 +13,7 @@ import {
   setConnectorAutomationEnabledCommand,
   startConnectorOAuthCommand,
 } from "../domain/connectors";
+import { ValidationError } from "../domain/errors";
 
 const serviceMocks = vi.hoisted(() => ({
   disconnectConnector: vi.fn(),
@@ -170,6 +171,28 @@ describe("connector domain commands", () => {
     expect(serviceMocks.startConnectorOAuth).toHaveBeenCalledWith(
       expect.anything(),
       { provider: "x" }
+    );
+  });
+
+  it("preserves domain errors raised by connector services", async () => {
+    serviceMocks.startConnectorOAuth.mockRejectedValueOnce(
+      new ValidationError(
+        "CONNECTOR_UNSUPPORTED_PROVIDER",
+        "Unsupported connector provider: fake"
+      )
+    );
+
+    await expect(
+      startConnectorOAuthCommand.run({
+        ctx: ctx({ admin: true, identity: xSetupIdentity }),
+        deps: deps(),
+        input: { provider: "x" },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "CONNECTOR_UNSUPPORTED_PROVIDER",
+        kind: "validation",
+      })
     );
   });
 

--- a/api/app/src/__tests__/user-connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/user-connectors-domain-commands.test.ts
@@ -1,0 +1,69 @@
+import type { Database } from "@db/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthIdentity } from "../auth/identity";
+import { actorFromAuthIdentity } from "../domain";
+import { ValidationError } from "../domain/errors";
+import {
+  createDefaultUserConnectorCommandDeps,
+  startUserConnectorCommand,
+} from "../domain/user-connectors";
+
+const serviceMocks = vi.hoisted(() => ({
+  disconnectUserConnector: vi.fn(),
+  startUserConnectorOAuth: vi.fn(),
+}));
+
+vi.mock("../services/user-connectors", () => ({
+  disconnectUserConnector: serviceMocks.disconnectUserConnector,
+  startUserConnectorOAuth: serviceMocks.startUserConnectorOAuth,
+}));
+
+const pendingIdentity = {
+  type: "pending",
+  userId: "user_current",
+} satisfies AuthIdentity;
+
+function ctx() {
+  return {
+    actor: actorFromAuthIdentity(pendingIdentity, "web"),
+    request: { id: "req_test", source: "tanstack" as const },
+  };
+}
+
+function deps() {
+  return createDefaultUserConnectorCommandDeps({
+    db: {} as Database,
+    disconnectUserConnector: serviceMocks.disconnectUserConnector,
+    headers: new Headers(),
+    startUserConnectorOAuth: serviceMocks.startUserConnectorOAuth,
+  });
+}
+
+describe("user connector domain commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves domain errors raised by user connector services", async () => {
+    serviceMocks.startUserConnectorOAuth.mockRejectedValueOnce(
+      new ValidationError(
+        "USER_CONNECTOR_UNSUPPORTED_PROVIDER",
+        "Unsupported user connector provider: fake"
+      )
+    );
+
+    await expect(
+      startUserConnectorCommand.run({
+        ctx: ctx(),
+        deps: deps(),
+        input: { provider: "granola" },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "USER_CONNECTOR_UNSUPPORTED_PROVIDER",
+        kind: "validation",
+      })
+    );
+  });
+});

--- a/api/app/src/domain/connectors/commands.ts
+++ b/api/app/src/domain/connectors/commands.ts
@@ -23,6 +23,7 @@ import {
   AuthzError,
   ConflictError,
   InternalDomainError,
+  isDomainError,
   NotFoundError,
   ValidationError,
 } from "../errors";
@@ -344,6 +345,10 @@ function mapConnectorServiceError(
   fallbackCode: string,
   fallbackMessage: string
 ) {
+  if (isDomainError(error)) {
+    return error;
+  }
+
   const code =
     error && typeof error === "object" && "code" in error
       ? String(error.code)

--- a/api/app/src/domain/user-connectors/commands.ts
+++ b/api/app/src/domain/user-connectors/commands.ts
@@ -12,7 +12,12 @@ import {
 } from "../../services/user-connectors";
 import type { Actor } from "../actor";
 import { defineCommand } from "../command";
-import { AuthzError, InternalDomainError, ValidationError } from "../errors";
+import {
+  AuthzError,
+  InternalDomainError,
+  isDomainError,
+  ValidationError,
+} from "../errors";
 import { requireClerkUserActor } from "../gates";
 
 interface UserConnectorServiceContext {
@@ -141,6 +146,10 @@ function mapUserConnectorServiceError(
   fallbackCode: string,
   fallbackMessage: string
 ) {
+  if (isDomainError(error)) {
+    return error;
+  }
+
   const code =
     error && typeof error === "object" && "code" in error
       ? String(error.code)

--- a/api/app/src/services/connectors/config.ts
+++ b/api/app/src/services/connectors/config.ts
@@ -3,8 +3,8 @@ import {
   resolveLinearEndpoints,
 } from "@repo/linear-app-node";
 import { resolveXEndpoints, type XEndpoints } from "@repo/x-app-node";
-import { TRPCError } from "@trpc/server";
 
+import { ConflictError } from "../../domain/errors";
 import { env as runtimeEnv } from "../../env";
 
 export const LINEAR_OAUTH_CALLBACK_PATH =
@@ -190,11 +190,11 @@ export function requireXConnectorConfig(
     return result.config;
   }
 
-  throw new TRPCError({
-    code: "PRECONDITION_FAILED",
-    message: "X connector is not configured.",
-    cause: result,
-  });
+  throw new ConflictError(
+    "CONNECTOR_NOT_CONFIGURED",
+    "X connector is not configured.",
+    { result }
+  );
 }
 
 export function resolveXConnectorMcpEndpoint(

--- a/api/app/src/services/connectors/index.ts
+++ b/api/app/src/services/connectors/index.ts
@@ -5,8 +5,8 @@ import type {
   connectorSetAutomationEnabledInputSchema,
   connectorStartConnectInputSchema,
 } from "@repo/connector-contract";
-import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
+import { ValidationError } from "../../domain/errors";
 import type { AuthContext } from "../../trpc";
 import { listConnectorsForOrg } from "./catalog";
 import {
@@ -67,10 +67,10 @@ export { handleXConnectorMcpRequest } from "./x-mcp-bridge";
 export { listConnectorsForOrg };
 
 function unsupportedProvider(provider: string): never {
-  throw new TRPCError({
-    code: "BAD_REQUEST",
-    message: `Unsupported connector provider: ${provider}`,
-  });
+  throw new ValidationError(
+    "CONNECTOR_UNSUPPORTED_PROVIDER",
+    `Unsupported connector provider: ${provider}`
+  );
 }
 
 export async function startConnectorOAuth(

--- a/api/app/src/services/user-connectors/index.ts
+++ b/api/app/src/services/user-connectors/index.ts
@@ -3,8 +3,8 @@ import type {
   userConnectorProviderInputSchema,
   userConnectorStartConnectInputSchema,
 } from "@repo/connector-contract";
-import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
+import { ValidationError } from "../../domain/errors";
 import type { AuthContext } from "../../trpc";
 import {
   disconnectGranolaUserConnector,
@@ -32,10 +32,10 @@ export {
 } from "./granola-flow";
 
 function unsupportedProvider(provider: string): never {
-  throw new TRPCError({
-    code: "BAD_REQUEST",
-    message: `Unsupported user connector provider: ${provider}`,
-  });
+  throw new ValidationError(
+    "USER_CONNECTOR_UNSUPPORTED_PROVIDER",
+    `Unsupported user connector provider: ${provider}`
+  );
 }
 
 export async function startUserConnectorOAuth(


### PR DESCRIPTION
## Summary
- Preserve domain errors raised by connector and user-connector services through command mappers.
- Replace connector dispatch/config `TRPCError` usage with framework-neutral domain errors.
- Add tests guarding domain-error passthrough and preventing tRPC imports in the cleaned service dispatch/config files.

## Test Plan
- `pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/connectors-domain-commands.test.ts src/__tests__/user-connectors-domain-commands.test.ts src/__tests__/connector-service-domain-errors-source.test.ts`
- `pnpm --filter @api/app exec vitest run --passWithNoTests`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @lightfast/app exec vitest run`
- `pnpm check`
- `git diff --check`
- agent-browser smoke against `https://auth-domain-service-errors.app.lightfast.localhost`
