### PR TITLE
Route public signals API through domain commands

### DIFF
--- a/api/app/src/__tests__/domain-core.test.ts
+++ b/api/app/src/__tests__/domain-core.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import type { ApiKeyAuthResult } from "../auth/api-key";
 import type { AuthIdentity } from "../auth/identity";
 import {
+  actorFromApiKeyAuth,
   actorFromAuthIdentity,
   DomainError,
   defineCommand,
@@ -35,6 +37,24 @@ describe("actorFromAuthIdentity", () => {
       kind: "clerkUser",
       source: "web",
       userId: "user_test",
+    });
+  });
+});
+
+describe("actorFromApiKeyAuth", () => {
+  it("creates an org-scoped API-key actor with creator attribution", () => {
+    const auth: ApiKeyAuthResult = {
+      apiKeyId: "key_test",
+      identity: boundIdentity,
+    };
+
+    expect(actorFromApiKeyAuth(auth, ["api:signals:read"])).toEqual({
+      createdByUserId: "user_test",
+      keyId: "key_test",
+      kind: "apiKey",
+      orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+      orgId: "org_test",
+      scopes: ["api:signals:read"],
     });
   });
 });

--- a/api/app/src/__tests__/signals-domain-commands.test.ts
+++ b/api/app/src/__tests__/signals-domain-commands.test.ts
@@ -187,6 +187,65 @@ describe("signal domain commands", () => {
     });
   });
 
