### PR TITLE
Keep diagnostics transport neutral

### DIFF
--- a/api/app/src/__tests__/diagnostics-boundary-source.test.ts
+++ b/api/app/src/__tests__/diagnostics-boundary-source.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("diagnostics boundary", () => {
+  it("keeps diagnostic payloads transport-neutral", () => {
+    const diagnosticsSource = source("diagnostics.ts");
+
+    expect(diagnosticsSource).not.toContain("@trpc/server");
+    expect(diagnosticsSource).not.toContain("TRPCError");
+    expect(diagnosticsSource).not.toContain("TRPC_ERROR_CODE_KEY");
+    expect(diagnosticsSource).not.toContain("trpcCode");
+  });
+
+  it("keeps tRPC error construction inside the tRPC adapter", () => {
+    const trpcSource = source("trpc.ts");
+    const githubGateSource = source("services/github/user-account/gate.ts");
+
+    expect(trpcSource).toContain("@trpc/server");
+    expect(trpcSource).toContain("createDiagnosticCause");
+    expect(trpcSource).toContain("new TRPCError");
+    expect(githubGateSource).not.toContain("../../../diagnostics");
+    expect(githubGateSource).not.toContain("throwDiagnostic");
+  });
+});

--- a/api/app/src/__tests__/diagnostics.test.ts
+++ b/api/app/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { createDiagnosticCause, isDiagnosticCause } from "../diagnostics";
+
+describe("diagnostics", () => {
+  it("creates a transport-neutral diagnostic cause", () => {
+    const cause = createDiagnosticCause({
+      code: "ORG_REQUIRED",
+      message: "Organization required.",
+      repair: { id: "create-or-join-org" },
+    });
+
+    expect(isDiagnosticCause(cause)).toBe(true);
+    expect(cause.diagnostics).toEqual([
+      {
+        code: "ORG_REQUIRED",
+        message: "Organization required.",
+        repair: { id: "create-or-join-org" },
+      },
+    ]);
+  });
+});

--- a/api/app/src/diagnostics.ts
+++ b/api/app/src/diagnostics.ts
@@ -1,28 +1,12 @@
 /**
- * Diagnostic envelope for tRPC errors.
+ * Diagnostic payloads for gate-style auth and identity failures.
  *
- * Every gate-style failure (auth, identity, …) attaches a structured `cause`
- * here so the `errorFormatter` in `./trpc.ts` can flatten it onto
- * `data.diagnostics` generically. Bearer transports (desktop, CLI, agents)
- * pattern-match on `code` and dispatch on `repair.id` instead of parsing
- * prose messages.
- *
- * Wire shape (inside the existing tRPC `data` envelope):
- *
- *   data: {
- *     ...,
- *     diagnostics: [
- *       { code: "ORG_REQUIRED", message: "...", repair: { id: "create-or-join-org" } }
- *     ]
- *   }
- *
- * `diagnostics` is always an array — empty `[]` when the error did not
- * originate from `throwDiagnostic`. The array shape is forward-compatible
- * with future compound errors (e.g. "session expired AND org missing").
+ * Transports can attach this neutral cause shape to their own error envelope so
+ * clients can pattern-match on `code` and dispatch on `repair.id` instead of
+ * parsing prose messages.
  */
 
 import type { OrgSetupRepairId } from "@repo/app-setup-contract";
-import { type TRPC_ERROR_CODE_KEY, TRPCError } from "@trpc/server";
 
 export const DIAGNOSTIC_CAUSE_KIND = "lightfast.diagnostic" as const;
 
@@ -57,9 +41,16 @@ export interface Diagnostic {
   repair?: Repair;
 }
 
