### PR TITLE
Use domain errors for developer services

### DIFF
--- a/api/app/src/__tests__/developer-connections-domain-commands.test.ts
+++ b/api/app/src/__tests__/developer-connections-domain-commands.test.ts
@@ -12,6 +12,7 @@ import {
   setDeveloperConnectionSandboxEnabledCommand,
   startSentryDeveloperConnectionAuthCommand,
 } from "../domain/developer-connections";
+import { ConflictError } from "../domain/errors";
 
 const serviceMocks = vi.hoisted(() => ({
   completeSentryDeveloperConnectionAuth: vi.fn(),
@@ -240,5 +241,31 @@ describe("developer connection domain commands", () => {
         },
       })
     ).resolves.toEqual({ provider: "sentry", status: "connected" });
+  });
+
+  it("preserves domain errors raised by developer connection services", async () => {
+    serviceMocks.connectDeveloperConnection.mockRejectedValueOnce(
+      new ConflictError(
+        "DEVELOPER_CONNECTION_RECONNECT_REQUIRED",
+        "sentry needs reconnect"
+      )
+    );
+
+    await expect(
+      connectDeveloperConnectionCommand.run({
+        ctx: ctx({ admin: true }),
+        deps: deps(),
+        input: {
+          provider: "sentry",
+          providerAccountName: "lightfast/app",
+          token: "token",
+        },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "DEVELOPER_CONNECTION_RECONNECT_REQUIRED",
+        kind: "conflict",
+      })
+    );
   });
 });

--- a/api/app/src/__tests__/developer-connections-service.test.ts
+++ b/api/app/src/__tests__/developer-connections-service.test.ts
@@ -188,6 +188,22 @@ describe("developer connection services", () => {
     );
   });
 
