### PR TITLE
Refactor hosted MCP audit through app API

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -41,6 +41,10 @@
       "types": "./src/adapters/internal/mcp-signals.ts",
       "default": "./src/adapters/internal/mcp-signals.ts"
     },
+    "./internal-api/mcp-audit": {
+      "types": "./src/adapters/internal/mcp-audit.ts",
+      "default": "./src/adapters/internal/mcp-audit.ts"
+    },
     "./public-api/signals": {
       "types": "./src/adapters/public/signals.ts",
       "default": "./src/adapters/public/signals.ts"

--- a/api/app/src/__tests__/mcp-audit-internal-adapter.test.ts
+++ b/api/app/src/__tests__/mcp-audit-internal-adapter.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signServiceJWT } from "../service-jwt";
+
+const mocks = vi.hoisted(() => ({
+  db: { kind: "mock-db" },
+  recordMcpAuditEvent: vi.fn(),
+}));
+
+vi.mock("@db/app", () => ({
+  recordMcpAuditEvent: mocks.recordMcpAuditEvent,
+}));
+
+vi.mock("@db/app/client", () => ({
+  db: mocks.db,
+}));
+
+const { handleRecordMcpAuditInternalRequest } = await import(
+  "../adapters/internal/mcp-audit"
+);
+
+const originalServiceJwtSecret = process.env.SERVICE_JWT_SECRET;
+const jwtSecret = "test-mcp-jwt-secret-test-mcp-jwt-secret";
+
+async function serviceToken() {
+  return signServiceJWT({
+    audience: "lightfast-app",
+    caller: "mcp",
+    jwtSecret,
+  });
+}
+
+function jsonRequest(input: { body: unknown; token?: string }) {
+  return new Request("https://lightfast.localhost/api/internal/mcp/audit", {
+    body: JSON.stringify(input.body),
+    headers: input.token
+      ? {
+          authorization: `Bearer ${input.token}`,
+          "content-type": "application/json",
+        }
+      : { "content-type": "application/json" },
+    method: "POST",
+  });
+}
+
+async function responseJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("MCP audit internal adapter", () => {
+  beforeEach(() => {
+    process.env.SERVICE_JWT_SECRET = jwtSecret;
+    vi.clearAllMocks();
+    mocks.recordMcpAuditEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (originalServiceJwtSecret === undefined) {
+      delete process.env.SERVICE_JWT_SECRET;
+      return;
+    }
+    process.env.SERVICE_JWT_SECRET = originalServiceJwtSecret;
+  });
+
+  it("rejects missing service JWTs before parsing audit events", async () => {
+    const response = await handleRecordMcpAuditInternalRequest(
+      jsonRequest({
+        body: {
+          eventName: "mcp.system.health",
+          outcome: "success",
+        },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "missing_token",
+    });
+    expect(mocks.recordMcpAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid audit request bodies", async () => {
+    const response = await handleRecordMcpAuditInternalRequest(
+      jsonRequest({
+        body: {
+          eventName: "",
+          outcome: "success",
+        },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "invalid_request",
+    });
+    expect(mocks.recordMcpAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it("records valid audit events through app-owned persistence", async () => {
+    const response = await handleRecordMcpAuditInternalRequest(
+      jsonRequest({
+        body: {
+          clientPublicId: "mcp_client_test",
+          clerkOrgId: "org_test",
+          clerkUserId: "user_test",
+          eventName: "mcp.system.health",
+          grantPublicId: "mcp_grant_test",
+          metadata: {
+            contractPath: "system.health",
+            latencyMs: 10,
+          },
+          outcome: "success",
+        },
+        token: await serviceToken(),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(responseJson(response)).resolves.toEqual({ success: true });
+    expect(mocks.recordMcpAuditEvent).toHaveBeenCalledWith(mocks.db, {
+      clientPublicId: "mcp_client_test",
+      clerkOrgId: "org_test",
+      clerkUserId: "user_test",
+      eventName: "mcp.system.health",
+      grantPublicId: "mcp_grant_test",
+      metadata: {
+        contractPath: "system.health",
+        latencyMs: 10,
+      },
+      outcome: "success",
+    });
+  });
+});

--- a/api/app/src/adapters/internal/mcp-audit.ts
+++ b/api/app/src/adapters/internal/mcp-audit.ts
@@ -1,0 +1,89 @@
+import { recordMcpAuditEvent } from "@db/app";
+import { db } from "@db/app/client";
+import { z } from "zod";
+import { verifyServiceJWT } from "../../service-jwt";
+
+const mcpAuditEventInputSchema = z
+  .object({
+    clientPublicId: z.string().min(1).nullable().optional(),
+    clerkOrgId: z.string().min(1).nullable().optional(),
+    clerkUserId: z.string().min(1).nullable().optional(),
+    eventName: z.string().min(1),
+    grantPublicId: z.string().min(1).nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    outcome: z.enum(["denied", "error", "success"]),
+  })
+  .strict();
+
+function bearerToken(request: Request): string | undefined {
+  const authorization = request.headers.get("authorization");
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+function jsonError(error: string, message: string, status: number): Response {
+  return Response.json({ error, message }, { status });
+}
+
+function serviceJwtSecret(): string | undefined {
+  const secret = process.env.SERVICE_JWT_SECRET;
+  return secret && secret.length >= 32 ? secret : undefined;
+}
+
+async function verifyMcpServiceRequest(
+  request: Request
+): Promise<Response | null> {
+  const token = bearerToken(request);
+  if (!token) {
+    return jsonError("missing_token", "Service bearer token is required.", 401);
+  }
+
+  const jwtSecret = serviceJwtSecret();
+  if (!jwtSecret) {
+    return jsonError(
+      "service_not_configured",
+      "Service JWT verification is not configured.",
+      500
+    );
+  }
+
+  try {
+    await verifyServiceJWT({
+      allowedCallers: ["mcp"],
+      audience: "lightfast-app",
+      jwtSecret,
+      token,
+    });
+    return null;
+  } catch (error) {
+    const status =
+      error instanceof Error && "status" in error
+        ? Number((error as { status: unknown }).status)
+        : 401;
+    return jsonError(
+      status === 403 ? "disallowed_caller" : "invalid_token",
+      status === 403
+        ? "Service caller is not allowed for this command."
+        : "Service token is invalid.",
+      status === 403 ? 403 : 401
+    );
+  }
+}
+
+export async function handleRecordMcpAuditInternalRequest(
+  request: Request
+): Promise<Response> {
+  const authError = await verifyMcpServiceRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const body = await request.json().catch(() => undefined);
+  const parsed = mcpAuditEventInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("invalid_request", "MCP audit request is invalid.", 400);
+  }
+
+  await recordMcpAuditEvent(db, parsed.data);
+  return Response.json({ success: true }, { status: 200 });
+}

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1376,6 +1376,7 @@ describe("app authenticated route migration", () => {
     const mcpProxyFindRouteSource = source(
       "src/routes/api/internal/mcp/proxy/find.ts"
     );
+    const mcpAuditRouteSource = source("src/routes/api/internal/mcp/audit.ts");
     const mcpSignalsRouteSource = source(
       "src/routes/api/internal/mcp/signals.ts"
     );
@@ -1453,6 +1454,12 @@ describe("app authenticated route migration", () => {
     expect(mcpProxyFindRouteSource).toContain(
       'createFileRoute("/api/internal/mcp/proxy/find")'
     );
+    expect(mcpAuditRouteSource).toContain(
+      'createFileRoute("/api/internal/mcp/audit")'
+    );
+    expect(mcpAuditRouteSource).toContain(
+      "handleRecordMcpAuditInternalRequest"
+    );
     expect(mcpSignalsRouteSource).toContain(
       'createFileRoute("/api/internal/mcp/signals")'
     );
@@ -1495,6 +1502,7 @@ describe("app authenticated route migration", () => {
       mcpProxyServerSource,
       mcpProxyCallRouteSource,
       mcpProxyFindRouteSource,
+      mcpAuditRouteSource,
       mcpSignalsRouteSource,
       mcpSignalsGetRouteSource,
     ]) {

--- a/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
+++ b/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
@@ -17,19 +17,26 @@ describe("internal MCP app routes", () => {
   it("mounts MCP signal intake through explicit api/app internal handlers", () => {
     const createRoute = appSource("src/routes/api/internal/mcp/signals.ts");
     const getRoute = appSource("src/routes/api/internal/mcp/signals/get.ts");
+    const auditRoute = appSource("src/routes/api/internal/mcp/audit.ts");
     const adapter = repoSource("api/app/src/adapters/internal/mcp-signals.ts");
+    const auditAdapter = repoSource(
+      "api/app/src/adapters/internal/mcp-audit.ts"
+    );
     const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
       exports: Record<string, unknown>;
     };
 
     expect(packageJson.exports).toHaveProperty("./internal-api/mcp-signals");
+    expect(packageJson.exports).toHaveProperty("./internal-api/mcp-audit");
 
     expect(createRoute).toContain('@api/app/internal-api/mcp-signals"');
     expect(createRoute).toContain("handleCreateMcpSignalInternalRequest");
     expect(getRoute).toContain('@api/app/internal-api/mcp-signals"');
     expect(getRoute).toContain("handleGetMcpSignalInternalRequest");
+    expect(auditRoute).toContain('@api/app/internal-api/mcp-audit"');
+    expect(auditRoute).toContain("handleRecordMcpAuditInternalRequest");
 
-    for (const source of [createRoute, getRoute]) {
+    for (const source of [createRoute, getRoute, auditRoute]) {
       expect(source).not.toContain("@db/app");
       expect(source).not.toContain("@repo/api-contract");
       expect(source).not.toContain("~/server/mcp-service-auth");
@@ -47,5 +54,9 @@ describe("internal MCP app routes", () => {
     expect(adapter).not.toContain('from "../../signals/service"');
     expect(adapter).not.toContain("createSignalForActor");
     expect(adapter).not.toContain("getVisibleSignalByPublicId");
+
+    expect(auditAdapter).toContain("process.env.SERVICE_JWT_SECRET");
+    expect(auditAdapter).toContain("recordMcpAuditEvent");
+    expect(auditAdapter).not.toContain('from "../../env"');
   });
 });

--- a/apps/app/src/__tests__/migration-readiness.test.ts
+++ b/apps/app/src/__tests__/migration-readiness.test.ts
@@ -53,6 +53,7 @@ const migratedNextAppRoutes = [
   "/api/github/webhook",
   "/api/health",
   "/api/inngest",
+  "/api/internal/mcp/audit",
   "/api/internal/mcp/proxy/call",
   "/api/internal/mcp/proxy/find",
   "/api/internal/mcp/signals",
@@ -129,7 +130,7 @@ describe("app migration readiness", () => {
   it("declares TanStack routes for every migrated legacy Next route", () => {
     const tanstackRoutes = new Set(tanstackRouteDeclarations());
 
-    expect(migratedNextAppRoutes.length).toBe(69);
+    expect(migratedNextAppRoutes.length).toBe(70);
     expect(tanstackRoutes.size).toBeGreaterThan(0);
     expect(
       migratedNextAppRoutes.filter((route) => !tanstackRoutes.has(route))

--- a/apps/app/src/__tests__/start-middleware.test.ts
+++ b/apps/app/src/__tests__/start-middleware.test.ts
@@ -26,6 +26,7 @@ describe("app start middleware", () => {
     expect(isAppOwnedApiRoute("/api/connectors/x/mcp")).toBe(true);
     expect(isAppOwnedApiRoute("/api/connectors/x/mcp/messages")).toBe(true);
     expect(isAppOwnedApiRoute("/api/inngest")).toBe(true);
+    expect(isAppOwnedApiRoute("/api/internal/mcp/audit")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/proxy/call")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/proxy/find")).toBe(true);
     expect(isAppOwnedApiRoute("/api/internal/mcp/signals")).toBe(true);

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -59,6 +59,7 @@ import { Route as ApiOauthClientConfigRouteImport } from './routes/api/oauth/$cl
 import { Route as ApiNativeProxyRoutinesRouteImport } from './routes/api/native/proxy/routines'
 import { Route as ApiNativeProxyCallRouteImport } from './routes/api/native/proxy/call'
 import { Route as ApiInternalMcpSignalsRouteImport } from './routes/api/internal/mcp/signals'
+import { Route as ApiInternalMcpAuditRouteImport } from './routes/api/internal/mcp/audit'
 import { Route as ApiGithubOauthCallbackRouteImport } from './routes/api/github/oauth/callback'
 import { Route as ApiConnectorsXMcpRouteImport } from './routes/api/connectors/x/mcp'
 import { Route as ApiChatIdStreamRouteImport } from './routes/api/chat/$id/stream'
@@ -356,6 +357,11 @@ const ApiInternalMcpSignalsRoute = ApiInternalMcpSignalsRouteImport.update({
   path: '/api/internal/mcp/signals',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiInternalMcpAuditRoute = ApiInternalMcpAuditRouteImport.update({
+  id: '/api/internal/mcp/audit',
+  path: '/api/internal/mcp/audit',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiGithubOauthCallbackRoute = ApiGithubOauthCallbackRouteImport.update({
   id: '/api/github/oauth/callback',
   path: '/api/github/oauth/callback',
@@ -612,6 +618,7 @@ export interface FileRoutesByFullPath {
   '/api/chat/$id/stream': typeof ApiChatIdStreamRoute
   '/api/connectors/x/mcp': typeof ApiConnectorsXMcpRoute
   '/api/github/oauth/callback': typeof ApiGithubOauthCallbackRoute
+  '/api/internal/mcp/audit': typeof ApiInternalMcpAuditRoute
   '/api/internal/mcp/signals': typeof ApiInternalMcpSignalsRouteWithChildren
   '/api/native/proxy/call': typeof ApiNativeProxyCallRoute
   '/api/native/proxy/routines': typeof ApiNativeProxyRoutinesRoute
@@ -689,6 +696,7 @@ export interface FileRoutesByTo {
   '/api/chat/$id/stream': typeof ApiChatIdStreamRoute
   '/api/connectors/x/mcp': typeof ApiConnectorsXMcpRoute
   '/api/github/oauth/callback': typeof ApiGithubOauthCallbackRoute
+  '/api/internal/mcp/audit': typeof ApiInternalMcpAuditRoute
   '/api/internal/mcp/signals': typeof ApiInternalMcpSignalsRouteWithChildren
   '/api/native/proxy/call': typeof ApiNativeProxyCallRoute
   '/api/native/proxy/routines': typeof ApiNativeProxyRoutinesRoute
@@ -775,6 +783,7 @@ export interface FileRoutesById {
   '/api/chat/$id/stream': typeof ApiChatIdStreamRoute
   '/api/connectors/x/mcp': typeof ApiConnectorsXMcpRoute
   '/api/github/oauth/callback': typeof ApiGithubOauthCallbackRoute
+  '/api/internal/mcp/audit': typeof ApiInternalMcpAuditRoute
   '/api/internal/mcp/signals': typeof ApiInternalMcpSignalsRouteWithChildren
   '/api/native/proxy/call': typeof ApiNativeProxyCallRoute
   '/api/native/proxy/routines': typeof ApiNativeProxyRoutinesRoute
@@ -862,6 +871,7 @@ export interface FileRouteTypes {
     | '/api/chat/$id/stream'
     | '/api/connectors/x/mcp'
     | '/api/github/oauth/callback'
+    | '/api/internal/mcp/audit'
     | '/api/internal/mcp/signals'
     | '/api/native/proxy/call'
     | '/api/native/proxy/routines'
@@ -939,6 +949,7 @@ export interface FileRouteTypes {
     | '/api/chat/$id/stream'
     | '/api/connectors/x/mcp'
     | '/api/github/oauth/callback'
+    | '/api/internal/mcp/audit'
     | '/api/internal/mcp/signals'
     | '/api/native/proxy/call'
     | '/api/native/proxy/routines'
@@ -1024,6 +1035,7 @@ export interface FileRouteTypes {
     | '/api/chat/$id/stream'
     | '/api/connectors/x/mcp'
     | '/api/github/oauth/callback'
+    | '/api/internal/mcp/audit'
     | '/api/internal/mcp/signals'
     | '/api/native/proxy/call'
     | '/api/native/proxy/routines'
@@ -1078,6 +1090,7 @@ export interface RootRouteChildren {
   OauthClientStartRoute: typeof OauthClientStartRoute
   ApiConnectorsXMcpRoute: typeof ApiConnectorsXMcpRoute
   ApiGithubOauthCallbackRoute: typeof ApiGithubOauthCallbackRoute
+  ApiInternalMcpAuditRoute: typeof ApiInternalMcpAuditRoute
   ApiInternalMcpSignalsRoute: typeof ApiInternalMcpSignalsRouteWithChildren
   ApiNativeProxyCallRoute: typeof ApiNativeProxyCallRoute
   ApiNativeProxyRoutinesRoute: typeof ApiNativeProxyRoutinesRoute
@@ -1443,6 +1456,13 @@ declare module '@tanstack/react-router' {
       path: '/api/internal/mcp/signals'
       fullPath: '/api/internal/mcp/signals'
       preLoaderRoute: typeof ApiInternalMcpSignalsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/internal/mcp/audit': {
+      id: '/api/internal/mcp/audit'
+      path: '/api/internal/mcp/audit'
+      fullPath: '/api/internal/mcp/audit'
+      preLoaderRoute: typeof ApiInternalMcpAuditRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/github/oauth/callback': {
@@ -1994,6 +2014,7 @@ const rootRouteChildren: RootRouteChildren = {
   OauthClientStartRoute: OauthClientStartRoute,
   ApiConnectorsXMcpRoute: ApiConnectorsXMcpRoute,
   ApiGithubOauthCallbackRoute: ApiGithubOauthCallbackRoute,
+  ApiInternalMcpAuditRoute: ApiInternalMcpAuditRoute,
   ApiInternalMcpSignalsRoute: ApiInternalMcpSignalsRouteWithChildren,
   ApiNativeProxyCallRoute: ApiNativeProxyCallRoute,
   ApiNativeProxyRoutinesRoute: ApiNativeProxyRoutinesRoute,

--- a/apps/app/src/routes/api/internal/mcp/audit.ts
+++ b/apps/app/src/routes/api/internal/mcp/audit.ts
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/internal/mcp/audit")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const { handleRecordMcpAuditInternalRequest } = await import(
+          "@api/app/internal-api/mcp-audit"
+        );
+        return handleRecordMcpAuditInternalRequest(request);
+      },
+    },
+  },
+});

--- a/apps/app/src/start.ts
+++ b/apps/app/src/start.ts
@@ -13,6 +13,7 @@ import { applySecurityHeaders } from "~/security/headers";
 export const APP_OWNED_API_PREFIXES = [
   "/api/connectors/x/mcp",
   "/api/inngest",
+  "/api/internal/mcp/audit",
   "/api/internal/mcp/proxy",
   "/api/internal/mcp/signals",
   "/api/v1",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@api/app": "workspace:*",
-    "@db/app": "workspace:*",
     "@lightfast/connector-core": "workspace:*",
     "@repo/api-contract": "workspace:*",
     "@repo/mcp-tools": "workspace:*",
@@ -30,7 +29,6 @@
     "@tanstack/react-start": "catalog:",
     "@vendor/jose": "workspace:*",
     "@vendor/mcp": "workspace:*",
-    "@vendor/observability": "workspace:*",
     "react": "catalog:react19",
     "react-dom": "catalog:react19",
     "zod": "catalog:"

--- a/apps/mcp/src/__tests__/app-proxy-intake.test.ts
+++ b/apps/mcp/src/__tests__/app-proxy-intake.test.ts
@@ -15,7 +15,6 @@ const proxyContext = {
     orgId: "org_test",
     userId: "user_test",
   },
-  db: {} as never,
   log: {
     error: vi.fn(),
     info: vi.fn(),

--- a/apps/mcp/src/__tests__/app-signal-intake.test.ts
+++ b/apps/mcp/src/__tests__/app-signal-intake.test.ts
@@ -31,7 +31,6 @@ describe("app signal intake adapter", () => {
 
     await expect(
       createSignalForActorViaApp(
-        {} as never,
         {
           actor: {
             clientId: "mcp_client_test",
@@ -96,7 +95,6 @@ describe("app signal intake adapter", () => {
 
     await expect(
       createSignalForActorViaApp(
-        {} as never,
         {
           actor: {
             clientId: "mcp_client_test",
@@ -129,7 +127,6 @@ describe("app signal intake adapter", () => {
 
     await expect(
       createSignalForActorViaApp(
-        {} as never,
         {
           actor: {
             clientId: "mcp_client_test",
@@ -166,7 +163,6 @@ describe("app signal intake adapter", () => {
 
     await expect(
       getSignalForActorViaApp(
-        {} as never,
         {
           actor: {
             clientId: "mcp_client_test",

--- a/apps/mcp/src/__tests__/audit.test.ts
+++ b/apps/mcp/src/__tests__/audit.test.ts
@@ -1,4 +1,3 @@
-import type { Database } from "@db/app";
 import { describe, expect, it, vi } from "vitest";
 
 import type { HostedMcpContext } from "../context";
@@ -6,8 +5,6 @@ import {
   type ExecuteHostedMcpToolDependencies,
   executeHostedMcpTool,
 } from "../tools/execute";
-
-const db = { kind: "mock-db" } as unknown as Database;
 
 const context = {
   clientId: "mcp_client_test",
@@ -31,10 +28,8 @@ function dependencies(): ExecuteHostedMcpToolDependencies {
       status: "succeeded",
     }),
     createSignalForActor: vi.fn(),
-    db,
     findProviderRoutines: vi.fn(),
-    getVisibleSignalByPublicId: vi.fn(),
-    listSignalEntityLinksForSignal: vi.fn().mockResolvedValue([]),
+    getSignalForActor: vi.fn(),
     now: vi
       .fn()
       .mockReturnValueOnce(new Date("2026-06-01T00:00:00.000Z"))
@@ -72,7 +67,6 @@ describe("hosted MCP audit", () => {
     expect(deps.recordMcpAuditEvent).toHaveBeenCalledTimes(2);
     expect(deps.recordMcpAuditEvent).toHaveBeenNthCalledWith(
       1,
-      db,
       expect.objectContaining({
         clientPublicId: "mcp_client_test",
         clerkOrgId: "org_test",
@@ -92,7 +86,6 @@ describe("hosted MCP audit", () => {
     );
     expect(deps.recordMcpAuditEvent).toHaveBeenNthCalledWith(
       2,
-      db,
       expect.objectContaining({
         outcome: "denied",
         metadata: expect.objectContaining({
@@ -130,7 +123,6 @@ describe("hosted MCP audit", () => {
     });
 
     expect(deps.recordMcpAuditEvent).toHaveBeenCalledWith(
-      db,
       expect.objectContaining({
         eventName: "mcp.proxy.call",
         metadata: expect.objectContaining({

--- a/apps/mcp/src/__tests__/e2e-oauth-mcp.test.ts
+++ b/apps/mcp/src/__tests__/e2e-oauth-mcp.test.ts
@@ -1,18 +1,79 @@
-import type {
-  Database,
-  McpOauthAuthorizationCode,
-  McpOauthClientWithRedirectUris,
-  McpOauthGrant,
-  McpOauthRefreshToken,
-  RecordMcpAuditEventInput,
-  Signal,
-} from "@db/app";
 import type { McpScope } from "@repo/api-contract";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ExecuteHostedMcpToolDependencies } from "../tools/execute";
 
+interface Database {
+  kind: "e2e-mock-db";
+}
+
+interface McpOauthClientWithRedirectUris {
+  clientName: string;
+  clientUri: string | null;
+  contacts: string[] | null;
+  createdAt: Date;
+  id: number;
+  logoUri: string | null;
+  metadata: Record<string, unknown> | null;
+  publicClientId: string;
+  redirectUris: string[];
+  status: "active";
+  updatedAt: Date;
+}
+
+interface McpOauthAuthorizationCode {
+  clerkOrgId: string;
+  clerkUserId: string;
+  clientPublicId: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+  codeHash: string;
+  consumedAt: Date | null;
+  createdAt: Date;
+  expiresAt: Date;
+  id: number;
+  redirectUri: string;
+  resource: string;
+  resourceHash: string;
+  scopes: McpScope[];
+  updatedAt: Date;
+}
+
+interface McpOauthGrant {
+  clerkOrgId: string;
+  clerkUserId: string;
+  clientPublicId: string;
+  createdAt: Date;
+  id: number;
+  lastUsedAt: Date | null;
+  metadata: Record<string, unknown> | null;
+  publicId: string;
+  resource: string;
+  resourceHash: string;
+  revokedAt: Date | null;
+  scopes: McpScope[];
+  status: "active" | "revoked";
+  updatedAt: Date;
+}
+
+interface McpOauthRefreshToken {
+  clerkOrgId: string;
+  clerkUserId: string;
+  clientPublicId: string;
+  createdAt: Date;
+  expiresAt: Date;
+  grantPublicId: string;
+  id: number;
+  parentTokenHash: string | null;
+  reuseDetectedAt: Date | null;
+  rotatedToTokenHash: string | null;
+  status: "active" | "reuse_detected" | "revoked" | "rotated";
+  tokenHash: string;
+  updatedAt: Date;
+}
+
 vi.mock("server-only", () => ({}));
+vi.mock("@tanstack/react-start/server-only", () => ({}));
 
 const consumeMcpAuthorizationCodeMock = vi.fn();
 const createMcpAuthorizationCodeMock = vi.fn();
@@ -45,12 +106,29 @@ vi.mock("@db/app", () => ({
   rotateMcpRefreshToken: rotateMcpRefreshTokenMock,
 }));
 
+vi.mock("../../../../db/app/src/index.ts", () => ({
+  consumeMcpAuthorizationCode: consumeMcpAuthorizationCodeMock,
+  createMcpAuthorizationCode: createMcpAuthorizationCodeMock,
+  createMcpOauthClient: createMcpOauthClientMock,
+  createMcpOauthGrant: createMcpOauthGrantMock,
+  createMcpRefreshToken: createMcpRefreshTokenMock,
+  getActiveMcpOauthGrant: getActiveMcpOauthGrantMock,
+  getActiveOrgBinding: getActiveOrgBindingMock,
+  getMcpOauthClientByClientId: getMcpOauthClientByClientIdMock,
+  getMcpOauthClientByRegistrationTokenHash:
+    getMcpOauthClientByRegistrationTokenHashMock,
+  getMcpOauthGrantByPublicId: getMcpOauthGrantByPublicIdMock,
+  revokeMcpOauthGrant: revokeMcpOauthGrantMock,
+  revokeMcpRefreshTokenByHash: revokeMcpRefreshTokenByHashMock,
+  rotateMcpRefreshToken: rotateMcpRefreshTokenMock,
+}));
+
 vi.mock("@vendor/clerk/server", () => ({
   auth: vi.fn(),
   clerkClient: vi.fn(),
 }));
 
-const db = { kind: "e2e-mock-db" } as unknown as Database;
+const db = { kind: "e2e-mock-db" } as never;
 const now = new Date("2026-06-01T00:00:00.000Z");
 const issuer = "https://app.lightfast.localhost";
 const jwtSecret = "test-mcp-jwt-secret-test-mcp-jwt-secret";
@@ -395,7 +473,7 @@ describe("hosted MCP OAuth integration smoke", () => {
       status: "queued",
       visibilityScope: "user",
     });
-    expect(toolDependencies.createSignalForActor).toHaveBeenCalledWith(db, {
+    expect(toolDependencies.createSignalForActor).toHaveBeenCalledWith({
       actor: {
         clientId: registeredClient.client_id,
         grantId: "mcp_grant_test",
@@ -571,16 +649,10 @@ function mcpToolDependencies(): ExecuteHostedMcpToolDependencies {
       status: "succeeded",
     }),
     createSignalForActor,
-    db,
     findProviderRoutines: vi.fn().mockResolvedValue({ routines: [] }),
-    getVisibleSignalByPublicId: vi
-      .fn()
-      .mockResolvedValue(undefined as Signal | undefined),
-    listSignalEntityLinksForSignal: vi.fn().mockResolvedValue([]),
+    getSignalForActor: vi.fn().mockResolvedValue(undefined),
     now: vi.fn(() => now),
-    recordMcpAuditEvent: vi
-      .fn()
-      .mockResolvedValue(undefined as RecordMcpAuditEventInput | undefined),
+    recordMcpAuditEvent: vi.fn().mockResolvedValue(undefined),
     version: "0.1.0-test",
   };
 }

--- a/apps/mcp/src/__tests__/env-config.test.ts
+++ b/apps/mcp/src/__tests__/env-config.test.ts
@@ -6,14 +6,16 @@ import { createSentryBuildOptions } from "../../vite.config";
 const appRoot = resolve(import.meta.dirname, "../..");
 
 describe("MCP environment validation wiring", () => {
-  it("validates DB env requirements in the MCP env schema", () => {
+  it("keeps DB env requirements out of the MCP env schema", () => {
     const envSource = readFileSync(resolve(appRoot, "src/env.ts"), "utf8");
 
     expect(envSource).toContain('import "@tanstack/react-start/server-only"');
-    expect(envSource).toContain('from "@db/app/env"');
+    expect(envSource).not.toContain("@db/app/env");
+    expect(envSource).not.toContain("DATABASE_HOST");
+    expect(envSource).not.toContain("DATABASE_USERNAME");
+    expect(envSource).not.toContain("DATABASE_PASSWORD");
     expect(envSource).not.toContain("@vendor/observability/sentry-env");
     expect(envSource).toContain('from "@t3-oss/env-core"');
-    expect(envSource).toContain("extends: [dbEnv]");
   });
 
   it("evaluates the MCP env schema during Vite config loading", () => {

--- a/apps/mcp/src/__tests__/mcp-app-boundary-source.test.ts
+++ b/apps/mcp/src/__tests__/mcp-app-boundary-source.test.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+
+const ignoredDirs = new Set([".next", ".turbo", "coverage", "node_modules"]);
+
+function source(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function walkFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    if (ignoredDirs.has(entry)) {
+      return [];
+    }
+
+    const path = resolve(dir, entry);
+    if (statSync(path).isDirectory()) {
+      return walkFiles(path);
+    }
+
+    return [path];
+  });
+}
+
+function productionSources() {
+  return walkFiles(resolve(appRoot, "src"))
+    .filter((path) => /\.(ts|tsx)$/.test(path))
+    .filter((path) => !relative(appRoot, path).includes("__tests__/"))
+    .filter((path) => !/\.test\.[tj]sx?$/.test(path));
+}
+
+describe("hosted MCP app boundary", () => {
+  it("keeps DB env and persistence out of apps/mcp", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    const envSource = source("src/env.ts");
+
+    expect(packageJson.dependencies?.["@db/app"]).toBeUndefined();
+    expect(envSource).not.toContain("@db/app/env");
+    expect(envSource).not.toContain("DATABASE_HOST");
+    expect(envSource).not.toContain("DATABASE_USERNAME");
+    expect(envSource).not.toContain("DATABASE_PASSWORD");
+
+    const staleSources = productionSources()
+      .filter((path) => readFileSync(path, "utf8").includes("@db/app"))
+      .map((path) => relative(appRoot, path))
+      .sort();
+
+    expect(staleSources).toEqual([]);
+  });
+});

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -1,4 +1,3 @@
-import type { Database, Signal } from "@db/app";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HostedMcpContext } from "../context";
@@ -8,7 +7,6 @@ import {
   listHostedMcpTools,
 } from "../tools/execute";
 
-const db = { kind: "mock-db" } as unknown as Database;
 const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
 const providerRoutineCallId = "provider_routine_call_123";
 
@@ -21,28 +19,6 @@ function context(overrides: Partial<HostedMcpContext> = {}): HostedMcpContext {
     requestId: "req_test",
     scopes: ["mcp:system:read", "mcp:signals:read", "mcp:signals:write"],
     userId: "user_test",
-    ...overrides,
-  };
-}
-
-function signal(overrides: Partial<Signal> = {}): Signal {
-  return {
-    id: 1,
-    classification: null,
-    classificationMetadata: null,
-    clerkOrgId: "org_test",
-    createdAt: new Date("2026-06-01T00:00:00.000Z"),
-    createdByApiKeyId: null,
-    createdByMcpClientId: "mcp_client_test",
-    createdByMcpGrantId: "mcp_grant_test",
-    createdByUserId: "user_test",
-    errorCode: null,
-    errorMessage: null,
-    input: "Review this profile",
-    publicId: signalId,
-    status: "queued",
-    updatedAt: new Date("2026-06-01T00:01:00.000Z"),
-    visibilityScope: "user",
     ...overrides,
   };
 }
@@ -65,7 +41,6 @@ function dependencies(
       status: "queued",
       visibilityScope: "user",
     }),
-    db,
     findProviderRoutines: vi.fn().mockResolvedValue({
       routines: [
         {
@@ -77,8 +52,16 @@ function dependencies(
         },
       ],
     }),
-    getVisibleSignalByPublicId: vi.fn().mockResolvedValue(signal()),
-    listSignalEntityLinksForSignal: vi.fn().mockResolvedValue([]),
+    getSignalForActor: vi.fn().mockResolvedValue({
+      classification: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      entityLinks: [],
+      id: signalId,
+      input: "Review this profile",
+      status: "queued",
+      updatedAt: "2026-06-01T00:01:00.000Z",
+      visibilityScope: "user",
+    }),
     now: vi.fn(() => new Date("2026-06-01T00:00:00.000Z")),
     recordMcpAuditEvent: vi.fn().mockResolvedValue(undefined),
     version: "0.1.0-test",
@@ -90,8 +73,8 @@ describe("hosted MCP tools", () => {
   afterEach(() => {
     vi.doUnmock("@api/app/mcp-oauth");
     vi.doUnmock("@api/app/signals/service");
-    vi.doUnmock("@db/app");
     vi.doUnmock("@repo/provider-routines");
+    vi.doUnmock("../tools/app-audit-intake");
     vi.doUnmock("../tools/app-proxy-intake");
     vi.doUnmock("../tools/app-signal-intake");
   });
@@ -142,11 +125,11 @@ describe("hosted MCP tools", () => {
       visibilityScope: "user",
     });
 
-    expect(deps.assertOrgAccess).toHaveBeenCalledWith(db, {
+    expect(deps.assertOrgAccess).toHaveBeenCalledWith({
       orgId: "org_test",
       userId: "user_test",
     });
-    expect(deps.createSignalForActor).toHaveBeenCalledWith(db, {
+    expect(deps.createSignalForActor).toHaveBeenCalledWith({
       actor: {
         clientId: "mcp_client_test",
         grantId: "mcp_grant_test",
@@ -179,14 +162,15 @@ describe("hosted MCP tools", () => {
       visibilityScope: "user",
     });
 
-    expect(deps.getVisibleSignalByPublicId).toHaveBeenCalledWith(db, {
-      clerkOrgId: "org_test",
-      createdByUserId: "user_test",
-      publicId: signalId,
-    });
-    expect(deps.listSignalEntityLinksForSignal).toHaveBeenCalledWith(db, {
-      clerkOrgId: "org_test",
-      signalId,
+    expect(deps.getSignalForActor).toHaveBeenCalledWith({
+      actor: {
+        clientId: "mcp_client_test",
+        grantId: "mcp_grant_test",
+        kind: "mcp",
+        orgId: "org_test",
+        userId: "user_test",
+      },
+      id: signalId,
     });
   });
 
@@ -232,7 +216,6 @@ describe("hosted MCP tools", () => {
     });
 
     expect(deps.recordMcpAuditEvent).toHaveBeenCalledWith(
-      db,
       expect.objectContaining({
         outcome: "denied",
         metadata: expect.objectContaining({
@@ -269,7 +252,6 @@ describe("hosted MCP tools", () => {
     });
 
     expect(deps.recordMcpAuditEvent).toHaveBeenCalledWith(
-      db,
       expect.objectContaining({
         outcome: "error",
         metadata: expect.objectContaining({
@@ -307,7 +289,6 @@ describe("hosted MCP tools", () => {
     expect(deps.findProviderRoutines).toHaveBeenCalledWith(
       expect.objectContaining({
         actor: { orgId: "org_test", userId: "user_test" },
-        db,
         scopes: {
           providerRoutineRead: true,
           providerRoutineWrite: false,
@@ -382,7 +363,6 @@ describe("hosted MCP tools", () => {
       }
     );
     expect(deps.recordMcpAuditEvent).toHaveBeenCalledWith(
-      db,
       expect.objectContaining({
         eventName: "mcp.proxy.call",
         metadata: expect.objectContaining({
@@ -421,11 +401,8 @@ describe("hosted MCP tools", () => {
   it("does not load unrelated default dependencies for system health", async () => {
     const recordMcpAuditEvent = vi.fn().mockResolvedValue(undefined);
 
-    vi.doMock("@db/app", () => ({
-      db,
-      getVisibleSignalByPublicId: vi.fn(),
-      listSignalEntityLinksForSignal: vi.fn(),
-      recordMcpAuditEvent,
+    vi.doMock("../tools/app-audit-intake", () => ({
+      recordMcpAuditEventViaApp: recordMcpAuditEvent,
     }));
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for system health");
@@ -452,7 +429,6 @@ describe("hosted MCP tools", () => {
     });
 
     expect(recordMcpAuditEvent).toHaveBeenCalledWith(
-      db,
       expect.objectContaining({
         eventName: "mcp.system.health",
         outcome: "success",
@@ -468,11 +444,8 @@ describe("hosted MCP tools", () => {
     });
     const recordMcpAuditEvent = vi.fn().mockResolvedValue(undefined);
 
-    vi.doMock("@db/app", () => ({
-      db,
-      getVisibleSignalByPublicId: vi.fn(),
-      listSignalEntityLinksForSignal: vi.fn(),
-      recordMcpAuditEvent,
+    vi.doMock("../tools/app-audit-intake", () => ({
+      recordMcpAuditEventViaApp: recordMcpAuditEvent,
     }));
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for signal creation");
@@ -499,7 +472,7 @@ describe("hosted MCP tools", () => {
       visibilityScope: "user",
     });
 
-    expect(createSignalForActor).toHaveBeenCalledWith(db, {
+    expect(createSignalForActor).toHaveBeenCalledWith({
       actor: {
         clientId: "mcp_client_test",
         grantId: "mcp_grant_test",
@@ -524,11 +497,8 @@ describe("hosted MCP tools", () => {
     });
     const recordMcpAuditEvent = vi.fn().mockResolvedValue(undefined);
 
-    vi.doMock("@db/app", () => ({
-      db,
-      getVisibleSignalByPublicId: vi.fn(),
-      listSignalEntityLinksForSignal: vi.fn(),
-      recordMcpAuditEvent,
+    vi.doMock("../tools/app-audit-intake", () => ({
+      recordMcpAuditEventViaApp: recordMcpAuditEvent,
     }));
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for signal get");
@@ -554,7 +524,7 @@ describe("hosted MCP tools", () => {
       status: "queued",
     });
 
-    expect(getSignalForActor).toHaveBeenCalledWith(db, {
+    expect(getSignalForActor).toHaveBeenCalledWith({
       actor: {
         clientId: "mcp_client_test",
         grantId: "mcp_grant_test",
@@ -578,11 +548,8 @@ describe("hosted MCP tools", () => {
     const findProviderRoutines = vi.fn();
     const recordMcpAuditEvent = vi.fn().mockResolvedValue(undefined);
 
-    vi.doMock("@db/app", () => ({
-      db,
-      getVisibleSignalByPublicId: vi.fn(),
-      listSignalEntityLinksForSignal: vi.fn(),
-      recordMcpAuditEvent,
+    vi.doMock("../tools/app-audit-intake", () => ({
+      recordMcpAuditEventViaApp: recordMcpAuditEvent,
     }));
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for proxy calls");

--- a/apps/mcp/src/env.ts
+++ b/apps/mcp/src/env.ts
@@ -1,11 +1,9 @@
 import "@tanstack/react-start/server-only";
 
-import { env as dbEnv } from "@db/app/env";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
 export const env = createEnv({
-  extends: [dbEnv],
   clientPrefix: "VITE_",
   client: {
     VITE_SENTRY_DSN: z.string().url().optional(),
@@ -26,9 +24,6 @@ export const env = createEnv({
       .default("development"),
   },
   runtimeEnv: {
-    DATABASE_HOST: process.env.DATABASE_HOST,
-    DATABASE_USERNAME: process.env.DATABASE_USERNAME,
-    DATABASE_PASSWORD: process.env.DATABASE_PASSWORD,
     NODE_ENV: process.env.NODE_ENV,
     MCP_AUTH_ISSUER: process.env.MCP_AUTH_ISSUER,
     MCP_RESOURCE_URL: process.env.MCP_RESOURCE_URL,

--- a/apps/mcp/src/tools/app-audit-intake.ts
+++ b/apps/mcp/src/tools/app-audit-intake.ts
@@ -1,0 +1,101 @@
+import { signServiceJWT } from "@api/app/service-jwt";
+import { env } from "../env";
+
+type Fetch = typeof fetch;
+
+export type McpAuditOutcome = "denied" | "error" | "success";
+
+export interface AppMcpAuditEventInput {
+  clerkOrgId?: string | null;
+  clerkUserId?: string | null;
+  clientPublicId?: string | null;
+  eventName: string;
+  grantPublicId?: string | null;
+  metadata?: Record<string, unknown> | null;
+  outcome: McpAuditOutcome;
+}
+
+export class AppAuditIntakeError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(
+    message: string,
+    options: ErrorOptions & { code?: string; status?: number } = {}
+  ) {
+    super(message, options);
+    this.code = options.code ?? "app_audit_intake_failed";
+    this.name = "AppAuditIntakeError";
+    this.status = options.status ?? 502;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return await response.json().catch(() => undefined);
+}
+
+function appAuditUrl(): string {
+  return new URL("/api/internal/mcp/audit", env.MCP_AUTH_ISSUER).toString();
+}
+
+function messageFromBody(body: unknown): string {
+  if (
+    body &&
+    typeof body === "object" &&
+    "message" in body &&
+    typeof (body as { message: unknown }).message === "string"
+  ) {
+    return (body as { message: string }).message;
+  }
+  return "App audit intake command failed.";
+}
+
+function errorCodeFromBody(responseStatus: number, body: unknown): string {
+  if (responseStatus !== 401 && responseStatus !== 403) {
+    return "app_audit_intake_failed";
+  }
+  if (
+    body &&
+    typeof body === "object" &&
+    "error" in body &&
+    typeof (body as { error: unknown }).error === "string"
+  ) {
+    return (body as { error: string }).error;
+  }
+  return "app_audit_intake_failed";
+}
+
+function mappedErrorStatus(responseStatus: number): number {
+  if (responseStatus === 401 || responseStatus === 403) {
+    return responseStatus;
+  }
+  return 502;
+}
+
+export async function recordMcpAuditEventViaApp(
+  input: AppMcpAuditEventInput,
+  dependencies: { fetch?: Fetch } = {}
+): Promise<void> {
+  const serviceToken = await signServiceJWT({
+    audience: "lightfast-app",
+    caller: "mcp",
+    jwtSecret: env.SERVICE_JWT_SECRET,
+  });
+  const requestFetch = dependencies.fetch ?? fetch;
+  const response = await requestFetch(appAuditUrl(), {
+    body: JSON.stringify(input),
+    headers: {
+      authorization: `Bearer ${serviceToken}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  const responseBody = await readJson(response);
+
+  if (!response.ok) {
+    throw new AppAuditIntakeError(messageFromBody(responseBody), {
+      code: errorCodeFromBody(response.status, responseBody),
+      status: mappedErrorStatus(response.status),
+    });
+  }
+}

--- a/apps/mcp/src/tools/app-signal-intake.ts
+++ b/apps/mcp/src/tools/app-signal-intake.ts
@@ -1,5 +1,4 @@
 import { signServiceJWT } from "@api/app/service-jwt";
-import type { Database } from "@db/app";
 import {
   type CreateSignalOutput,
   createMcpSignalCommandInput,
@@ -102,7 +101,6 @@ async function postAppSignalCommand(input: {
 }
 
 export async function createSignalForActorViaApp(
-  _db: Database,
   input: {
     actor: {
       clientId: string;
@@ -132,7 +130,6 @@ export async function createSignalForActorViaApp(
 }
 
 export async function getSignalForActorViaApp(
-  _db: Database,
   input: {
     actor: {
       clientId: string;

--- a/apps/mcp/src/tools/execute.ts
+++ b/apps/mcp/src/tools/execute.ts
@@ -1,4 +1,3 @@
-import type { Database, RecordMcpAuditEventInput, Signal } from "@db/app";
 import {
   type ProviderRoutineCallInput,
   type ProviderRoutineCallSuccess,
@@ -30,6 +29,10 @@ import {
   type HostedMcpAuthInfo,
   type HostedMcpContext,
 } from "../context";
+import type {
+  AppMcpAuditEventInput,
+  McpAuditOutcome,
+} from "./app-audit-intake";
 
 const DEFAULT_VERSION = "0.1.0";
 
@@ -54,7 +57,7 @@ export class HostedMcpToolError extends Error {
     readonly code: HostedMcpToolErrorCode,
     message: string,
     readonly status: number,
-    readonly auditOutcome: RecordMcpAuditEventInput["outcome"] = "error",
+    readonly auditOutcome: McpAuditOutcome = "error",
     options?: ErrorOptions,
     readonly providerRoutineCallId?: string
   ) {
@@ -64,57 +67,32 @@ export class HostedMcpToolError extends Error {
 }
 
 export interface ExecuteHostedMcpToolDependencies {
-  assertOrgAccess: (
-    db: Database,
-    input: { orgId: string; userId: string }
-  ) => Promise<void>;
+  assertOrgAccess: (input: { orgId: string; userId: string }) => Promise<void>;
   callProviderRoutine: CallProviderRoutineService;
-  createSignalForActor: (
-    db: Database,
-    input: {
-      actor: {
-        clientId: string;
-        grantId: string;
-        kind: "mcp";
-        orgId: string;
-        userId: string;
-      };
-      input: string;
-    }
-  ) => Promise<unknown>;
-  db: Database;
+  createSignalForActor: (input: {
+    actor: {
+      clientId: string;
+      grantId: string;
+      kind: "mcp";
+      orgId: string;
+      userId: string;
+    };
+    input: string;
+  }) => Promise<unknown>;
   findProviderRoutines: FindProviderRoutinesService;
-  getSignalForActor?: (
-    db: Database,
-    input: {
-      actor: {
-        clientId: string;
-        grantId: string;
-        kind: "mcp";
-        orgId: string;
-        userId: string;
-      };
-      id: string;
-    }
-  ) => Promise<GetSignalOutput | null | undefined>;
-  getVisibleSignalByPublicId: (
-    db: Database,
-    input: {
-      clerkOrgId: string;
-      createdByUserId: string;
-      publicId: string;
-    }
-  ) => Promise<Signal | undefined>;
-  listSignalEntityLinksForSignal: (
-    db: Database,
-    input: { clerkOrgId: string; signalId: string }
-  ) => Promise<GetSignalOutput["entityLinks"]>;
+  getSignalForActor: (input: {
+    actor: {
+      clientId: string;
+      grantId: string;
+      kind: "mcp";
+      orgId: string;
+      userId: string;
+    };
+    id: string;
+  }) => Promise<GetSignalOutput | null | undefined>;
   now: () => Date;
   providerRoutineLog?: ProviderRoutineServiceLog;
-  recordMcpAuditEvent: (
-    db: Database,
-    input: RecordMcpAuditEventInput
-  ) => Promise<void>;
+  recordMcpAuditEvent: (input: AppMcpAuditEventInput) => Promise<void>;
   version: string;
 }
 
@@ -129,7 +107,6 @@ interface ProviderRoutineServiceContext {
     orgId: string;
     userId: string;
   };
-  db: Database;
   log: ProviderRoutineServiceLog;
   now: () => Date;
   scopes: {
@@ -251,7 +228,7 @@ export async function executeHostedMcpTool(
   try {
     ensureScope(input.context, tool.requiredScope);
     if (tool.requiresBoundOrg) {
-      await dependencies.assertOrgAccess(dependencies.db, {
+      await dependencies.assertOrgAccess({
         orgId: input.context.orgId,
         userId: input.context.userId,
       });
@@ -307,72 +284,34 @@ async function executeParsedTool(input: {
 
     case "signals.create": {
       const createInput = input.parsedInput as CreateSignalInput;
-      return await input.dependencies.createSignalForActor(
-        input.dependencies.db,
-        {
-          actor: {
-            clientId: input.context.clientId,
-            grantId: input.context.grantId,
-            kind: "mcp",
-            orgId: input.context.orgId,
-            userId: input.context.userId,
-          },
-          input: createInput.input,
-        }
-      );
+      return await input.dependencies.createSignalForActor({
+        actor: {
+          clientId: input.context.clientId,
+          grantId: input.context.grantId,
+          kind: "mcp",
+          orgId: input.context.orgId,
+          userId: input.context.userId,
+        },
+        input: createInput.input,
+      });
     }
 
     case "signals.get": {
       const getInput = input.parsedInput as GetSignalInput;
-      if (input.dependencies.getSignalForActor) {
-        const result = await input.dependencies.getSignalForActor(
-          input.dependencies.db,
-          {
-            actor: {
-              clientId: input.context.clientId,
-              grantId: input.context.grantId,
-              kind: "mcp",
-              orgId: input.context.orgId,
-              userId: input.context.userId,
-            },
-            id: getInput.id,
-          }
-        );
-        if (!result) {
-          throw new HostedMcpToolError("not_found", "Signal not found.", 404);
-        }
-        return result;
-      }
-
-      const signal = await input.dependencies.getVisibleSignalByPublicId(
-        input.dependencies.db,
-        {
-          publicId: getInput.id,
-          clerkOrgId: input.context.orgId,
-          createdByUserId: input.context.userId,
-        }
-      );
-      if (!signal) {
+      const result = await input.dependencies.getSignalForActor({
+        actor: {
+          clientId: input.context.clientId,
+          grantId: input.context.grantId,
+          kind: "mcp",
+          orgId: input.context.orgId,
+          userId: input.context.userId,
+        },
+        id: getInput.id,
+      });
+      if (!result) {
         throw new HostedMcpToolError("not_found", "Signal not found.", 404);
       }
-      const entityLinks =
-        await input.dependencies.listSignalEntityLinksForSignal(
-          input.dependencies.db,
-          {
-            clerkOrgId: input.context.orgId,
-            signalId: signal.publicId,
-          }
-        );
-      return {
-        id: signal.publicId,
-        input: signal.input,
-        status: signal.status,
-        classification: signal.classification,
-        entityLinks,
-        visibilityScope: signal.visibilityScope,
-        createdAt: signal.createdAt.toISOString(),
-        updatedAt: signal.updatedAt.toISOString(),
-      };
+      return result;
     }
 
     case "proxy.find": {
@@ -461,13 +400,13 @@ async function recordAudit(input: {
   context: HostedMcpContext;
   dependencies: ExecuteHostedMcpToolDependencies;
   error: HostedMcpToolError | null;
-  outcome: RecordMcpAuditEventInput["outcome"];
+  outcome: McpAuditOutcome;
   providerRoutineCallId?: string;
   startedAt: Date;
   tool: LightfastMcpToolDefinition;
 }): Promise<void> {
   const endedAt = input.dependencies.now();
-  await input.dependencies.recordMcpAuditEvent(input.dependencies.db, {
+  await input.dependencies.recordMcpAuditEvent({
     clientPublicId: input.context.clientId,
     clerkOrgId: input.context.orgId,
     clerkUserId: input.context.userId,
@@ -568,12 +507,11 @@ function normalizeToolError(error: unknown): HostedMcpToolError {
 async function defaultDependencies(
   contractPath: string
 ): Promise<ExecuteHostedMcpToolDependencies> {
-  const dbApp = await import("@db/app");
+  const appAuditIntake = await import("./app-audit-intake");
   const base = {
-    db: dbApp.db,
     now: () => new Date(),
     providerRoutineLog: sentryProviderRoutineLog,
-    recordMcpAuditEvent: dbApp.recordMcpAuditEvent,
+    recordMcpAuditEvent: appAuditIntake.recordMcpAuditEventViaApp,
     version: process.env.npm_package_version ?? DEFAULT_VERSION,
   };
 
@@ -584,8 +522,7 @@ async function defaultDependencies(
       callProviderRoutine: unavailableCallProviderRoutine,
       createSignalForActor: unavailableCreateSignalForActor,
       findProviderRoutines: unavailableFindProviderRoutines,
-      getVisibleSignalByPublicId: dbApp.getVisibleSignalByPublicId,
-      listSignalEntityLinksForSignal: dbApp.listSignalEntityLinksForSignal,
+      getSignalForActor: unavailableGetSignalForActor,
     };
   }
 
@@ -597,8 +534,7 @@ async function defaultDependencies(
       callProviderRoutine: unavailableCallProviderRoutine,
       createSignalForActor: appSignalIntake.createSignalForActorViaApp,
       findProviderRoutines: unavailableFindProviderRoutines,
-      getVisibleSignalByPublicId: dbApp.getVisibleSignalByPublicId,
-      listSignalEntityLinksForSignal: dbApp.listSignalEntityLinksForSignal,
+      getSignalForActor: unavailableGetSignalForActor,
     };
   }
 
@@ -611,8 +547,6 @@ async function defaultDependencies(
       createSignalForActor: unavailableCreateSignalForActor,
       findProviderRoutines: unavailableFindProviderRoutines,
       getSignalForActor: appSignalIntake.getSignalForActorViaApp,
-      getVisibleSignalByPublicId: dbApp.getVisibleSignalByPublicId,
-      listSignalEntityLinksForSignal: dbApp.listSignalEntityLinksForSignal,
     };
   }
 
@@ -624,8 +558,7 @@ async function defaultDependencies(
       callProviderRoutine: appProxyIntake.callProviderRoutineViaApp,
       createSignalForActor: unavailableCreateSignalForActor,
       findProviderRoutines: appProxyIntake.findProviderRoutinesViaApp,
-      getVisibleSignalByPublicId: dbApp.getVisibleSignalByPublicId,
-      listSignalEntityLinksForSignal: dbApp.listSignalEntityLinksForSignal,
+      getSignalForActor: unavailableGetSignalForActor,
     };
   }
 
@@ -635,8 +568,7 @@ async function defaultDependencies(
     callProviderRoutine: unavailableCallProviderRoutine,
     createSignalForActor: unavailableCreateSignalForActor,
     findProviderRoutines: unavailableFindProviderRoutines,
-    getVisibleSignalByPublicId: dbApp.getVisibleSignalByPublicId,
-    listSignalEntityLinksForSignal: dbApp.listSignalEntityLinksForSignal,
+    getSignalForActor: unavailableGetSignalForActor,
   };
 }
 
@@ -653,6 +585,10 @@ async function appOrgAccessHandledDownstream(): Promise<void> {
 }
 
 async function unavailableCreateSignalForActor(): Promise<never> {
+  throw unavailableDependencyError();
+}
+
+async function unavailableGetSignalForActor(): Promise<never> {
   throw unavailableDependencyError();
 }
 
@@ -682,7 +618,6 @@ function providerRoutineContext(
       orgId: context.orgId,
       userId: context.userId,
     },
-    db: dependencies.db,
     log: dependencies.providerRoutineLog ?? noopProviderRoutineLog,
     now: dependencies.now,
     scopes: {
@@ -746,7 +681,7 @@ function isProviderRoutineErrorLike(
 function mapProviderRoutineError(error: { code: string }): {
   code: HostedMcpToolErrorCode;
   message: string;
-  outcome: RecordMcpAuditEventInput["outcome"];
+  outcome: McpAuditOutcome;
   status: number;
 } {
   switch (error.code) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,9 +1017,6 @@ importers:
       '@api/app':
         specifier: workspace:*
         version: link:../../api/app
-      '@db/app':
-        specifier: workspace:*
-        version: link:../../db/app
       '@lightfast/connector-core':
         specifier: workspace:*
         version: link:../../connectors/core
@@ -1047,9 +1044,6 @@ importers:
       '@vendor/mcp':
         specifier: workspace:*
         version: link:../../vendor/mcp
-      '@vendor/observability':
-        specifier: workspace:*
-        version: link:../../vendor/observability
       react:
         specifier: ^19.2.6
         version: 19.2.6


### PR DESCRIPTION
## Summary
- move hosted MCP audit recording behind an app-owned internal API route
- remove DB/env persistence ownership from apps/mcp production code and package deps
- add source ratchets for the MCP app boundary and app internal audit route

## Verification
- pnpm --filter @lightfast/mcp test -- src/__tests__/mcp-app-boundary-source.test.ts src/__tests__/tools.test.ts src/__tests__/audit.test.ts src/__tests__/app-signal-intake.test.ts src/__tests__/app-proxy-intake.test.ts src/__tests__/env-config.test.ts src/__tests__/e2e-oauth-mcp.test.ts
- pnpm --filter @lightfast/mcp typecheck
- pnpm --filter @lightfast/app test -- src/__tests__/start-middleware.test.ts src/__tests__/internal-mcp-routes-source.test.ts src/__tests__/migration-readiness.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app test -- src/__tests__/mcp-audit-internal-adapter.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- SKIP_ENV_VALIDATION=true pnpm exec knip --dependencies --no-config-hints --max-show-issues 120 (expected repo-wide dependency drift remains; apps/mcp no longer reports @db/app or @vendor/observability production deps)