-interface DiagnosticCause {
+export interface DiagnosticCause {
   diagnostics: Diagnostic[];
   kind: typeof DIAGNOSTIC_CAUSE_KIND;
+}
+
+export function createDiagnosticCause(diagnostic: Diagnostic): DiagnosticCause {
+  return {
+    kind: DIAGNOSTIC_CAUSE_KIND,
+    diagnostics: [diagnostic],
+  };
 }
 
 export function isDiagnosticCause(cause: unknown): cause is DiagnosticCause {
@@ -69,19 +60,4 @@ export function isDiagnosticCause(cause: unknown): cause is DiagnosticCause {
     "kind" in cause &&
     (cause as { kind?: unknown }).kind === DIAGNOSTIC_CAUSE_KIND
   );
-}
-
-export function throwDiagnostic(args: {
-  trpcCode: TRPC_ERROR_CODE_KEY;
-  diagnostic: Diagnostic;
-}): never {
-  const cause: DiagnosticCause = {
-    kind: DIAGNOSTIC_CAUSE_KIND,
-    diagnostics: [args.diagnostic],
-  };
-  throw new TRPCError({
-    code: args.trpcCode,
-    message: args.diagnostic.message,
-    cause,
-  });
 }

--- a/api/app/src/services/github/user-account/gate.ts
+++ b/api/app/src/services/github/user-account/gate.ts
@@ -1,6 +1,6 @@
 import { type Database, getActiveUserSourceControlAccount } from "@db/app";
 
-import { throwDiagnostic } from "../../../diagnostics";
+import { AuthzError } from "../../../domain/errors";
 
 export async function requireGitHubUserAccount(input: {
   clerkUserId: string;
@@ -11,14 +11,11 @@ export async function requireGitHubUserAccount(input: {
     input.clerkUserId
   );
   if (!account) {
-    throwDiagnostic({
-      trpcCode: "FORBIDDEN",
-      diagnostic: {
-        code: "GITHUB_USER_ACCOUNT_REQUIRED",
-        message: "Connect your GitHub account before using this feature.",
-        repair: { id: "connect-github-account" },
-      },
-    });
+    throw new AuthzError(
+      "GITHUB_USER_ACCOUNT_REQUIRED",
+      "Connect your GitHub account before using this feature.",
+      { repair: { id: "connect-github-account" } }
+    );
   }
   return account;
 }

--- a/api/app/src/trpc.ts
+++ b/api/app/src/trpc.ts
@@ -12,14 +12,18 @@
 
 import { db } from "@db/app/client";
 import { repairIdForSetupRequirement } from "@repo/app-setup-contract";
-import { initTRPC } from "@trpc/server";
+import { initTRPC, type TRPC_ERROR_CODE_KEY, TRPCError } from "@trpc/server";
 import { createObservabilityMiddleware } from "@vendor/observability/trpc";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
 import type { AuthAccess, AuthIdentity } from "./auth/identity";
 import { resolveAuthContextFromClerk } from "./auth/identity";
-import { isDiagnosticCause, throwDiagnostic } from "./diagnostics";
+import {
+  createDiagnosticCause,
+  type Diagnostic,
+  isDiagnosticCause,
+} from "./diagnostics";
 
 /**
  * Authentication context — identity is the only auth dimension: "who is this
@@ -56,6 +60,17 @@ export const createTRPCContext = async (opts: { headers: Headers }) => ({
  * transformer.
  */
 const isProduction = process.env.NODE_ENV === "production";
+
+function throwDiagnostic(args: {
+  diagnostic: Diagnostic;
+  trpcCode: TRPC_ERROR_CODE_KEY;
+}): never {
+  throw new TRPCError({
+    code: args.trpcCode,
+    message: args.diagnostic.message,
+    cause: createDiagnosticCause(args.diagnostic),
+  });
+}
 
 const t = initTRPC.context<typeof createTRPCContext>().create({
   transformer: superjson,


### PR DESCRIPTION
## Summary
- Move diagnostic cause construction into a transport-neutral helper.
- Keep TRPCError construction inside api/app tRPC adapter code.
- Convert the GitHub user-account service gate to a domain AuthzError.

## Test Plan
- pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/diagnostics-boundary-source.test.ts src/__tests__/diagnostics.test.ts src/__tests__/trpc-gates.test.ts
- pnpm --filter @api/app exec vitest run --passWithNoTests
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- git diff --check
- agent-browser smoke: https://auth-diagnostics-domain-errors.app.lightfast.localhost showed `Lightfast Console TanStack`