+  it("creates a signal as an API-key actor with key attribution", async () => {
+    await expect(
+      createSignalCommand.run({
+        ctx: {
+          actor: {
+            createdByUserId: "user_test",
+            keyId: "key_test",
+            kind: "apiKey",
+            orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+            orgId: "org_test",
+            scopes: ["api:signals:write"],
+          },
+        },
+        deps: deps(),
+        input: { input: "new signal" },
+      })
+    ).resolves.toEqual({
+      id: signalRow.publicId,
+      status: "queued",
+      visibilityScope: "user",
+    });
+
+    expect(createSignalForActorMock).toHaveBeenCalledWith(expect.anything(), {
+      actor: {
+        apiKeyId: "key_test",
+        kind: "api_key",
+        orgId: "org_test",
+        userId: "user_test",
+      },
+      input: "new signal",
+    });
+  });
+
+  it("loads signal detail as an API-key actor using creator visibility", async () => {
+    await getSignalCommand.run({
+      ctx: {
+        actor: {
+          createdByUserId: "user_test",
+          keyId: "key_test",
+          kind: "apiKey",
+          orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+          orgId: "org_test",
+          scopes: ["api:signals:read"],
+        },
+      },
+      deps: deps(),
+      input: { publicId: signalRow.publicId },
+    });
+
+    expect(getVisibleSignalByPublicIdMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_test",
+        createdByUserId: "user_test",
+        publicId: signalRow.publicId,
+      }
+    );
+  });
+
   it("maps queue failures to an internal domain error", async () => {
     const error = new Error("queue failed");
     error.name = "SignalCreateQueueError";

--- a/api/app/src/adapters/public/signals.ts
+++ b/api/app/src/adapters/public/signals.ts
@@ -1,7 +1,3 @@
-import {
-  getVisibleSignalByPublicId,
-  listSignalEntityLinksForSignal,
-} from "@db/app";
 import { db } from "@db/app/client";
 import {
   createSignalInput,
@@ -9,15 +5,24 @@ import {
   getSignalInput,
   getSignalOutput,
 } from "@repo/api-contract";
-import { repairIdForSetupRequirement } from "@repo/app-setup-contract";
+import {
+  type OrgSetupRequirement,
+  orgSetupRequirementSchema,
+  repairIdForSetupRequirement,
+} from "@repo/app-setup-contract";
 
 import {
   type ApiKeyAuthResult,
   isApiKeyAuthError,
   resolveApiKeyAuth,
 } from "../../auth/api-key";
-import { isSignalCreateQueueError } from "../../signals/create-signal";
-import { createSignalForActor } from "../../signals/service";
+import { actorFromApiKeyAuth, isDomainError } from "../../domain";
+import {
+  createSignalCommand,
+  createSignalCommandDeps,
+  getSignalCommand,
+  getSignalCommandDeps,
+} from "../../domain/signals";
 
 type PublicApiStatus = 400 | 401 | 403 | 404 | 500;
 
@@ -82,6 +87,69 @@ function orgSetupErrorResponse(auth: ApiKeyAuthResult): Response {
   });
 }
 
+function requestId() {
+  return crypto.randomUUID();
+}
+
+function publicSignalContext(auth: ApiKeyAuthResult) {
+  return {
+    actor: actorFromApiKeyAuth(auth, ["api:signals:read", "api:signals:write"]),
+    request: { id: requestId(), source: "public-api" as const },
+  };
+}
+
+function setupRequirementOrDefault(requirement: unknown): OrgSetupRequirement {
+  const parsed = orgSetupRequirementSchema.safeParse(requirement);
+  return parsed.success ? parsed.data : "github_org";
+}
+
+function domainErrorResponse(
+  error: unknown,
+  fallbackMessage: string
+): Response {
+  if (!isDomainError(error)) {
+    return jsonError("internal_error", fallbackMessage, 500);
+  }
+
+  if (error.code === "SIGNAL_NOT_FOUND") {
+    return jsonError("not_found", "Signal not found.", 404);
+  }
+
+  if (error.code === "SIGNAL_QUEUE_FAILED") {
+    return jsonError("signal_enqueue_failed", error.message, 500);
+  }
+
+  if (error.code === "ORG_SETUP_REQUIRED") {
+    return jsonError("org_setup_required", error.message, 403, {
+      diagnostics: [
+        {
+          code: error.code,
+          message: error.message,
+          repair: {
+            id: repairIdForSetupRequirement(
+              setupRequirementOrDefault(error.details.nextSetupRequirement)
+            ),
+          },
+        },
+      ],
+    });
+  }
+
+  if (error.kind === "authz") {
+    return jsonError("forbidden", error.message, 403, {
+      diagnostics: [{ code: error.code, message: error.message }],
+    });
+  }
+
+  if (error.kind === "validation") {
+    return jsonError("invalid_request", error.message, 400, {
+      diagnostics: error.details.issues,
+    });
+  }
+
+  return jsonError("internal_error", fallbackMessage, 500);
+}
+
 function isResponse(value: unknown): value is Response {
   return value instanceof Response;
 }
@@ -129,21 +197,14 @@ export async function handleCreateSignalPublicApiRequest(
   }
 
   try {
-    const result = await createSignalForActor(db, {
-      actor: {
-        apiKeyId: auth.apiKeyId,
-        kind: "api_key",
-        orgId: auth.identity.orgId,
-        userId: auth.identity.userId,
-      },
-      input: parsed.data.input,
+    const result = await createSignalCommand.run({
+      ctx: publicSignalContext(auth),
+      deps: createSignalCommandDeps({ db }),
+      input: parsed.data,
     });
     return jsonResponse(createSignalOutput.parse(result), 202);
   } catch (error) {
-    if (isSignalCreateQueueError(error)) {
-      return jsonError("signal_enqueue_failed", error.message, 500);
-    }
-    return jsonError("internal_error", "Failed to create signal.", 500);
+    return domainErrorResponse(error, "Failed to create signal.");
   }
 }
 
@@ -164,19 +225,10 @@ export async function handleGetSignalPublicApiRequest(
   }
 
   try {
-    const signal = await getVisibleSignalByPublicId(db, {
-      clerkOrgId: auth.identity.orgId,
-      createdByUserId: auth.identity.userId,
-      publicId: parsed.data.id,
-    });
-
-    if (!signal) {
-      return jsonError("not_found", "Signal not found.", 404);
-    }
-
-    const entityLinks = await listSignalEntityLinksForSignal(db, {
-      clerkOrgId: auth.identity.orgId,
-      signalId: signal.publicId,
+    const signal = await getSignalCommand.run({
+      ctx: publicSignalContext(auth),
+      deps: getSignalCommandDeps({ db }),
+      input: { publicId: parsed.data.id },
     });
 
     const output = getSignalOutput.parse({
@@ -184,7 +236,7 @@ export async function handleGetSignalPublicApiRequest(
       input: signal.input,
       status: signal.status,
       classification: signal.classification,
-      entityLinks,
+      entityLinks: signal.entityLinks,
       visibilityScope: signal.visibilityScope,
       createdAt: signal.createdAt.toISOString(),
       updatedAt: signal.updatedAt.toISOString(),
@@ -192,9 +244,6 @@ export async function handleGetSignalPublicApiRequest(
 
     return jsonResponse(output, 200);
   } catch (error) {
-    if (error instanceof Response) {
-      return withPublicApiCors(error);
-    }
-    return jsonError("internal_error", "Failed to get signal.", 500);
+    return domainErrorResponse(error, "Failed to get signal.");
   }
 }

--- a/api/app/src/domain/actor.ts
+++ b/api/app/src/domain/actor.ts
@@ -1,3 +1,4 @@
+import type { ApiKeyAuthResult } from "../auth/api-key";
 import type { AuthIdentity, OrgGate } from "../auth/identity";
 import { AuthzError } from "./errors";
 
@@ -18,8 +19,10 @@ export type Actor =
       userId: string;
     }
   | {
+      createdByUserId: string;
       keyId: string;
       kind: "apiKey";
+      orgGate?: OrgGate;
       orgId: string;
       scopes: string[];
     }
@@ -79,5 +82,19 @@ export function actorFromAuthIdentity(
     orgId: identity.orgId,
     source,
     userId: identity.userId,
+  };
+}
+
+export function actorFromApiKeyAuth(
+  auth: ApiKeyAuthResult,
+  scopes: string[] = []
+): Actor {
+  return {
+    createdByUserId: auth.identity.userId,
+    keyId: auth.apiKeyId,
+    kind: "apiKey",
+    orgGate: auth.identity.orgGate,
+    orgId: auth.identity.orgId,
+    scopes,
   };
 }

--- a/api/app/src/domain/signals/commands.ts
+++ b/api/app/src/domain/signals/commands.ts
@@ -14,8 +14,9 @@ import {
 import { z } from "zod";
 import { isSignalCreateQueueError } from "../../signals/create-signal";
 import { createSignalForActor } from "../../signals/service";
+import type { ExecutionContext } from "../actor";
 import { type CommandRunArgs, defineCommand } from "../command";
-import { InternalDomainError, NotFoundError } from "../errors";
+import { AuthzError, InternalDomainError, NotFoundError } from "../errors";
 import { requireBoundClerkOrgActor } from "../gates";
 
 export type ListProcessingSignalsResult = Awaited<
@@ -55,13 +56,49 @@ const getSignalInput = z
   })
   .strict();
 
-export interface SignalCommandDeps {
-  createSignalForActor: typeof createSignalForActor;
+interface SignalCommandBaseDeps {
   db: Database;
+}
+
+export interface SignalCreateCommandDeps extends SignalCommandBaseDeps {
+  createSignalForActor: typeof createSignalForActor;
+}
+
+export interface SignalGetCommandDeps extends SignalCommandBaseDeps {
   getVisibleSignalByPublicId: typeof getVisibleSignalByPublicId;
   listSignalEntityLinksForSignal: typeof listSignalEntityLinksForSignal;
+}
+
+export interface SignalListProcessingCommandDeps extends SignalCommandBaseDeps {
   listSignals: typeof listSignals;
+}
+
+export interface SignalListWorkingSetCommandDeps extends SignalCommandBaseDeps {
   listWorkspaceSignals: typeof listWorkspaceSignals;
+}
+
+export type SignalCommandDeps = SignalCreateCommandDeps &
+  SignalGetCommandDeps &
+  SignalListProcessingCommandDeps &
+  SignalListWorkingSetCommandDeps;
+
+export function createSignalCommandDeps(input: {
+  db: Database;
+}): SignalCreateCommandDeps {
+  return {
+    db: input.db,
+    createSignalForActor,
+  };
+}
+
+export function getSignalCommandDeps(input: {
+  db: Database;
+}): SignalGetCommandDeps {
+  return {
+    db: input.db,
+    getVisibleSignalByPublicId,
+    listSignalEntityLinksForSignal,
+  };
 }
 
 export function createDefaultSignalCommandDeps(input: {
@@ -80,11 +117,48 @@ export function createDefaultSignalCommandDeps(input: {
 const objectOutput = <T>() =>
   z.custom<T>((value) => typeof value === "object" && value !== null);
 
-type SignalCommandRunArgs<TInput, TOutput> = CommandRunArgs<
+type SignalCommandRunArgs<
   TInput,
   TOutput,
-  SignalCommandDeps
->;
+  TDeps extends object,
+> = CommandRunArgs<TInput, TOutput, TDeps>;
+
+type ResolvedSignalCommandActor =
+  | { kind: "web"; orgId: string; userId: string }
+  | { apiKeyId: string; kind: "api_key"; orgId: string; userId: string };
+
+function requireSignalCommandActor(
+  ctx: ExecutionContext
+): ResolvedSignalCommandActor {
+  if (ctx.actor.kind === "clerkUser") {
+    const actor = requireBoundClerkOrgActor(ctx);
+    return { kind: "web", orgId: actor.orgId, userId: actor.userId };
+  }
+
+  if (ctx.actor.kind === "apiKey") {
+    if (ctx.actor.orgGate?.bindingStatus !== "bound") {
+      throw new AuthzError(
+        "ORG_SETUP_REQUIRED",
+        "Organization setup required. Complete setup before using Lightfast features.",
+        {
+          nextSetupRequirement: ctx.actor.orgGate?.nextSetupRequirement,
+        }
+      );
+    }
+
+    return {
+      apiKeyId: ctx.actor.keyId,
+      kind: "api_key",
+      orgId: ctx.actor.orgId,
+      userId: ctx.actor.createdByUserId,
+    };
+  }
+
+  throw new AuthzError(
+    "SIGNAL_ACTOR_REQUIRED",
+    "A Lightfast user or API key is required."
+  );
+}
 
 export const listProcessingSignalsCommand = defineCommand({
   name: "signals.listProcessing",
@@ -96,9 +170,10 @@ export const listProcessingSignalsCommand = defineCommand({
     input,
   }: SignalCommandRunArgs<
     z.infer<typeof listProcessingSignalsInput>,
-    ListProcessingSignalsResult
+    ListProcessingSignalsResult,
+    SignalListProcessingCommandDeps
   >) => {
-    const actor = requireBoundClerkOrgActor(ctx);
+    const actor = requireSignalCommandActor(ctx);
     return deps.listSignals(deps.db, {
       clerkOrgId: actor.orgId,
       createdByUserId: actor.userId,
@@ -118,9 +193,10 @@ export const listWorkingSetSignalsCommand = defineCommand({
     deps,
   }: SignalCommandRunArgs<
     z.infer<typeof listWorkingSetSignalsInput>,
-    ListWorkingSetSignalsResult
+    ListWorkingSetSignalsResult,
+    SignalListWorkingSetCommandDeps
   >) => {
-    const actor = requireBoundClerkOrgActor(ctx);
+    const actor = requireSignalCommandActor(ctx);
     return deps.listWorkspaceSignals(deps.db, {
       clerkOrgId: actor.orgId,
       createdByUserId: actor.userId,
@@ -138,9 +214,10 @@ export const getSignalCommand = defineCommand({
     input,
   }: SignalCommandRunArgs<
     z.infer<typeof getSignalInput>,
-    SignalDetailResult
+    SignalDetailResult,
+    SignalGetCommandDeps
   >) => {
-    const actor = requireBoundClerkOrgActor(ctx);
+    const actor = requireSignalCommandActor(ctx);
     const signal = await deps.getVisibleSignalByPublicId(deps.db, {
       clerkOrgId: actor.orgId,
       createdByUserId: actor.userId,
@@ -170,12 +247,13 @@ export const createSignalCommand = defineCommand({
     input,
   }: SignalCommandRunArgs<
     z.infer<typeof createSignalInput>,
-    z.infer<typeof createSignalOutput>
+    z.infer<typeof createSignalOutput>,
+    SignalCreateCommandDeps
   >) => {
-    const actor = requireBoundClerkOrgActor(ctx);
+    const actor = requireSignalCommandActor(ctx);
     try {
       return await deps.createSignalForActor(deps.db, {
-        actor: { kind: "web", orgId: actor.orgId, userId: actor.userId },
+        actor,
         input: input.input,
       });
     } catch (error) {

--- a/apps/app/src/__tests__/public-api-routes-source.test.ts
+++ b/apps/app/src/__tests__/public-api-routes-source.test.ts
@@ -66,9 +66,14 @@ describe("public API route boundaries", () => {
 
     expect(packageJson.exports).toHaveProperty("./public-api/signals");
     expect(adapter).toContain("resolveApiKeyAuth");
+    expect(adapter).toContain("actorFromApiKeyAuth");
+    expect(adapter).toContain("createSignalCommand");
+    expect(adapter).toContain("getSignalCommand");
     expect(adapter).toContain("createSignalInput");
     expect(adapter).toContain("getSignalOutput.parse");
-    expect(adapter).toContain("createSignalForActor");
+    expect(adapter).not.toContain("createSignalForActor");
+    expect(adapter).not.toContain("getVisibleSignalByPublicId");
+    expect(adapter).not.toContain("listSignalEntityLinksForSignal");
     expect(adapter).not.toContain("ORPCError");
     expect(adapter).not.toContain("@orpc/");
     expect(adapter).not.toContain("OpenAPIHandler");


### PR DESCRIPTION
## Summary
- Route public `/api/v1/signals` create/get through the signal domain commands instead of direct DB/service helpers.
- Add API-key actor construction with creator attribution so public API keys remain org-scoped while preserving user visibility metadata.
- Narrow signal command dependency types so public create/get adapters do not depend on workspace list internals.

## Test Plan
- `pnpm --filter @api/app test -- src/__tests__/domain-core.test.ts src/__tests__/signals-domain-commands.test.ts src/__tests__/public-signals-api.test.ts`
- `pnpm --filter @lightfast/app test -- src/__tests__/public-api-routes-source.test.ts`
- `SKIP_ENV_VALIDATION=true pnpm --filter @api/app typecheck`
- `pnpm lint:ws`
- `SKIP_ENV_VALIDATION=true pnpm typecheck`
- `pnpm check`
- `git diff --check`
- `agent-browser --session public-signals-smoke open https://public-signals-command-boundary.app.lightfast.localhost/`
- `agent-browser --session public-signals-smoke get title`
- `agent-browser --session public-signals-smoke snapshot -i -c`
- live route smoke: `OPTIONS /api/v1/signals` returned 204 with public CORS headers
- live route smoke: unauthenticated `POST /api/v1/signals` and `GET /api/v1/signals/:id` returned public `auth_required` JSON
