### PR TITLE
Use domain errors in connector provider flows

### DIFF
--- a/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
@@ -22,4 +22,18 @@ describe("connector service domain errors", () => {
       expect(fileSource, file).not.toContain("TRPCError");
     }
   });
+
+  it("keeps connector provider flow errors framework-neutral", () => {
+    for (const file of [
+      "services/connectors/linear-flow.ts",
+      "services/connectors/x-flow.ts",
+      "services/user-connectors/granola-flow.ts",
+    ]) {
+      const fileSource = source(file);
+
+      expect(fileSource, file).toContain("../../domain/errors");
+      expect(fileSource, file).not.toContain("@trpc/server");
+      expect(fileSource, file).not.toContain("TRPCError");
+    }
+  });
 });

--- a/api/app/src/__tests__/connectors-flow.test.ts
+++ b/api/app/src/__tests__/connectors-flow.test.ts
@@ -782,6 +782,25 @@ describe("Linear connector flow", () => {
     );
   });
 
+  it("throws a domain authz error when Linear starts without an active organization", async () => {
+    const context = ctx();
+
+    await expect(
+      startLinearConnectorOAuth({
+        ...context,
+        auth: {
+          ...context.auth,
+          identity: { type: "pending" as const, userId: "user_current" },
+        },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "ORG_REQUIRED",
+        kind: "authz",
+      })
+    );
+  });
+
   it("completes OAuth with the public oauth callback path", async () => {
     const issued = await issueConnectorOAuthAttempt({
       clerkOrgId: "org_acme",
@@ -1195,6 +1214,19 @@ describe("Linear connector flow", () => {
     );
   });
 
+  it("throws a domain not-found error when Linear enablement has no current connection", async () => {
+    setConnectorAgentEnabledDbMock.mockResolvedValueOnce(false);
+
+    await expect(
+      linearFlow.setLinearConnectorAgentEnabled?.(ctx(), { enabled: true })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "CONNECTOR_NOT_CONNECTED",
+        kind: "not_found",
+      })
+    );
+  });
+
   it("wipes local tokens and manifest even when provider revoke fails", async () => {
     getCurrentOrgConnectorConnectionMock.mockResolvedValue(connection());
     revokeLinearOAuthTokenMock.mockRejectedValue(
@@ -1395,6 +1427,25 @@ describe("X connector flow", () => {
       "connector-oauth-attempt:x:attempt_123456789012345678901234",
       expect.objectContaining({ mode: "reconnect", provider: "x" }),
       { ex: 900 }
+    );
+  });
+
+  it("throws a domain authz error when X starts without an active organization", async () => {
+    const context = ctx();
+
+    await expect(
+      startXConnectorOAuth({
+        ...context,
+        auth: {
+          ...context.auth,
+          identity: { type: "pending" as const, userId: "user_current" },
+        },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "ORG_REQUIRED",
+        kind: "authz",
+      })
     );
   });
 

--- a/api/app/src/__tests__/user-connectors-flow.test.ts
+++ b/api/app/src/__tests__/user-connectors-flow.test.ts
@@ -402,6 +402,17 @@ describe("Granola user connector OAuth flow", () => {
     );
   });
 
+  it("throws a domain authz error when Granola starts without authentication", async () => {
+    await expect(
+      startGranolaUserConnectorOAuth(ctx({ identity: "unauthenticated" }))
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "AUTH_REQUIRED",
+        kind: "authz",
+      })
+    );
+  });
+
   it("adds a Lightfast state when the provider authorization URL lacks state", async () => {
     listGranolaMcpToolsMock.mockImplementationOnce(
       async ({

--- a/api/app/src/services/connectors/linear-flow.ts
+++ b/api/app/src/services/connectors/linear-flow.ts
@@ -23,9 +23,9 @@ import {
   refreshLinearOAuthToken,
   revokeLinearOAuthToken,
 } from "@repo/linear-app-node";
-import { TRPCError } from "@trpc/server";
 import { log } from "@vendor/observability/log/next";
 import { findUserOrganizationMembership } from "../../auth/clerk-org-membership";
+import { AuthzError, NotFoundError } from "../../domain/errors";
 import { env } from "../../env";
 import type { AuthContext } from "../../trpc";
 import {
@@ -52,10 +52,7 @@ export interface LinearRedirectResult {
 
 function activeIdentity(ctx: ConnectorServiceContext) {
   if (ctx.auth.identity.type !== "active") {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "An active organization is required.",
-    });
+    throw new AuthzError("ORG_REQUIRED", "An active organization is required.");
   }
   return ctx.auth.identity;
 }
@@ -70,10 +67,10 @@ async function getOrgSlug(input: {
   });
   const slug = membership?.organization.slug;
   if (!slug) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "Organization access is required.",
-    });
+    throw new AuthzError(
+      "ORG_ACCESS_REQUIRED",
+      "Organization access is required."
+    );
   }
   return slug;
 }
@@ -625,10 +622,10 @@ export async function refreshLinearConnectorTools(
     provider: "linear",
   });
   if (!connection) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Linear connector is not connected.",
-    });
+    throw new NotFoundError(
+      "CONNECTOR_NOT_CONNECTED",
+      "Linear connector is not connected."
+    );
   }
 
   let accessToken: string;
@@ -734,10 +731,10 @@ export async function setLinearConnectorAutomationEnabled(
     provider: "linear",
   });
   if (!updated) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Linear connector is not connected.",
