### PR TITLE
Remove tRPC CORS residue

### DIFF
--- a/apps/app/src/__tests__/trpc-route.test.ts
+++ b/apps/app/src/__tests__/trpc-route.test.ts
@@ -13,6 +13,7 @@ describe("app tRPC route", () => {
       resolve(appRoot, "src/routeTree.gen.ts"),
       "utf8"
     );
+    const corsSource = readFileSync(resolve(appRoot, "src/cors.ts"), "utf8");
 
     expect(existsSync(resolve(appRoot, "src/routes/api/trpc.$.ts"))).toBe(
       false
@@ -25,5 +26,7 @@ describe("app tRPC route", () => {
     ).toBeUndefined();
     expect(routeTreeSource).not.toContain("/api/trpc");
     expect(routeTreeSource).not.toContain("ApiTrpcSplatRoute");
+    expect(corsSource).not.toContain("x-trpc-source");
+    expect(corsSource).not.toContain("trpc-accept");
   });
 });

--- a/apps/app/src/cors.ts
+++ b/apps/app/src/cors.ts
@@ -80,7 +80,7 @@ export function setCorsHeaders(request: Request, response: Response) {
   response.headers.set("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
   response.headers.set(
     "Access-Control-Allow-Headers",
-    "content-type,authorization,x-trpc-source,trpc-accept,x-lightfast-desktop,x-lightfast-native-client,x-lightfast-organization-id"
+    "content-type,authorization,x-lightfast-desktop,x-lightfast-native-client,x-lightfast-organization-id"
   );
   response.headers.set("Vary", "Origin");
   response.headers.set("Access-Control-Allow-Credentials", "true");


### PR DESCRIPTION
## Summary
- Remove stale `x-trpc-source` and `trpc-accept` from the app CORS allow-list.
- Extend the app tRPC-removal source ratchet so these headers do not return.

## Test Plan
- `pnpm --filter @lightfast/app test -- src/__tests__/trpc-route.test.ts` red on the CORS assertion; note this command also currently runs unrelated app source tests locally.
- `pnpm --filter @lightfast/app exec vitest run src/__tests__/trpc-route.test.ts`
- `pnpm --filter @lightfast/app typecheck`
- `pnpm lint:ws`
- `git diff --check`
- `pnpm check`
- `SKIP_ENV_VALIDATION=true pnpm typecheck`