+  it("throws a domain authz error when non-admin users manage developer connections", async () => {
+    await expect(
+      connectDeveloperConnection(ctx({ isAdmin: false }), {
+        provider: "pscale",
+        providerAccountName: "lightfast/main",
+        serviceTokenId: "token-id",
+        serviceToken: "token-secret",
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "PERMISSION_REQUIRED",
+        kind: "authz",
+      })
+    );
+  });
+
   it("starts and completes Sentry auth through the auth-box client", async () => {
     await expect(
       startSentryDeveloperConnectionAuth(ctx(), {
@@ -293,6 +309,23 @@ describe("developer connection services", () => {
         }),
       ],
     });
+  });
+
+  it("throws a domain conflict error when a requested developer connection is missing", async () => {
+    listCurrentDeveloperConnectionsMock.mockResolvedValue([]);
+
+    await expect(
+      issueDeveloperConnectionLeases(ctx(), {
+        providers: ["sentry"],
+        sandboxRunId: "sandbox_run_1",
+        workflowRunId: "workflow_run_1",
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "DEVELOPER_CONNECTION_RECONNECT_REQUIRED",
+        kind: "conflict",
+      })
+    );
   });
 
   it("issues leases for all enabled connected developer connections", async () => {

--- a/api/app/src/__tests__/developer-sandbox-runs-service.test.ts
+++ b/api/app/src/__tests__/developer-sandbox-runs-service.test.ts
@@ -61,6 +61,15 @@ function ctx() {
   };
 }
 
+function unauthenticatedCtx() {
+  return {
+    auth: {
+      identity: { type: "unauthenticated" as const },
+    },
+    db: {} as Database,
+  };
+}
+
 function sandboxRun(overrides: Record<string, unknown> = {}) {
   return {
     id: 100,
@@ -266,6 +275,37 @@ describe("developer sandbox run service", () => {
       })
     );
     expect(issueAllEnabledDeveloperConnectionLeasesMock).not.toHaveBeenCalled();
+  });
+
+  it("throws a domain authz error when creating without an active identity", async () => {
+    const fakeRuntime = runtime();
+    const service = createService(fakeRuntime);
+
+    await expect(
+      service.createDeveloperSandboxRun(unauthenticatedCtx())
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "AUTH_REQUIRED",
+        kind: "authz",
+      })
+    );
+  });
+
+  it("throws a domain not-found error when a sandbox run cannot be loaded", async () => {
+    getDeveloperSandboxRunByPublicIdMock.mockResolvedValueOnce(undefined);
+    const fakeRuntime = runtime();
+    const service = createService(fakeRuntime);
+
+    await expect(
+      service.stopDeveloperSandboxRun(ctx(), {
+        sandboxRunId: "developer_sandbox_run_missing",
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "DEVELOPER_SANDBOX_RUN_NOT_FOUND",
+        kind: "not_found",
+      })
+    );
   });
 
   it("blocks denied commands before loading credentials", async () => {

--- a/api/app/src/__tests__/developer-services-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/developer-services-domain-errors-source.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("developer service domain errors", () => {
+  it("keeps developer service errors framework-neutral", () => {
+    for (const file of [
+      "services/developer-connections/auth-box.ts",
+      "services/developer-connections/index.ts",
+      "services/developer-connections/leases.ts",
+      "services/developer-sandbox-runs/index.ts",
+    ]) {
+      const fileSource = source(file);
+
+      expect(fileSource, file).toContain("../../domain/errors");
+      expect(fileSource, file).not.toContain("@trpc/server");
+      expect(fileSource, file).not.toContain("TRPCError");
+    }
+  });
+});

--- a/api/app/src/domain/developer-connections/commands.ts
+++ b/api/app/src/domain/developer-connections/commands.ts
@@ -25,6 +25,7 @@ import {
   AuthzError,
   ConflictError,
   InternalDomainError,
+  isDomainError,
   ValidationError,
 } from "../errors";
 import { requireBoundClerkOrgActor, requireClerkOrgAdminActor } from "../gates";
@@ -313,6 +314,10 @@ function mapDeveloperConnectionServiceError(
   fallbackCode: string,
   fallbackMessage: string
 ) {
+  if (isDomainError(error)) {
+    return error;
+  }
+
   const code =
     error && typeof error === "object" && "code" in error
       ? String(error.code)

--- a/api/app/src/services/developer-connections/auth-box.ts
+++ b/api/app/src/services/developer-connections/auth-box.ts
@@ -1,4 +1,4 @@
-import { TRPCError } from "@trpc/server";
+import { ConflictError, InternalDomainError } from "../../domain/errors";
 import { env } from "../../env";
 
 export interface SentryAuthBoxStartResult {
@@ -31,10 +31,10 @@ export interface SentryAuthBoxClient {
 
 function authBoxConfig() {
   if (!(env.DEVELOPER_AUTH_BOX_ORIGIN && env.DEVELOPER_AUTH_BOX_TOKEN)) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "Developer auth box is not configured.",
-    });
+    throw new ConflictError(
+      "DEVELOPER_AUTH_BOX_NOT_CONFIGURED",
+      "Developer auth box is not configured."
+    );
   }
   return {
     origin: env.DEVELOPER_AUTH_BOX_ORIGIN.replace(/\/$/, ""),
@@ -57,10 +57,11 @@ async function authBoxRequest<T>(
   });
 
   if (!response.ok) {
-    throw new TRPCError({
-      code: "BAD_GATEWAY",
-      message: `Developer auth box request failed with ${response.status}.`,
-    });
+    throw new InternalDomainError(
+      "DEVELOPER_AUTH_BOX_REQUEST_FAILED",
+      `Developer auth box request failed with ${response.status}.`,
+      { status: response.status }
+    );
   }
 
   return (await response.json()) as T;

--- a/api/app/src/services/developer-connections/index.ts
+++ b/api/app/src/services/developer-connections/index.ts
@@ -11,7 +11,7 @@ import type {
   DeveloperConnectionSetSandboxEnabledInput,
   DeveloperConnectionStartAuthInput,
 } from "@repo/developer-connection-contract";
-import { TRPCError } from "@trpc/server";
+import { AuthzError } from "../../domain/errors";
 import type { AuthContext } from "../../trpc";
 import { verifyDeveloperConnectionInput } from "./adapters";
 import { sentryAuthBoxClient } from "./auth-box";
@@ -46,7 +46,10 @@ function activeAdmin(ctx: DeveloperConnectionServiceContext) {
     access.orgId !== identity.orgId ||
     !access.has({ role: "org:admin" })
   ) {
-    throw new TRPCError({ code: "FORBIDDEN" });
+    throw new AuthzError(
+      "PERMISSION_REQUIRED",
+      "Only organization administrators can perform this action."
+    );
   }
   return identity;
 }

--- a/api/app/src/services/developer-connections/leases.ts
+++ b/api/app/src/services/developer-connections/leases.ts
@@ -13,7 +13,7 @@ import {
   DEVELOPER_CONNECTION_PROVIDERS,
   type DeveloperConnectionIssueLeaseInput,
 } from "@repo/developer-connection-contract";
-import { TRPCError } from "@trpc/server";
+import { AuthzError, ConflictError } from "../../domain/errors";
 import type { AuthContext } from "../../trpc";
 import {
   type DeveloperConnectionMaterialization,
@@ -39,23 +39,23 @@ interface LeaseMaterializationResult {
 function activeIdentity(ctx: DeveloperConnectionServiceContext) {
   const identity = ctx.auth.identity;
   if (identity.type !== "active") {
-    throw new TRPCError({ code: "UNAUTHORIZED" });
+    throw new AuthzError("AUTH_REQUIRED", "Authentication required.");
   }
   return identity;
 }
 
 function assertUsableConnection(connection: DeveloperConnection) {
   if (connection.status !== "connected") {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: `${connection.provider} needs reconnect`,
-    });
+    throw new ConflictError(
+      "DEVELOPER_CONNECTION_RECONNECT_REQUIRED",
+      `${connection.provider} needs reconnect`
+    );
   }
   if (!connection.encryptedCredential) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: `${connection.provider} has no credential material`,
-    });
+    throw new ConflictError(
+      "DEVELOPER_CONNECTION_CREDENTIAL_MISSING",
+      `${connection.provider} has no credential material`
+    );
   }
 }
 
