### PR TITLE
Use domain errors for repository eligibility

### DIFF
--- a/api/app/src/__tests__/eligibility-domain-errors.test.ts
+++ b/api/app/src/__tests__/eligibility-domain-errors.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Database } from "@db/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  listIdentityIndexRefreshCandidates: vi.fn(),
+  listSkillIndexableSourceControlRepositoryCandidates: vi.fn(),
+}));
+
+vi.mock("@db/app", () => ({
+  listIdentityIndexRefreshCandidates:
+    dbMocks.listIdentityIndexRefreshCandidates,
+  listSkillIndexableSourceControlRepositoryCandidates:
+    dbMocks.listSkillIndexableSourceControlRepositoryCandidates,
+}));
+
+const { getVerifiedLightfastIdentitySourceRepositoryId } = await import(
+  "../services/identity/eligibility"
+);
+const { getVerifiedLightfastSkillSourceRepositoryId } = await import(
+  "../services/skills/eligibility"
+);
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("repository eligibility domain errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws a domain conflict error when no skills repository is verified", async () => {
+    dbMocks.listSkillIndexableSourceControlRepositoryCandidates.mockResolvedValueOnce(
+      []
+    );
+
+    await expect(
+      getVerifiedLightfastSkillSourceRepositoryId({} as Database, {
+        clerkOrgId: "org_acme",
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "SKILLS_REPOSITORY_NOT_CONFIGURED",
+        kind: "conflict",
+      })
+    );
+  });
+
+  it("throws a domain conflict error when no identity repository is verified", async () => {
+    dbMocks.listIdentityIndexRefreshCandidates.mockResolvedValueOnce([]);
+
+    await expect(
+      getVerifiedLightfastIdentitySourceRepositoryId({} as Database, {
+        clerkOrgId: "org_acme",
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "IDENTITY_REPOSITORY_NOT_CONFIGURED",
+        kind: "conflict",
+      })
+    );
+  });
+
+  it("keeps eligibility errors framework-neutral", () => {
+    for (const file of [
+      "services/identity/eligibility.ts",
+      "services/skills/eligibility.ts",
+    ]) {
+      const fileSource = source(file);
+
+      expect(fileSource, file).toContain("../../domain/errors");
+      expect(fileSource, file).not.toContain("@trpc/server");
+      expect(fileSource, file).not.toContain("TRPCError");
+    }
+  });
+});

--- a/api/app/src/services/identity/eligibility.ts
+++ b/api/app/src/services/identity/eligibility.ts
@@ -5,7 +5,7 @@ import {
   type SourceControlRepository,
 } from "@db/app";
 import { githubLightfastRepositoryProofSchema } from "@repo/app-setup-contract";
-import { TRPCError } from "@trpc/server";
+import { ConflictError } from "../../domain/errors";
 
 export function isVerifiedLightfastIdentityRepository(input: {
   binding: OrgSourceControlBinding;
@@ -47,10 +47,10 @@ export async function getVerifiedLightfastIdentitySourceRepositoryId(
     isVerifiedLightfastIdentityRepository(row)
   );
   if (!candidate) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "No verified Lightfast identity repository is configured.",
-    });
+    throw new ConflictError(
+      "IDENTITY_REPOSITORY_NOT_CONFIGURED",
+      "No verified Lightfast identity repository is configured."
+    );
   }
   return candidate.repository.id;
 }

--- a/api/app/src/services/skills/eligibility.ts
+++ b/api/app/src/services/skills/eligibility.ts
@@ -5,7 +5,7 @@ import {
   type SourceControlRepository,
 } from "@db/app";
 import { githubLightfastRepositoryProofSchema } from "@repo/app-setup-contract";
-import { TRPCError } from "@trpc/server";
+import { ConflictError } from "../../domain/errors";
 
 export function isVerifiedLightfastSkillRepository(input: {
   binding: OrgSourceControlBinding;
@@ -47,10 +47,10 @@ export async function getVerifiedLightfastSkillSourceRepositoryId(
     isVerifiedLightfastSkillRepository(row)
   );
   if (!candidate) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "No verified Lightfast skills repository is configured.",
-    });
+    throw new ConflictError(
+      "SKILLS_REPOSITORY_NOT_CONFIGURED",
+      "No verified Lightfast skills repository is configured."
+    );
   }
   return candidate.repository.id;
 }


### PR DESCRIPTION
## Summary
- Replace tRPC `PRECONDITION_FAILED` errors in skill and identity repository eligibility helpers with domain `ConflictError`s.
- Add coverage for the new domain error codes and a source ratchet against `@trpc/server` in eligibility helpers.

## Test Plan
- `pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/eligibility-domain-errors.test.ts`
- `pnpm --filter @api/app exec vitest run --passWithNoTests`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm check`
- `git diff --check`
- agent-browser smoke: `https://auth-eligibility-domain-errors.app.lightfast.localhost` rendered `Lightfast Console TanStack`
