### PR TITLE
Refresh app migration source ratchets

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -795,7 +795,7 @@ describe("app authenticated route migration", () => {
       "@repo/ui-v2/components/ai-elements/message"
     );
     expect(messagePartSource).toContain(
-      "@repo/ui-v2/components/ai-elements/reasoning"
+      "@repo/ui-v2/components/ai-elements/thinking-steps"
     );
     expect(messagePartSource).toContain(
       "@repo/ui-v2/components/ai-elements/tool"

--- a/apps/app/src/__tests__/chat-api-source.test.ts
+++ b/apps/app/src/__tests__/chat-api-source.test.ts
@@ -43,8 +43,12 @@ describe("app chat API route migration", () => {
     expect(chatSource).toContain(
       "setWorkspaceAssistantConversationActiveStream"
     );
+    expect(chatSource).toContain("createWorkspaceAssistantTools");
     expect(chatSource).toContain(
-      "createWorkspaceAssistantProviderRoutineTools"
+      "createWorkspaceAssistantProviderRoutineToolDefinitions"
+    );
+    expect(chatSource).toContain(
+      "createWorkspaceAssistantUserConnectorToolDefinitions"
     );
     expect(streamSource).toContain("resumeExistingStream");
     expect(streamSource).toContain("UI_MESSAGE_STREAM_HEADERS");


### PR DESCRIPTION
## Summary
- Update app migration source ratchets to match the current workspace assistant UI imports.
- Update chat API source ratchets to assert the current provider/user connector tool-definition composition.

## Test Plan
- [x] `pnpm --filter @lightfast/app exec vitest run src/__tests__/authenticated-routes-source.test.ts src/__tests__/chat-api-source.test.ts`
- [x] `pnpm --filter @lightfast/app test`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm lint:ws`
- [x] `pnpm check`
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`