### PR TITLE
Remove retired tRPC catalog pins

### DIFF
--- a/apps/app/src/__tests__/trpc-route.test.ts
+++ b/apps/app/src/__tests__/trpc-route.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const appRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(appRoot, "../..");
 
 describe("app tRPC route", () => {
   it("removes the app tRPC catch-all route after UI migration", () => {
@@ -14,6 +15,10 @@ describe("app tRPC route", () => {
       "utf8"
     );
     const corsSource = readFileSync(resolve(appRoot, "src/cors.ts"), "utf8");
+    const workspaceSource = readFileSync(
+      resolve(repoRoot, "pnpm-workspace.yaml"),
+      "utf8"
+    );
 
     expect(existsSync(resolve(appRoot, "src/routes/api/trpc.$.ts"))).toBe(
       false
@@ -28,5 +33,6 @@ describe("app tRPC route", () => {
     expect(routeTreeSource).not.toContain("ApiTrpcSplatRoute");
     expect(corsSource).not.toContain("x-trpc-source");
     expect(corsSource).not.toContain("trpc-accept");
+    expect(workspaceSource).not.toContain("@trpc/");
   });
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,9 +85,6 @@ catalog:
   '@tanstack/react-virtual': ^3.13.12
   '@tanstack/router-plugin': ^1.168.14
   '@testing-library/react': ^16.3.2
-  '@trpc/client': ^11.16.0
-  '@trpc/server': ^11.16.0
-  '@trpc/tanstack-react-query': ^11.16.0
   '@unkey/api': 2.3.4
   '@types/node': ^24.9.1
   '@turbo/gen': ^2.9.6


### PR DESCRIPTION
## Summary
- Remove unused tRPC packages from the root pnpm catalog.
- Extend the app tRPC removal ratchet so root catalog pins cannot quietly reappear.

## Test Plan
- [x] `pnpm --filter @lightfast/app exec vitest run src/__tests__/trpc-route.test.ts`
- [x] `pnpm --filter @lightfast/app test`
- [x] `pnpm lint:ws`
- [x] `pnpm check`
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`