-    });
+    throw new NotFoundError(
+      "CONNECTOR_NOT_CONNECTED",
+      "Linear connector is not connected."
+    );
   }
   return { enabled: input.enabled };
 }
@@ -753,10 +750,10 @@ export async function setLinearConnectorAgentEnabled(
     provider: "linear",
   });
   if (!updated) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Linear connector is not connected.",
-    });
+    throw new NotFoundError(
+      "CONNECTOR_NOT_CONNECTED",
+      "Linear connector is not connected."
+    );
   }
   return { enabled: input.enabled };
 }

--- a/api/app/src/services/connectors/x-flow.ts
+++ b/api/app/src/services/connectors/x-flow.ts
@@ -27,9 +27,9 @@ import {
   revokeXOAuthToken,
   XAppNodeError,
 } from "@repo/x-app-node";
-import { TRPCError } from "@trpc/server";
 import { log } from "@vendor/observability/log/next";
 import { findUserOrganizationMembership } from "../../auth/clerk-org-membership";
+import { AuthzError, NotFoundError } from "../../domain/errors";
 import { env } from "../../env";
 import type { AuthContext } from "../../trpc";
 import {
@@ -57,10 +57,7 @@ export interface XRedirectResult {
 
 function activeIdentity(ctx: ConnectorServiceContext) {
   if (ctx.auth.identity.type !== "active") {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "An active organization is required.",
-    });
+    throw new AuthzError("ORG_REQUIRED", "An active organization is required.");
   }
   return ctx.auth.identity;
 }
@@ -75,10 +72,10 @@ async function getOrgSlug(input: {
   });
   const slug = membership?.organization.slug;
   if (!slug) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "Organization access is required.",
-    });
+    throw new AuthzError(
+      "ORG_ACCESS_REQUIRED",
+      "Organization access is required."
+    );
   }
   return slug;
 }
@@ -758,10 +755,10 @@ export async function setXConnectorAutomationEnabled(
     provider: "x",
   });
   if (!updated) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "X connector is not connected.",
-    });
+    throw new NotFoundError(
+      "CONNECTOR_NOT_CONNECTED",
+      "X connector is not connected."
+    );
   }
   return { enabled: input.enabled };
 }
@@ -777,10 +774,10 @@ export async function setXConnectorAgentEnabled(
     provider: "x",
   });
   if (!updated) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "X connector is not connected.",
-    });
+    throw new NotFoundError(
+      "CONNECTOR_NOT_CONNECTED",
+      "X connector is not connected."
+    );
   }
   return { enabled: input.enabled };
 }

--- a/api/app/src/services/user-connectors/granola-flow.ts
+++ b/api/app/src/services/user-connectors/granola-flow.ts
@@ -13,11 +13,11 @@ import {
   granolaClientMetadata,
   listGranolaMcpTools,
 } from "@repo/granola-app-node";
-import { TRPCError } from "@trpc/server";
 import { auth } from "@vendor/clerk/server";
 import type { OAuthClientInformationMixed, OAuthTokens } from "@vendor/mcp";
 import { StreamableHTTPClientTransport } from "@vendor/mcp";
 import { log } from "@vendor/observability/log/next";
+import { AuthzError, InternalDomainError } from "../../domain/errors";
 import { env } from "../../env";
 import type { AuthContext } from "../../trpc";
 import {
@@ -43,10 +43,7 @@ export interface GranolaRedirectResult {
 function signedInIdentity(ctx: GranolaUserConnectorServiceContext) {
   const identity = ctx.auth.identity;
   if (identity.type === "unauthenticated") {
-    throw new TRPCError({
-      code: "UNAUTHORIZED",
-      message: "Authentication required.",
-    });
+    throw new AuthzError("AUTH_REQUIRED", "Authentication required.");
   }
   return identity;
 }
@@ -245,19 +242,20 @@ export async function startGranolaUserConnectorOAuth(
     });
   } catch (error) {
     if (!isGranolaAuthRequired(error)) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Granola authorization could not be started.",
-        cause: error,
-      });
+      throw new InternalDomainError(
+        "USER_CONNECTOR_AUTH_START_FAILED",
+        "Granola authorization could not be started.",
+        {},
+        { cause: error }
+      );
     }
   }
 
   if (!authorizationUrl) {
-    throw new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
-      message: "Granola authorization URL was not provided.",
-    });
+    throw new InternalDomainError(
+      "USER_CONNECTOR_AUTH_URL_MISSING",
+      "Granola authorization URL was not provided."
+    );
   }
 
   const providerState = authorizationUrl.searchParams.get("state") ?? undefined;


### PR DESCRIPTION
## Summary
- Replace remaining `TRPCError` throws in Linear, X, and Granola connector provider flows with framework-neutral domain errors.
- Preserve connector missing/auth-required cases as domain `authz` and `not_found` errors before they reach command/adapters.
- Extend connector flow tests and source ratchets so provider-flow files cannot reintroduce tRPC transport errors.

## Test Plan
- `pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/connector-service-domain-errors-source.test.ts src/__tests__/connectors-flow.test.ts src/__tests__/user-connectors-flow.test.ts`
- `pnpm --filter @api/app exec vitest run --passWithNoTests`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm check`
- `git diff --check`
- agent-browser smoke: `https://auth-connector-provider-domain-errors.app.lightfast.localhost` rendered `Lightfast Console TanStack`
