### PR TITLE
Remove retired www tRPC proxy matcher

### DIFF
--- a/apps/www/src/__tests__/proxy-source.test.ts
+++ b/apps/www/src/__tests__/proxy-source.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const proxySource = readFileSync(
+  fileURLToPath(new URL("../proxy.ts", import.meta.url)),
+  "utf8"
+);
+
+describe("www proxy source", () => {
+  it("does not keep the retired tRPC route matcher alive", () => {
+    expect(proxySource).toContain("api");
+    expect(proxySource).not.toContain("trpc");
+  });
+});

--- a/apps/www/src/proxy.ts
+++ b/apps/www/src/proxy.ts
@@ -80,6 +80,6 @@ export default async function proxy(req: NextRequest, event: NextFetchEvent) {
 export const config = {
   matcher: [
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    "/(api|trpc)(.*)",
+    "/api(.*)",
   ],
 };


### PR DESCRIPTION
## Summary
- Remove the retired `/trpc` matcher from the www proxy config now that app tRPC routes are gone.
- Add a source ratchet so the www proxy cannot quietly reintroduce tRPC routing residue.

## Test Plan
- [x] `pnpm --filter @lightfast/www exec vitest run src/__tests__/proxy-source.test.ts`
- [x] `pnpm --filter @lightfast/www test`
- [x] `pnpm --filter @lightfast/www typecheck`
- [x] `pnpm lint:ws`
- [x] `pnpm check`
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`
- [x] `pnpm build:www`