### PR TITLE
Remove oRPC from public contract and SDK

### DIFF
--- a/.changeset/lightfast-direct-fetch-sdk.md
+++ b/.changeset/lightfast-direct-fetch-sdk.md
@@ -1,0 +1,5 @@
+---
+"lightfast": patch
+---
+
+Remove the SDK oRPC client runtime and call the public `/api/v1` routes through a direct typed fetch client.

--- a/core/lightfast/CHANGELOG.md
+++ b/core/lightfast/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Minor Changes
 
-- 55e5e6c: Adopt oRPC for the public SDK and MCP surfaces.
+- 55e5e6c: Adopt explicit public API metadata for the SDK and MCP surfaces.
 
-  - SDK (`lightfast`): `createLightfast(apiKey, options)` now returns a typed `ContractRouterClient<Contract>` constructed via `@orpc/openapi-client/fetch`. Calls hit the new `/api/v1/*` REST surface on `apps/app`. The `LightfastClient` class is removed — it's now a type alias to `ContractRouterClient<Contract>`. This is a pre-1.0 incompatible API change for any consumer using `new LightfastClient(...)`.
-  - MCP (`@lightfastai/mcp`): The server auto-registers tools from `@repo/api-contract`. Current exposed tools are `lightfast_system_health`, `lightfast_signals_create`, and `lightfast_signals_get`. Adding procedures to the contract auto-registers them as MCP tools — no `core/mcp` changes required.
+  - SDK (`lightfast`): `createLightfast(apiKey, options)` now returns a direct typed fetch client with `system.health`, `signals.create`, and `signals.get` methods. Calls hit the new `/api/v1/*` REST surface on `apps/app`. The `LightfastClient` class is removed; it is now the interface returned by `createLightfast`. This is a pre-1.0 incompatible API change for any consumer using `new LightfastClient(...)`.
+  - MCP (`@lightfastai/mcp`): The server auto-registers tools from `@repo/api-contract`. Current exposed tools are `lightfast_system_health`, `lightfast_signals_create`, and `lightfast_signals_get`. Adding public API contract entries can expose them as MCP tools according to MCP policy, with no `core/mcp` changes required.
   - Publish hygiene: `@repo/api-contract` is bundled into the published `dist/` via tsup `noExternal`. Moved from `dependencies` to `devDependencies` to keep the published manifest free of private workspace references. `lightfast` (in MCP) moved the same way. Stable releases publish to the npm `latest` dist-tag.
 
   Requires: `LIGHTFAST_API_KEY` (`lf_` org API key) to authenticate. Optional: `LIGHTFAST_API_URL` to point at non-prod environments.
@@ -26,10 +26,10 @@
 
 ### Major Changes
 
-- 55e5e6c: Adopt oRPC for the public SDK and MCP surfaces.
+- 55e5e6c: Adopt explicit public API metadata for the SDK and MCP surfaces.
 
-  - SDK (`lightfast`): `createLightfast(apiKey, options)` now returns a typed `ContractRouterClient<Contract>` constructed via `@orpc/openapi-client/fetch`. Calls hit the new `/api/v1/*` REST surface on `apps/app`. The `LightfastClient` class is removed — it's now a type alias to `ContractRouterClient<Contract>`. Breaking change for any consumer using `new LightfastClient(...)`.
-  - MCP (`@lightfastai/mcp`): The server auto-registers tools from `@repo/api-contract`. Current exposed tools are `lightfast_system_health`, `lightfast_signals_create`, and `lightfast_signals_get`. Adding procedures to the contract auto-registers them as MCP tools — no `core/mcp` changes required.
+  - SDK (`lightfast`): `createLightfast(apiKey, options)` now returns a direct typed fetch client with `system.health`, `signals.create`, and `signals.get` methods. Calls hit the new `/api/v1/*` REST surface on `apps/app`. The `LightfastClient` class is removed; it is now the interface returned by `createLightfast`. Breaking change for any consumer using `new LightfastClient(...)`.
+  - MCP (`@lightfastai/mcp`): The server auto-registers tools from `@repo/api-contract`. Current exposed tools are `lightfast_system_health`, `lightfast_signals_create`, and `lightfast_signals_get`. Adding public API contract entries can expose them as MCP tools according to MCP policy, with no `core/mcp` changes required.
   - Publish hygiene: `@repo/api-contract` is bundled into the published `dist/` via tsup `noExternal`. Moved from `dependencies` to `devDependencies` to keep the published manifest free of private workspace references. `lightfast` (in MCP) moved the same way. `publishConfig.tag` changed from `"latest"` to `"alpha"` so pre-release versions no longer claim the default install slot.
 
   Requires: `LIGHTFAST_API_KEY` (`lf_` org API key) to authenticate. Optional: `LIGHTFAST_API_URL` to point at non-prod environments.

