### PR TITLE
Use explicit MCP OAuth entrypoint

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -5,10 +5,6 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
-    },
     "./mcp-oauth": {
       "types": "./src/mcp-oauth/index.ts",
       "default": "./src/mcp-oauth/index.ts"

--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -13,8 +13,8 @@ describe("api/app app-facing tRPC root", () => {
     const packageJson = JSON.parse(source("../package.json")) as {
       dependencies?: Record<string, string>;
     };
-    const indexSource = source("index.ts");
     const trpcPath = resolve(apiRoot, "trpc.ts");
+    const indexPath = resolve(apiRoot, "index.ts");
     const workspaceListInputPath = resolve(
       apiRoot,
       "router/(pending-not-allowed)/workspace-list-input.ts"
@@ -27,13 +27,8 @@ describe("api/app app-facing tRPC root", () => {
     expect(existsSync(trpcPath)).toBe(false);
     expect(existsSync(workspaceListInputPath)).toBe(false);
     expect(existsSync(taskRouterPath)).toBe(false);
+    expect(existsSync(indexPath)).toBe(false);
     expect(packageJson.dependencies?.["@trpc/server"]).toBeUndefined();
-    expect(indexSource).toContain('export * from "./mcp-oauth"');
-    expect(indexSource).not.toContain("@trpc/server");
-    expect(indexSource).not.toContain("AppRouter");
-    expect(indexSource).not.toContain("appRouter");
-    expect(indexSource).not.toContain("createTRPCContext");
-    expect(indexSource).not.toContain("createCallerFactory");
 
     const rootSource = source("root.ts");
     expect(rootSource).not.toContain("createTRPCRouter");

--- a/api/app/src/__tests__/mcp-oauth-entrypoint-source.test.ts
+++ b/api/app/src/__tests__/mcp-oauth-entrypoint-source.test.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("MCP OAuth package entrypoint", () => {
+  it("keeps MCP OAuth behind its explicit api/app entrypoint", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      exports?: Record<string, unknown>;
+    };
+
+    expect(packageJson.exports).toHaveProperty("./mcp-oauth");
+    expect(Object.hasOwn(packageJson.exports ?? {}, ".")).toBe(false);
+    expect(existsSync(resolve(apiRoot, "src/index.ts"))).toBe(false);
+  });
+});

--- a/api/app/src/__tests__/public-api-orpc-cleanup-source.test.ts
+++ b/api/app/src/__tests__/public-api-orpc-cleanup-source.test.ts
@@ -12,12 +12,12 @@ describe("public API oRPC server cleanup", () => {
   it("removes the legacy api/app oRPC server router", () => {
     const packageJson = JSON.parse(source("package.json")) as {
       dependencies?: Record<string, string>;
+      exports?: Record<string, unknown>;
     };
-    const indexSource = source("src/index.ts");
 
     expect(existsSync(resolve(repoRoot, "src/orpc"))).toBe(false);
+    expect(existsSync(resolve(repoRoot, "src/index.ts"))).toBe(false);
     expect(packageJson.dependencies?.["@orpc/server"]).toBeUndefined();
-    expect(indexSource).not.toContain("orpcRouter");
-    expect(indexSource).not.toContain("./orpc");
+    expect(Object.hasOwn(packageJson.exports ?? {}, ".")).toBe(false);
   });
 });

--- a/api/app/src/index.ts
+++ b/api/app/src/index.ts
@@ -1,1 +1,0 @@
-export * from "./mcp-oauth";

--- a/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
+++ b/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
@@ -8,6 +8,8 @@ function source(path: string) {
   return readFileSync(resolve(appRoot, path), "utf8");
 }
 
+const rootApiAppImportPattern = /from\s+["@']@api\/app["@']/;
+
 describe("app OAuth protocol route migration", () => {
   it("ports MCP OAuth protocol endpoints as TanStack server routes", () => {
     const metadataSource = source(
@@ -20,37 +22,60 @@ describe("app OAuth protocol route migration", () => {
     );
     const tokenSource = source("src/routes/oauth/token.ts");
     const revokeSource = source("src/routes/oauth/revoke.ts");
+    const consentSource = source("src/oauth/mcp-consent.server.ts");
     const responseSource = source("src/server/oauth/mcp-response.ts");
 
     expect(metadataSource).toContain(
       'createFileRoute("/.well-known/oauth-authorization-server")'
     );
+    expect(metadataSource).toContain('@api/app/mcp-oauth"');
     expect(metadataSource).toContain("MCP_SUPPORTED_SCOPES");
     expect(metadataSource).toContain("authorization_endpoint");
     expect(metadataSource).toContain("token_endpoint_auth_methods_supported");
     expect(jwksSource).toContain('createFileRoute("/oauth/jwks")');
+    expect(jwksSource).toContain('@api/app/mcp-oauth"');
     expect(jwksSource).toContain("getMcpOAuthJwks");
     expect(registerSource).toContain('createFileRoute("/oauth/register")');
+    expect(registerSource).toContain('@api/app/mcp-oauth"');
     expect(registerSource).toContain("registerMcpOAuthClient");
     expect(registerSource).toContain("readOAuthBody");
     expect(registerSource).toContain("POST:");
     expect(registeredClientSource).toContain(
       'createFileRoute("/oauth/register/$clientId")'
     );
+    expect(registeredClientSource).toContain('@api/app/mcp-oauth"');
     expect(registeredClientSource).toContain("getRegisteredMcpOAuthClient");
     expect(registeredClientSource).toContain("bearerToken");
     expect(registeredClientSource).toContain("params.clientId");
     expect(tokenSource).toContain('createFileRoute("/oauth/token")');
+    expect(tokenSource).toContain('@api/app/mcp-oauth"');
     expect(tokenSource).toContain("exchangeMcpAuthorizationCode");
     expect(tokenSource).toContain("rotateMcpRefreshTokenSecret");
     expect(tokenSource).toContain("requireOAuthServiceJwtSecret");
     expect(revokeSource).toContain('createFileRoute("/oauth/revoke")');
+    expect(revokeSource).toContain('@api/app/mcp-oauth"');
     expect(revokeSource).toContain("revokeMcpRefreshTokenSecret");
+    expect(consentSource).toContain('@api/app/mcp-oauth"');
+    expect(consentSource).toContain("issueMcpAuthorizationCode");
     expect(responseSource).toContain("env.VITE_LIGHTFAST_APP_URL");
+    expect(responseSource).toContain('@api/app/mcp-oauth"');
     expect(responseSource).toContain("McpOAuthError");
     expect(responseSource).toContain("cache-control");
     expect(responseSource).toContain("readOAuthBody");
     expect(responseSource).toContain("bearerToken");
+
+    for (const routeSource of [
+      metadataSource,
+      jwksSource,
+      registerSource,
+      registeredClientSource,
+      tokenSource,
+      revokeSource,
+      consentSource,
+      responseSource,
+    ]) {
+      expect(routeSource).not.toMatch(rootApiAppImportPattern);
+    }
 
     for (const routeSource of [
       metadataSource,

--- a/apps/app/src/oauth/mcp-consent.server.ts
+++ b/apps/app/src/oauth/mcp-consent.server.ts
@@ -5,7 +5,7 @@ import {
   isValidMcpS256CodeChallenge,
   McpOAuthError,
   parseMcpScopes,
-} from "@api/app";
+} from "@api/app/mcp-oauth";
 import { getMcpOauthClientByClientId } from "@db/app";
 import { db } from "@db/app/client";
 import type { McpScope } from "@repo/api-contract";

--- a/apps/app/src/routes/[.]well-known/oauth-authorization-server.ts
+++ b/apps/app/src/routes/[.]well-known/oauth-authorization-server.ts
@@ -1,4 +1,4 @@
-import { MCP_SUPPORTED_SCOPES } from "@api/app";
+import { MCP_SUPPORTED_SCOPES } from "@api/app/mcp-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 import { oauthJson, oauthUrl } from "~/server/oauth/mcp-response";
 

--- a/apps/app/src/routes/oauth/jwks.ts
+++ b/apps/app/src/routes/oauth/jwks.ts
@@ -1,4 +1,4 @@
-import { getMcpOAuthJwks } from "@api/app";
+import { getMcpOAuthJwks } from "@api/app/mcp-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 import { oauthJson } from "~/server/oauth/mcp-response";
 

--- a/apps/app/src/routes/oauth/register.ts
+++ b/apps/app/src/routes/oauth/register.ts
@@ -1,4 +1,4 @@
-import { registerMcpOAuthClient } from "@api/app";
+import { registerMcpOAuthClient } from "@api/app/mcp-oauth";
 import { db } from "@db/app/client";
 import { createFileRoute } from "@tanstack/react-router";
 import {

--- a/apps/app/src/routes/oauth/register/$clientId.ts
+++ b/apps/app/src/routes/oauth/register/$clientId.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/style/useFilenamingConvention: TanStack route params must be valid JavaScript identifiers.
-import { getRegisteredMcpOAuthClient, McpOAuthError } from "@api/app";
+import { getRegisteredMcpOAuthClient, McpOAuthError } from "@api/app/mcp-oauth";
 import { db } from "@db/app/client";
 import { createFileRoute } from "@tanstack/react-router";
 import {

--- a/apps/app/src/routes/oauth/revoke.ts
+++ b/apps/app/src/routes/oauth/revoke.ts
@@ -1,4 +1,4 @@
-import { revokeMcpRefreshTokenSecret } from "@api/app";
+import { revokeMcpRefreshTokenSecret } from "@api/app/mcp-oauth";
 import { db } from "@db/app/client";
 import { createFileRoute } from "@tanstack/react-router";
 import {

--- a/apps/app/src/routes/oauth/token.ts
+++ b/apps/app/src/routes/oauth/token.ts
@@ -2,7 +2,7 @@ import {
   exchangeMcpAuthorizationCode,
   McpOAuthError,
   rotateMcpRefreshTokenSecret,
-} from "@api/app";
+} from "@api/app/mcp-oauth";
 import { db } from "@db/app/client";
 import { createFileRoute } from "@tanstack/react-router";
 import {

--- a/apps/app/src/server/oauth/mcp-response.ts
+++ b/apps/app/src/server/oauth/mcp-response.ts
@@ -1,4 +1,4 @@
-import { McpOAuthError } from "@api/app";
+import { McpOAuthError } from "@api/app/mcp-oauth";
 import { env } from "~/env";
 
 export function oauthIssuer(): string {


### PR DESCRIPTION
## Summary
- Move MCP OAuth route/helper imports from the root @api/app barrel to @api/app/mcp-oauth.
- Remove the root @api/app package export and delete api/app/src/index.ts so the root cannot hide adapter boundaries.
- Add source ratchets for explicit MCP OAuth entrypoint usage and no bare root @api/app imports.

## Test Plan
- RED: pnpm --filter @lightfast/app test -- src/__tests__/oauth-protocol-routes-source.test.ts (failed while OAuth routes still imported @api/app)
- RED: pnpm --filter @api/app test -- src/__tests__/mcp-oauth-entrypoint-source.test.ts (failed while src/index.ts re-exported MCP OAuth)
- pnpm --filter @lightfast/app test -- src/__tests__/oauth-protocol-routes-source.test.ts
- pnpm --filter @api/app test -- src/__tests__/mcp-oauth-entrypoint-source.test.ts src/__tests__/app-trpc-root-source.test.ts src/__tests__/public-api-orpc-cleanup-source.test.ts
- SKIP_ENV_VALIDATION=true pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm lint:ws
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- agent-browser smoke at http://127.0.0.1:5177/ saw title/heading "Lightfast Console TanStack"