### PR TITLE
Inline skills list query hook

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -481,7 +481,7 @@ describe("app authenticated route migration", () => {
     );
     const skillsClientSource = source("src/skills/skills-client.tsx");
     const skillsSearchSource = source("src/skills/skills-search-params.ts");
-    const skillsQuerySource = source("src/skills/use-skills-list-query.ts");
+    const skillsQuerySource = source("src/skills/skills-queries.ts");
     const connectorsRouteSource = source(
       "src/routes/_authenticated/$slug/connectors.tsx"
     );
@@ -537,6 +537,7 @@ describe("app authenticated route migration", () => {
     expect(skillsQuerySource).toContain(
       'enabled: typeof window !== "undefined"'
     );
+    expect(skillsClientSource).not.toContain("useSkillsListQuery");
 
     expect(connectorsRouteSource).toContain("validateConnectorsSearch");
     expect(connectorsRouteSource).toContain("setSearchParams");

--- a/apps/app/src/__tests__/skills-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/skills-no-trpc-source.test.ts
@@ -11,7 +11,7 @@ function source(path: string) {
 describe("migrated skills data access", () => {
   it("uses TanStack server functions instead of tRPC", () => {
     const skillsAdapterImport = /from\s+["']@api\/app\/tanstack\/skills["']/;
-    const querySource = source("src/skills/use-skills-list-query.ts");
+    const querySource = source("src/skills/skills-queries.ts");
     const controllerSource = source(
       "src/skills/use-skill-index-refresh-controller.ts"
     );

--- a/apps/app/src/__tests__/skills-queries-source.test.ts
+++ b/apps/app/src/__tests__/skills-queries-source.test.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+describe("skills app data access", () => {
+  it("uses local TanStack query helpers backed by api/app server functions", () => {
+    const querySource = source("src/skills/skills-queries.ts");
+
+    expect(querySource).toContain('@api/app/tanstack/skills"');
+    expect(querySource).toContain("skillsListQueryKey");
+    expect(querySource).toContain("skillsListQueryOptions");
+    expect(querySource).not.toContain("useTRPC");
+  });
+
+  it("inlines the shared skills list hook into its consumers", () => {
+    const listHookPath = resolve(
+      appRoot,
+      "src/skills/use-skills-list-query.ts"
+    );
+    const clientSource = source("src/skills/skills-client.tsx");
+    const topbarSource = source("src/workspace/workspace-topbar-actions.tsx");
+    const controllerSource = source(
+      "src/skills/use-skill-index-refresh-controller.ts"
+    );
+
+    expect(existsSync(listHookPath)).toBe(false);
+    expect(clientSource).toContain("useQuery");
+    expect(clientSource).toContain("skillsListQueryOptions");
+    expect(clientSource).not.toContain("useSkillsListQuery");
+    expect(clientSource).not.toContain("./use-skills-list-query");
+    expect(topbarSource).toContain("useQuery");
+    expect(topbarSource).toContain("skillsListQueryOptions");
+    expect(topbarSource).not.toContain("useSkillsListQuery");
+    expect(topbarSource).not.toContain("~/skills/use-skills-list-query");
+    expect(controllerSource).toContain('from "./skills-queries"');
+  });
+});

--- a/apps/app/src/skills/skills-client.tsx
+++ b/apps/app/src/skills/skills-client.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@repo/ui/components/ui/button";
 import { Input } from "@repo/ui/components/ui/input";
+import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { useDeferredValue, useMemo, useState } from "react";
 import { LfSelect } from "~/components/lf-select";
@@ -8,10 +9,10 @@ import { SkillDialog } from "./skill-dialog";
 import { SkillGrid } from "./skill-grid";
 import { SkillsLoading } from "./skills-loading";
 import { getVisibleSkills, type SkillFilter } from "./skills-model";
+import { skillsListQueryOptions } from "./skills-queries";
 import type { NormalizedSkillsSearch } from "./skills-search-params";
 import type { SkillsListResult } from "./skills-types";
 import { useSkillIndexRefreshController } from "./use-skill-index-refresh-controller";
-import { useSkillsListQuery } from "./use-skills-list-query";
 
 export function SkillsClient({
   search,
@@ -20,7 +21,7 @@ export function SkillsClient({
   search: NormalizedSkillsSearch;
   setSearchParams: (updates: Partial<NormalizedSkillsSearch>) => void;
 }) {
-  const { query: skillsQuery } = useSkillsListQuery();
+  const skillsQuery = useQuery(skillsListQueryOptions());
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<SkillFilter>("all");
   const data = skillsQuery.data;

--- a/apps/app/src/skills/skills-queries.ts
+++ b/apps/app/src/skills/skills-queries.ts
@@ -1,16 +1,14 @@
 import { type ListSkillsResult, listSkills } from "@api/app/tanstack/skills";
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 
 export const skillsListQueryKey = ["skills", "list"] as const;
 
-export function useSkillsListQuery() {
-  const options = {
+export function skillsListQueryOptions() {
+  return queryOptions({
     enabled: typeof window !== "undefined",
     queryFn: async (): Promise<ListSkillsResult> =>
       (await listSkills()) as ListSkillsResult,
     queryKey: skillsListQueryKey,
     staleTime: 0,
-  };
-
-  return { query: useQuery(options), queryKey: options.queryKey };
+  });
 }

--- a/apps/app/src/skills/use-skill-index-refresh-controller.ts
+++ b/apps/app/src/skills/use-skill-index-refresh-controller.ts
@@ -1,8 +1,8 @@
 import { requestSkillRefresh } from "@api/app/tanstack/skills";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
+import { skillsListQueryKey } from "./skills-queries";
 import type { SkillsListResult } from "./skills-types";
-import { skillsListQueryKey } from "./use-skills-list-query";
 
 const REFRESHABLE_STATUSES = new Set(["stale", "unavailable"]);
 const POLLABLE_STATUSES = new Set(["refreshing", "stale", "unavailable"]);

--- a/apps/app/src/workspace/workspace-topbar-actions.tsx
+++ b/apps/app/src/workspace/workspace-topbar-actions.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import {
   getRouteApi,
   type StaticDataRouteOption,
@@ -20,7 +21,7 @@ import {
 } from "~/signals/signals-search-params";
 import { SignalsViewSwitcher } from "~/signals/signals-view-switcher";
 import { SkillsActions } from "~/skills/skills-actions";
-import { useSkillsListQuery } from "~/skills/use-skills-list-query";
+import { skillsListQueryOptions } from "~/skills/skills-queries";
 
 type WorkspaceTopbarAction = "connectors" | "people" | "signals" | "skills";
 
@@ -150,7 +151,7 @@ function PeopleTopbarActions() {
 }
 
 function SkillsTopbarActions() {
-  const { query } = useSkillsListQuery();
+  const query = useQuery(skillsListQueryOptions());
   const data = query.data;
 
   if (!data) {


### PR DESCRIPTION
## Summary
- Rename the skills list hook boundary into `skills-queries.ts` with `skillsListQueryOptions`.
- Inline direct `useQuery(...)` calls in the skills page and workspace topbar actions.
- Keep the refresh controller on the shared skills query key without importing a hook module.

## Verification
- Red test first: `pnpm --filter @lightfast/app exec vitest run --passWithNoTests src/__tests__/skills-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/skills-no-trpc-source.test.ts src/__tests__/skills-refresh-controller-source.test.ts` failed because `skills-queries.ts` was missing and `use-skills-list-query.ts` still existed.
- `pnpm --filter @lightfast/app exec vitest run --passWithNoTests src/__tests__/skills-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/skills-no-trpc-source.test.ts src/__tests__/skills-refresh-controller-source.test.ts`
- `pnpm --filter @lightfast/app exec vitest run --passWithNoTests`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm --filter @api/app typecheck`
- `pnpm check`
- `git diff --check`
- agent-browser smoke: opened `https://inline-skills-list-query.app.lightfast.localhost`, waited for network idle, verified title and heading `Lightfast Console TanStack`.

## Notes
- `pnpm dev` reported the known `@lightfast/app:proxy` `EADDRINUSE` warning on port 3024; the direct branch app service started and passed smoke.