### PR TITLE
Route MCP signals through domain commands

### DIFF
--- a/api/app/src/__tests__/mcp-signals-internal-adapter.test.ts
+++ b/api/app/src/__tests__/mcp-signals-internal-adapter.test.ts
@@ -1,15 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { NotFoundError } from "../domain/errors";
 import { signServiceJWT } from "../service-jwt";
 
 const mocks = vi.hoisted(() => ({
   assertHostedMcpOrgAccess: vi.fn(),
-  createSignalForActor: vi.fn(),
-  getVisibleSignalByPublicId: vi.fn(),
-}));
-
-vi.mock("@db/app", () => ({
-  getVisibleSignalByPublicId: mocks.getVisibleSignalByPublicId,
+  createSignalCommandDeps: vi.fn(() => ({ kind: "createDeps" })),
+  createSignalCommandRun: vi.fn(),
+  getSignalCommandDeps: vi.fn(() => ({ kind: "getDeps" })),
+  getSignalCommandRun: vi.fn(),
 }));
 
 vi.mock("@db/app/client", () => ({
@@ -20,8 +19,15 @@ vi.mock("../mcp-oauth/resource-access", () => ({
   assertHostedMcpOrgAccess: mocks.assertHostedMcpOrgAccess,
 }));
 
-vi.mock("../signals/service", () => ({
-  createSignalForActor: mocks.createSignalForActor,
+vi.mock("../domain/signals", () => ({
+  createSignalCommand: {
+    run: mocks.createSignalCommandRun,
+  },
+  createSignalCommandDeps: mocks.createSignalCommandDeps,
+  getSignalCommand: {
+    run: mocks.getSignalCommandRun,
+  },
+  getSignalCommandDeps: mocks.getSignalCommandDeps,
 }));
 
 const {
@@ -72,6 +78,21 @@ describe("MCP signal internal adapter", () => {
   beforeEach(() => {
     process.env.SERVICE_JWT_SECRET = jwtSecret;
     vi.clearAllMocks();
+    mocks.createSignalCommandRun.mockResolvedValue({
+      id: invisibleSignalId,
+      status: "queued",
+      visibilityScope: "user",
+    });
+    mocks.getSignalCommandRun.mockResolvedValue({
+      classification: null,
+      createdAt: new Date("2026-05-27T01:00:00.000Z"),
+      entityLinks: [],
+      input: "hello",
+      publicId: invisibleSignalId,
+      status: "queued",
+      updatedAt: new Date("2026-05-27T01:01:00.000Z"),
+      visibilityScope: "user",
+    });
   });
 
   afterEach(() => {
@@ -92,7 +113,7 @@ describe("MCP signal internal adapter", () => {
       error: "missing_token",
     });
     expect(mocks.assertHostedMcpOrgAccess).not.toHaveBeenCalled();
-    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+    expect(mocks.createSignalCommandRun).not.toHaveBeenCalled();
   });
 
   it("rejects expired service JWTs before org access checks", async () => {
@@ -108,7 +129,7 @@ describe("MCP signal internal adapter", () => {
       error: "invalid_token",
     });
     expect(mocks.assertHostedMcpOrgAccess).not.toHaveBeenCalled();
-    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+    expect(mocks.createSignalCommandRun).not.toHaveBeenCalled();
   });
 
   it("rejects service JWTs from non-MCP callers", async () => {
@@ -124,7 +145,7 @@ describe("MCP signal internal adapter", () => {
       error: "disallowed_caller",
     });
     expect(mocks.assertHostedMcpOrgAccess).not.toHaveBeenCalled();
-    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+    expect(mocks.createSignalCommandRun).not.toHaveBeenCalled();
   });
 
   it("rejects create commands when hosted MCP org access is denied", async () => {
@@ -145,7 +166,7 @@ describe("MCP signal internal adapter", () => {
       error: "org_access_denied",
       message: "No access to this organization.",
     });
-    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
+    expect(mocks.createSignalCommandRun).not.toHaveBeenCalled();
   });
 
   it("rejects get commands when hosted MCP org access is denied", async () => {
@@ -166,11 +187,84 @@ describe("MCP signal internal adapter", () => {
       error: "org_access_denied",
       message: "No access to this organization.",
     });
-    expect(mocks.getVisibleSignalByPublicId).not.toHaveBeenCalled();
+    expect(mocks.getSignalCommandRun).not.toHaveBeenCalled();
+  });
+
+  it("creates signals through the domain command as an apps-mcp service caller", async () => {
+    const response = await handleCreateMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, input: "hello" },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      id: invisibleSignalId,
+      status: "queued",
+      visibilityScope: "user",
+    });
+    expect(mocks.createSignalCommandDeps).toHaveBeenCalledWith({ db: {} });
+    expect(mocks.createSignalCommandRun).toHaveBeenCalledWith({
+      ctx: {
+        actor: {
+          clientId: "client_1",
+          grantId: "grant_1",
+          kind: "mcpClient",
+          orgId: "org_1",
+          scopes: [],
+          userId: "user_1",
+        },
+        caller: { kind: "service", service: "apps-mcp" },
+        request: { id: expect.any(String), source: "mcp" },
+      },
+      deps: { kind: "createDeps" },
+      input: { input: "hello" },
+    });
+  });
+
+  it("gets signals through the domain command and maps public MCP output", async () => {
+    const response = await handleGetMcpSignalInternalRequest(
+      jsonRequest({
+        body: { actor, id: invisibleSignalId },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      classification: null,
+      createdAt: "2026-05-27T01:00:00.000Z",
+      entityLinks: [],
+      id: invisibleSignalId,
+      input: "hello",
+      status: "queued",
+      updatedAt: "2026-05-27T01:01:00.000Z",
+      visibilityScope: "user",
+    });
+    expect(mocks.getSignalCommandDeps).toHaveBeenCalledWith({ db: {} });
+    expect(mocks.getSignalCommandRun).toHaveBeenCalledWith({
+      ctx: {
+        actor: {
+          clientId: "client_1",
+          grantId: "grant_1",
+          kind: "mcpClient",
+          orgId: "org_1",
+          scopes: [],
+          userId: "user_1",
+        },
+        caller: { kind: "service", service: "apps-mcp" },
+        request: { id: expect.any(String), source: "mcp" },
+      },
+      deps: { kind: "getDeps" },
+      input: { publicId: invisibleSignalId },
+    });
   });
 
   it("returns not found when a requested signal is outside actor visibility", async () => {
-    mocks.getVisibleSignalByPublicId.mockResolvedValueOnce(null);
+    mocks.getSignalCommandRun.mockRejectedValueOnce(
+      new NotFoundError("SIGNAL_NOT_FOUND", "Signal not found.")
+    );
 
     const response = await handleGetMcpSignalInternalRequest(
       jsonRequest({
@@ -183,13 +277,6 @@ describe("MCP signal internal adapter", () => {
     await expect(responseJson(response)).resolves.toMatchObject({
       error: "not_found",
     });
-    expect(mocks.getVisibleSignalByPublicId).toHaveBeenCalledWith(
-      {},
-      {
-        clerkOrgId: "org_1",
-        createdByUserId: "user_1",
-        publicId: invisibleSignalId,
-      }
-    );
+    expect(mocks.getSignalCommandRun).toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/signals-domain-commands.test.ts
+++ b/api/app/src/__tests__/signals-domain-commands.test.ts
@@ -220,6 +220,42 @@ describe("signal domain commands", () => {
     });
   });
 
+  it("creates a signal as an MCP client actor with grant attribution", async () => {
+    await expect(
+      createSignalCommand.run({
+        ctx: {
+          actor: {
+            clientId: "client_test",
+            grantId: "grant_test",
+            kind: "mcpClient",
+            orgId: "org_test",
+            scopes: [],
+            userId: "user_test",
+          },
+          caller: { kind: "service", service: "apps-mcp" },
+          request: { id: "req_mcp_test", source: "mcp" },
+        },
+        deps: deps(),
+        input: { input: "new signal" },
+      })
+    ).resolves.toEqual({
+      id: signalRow.publicId,
+      status: "queued",
+      visibilityScope: "user",
+    });
+
+    expect(createSignalForActorMock).toHaveBeenCalledWith(expect.anything(), {
+      actor: {
+        clientId: "client_test",
+        grantId: "grant_test",
+        kind: "mcp",
+        orgId: "org_test",
+        userId: "user_test",
+      },
+      input: "new signal",
+    });
+  });
+
   it("loads signal detail as an API-key actor using creator visibility", async () => {
     await getSignalCommand.run({
       ctx: {
@@ -231,6 +267,34 @@ describe("signal domain commands", () => {
           orgId: "org_test",
           scopes: ["api:signals:read"],
         },
+      },
+      deps: deps(),
+      input: { publicId: signalRow.publicId },
+    });
+
+    expect(getVisibleSignalByPublicIdMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        clerkOrgId: "org_test",
+        createdByUserId: "user_test",
+        publicId: signalRow.publicId,
+      }
+    );
+  });
+
+  it("loads signal detail as an MCP client actor using creator visibility", async () => {
+    await getSignalCommand.run({
+      ctx: {
+        actor: {
+          clientId: "client_test",
+          grantId: "grant_test",
+          kind: "mcpClient",
+          orgId: "org_test",
+          scopes: [],
+          userId: "user_test",
+        },
+        caller: { kind: "service", service: "apps-mcp" },
+        request: { id: "req_mcp_test", source: "mcp" },
       },
       deps: deps(),
       input: { publicId: signalRow.publicId },

--- a/api/app/src/adapters/internal/mcp-signals.ts
+++ b/api/app/src/adapters/internal/mcp-signals.ts
@@ -1,14 +1,21 @@
-import { getVisibleSignalByPublicId } from "@db/app";
 import { db } from "@db/app/client";
 import {
+  type CreateMcpSignalCommandInput,
   createMcpSignalCommandInput,
+  type GetMcpSignalCommandInput,
   getMcpSignalCommandInput,
   getSignalOutput,
 } from "@repo/api-contract";
 
+import { type ExecutionContext, isDomainError } from "../../domain";
+import {
+  createSignalCommand,
+  createSignalCommandDeps,
+  getSignalCommand,
+  getSignalCommandDeps,
+} from "../../domain/signals";
 import { assertHostedMcpOrgAccess } from "../../mcp-oauth/resource-access";
 import { verifyServiceJWT } from "../../service-jwt";
-import { createSignalForActor } from "../../signals/service";
 
 function bearerToken(request: Request): string | undefined {
   const authorization = request.headers.get("authorization");
@@ -82,8 +89,54 @@ function mcpOrgAccessDeniedMessage(error: { message?: unknown }): string {
     : "MCP organization access denied.";
 }
 
-function isSignalCreateQueueErrorLike(error: unknown): error is Error {
-  return error instanceof Error && error.name === "SignalCreateQueueError";
+function requestId() {
+  return crypto.randomUUID();
+}
+
+type McpSignalActor =
+  | CreateMcpSignalCommandInput["actor"]
+  | GetMcpSignalCommandInput["actor"];
+
+function mcpSignalContext(actor: McpSignalActor): ExecutionContext {
+  return {
+    actor: {
+      clientId: actor.clientId,
+      grantId: actor.grantId,
+      kind: "mcpClient",
+      orgId: actor.orgId,
+      scopes: [],
+      userId: actor.userId,
+    },
+    caller: { kind: "service", service: "apps-mcp" },
+    request: { id: requestId(), source: "mcp" },
+  };
+}
+
+function domainErrorResponse(
+  error: unknown,
+  fallbackMessage: string
+): Response {
+  if (!isDomainError(error)) {
+    return jsonError("internal_error", fallbackMessage, 500);
+  }
+
+  if (error.code === "SIGNAL_NOT_FOUND") {
+    return jsonError("not_found", "Signal not found.", 404);
+  }
+
+  if (error.code === "SIGNAL_QUEUE_FAILED") {
+    return jsonError("signal_enqueue_failed", error.message, 500);
+  }
+
+  if (error.kind === "authz") {
+    return jsonError("forbidden", error.message, 403);
+  }
+
+  if (error.kind === "validation") {
+    return jsonError("invalid_request", error.message, 400);
+  }
+
+  return jsonError("internal_error", fallbackMessage, 500);
 }
 
 export async function handleCreateMcpSignalInternalRequest(
@@ -109,7 +162,11 @@ export async function handleCreateMcpSignalInternalRequest(
       orgId: parsed.data.actor.orgId,
       userId: parsed.data.actor.userId,
     });
-    const result = await createSignalForActor(db, parsed.data);
+    const result = await createSignalCommand.run({
+      ctx: mcpSignalContext(parsed.data.actor),
+      deps: createSignalCommandDeps({ db }),
+      input: { input: parsed.data.input },
+    });
     return Response.json(result, { status: 200 });
   } catch (error) {
     if (isMcpOrgAccessDenied(error)) {
@@ -119,10 +176,7 @@ export async function handleCreateMcpSignalInternalRequest(
         403
       );
     }
-    if (isSignalCreateQueueErrorLike(error)) {
-      return jsonError("signal_enqueue_failed", error.message, 500);
-    }
-    return jsonError("internal_error", "Failed to create signal.", 500);
+    return domainErrorResponse(error, "Failed to create signal.");
   }
 }
 
@@ -149,21 +203,18 @@ export async function handleGetMcpSignalInternalRequest(
       orgId: parsed.data.actor.orgId,
       userId: parsed.data.actor.userId,
     });
-    const signal = await getVisibleSignalByPublicId(db, {
-      publicId: parsed.data.id,
-      clerkOrgId: parsed.data.actor.orgId,
-      createdByUserId: parsed.data.actor.userId,
+    const signal = await getSignalCommand.run({
+      ctx: mcpSignalContext(parsed.data.actor),
+      deps: getSignalCommandDeps({ db }),
+      input: { publicId: parsed.data.id },
     });
-
-    if (!signal) {
-      return jsonError("not_found", "Signal not found.", 404);
-    }
 
     const output = getSignalOutput.parse({
       id: signal.publicId,
       input: signal.input,
       status: signal.status,
       classification: signal.classification,
+      entityLinks: signal.entityLinks,
       visibilityScope: signal.visibilityScope,
       createdAt: signal.createdAt.toISOString(),
       updatedAt: signal.updatedAt.toISOString(),
@@ -177,6 +228,6 @@ export async function handleGetMcpSignalInternalRequest(
         403
       );
     }
-    return jsonError("internal_error", "Failed to get signal.", 500);
+    return domainErrorResponse(error, "Failed to get signal.");
   }
 }

--- a/api/app/src/domain/actor.ts
+++ b/api/app/src/domain/actor.ts
@@ -28,10 +28,11 @@ export type Actor =
     }
   | {
       clientId: string;
-      connectionId: string;
+      grantId: string;
       kind: "mcpClient";
       orgId: string;
       scopes: string[];
+      userId: string;
     }
   | {
       kind: "service";

--- a/api/app/src/domain/signals/commands.ts
+++ b/api/app/src/domain/signals/commands.ts
@@ -125,7 +125,14 @@ type SignalCommandRunArgs<
 
 type ResolvedSignalCommandActor =
   | { kind: "web"; orgId: string; userId: string }
-  | { apiKeyId: string; kind: "api_key"; orgId: string; userId: string };
+  | { apiKeyId: string; kind: "api_key"; orgId: string; userId: string }
+  | {
+      clientId: string;
+      grantId: string;
+      kind: "mcp";
+      orgId: string;
+      userId: string;
+    };
 
 function requireSignalCommandActor(
   ctx: ExecutionContext
@@ -154,9 +161,30 @@ function requireSignalCommandActor(
     };
   }
 
+  if (ctx.actor.kind === "mcpClient") {
+    if (
+      ctx.caller?.kind !== "service" ||
+      ctx.caller.service !== "apps-mcp" ||
+      ctx.request?.source !== "mcp"
+    ) {
+      throw new AuthzError(
+        "MCP_SERVICE_CALLER_REQUIRED",
+        "MCP signal commands require the apps-mcp service caller."
+      );
+    }
+
+    return {
+      clientId: ctx.actor.clientId,
+      grantId: ctx.actor.grantId,
+      kind: "mcp",
+      orgId: ctx.actor.orgId,
+      userId: ctx.actor.userId,
+    };
+  }
+
   throw new AuthzError(
     "SIGNAL_ACTOR_REQUIRED",
-    "A Lightfast user or API key is required."
+    "A Lightfast user, API key, or MCP client is required."
   );
 }
 

--- a/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
+++ b/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
@@ -40,6 +40,12 @@ describe("internal MCP app routes", () => {
     }
 
     expect(adapter).toContain("process.env.SERVICE_JWT_SECRET");
+    expect(adapter).toContain('from "../../domain/signals"');
+    expect(adapter).toContain("createSignalCommand.run");
+    expect(adapter).toContain("getSignalCommand.run");
     expect(adapter).not.toContain('from "../../env"');
+    expect(adapter).not.toContain('from "../../signals/service"');
+    expect(adapter).not.toContain("createSignalForActor");
+    expect(adapter).not.toContain("getVisibleSignalByPublicId");
   });
 });


### PR DESCRIPTION
## Summary
- Route internal MCP signal create/get handlers through `signals.create` and `signals.get` domain commands.
- Extend the domain `mcpClient` actor with grant/user attribution and require the `apps-mcp` service caller for MCP signal commands.
- Add behavior and source ratchets that prevent the internal MCP adapter from reaching directly into signal DB/service internals.

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/mcp-signals-internal-adapter.test.ts src/__tests__/signals-domain-commands.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/internal-mcp-routes-source.test.ts
- pnpm --filter @api/app typecheck
- git diff --check
- pnpm lint:ws
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- agent-browser open http://127.0.0.1:5177/
- agent-browser snapshot -i