--- a/core/lightfast/package.json
+++ b/core/lightfast/package.json
@@ -39,11 +39,6 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "@orpc/client": "^1.14.2",
-    "@orpc/contract": "^1.14.2",
-    "@orpc/openapi-client": "^1.14.2"
-  },
   "devDependencies": {
     "@repo/api-contract": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/core/lightfast/src/__tests__/client.test.ts
+++ b/core/lightfast/src/__tests__/client.test.ts
@@ -1,8 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { createLightfast } from "../index";
 
+const packageRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(packageRoot, path), "utf8");
+}
+
 describe("createLightfast", () => {
+  it("uses explicit fetch routes without oRPC client dependencies", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    const clientSource = source("src/index.ts");
+    const tsupSource = source("tsup.config.ts");
+
+    expect(packageJson.dependencies?.["@orpc/client"]).toBeUndefined();
+    expect(packageJson.dependencies?.["@orpc/contract"]).toBeUndefined();
+    expect(packageJson.dependencies?.["@orpc/openapi-client"]).toBeUndefined();
+    expect(clientSource).not.toContain("@orpc/");
+    expect(clientSource).not.toContain("createORPCClient");
+    expect(clientSource).not.toContain("OpenAPILink");
+    expect(tsupSource).not.toContain("@orpc/");
+  });
+
   it("rejects keys without the lf_ prefix", () => {
     expect(() => createLightfast("not-a-key")).toThrow(
       /Invalid Lightfast API key/

--- a/core/lightfast/src/index.ts
+++ b/core/lightfast/src/index.ts
@@ -1,7 +1,10 @@
-import { createORPCClient } from "@orpc/client";
-import type { ContractRouterClient } from "@orpc/contract";
-import { OpenAPILink } from "@orpc/openapi-client/fetch";
-import { apiContract, type Contract } from "@repo/api-contract";
+import type {
+  CreateSignalInput,
+  CreateSignalOutput,
+  GetSignalInput,
+  GetSignalOutput,
+  SystemHealthOutput,
+} from "@repo/api-contract";
 
 declare const __SDK_VERSION__: string;
 
@@ -12,7 +15,81 @@ export interface LightfastOptions {
   fetch?: typeof fetch;
 }
 
-export type LightfastClient = ContractRouterClient<Contract>;
+export interface LightfastClient {
+  signals: {
+    create(input: CreateSignalInput): Promise<CreateSignalOutput>;
+    get(input: GetSignalInput): Promise<GetSignalOutput>;
+  };
+  system: {
+    health(): Promise<SystemHealthOutput>;
+  };
+}
+
+export class LightfastApiError extends Error {
+  readonly body: unknown;
+  readonly status: number;
+
+  constructor(input: { body: unknown; status: number; statusText: string }) {
+    super(`Lightfast API request failed: ${input.status} ${input.statusText}`);
+    this.name = "LightfastApiError";
+    this.body = input.body;
+    this.status = input.status;
+  }
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "").replace(/\/api\/v1$/, "");
+}
+
+function apiUrl(baseUrl: string, path: string): string {
+  return `${baseUrl}/api/v1${path}`;
+}
+
+async function responseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+async function requestJson<TOutput>(input: {
+  apiKey: string;
+  body?: unknown;
+  fetch: typeof fetch;
+  method: "GET" | "POST";
+  url: string;
+}): Promise<TOutput> {
+  const headers = new Headers({
+    authorization: `Bearer ${input.apiKey}`,
+  });
+  const init: RequestInit = {
+    headers,
+    method: input.method,
+  };
+
+  if (input.body !== undefined) {
+    headers.set("content-type", "application/json");
+    init.body = JSON.stringify(input.body);
+  }
+
+  const response = await input.fetch(new Request(input.url, init));
+  const body = await responseBody(response);
+  if (!response.ok) {
+    throw new LightfastApiError({
+      body,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+
+  return body as TOutput;
+}
 
 export function createLightfast(
   apiKey: string,
@@ -23,19 +100,43 @@ export function createLightfast(
   }
 
   const baseUrl = options.baseUrl ?? "https://lightfast.ai";
-  // Strip trailing slash and any trailing /api/v1 so callers can pass either form.
-  const normalizedBase = baseUrl.replace(/\/$/, "").replace(/\/api\/v1$/, "");
+  const normalizedBase = normalizeBaseUrl(baseUrl);
+  const fetchImpl = options.fetch ?? fetch;
 
-  const link = new OpenAPILink(apiContract, {
-    url: `${normalizedBase}/api/v1`,
-    headers: () => ({
-      authorization: `Bearer ${apiKey}`,
-    }),
-    ...(options.fetch && { fetch: options.fetch }),
-  });
-
-  return createORPCClient(link);
+  return {
+    signals: {
+      create(input) {
+        return requestJson({
+          apiKey,
+          body: input,
+          fetch: fetchImpl,
+          method: "POST",
+          url: apiUrl(normalizedBase, "/signals"),
+        });
+      },
+      get(input) {
+        return requestJson({
+          apiKey,
+          fetch: fetchImpl,
+          method: "GET",
+          url: apiUrl(
+            normalizedBase,
+            `/signals/${encodeURIComponent(input.id)}`
+          ),
+        });
+      },
+    },
+    system: {
+      health() {
+        return requestJson({
+          apiKey,
+          fetch: fetchImpl,
+          method: "GET",
+          url: apiUrl(normalizedBase, "/system/health"),
+        });
+      },
+    },
+  };
 }
 
 export const VERSION: string = __SDK_VERSION__;
-export type { Contract } from "@repo/api-contract";

--- a/core/lightfast/tsup.config.ts
+++ b/core/lightfast/tsup.config.ts
@@ -9,12 +9,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: [],
-  noExternal: [
-    "@orpc/client",
-    "@orpc/contract",
-    "@orpc/openapi-client",
-    "@repo/api-contract",
-  ],
+  noExternal: ["@repo/api-contract"],
   target: "node18",
   bundle: true,
   silent: false,

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -17,7 +17,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@orpc/contract": "^1.14.2",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/api-contract/src/__tests__/contract.test.ts
+++ b/packages/api-contract/src/__tests__/contract.test.ts
@@ -1,60 +1,51 @@
-import { isContractProcedure } from "@orpc/contract";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { apiContract } from "../contract";
+import { createSignalInput, createSignalOutput } from "../schemas/signals";
+import { systemHealthOutput } from "../schemas/system";
+
+const packageRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(packageRoot, path), "utf8");
+}
 
 describe("apiContract", () => {
-  it("exposes system.health as a contract procedure", () => {
-    expect(isContractProcedure(apiContract.system.health)).toBe(true);
+  it("keeps public API route metadata as plain contract data", () => {
+    expect(apiContract.system.health.route).toMatchObject({
+      method: "GET",
+      path: "/system/health",
+    });
+    expect(apiContract.system.health.outputSchema).toBe(systemHealthOutput);
+
+    expect(apiContract.signals.create.route).toMatchObject({
+      method: "POST",
+      path: "/signals",
+      successStatus: 202,
+    });
+    expect(apiContract.signals.create.inputSchema).toBe(createSignalInput);
+    expect(apiContract.signals.create.outputSchema).toBe(createSignalOutput);
+
+    expect(apiContract.signals.get.route).toMatchObject({
+      method: "GET",
+      path: "/signals/{id}",
+    });
   });
 
-  it("exposes signals.create as a contract procedure", () => {
-    expect(isContractProcedure(apiContract.signals.create)).toBe(true);
-  });
+  it("does not expose oRPC procedure internals or package dependencies", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    const contractSource = source("src/contract.ts");
+    const mcpSource = source("src/mcp.ts");
 
-  it("exposes signals.get as a contract procedure", () => {
-    expect(isContractProcedure(apiContract.signals.get)).toBe(true);
-  });
-
-  it("system.health declares GET /system/health", () => {
-    const def = (
-      apiContract.system.health as {
-        "~orpc": { route?: { method?: string; path?: string } };
-      }
-    )["~orpc"];
-    expect(def.route?.method).toBe("GET");
-    expect(def.route?.path).toBe("/system/health");
-  });
-
-  it("system.health declares an output schema", () => {
-    const def = (
-      apiContract.system.health as {
-        "~orpc": { outputSchema?: unknown };
-      }
-    )["~orpc"];
-    expect(def.outputSchema).toBeDefined();
-  });
-
-  it("signals.create declares POST /signals with 202 success", () => {
-    const def = (
-      apiContract.signals.create as {
-        "~orpc": {
-          route?: { method?: string; path?: string; successStatus?: number };
-        };
-      }
-    )["~orpc"];
-    expect(def.route?.method).toBe("POST");
-    expect(def.route?.path).toBe("/signals");
-    expect(def.route?.successStatus).toBe(202);
-  });
-
-  it("signals.get declares GET /signals/{id}", () => {
-    const def = (
-      apiContract.signals.get as {
-        "~orpc": { route?: { method?: string; path?: string } };
-      }
-    )["~orpc"];
-    expect(def.route?.method).toBe("GET");
-    expect(def.route?.path).toBe("/signals/{id}");
+    expect(packageJson.dependencies?.["@orpc/contract"]).toBeUndefined();
+    expect(contractSource).not.toContain("@orpc/contract");
+    expect(contractSource).not.toContain("~orpc");
+    expect(mcpSource).not.toContain("@orpc/contract");
+    expect(mcpSource).not.toContain("isContractProcedure");
+    expect(apiContract.signals.create).not.toHaveProperty("~orpc");
   });
 });

--- a/packages/api-contract/src/__tests__/mcp.test.ts
+++ b/packages/api-contract/src/__tests__/mcp.test.ts
@@ -1,4 +1,3 @@
-import { isContractProcedure } from "@orpc/contract";
 import { describe, expect, it } from "vitest";
 
 import { apiContract } from "../contract";
@@ -47,8 +46,9 @@ describe("lightfastMcpToolPolicy", () => {
     } satisfies Partial<McpToolPolicyEntry>);
   });
 
-  it("only counts oRPC contract procedures", () => {
-    expect(isContractProcedure(apiContract.signals.create)).toBe(true);
+  it("only counts plain public API contract procedures", () => {
+    expect(apiContract.signals.create.route.path).toBe("/signals");
+    expect(getContractProcedurePaths({ misc: { value: true } })).toEqual([]);
   });
 
   it("includes provider routine MCP scopes in the public scope type", () => {

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -1,4 +1,4 @@
-import { oc } from "@orpc/contract";
+import type { z } from "zod";
 
 import {
   createSignalInput,
@@ -8,41 +8,93 @@ import {
 } from "./schemas/signals";
 import { systemHealthOutput } from "./schemas/system";
 
+export interface PublicApiRouteMetadata {
+  description: string;
+  method: "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+  path: string;
+  successStatus?: number;
+  summary: string;
+}
+
+export interface PublicApiContractProcedure<
+  TInputSchema extends z.ZodTypeAny | undefined = z.ZodTypeAny | undefined,
+  TOutputSchema extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  inputSchema?: TInputSchema;
+  outputSchema: TOutputSchema;
+  route: PublicApiRouteMetadata;
+}
+
+export type PublicApiContractNode =
+  | PublicApiContractProcedure
+  | { [key: string]: PublicApiContractNode };
+
+export type PublicApiContract = Record<string, PublicApiContractNode>;
+
+export function publicApiProcedure<
+  TInputSchema extends z.ZodTypeAny | undefined,
+  TOutputSchema extends z.ZodTypeAny,
+>(input: {
+  inputSchema?: TInputSchema;
+  outputSchema: TOutputSchema;
+  route: PublicApiRouteMetadata;
+}): PublicApiContractProcedure<TInputSchema, TOutputSchema> {
+  return input;
+}
+
+export function isPublicApiContractProcedure(
+  node: unknown
+): node is PublicApiContractProcedure {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+  const candidate = node as { outputSchema?: unknown; route?: unknown };
+  return (
+    typeof candidate.outputSchema === "object" &&
+    candidate.outputSchema !== null &&
+    typeof candidate.route === "object" &&
+    candidate.route !== null
+  );
+}
+
 const system = {
-  health: oc
-    .route({
+  health: publicApiProcedure({
+    outputSchema: systemHealthOutput,
+    route: {
       method: "GET",
       path: "/system/health",
       summary: "Health check",
       description:
         "Returns service status, server timestamp, and API version. Requires a valid org API key.",
-    })
-    .output(systemHealthOutput),
+    },
+  }),
 };
 
 const signals = {
-  create: oc
-    .route({
+  create: publicApiProcedure({
+    inputSchema: createSignalInput,
+    outputSchema: createSignalOutput,
+    route: {
       method: "POST",
       path: "/signals",
       successStatus: 202,
       summary: "Create signal",
       description:
         "Creates a creator-visible signal from raw text and queues asynchronous classification.",
-    })
-    .input(createSignalInput)
-    .output(createSignalOutput),
+    },
+  }),
 
-  get: oc
-    .route({
+  get: publicApiProcedure({
+    inputSchema: getSignalInput,
+    outputSchema: getSignalOutput,
+    route: {
       method: "GET",
       path: "/signals/{id}",
       summary: "Get signal",
       description:
         "Returns a visible signal and its current classification state.",
-    })
-    .input(getSignalInput)
-    .output(getSignalOutput),
+    },
+  }),
 };
 
 export const apiContract = { signals, system };

--- a/packages/api-contract/src/mcp.ts
+++ b/packages/api-contract/src/mcp.ts
@@ -1,6 +1,4 @@
-import { isContractProcedure } from "@orpc/contract";
-
-import type { Contract } from "./contract";
+import { type Contract, isPublicApiContractProcedure } from "./contract";
 
 export type McpScope =
   | "mcp:system:read"
@@ -36,7 +34,7 @@ export function getContractProcedurePaths(
   const paths: string[] = [];
 
   function walk(node: unknown, keyPath: string[]): void {
-    if (isContractProcedure(node)) {
+    if (isPublicApiContractProcedure(node)) {
       paths.push(keyPath.join("."));
       return;
     }

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -17,11 +17,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@orpc/contract": "^1.14.2",
     "@repo/api-contract": "workspace:*",
     "@vendor/mcp": "workspace:*",
-    "@vendor/observability": "workspace:*",
-    "zod": "catalog:"
+    "@vendor/observability": "workspace:*"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/mcp-tools/src/__tests__/policy.test.ts
+++ b/packages/mcp-tools/src/__tests__/policy.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { apiContract, lightfastMcpToolPolicy } from "@repo/api-contract";
 import { Client, InMemoryTransport, McpServer } from "@vendor/mcp";
 import { describe, expect, it } from "vitest";
@@ -8,7 +10,24 @@ import {
 } from "../policy";
 import { registerLightfastMcpTools } from "../register";
 
+const packageRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(packageRoot, path), "utf8");
+}
+
 describe("createLightfastMcpToolDefinitions", () => {
+  it("uses plain contract schema metadata instead of oRPC internals", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    const policySource = source("src/policy.ts");
+
+    expect(packageJson.dependencies?.["@orpc/contract"]).toBeUndefined();
+    expect(policySource).not.toContain("@orpc/contract");
+    expect(policySource).not.toContain("~orpc");
+  });
+
   it("creates stable exposed tool definitions from contract policy", () => {
     expect(() =>
       validateMcpPolicyCoverage(apiContract, lightfastMcpToolPolicy)

--- a/packages/mcp-tools/src/policy.ts
+++ b/packages/mcp-tools/src/policy.ts
@@ -23,18 +23,17 @@ function getNodeAtPath(root: Record<string, unknown>, path: string): unknown {
   return node;
 }
 
-function getOrpcSchemas(node: unknown): {
+function getContractSchemas(node: unknown): {
   inputSchema?: unknown;
   outputSchema?: unknown;
 } {
-  const def = (
-    node as {
-      "~orpc"?: {
-        inputSchema?: unknown;
-        outputSchema?: unknown;
-      };
-    }
-  )["~orpc"];
+  if (!node || typeof node !== "object") {
+    return {};
+  }
+  const def = node as {
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+  };
 
   return {
     inputSchema: def?.inputSchema,
@@ -66,7 +65,7 @@ export function createLightfastMcpToolDefinitions(input: {
       if (!entry.expose) {
         return [];
       }
-      const schemas = getOrpcSchemas(
+      const schemas = getContractSchemas(
         getNodeAtPath(input.contract, contractPath)
       );
       return [

--- a/packages/mcp-tools/src/results.ts
+++ b/packages/mcp-tools/src/results.ts
@@ -1,6 +1,6 @@
 import { parseError } from "@vendor/observability/error/next";
 
-export interface LightfastMcpContent {
+interface LightfastMcpContent {
   text: string;
   type: "text";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1592,16 +1592,6 @@ importers:
         version: 4.3.6
 
   core/lightfast:
-    dependencies:
-      '@orpc/client':
-        specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/contract':
-        specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/openapi-client':
-        specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)
     devDependencies:
       '@repo/api-contract':
         specifier: workspace:*
@@ -1961,9 +1951,6 @@ importers:
 
   packages/api-contract:
     dependencies:
-      '@orpc/contract':
-        specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -2255,9 +2242,6 @@ importers:
 
   packages/mcp-tools:
     dependencies:
-      '@orpc/contract':
-        specifier: ^1.14.2
-        version: 1.14.2(@opentelemetry/api@1.9.1)
       '@repo/api-contract':
         specifier: workspace:*
         version: link:../api-contract
@@ -2267,9 +2251,6 @@ importers:
       '@vendor/observability':
         specifier: workspace:*
         version: link:../../vendor/observability
-      zod:
-        specifier: 'catalog:'
-        version: 4.3.6
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
@@ -6508,9 +6489,6 @@ packages:
 
   '@orpc/interop@1.14.2':
     resolution: {integrity: sha512-FkrXlR0vmhx5D0t5WA6YN7XyC1WwjGGmkaaShVUGdnFu6m0bl4v3vZZWIMcPy5fG/6wF7KCTEGx0B6+kMmLWiQ==}
-
-  '@orpc/openapi-client@1.14.2':
-    resolution: {integrity: sha512-KIXSVuGYh3JvO0lxUUztuMkEj6FV5C96QivR+H/HvqfFidC3hEH0nqi0vEWmUzlbzH3jbCaJV8KKV41HKnUNYw==}
 
   '@orpc/server@1.14.2':
     resolution: {integrity: sha512-+MkYqqI1CmR/eWsktpAxN4+Dd1rbDGO3xh9ZQae/V4zID5uz7smUnsIJL97GRDIZkwRUYlC8TDLLPAkxij22Iw==}
@@ -19263,15 +19241,6 @@ snapshots:
       - '@opentelemetry/api'
 
   '@orpc/interop@1.14.2': {}
-
-  '@orpc/openapi-client@1.14.2(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@orpc/client': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/contract': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/shared': 1.14.2(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.14.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
 
   '@orpc/server@1.14.2(@opentelemetry/api@1.9.1)(crossws@0.4.5(srvx@0.11.16))(ws@8.20.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- Replace the public API contract's oRPC procedure builder shape with explicit route/input/output metadata.
- Update MCP tool policy generation to read schemas directly from the public contract metadata.
- Replace the `lightfast` SDK oRPC/OpenAPI client runtime with a direct typed fetch client over `/api/v1` routes and remove the oRPC package deps.

## Verification
- `pnpm --dir core/lightfast test`
- `pnpm --filter @repo/api-contract test`
- `pnpm --filter @repo/mcp-tools test`
- `pnpm --dir core/lightfast typecheck`
- `pnpm --dir core/lightfast build`
- `pnpm --filter @repo/api-contract typecheck`
- `pnpm --filter @repo/mcp-tools typecheck`
- `SKIP_ENV_VALIDATION=true pnpm knip --workspace packages/mcp-tools`
- `pnpm lint:ws`
- `pnpm check`
- `SKIP_ENV_VALIDATION=true pnpm typecheck`
- `git diff --check`
- `agent-browser open http://127.0.0.1:5177/` verified title `Lightfast Console TanStack` and visible heading `Lightfast Console TanStack`

## Notes
- Full repo `pnpm knip` still has existing unrelated drift; this slice keeps the targeted MCP tools knip ratchet clean.
- The changeset is patch-level for `lightfast`; the fixed changeset group also reports `@lightfastai/mcp` in the patch bump set.