@@ -65,10 +65,10 @@ async function materializeConnection(
   assertUsableConnection(connection);
   const encryptedCredential = connection.encryptedCredential;
   if (!encryptedCredential) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: `${connection.provider} has no credential material`,
-    });
+    throw new ConflictError(
+      "DEVELOPER_CONNECTION_CREDENTIAL_MISSING",
+      `${connection.provider} has no credential material`
+    );
   }
   const credentialPayload =
     await decryptDeveloperCredential<Record<string, unknown>>(
@@ -107,17 +107,17 @@ export async function issueDeveloperConnectionLeases(
   for (const provider of requested) {
     const connection = byProvider.get(provider);
     if (!connection) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: `${provider} needs reconnect`,
-      });
+      throw new ConflictError(
+        "DEVELOPER_CONNECTION_RECONNECT_REQUIRED",
+        `${provider} needs reconnect`
+      );
     }
     assertUsableConnection(connection);
     if (!connection.enabledForSandboxes) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: `${provider} is disabled for sandboxes`,
-      });
+      throw new ConflictError(
+        "DEVELOPER_CONNECTION_SANDBOX_DISABLED",
+        `${provider} is disabled for sandboxes`
+      );
     }
 
     const lease = await issueDeveloperConnectionLease(ctx.db, {
@@ -194,10 +194,10 @@ export async function materializeDeveloperConnectionLeasesForSandboxRun(
       lease.connectionId
     );
     if (!connection || connection.clerkOrgId !== identity.orgId) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: `${lease.provider} has no credential material`,
-      });
+      throw new ConflictError(
+        "DEVELOPER_CONNECTION_CREDENTIAL_MISSING",
+        `${lease.provider} has no credential material`
+      );
     }
     materialization.push(await materializeConnection(connection));
   }

--- a/api/app/src/services/developer-sandbox-runs/index.ts
+++ b/api/app/src/services/developer-sandbox-runs/index.ts
@@ -17,7 +17,7 @@ import {
   createVercelSandboxRuntime,
   type SandboxRuntime,
 } from "@repo/sandbox-runtime";
-import { TRPCError } from "@trpc/server";
+import { AuthzError, ConflictError, NotFoundError } from "../../domain/errors";
 import type { AuthContext } from "../../trpc";
 import {
   issueAllEnabledDeveloperConnectionLeases,
@@ -63,23 +63,23 @@ export function canUseDeveloperSandboxes(
 function activeIdentity(ctx: DeveloperSandboxRunServiceContext) {
   const identity = ctx.auth.identity;
   if (!canUseDeveloperSandboxes(ctx) || identity.type !== "active") {
-    throw new TRPCError({ code: "UNAUTHORIZED" });
+    throw new AuthzError("AUTH_REQUIRED", "Authentication required.");
   }
   return identity;
 }
 
 function ensureRunnableRun(run: DeveloperSandboxRun, now: Date) {
   if (run.status !== "running" && run.status !== "starting") {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: `Developer sandbox run is ${run.status}`,
-    });
+    throw new ConflictError(
+      "DEVELOPER_SANDBOX_RUN_NOT_RUNNABLE",
+      `Developer sandbox run is ${run.status}`
+    );
   }
   if (run.expiresAt <= now) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "Developer sandbox run has expired",
-    });
+    throw new ConflictError(
+      "DEVELOPER_SANDBOX_RUN_EXPIRED",
+      "Developer sandbox run has expired"
+    );
   }
 }
 
@@ -136,7 +136,10 @@ export function createDeveloperSandboxRunService(
       publicId: sandboxRunId,
     });
     if (!run) {
-      throw new TRPCError({ code: "NOT_FOUND" });
+      throw new NotFoundError(
+        "DEVELOPER_SANDBOX_RUN_NOT_FOUND",
+        "Developer sandbox run was not found."
+      );
     }
     return { identity, run };
   }


### PR DESCRIPTION
## Summary
- Replace developer connection and sandbox service `TRPCError` throws with domain errors.
- Preserve domain errors through the developer connection command mapper.
- Add service behavior tests and a source ratchet to keep developer service errors framework-neutral.

## Test Plan
- `pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/developer-services-domain-errors-source.test.ts src/__tests__/developer-connections-domain-commands.test.ts src/__tests__/developer-connections-service.test.ts src/__tests__/developer-sandbox-runs-service.test.ts`
- `pnpm --filter @api/app exec vitest run --passWithNoTests`
- `pnpm --filter @api/app typecheck`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm check`
- `git diff --check`
- agent-browser smoke: `https://auth-developer-service-domain-errors.app.lightfast.localhost` rendered `Lightfast Console TanStack`
