### PR TITLE
Expose TanStack query input contracts

### DIFF
--- a/api/app/src/adapters/tanstack/connectors.ts
+++ b/api/app/src/adapters/tanstack/connectors.ts
@@ -1,6 +1,7 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import type { z } from "zod";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
@@ -15,6 +16,22 @@ import {
   setConnectorAutomationEnabledCommand,
   startConnectorOAuthCommand,
 } from "../../domain/connectors";
+
+export type StartConnectorInput = z.input<
+  typeof startConnectorOAuthCommand.input
+>;
+export type RefreshConnectorToolsInput = z.input<
+  typeof refreshConnectorToolsCommand.input
+>;
+export type SetConnectorAutomationEnabledInput = z.input<
+  typeof setConnectorAutomationEnabledCommand.input
+>;
+export type SetConnectorAgentEnabledInput = z.input<
+  typeof setConnectorAgentEnabledCommand.input
+>;
+export type DisconnectConnectorInput = z.input<
+  typeof disconnectConnectorCommand.input
+>;
 
 function requestId() {
   return crypto.randomUUID();
@@ -192,3 +209,4 @@ export type ListConnectorsResult = Awaited<ReturnType<typeof listConnectors>>;
 export type ConnectorSectionsResult = Awaited<
   ReturnType<typeof listConnectorSections>
 >;
+export type StartConnectorResult = Awaited<ReturnType<typeof startConnector>>;

--- a/api/app/src/adapters/tanstack/decisions.ts
+++ b/api/app/src/adapters/tanstack/decisions.ts
@@ -53,6 +53,8 @@ const listDecisionsInput = z.object({
     .optional(),
 });
 
+export type ListDecisionsInput = z.input<typeof listDecisionsInput>;
+
 type DecisionListPage = Awaited<ReturnType<typeof listProviderRoutineCalls>>;
 type DecisionRow = DecisionListPage["items"][number];
 

--- a/api/app/src/adapters/tanstack/developer-connections.ts
+++ b/api/app/src/adapters/tanstack/developer-connections.ts
@@ -1,6 +1,7 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import type { z } from "zod";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
@@ -14,6 +15,22 @@ import {
   setDeveloperConnectionSandboxEnabledCommand,
   startSentryDeveloperConnectionAuthCommand,
 } from "../../domain/developer-connections";
+
+export type ConnectDeveloperConnectionInput = z.input<
+  typeof connectDeveloperConnectionCommand.input
+>;
+export type StartSentryDeveloperConnectionAuthInput = z.input<
+  typeof startSentryDeveloperConnectionAuthCommand.input
+>;
+export type CompleteSentryDeveloperConnectionAuthInput = z.input<
+  typeof completeSentryDeveloperConnectionAuthCommand.input
+>;
+export type SetDeveloperConnectionSandboxEnabledInput = z.input<
+  typeof setDeveloperConnectionSandboxEnabledCommand.input
+>;
+export type DisconnectDeveloperConnectionInput = z.input<
+  typeof disconnectDeveloperConnectionCommand.input
+>;
 
 function requestId() {
   return crypto.randomUUID();
@@ -186,4 +203,7 @@ export const disconnectDeveloperConnection = createServerFn({ method: "POST" })
 
 export type ListDeveloperConnectionsResult = Awaited<
   ReturnType<typeof listDeveloperConnections>
+>;
+export type StartSentryDeveloperConnectionAuthResult = Awaited<
+  ReturnType<typeof startSentryDeveloperConnectionAuth>
 >;

--- a/api/app/src/adapters/tanstack/people.ts
+++ b/api/app/src/adapters/tanstack/people.ts
@@ -1,6 +1,7 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import type { z } from "zod";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
@@ -11,6 +12,9 @@ import {
   getPersonCommand,
   listPeopleCommand,
 } from "../../domain/people";
+
+export type ListPeopleInput = z.input<typeof listPeopleCommand.input>;
+export type GetPersonInput = z.input<typeof getPersonCommand.input>;
 
 type SerializableValue =
   | SerializableValue[]

--- a/apps/app/src/__tests__/tanstack-query-input-types-source.test.ts
+++ b/apps/app/src/__tests__/tanstack-query-input-types-source.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(appRoot, "../..");
+
+function appSource(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("TanStack query input type boundaries", () => {
+  const queryFiles = [
+    "src/connectors/connectors-queries.ts",
+    "src/decisions/decisions-queries.ts",
+    "src/developer-connections/developer-connections-queries.ts",
+    "src/people/people-queries.ts",
+  ];
+
+  it("does not infer app query input types from server function call shape", () => {
+    for (const path of queryFiles) {
+      const source = appSource(path);
+
+      expect(source).not.toContain("ServerFunctionData");
+      expect(source).not.toContain("TFn extends");
+    }
+  });
+
+  it("imports explicit input contracts from api/app TanStack adapters", () => {
+    expect(appSource("src/people/people-queries.ts")).toContain(
+      "type ListPeopleInput"
+    );
+    expect(appSource("src/people/people-queries.ts")).toContain(
+      "type GetPersonInput"
+    );
+    expect(appSource("src/connectors/connectors-queries.ts")).toContain(
+      "type StartConnectorInput"
+    );
+    expect(appSource("src/connectors/connectors-queries.ts")).toContain(
+      "type RefreshConnectorToolsInput"
+    );
+    expect(
+      appSource("src/developer-connections/developer-connections-queries.ts")
+    ).toContain("type ConnectDeveloperConnectionInput");
+    expect(
+      appSource("src/developer-connections/developer-connections-queries.ts")
+    ).toContain("type StartSentryDeveloperConnectionAuthInput");
+    expect(appSource("src/decisions/decisions-queries.ts")).toContain(
+      "type ListDecisionsInput"
+    );
+  });
+
+  it("exports explicit input contracts from api/app TanStack adapters", () => {
+    expect(repoSource("api/app/src/adapters/tanstack/people.ts")).toContain(
+      "export type ListPeopleInput"
+    );
+    expect(repoSource("api/app/src/adapters/tanstack/people.ts")).toContain(
+      "export type GetPersonInput"
+    );
+    expect(repoSource("api/app/src/adapters/tanstack/connectors.ts")).toContain(
+      "export type StartConnectorInput"
+    );
+    expect(repoSource("api/app/src/adapters/tanstack/connectors.ts")).toContain(
+      "export type RefreshConnectorToolsInput"
+    );
+    expect(
+      repoSource("api/app/src/adapters/tanstack/developer-connections.ts")
+    ).toContain("export type ConnectDeveloperConnectionInput");
+    expect(
+      repoSource("api/app/src/adapters/tanstack/developer-connections.ts")
+    ).toContain("export type StartSentryDeveloperConnectionAuthInput");
+    expect(repoSource("api/app/src/adapters/tanstack/decisions.ts")).toContain(
+      "export type ListDecisionsInput"
+    );
+  });
+});

--- a/apps/app/src/connectors/connectors-queries.ts
+++ b/apps/app/src/connectors/connectors-queries.ts
@@ -1,31 +1,21 @@
 import {
   type ConnectorSectionsResult,
+  type DisconnectConnectorInput,
   disconnectConnector,
   type ListConnectorsResult,
   listConnectorSections,
   listConnectors,
+  type RefreshConnectorToolsInput,
   refreshConnectorTools,
+  type SetConnectorAgentEnabledInput,
+  type SetConnectorAutomationEnabledInput,
+  type StartConnectorInput,
+  type StartConnectorResult,
   setConnectorAgentEnabled,
   setConnectorAutomationEnabled,
   startConnector,
 } from "@api/app/tanstack/connectors";
 import { mutationOptions, queryOptions } from "@tanstack/react-query";
-
-type ServerFunctionData<TFn> = TFn extends (args: {
-  data: infer TData;
-}) => unknown
-  ? TData
-  : never;
-
-type ConnectorProviderInput = ServerFunctionData<typeof disconnectConnector>;
-type ConnectorStartInput = ServerFunctionData<typeof startConnector>;
-type ConnectorSetAutomationEnabledInput = ServerFunctionData<
-  typeof setConnectorAutomationEnabled
->;
-type ConnectorSetAgentEnabledInput = ServerFunctionData<
-  typeof setConnectorAgentEnabled
->;
-type StartConnectorResult = Awaited<ReturnType<typeof startConnector>>;
 
 export type ConnectorSections = ConnectorSectionsResult;
 export type TeamConnectorCatalogRow =
@@ -64,7 +54,7 @@ export function startConnectorMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to connect provider" },
-    mutationFn: (data: ConnectorStartInput) => startConnector({ data }),
+    mutationFn: (data: StartConnectorInput) => startConnector({ data }),
     onSuccess: input?.onSuccess,
   });
 }
@@ -74,7 +64,7 @@ export function refreshConnectorToolsMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to refresh connector tools" },
-    mutationFn: (data: ConnectorProviderInput) =>
+    mutationFn: (data: RefreshConnectorToolsInput) =>
       refreshConnectorTools({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -85,7 +75,7 @@ export function setConnectorAutomationEnabledMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to update connector automation access" },
-    mutationFn: (data: ConnectorSetAutomationEnabledInput) =>
+    mutationFn: (data: SetConnectorAutomationEnabledInput) =>
       setConnectorAutomationEnabled({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -96,7 +86,7 @@ export function setConnectorAgentEnabledMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to update connector agent access" },
-    mutationFn: (data: ConnectorSetAgentEnabledInput) =>
+    mutationFn: (data: SetConnectorAgentEnabledInput) =>
       setConnectorAgentEnabled({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -107,7 +97,8 @@ export function disconnectConnectorMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to disconnect provider" },
-    mutationFn: (data: ConnectorProviderInput) => disconnectConnector({ data }),
+    mutationFn: (data: DisconnectConnectorInput) =>
+      disconnectConnector({ data }),
     onSuccess: input?.onSuccess,
   });
 }

--- a/apps/app/src/decisions/decisions-queries.ts
+++ b/apps/app/src/decisions/decisions-queries.ts
@@ -1,30 +1,23 @@
 import {
+  type ListDecisionsInput,
   type ListDecisionsResult,
   listDecisions,
 } from "@api/app/tanstack/decisions";
 import { infiniteQueryOptions, keepPreviousData } from "@tanstack/react-query";
 
-type ServerFunctionData<TFn> = TFn extends (args: {
-  data: infer TData;
-}) => unknown
-  ? TData
-  : never;
-
-type DecisionsListInput = ServerFunctionData<typeof listDecisions>;
-
 export const decisionsQueryKeys = {
   all: ["decisions"] as const,
-  list: (input: Omit<DecisionsListInput, "cursor">) =>
+  list: (input: Omit<ListDecisionsInput, "cursor">) =>
     ["decisions", "list", input] as const,
 };
 
 export function decisionsListInfiniteQueryOptions(
-  input: Omit<DecisionsListInput, "cursor">
+  input: Omit<ListDecisionsInput, "cursor">
 ) {
   return infiniteQueryOptions({
     enabled: typeof window !== "undefined",
     getNextPageParam: (lastPage: ListDecisionsResult) => lastPage.nextCursor,
-    initialPageParam: undefined as DecisionsListInput["cursor"],
+    initialPageParam: undefined as ListDecisionsInput["cursor"],
     placeholderData: keepPreviousData,
     queryFn: async ({ pageParam }): Promise<ListDecisionsResult> =>
       (await listDecisions({

--- a/apps/app/src/developer-connections/developer-connections-queries.ts
+++ b/apps/app/src/developer-connections/developer-connections-queries.ts
@@ -1,36 +1,18 @@
 import {
+  type CompleteSentryDeveloperConnectionAuthInput,
+  type ConnectDeveloperConnectionInput,
   completeSentryDeveloperConnectionAuth,
   connectDeveloperConnection,
+  type DisconnectDeveloperConnectionInput,
   disconnectDeveloperConnection,
   listDeveloperConnections,
+  type SetDeveloperConnectionSandboxEnabledInput,
+  type StartSentryDeveloperConnectionAuthInput,
+  type StartSentryDeveloperConnectionAuthResult,
   setDeveloperConnectionSandboxEnabled,
   startSentryDeveloperConnectionAuth,
 } from "@api/app/tanstack/developer-connections";
 import { mutationOptions, queryOptions } from "@tanstack/react-query";
-
-type ServerFunctionData<TFn> = TFn extends (args: {
-  data: infer TData;
-}) => unknown
-  ? TData
-  : never;
-type DeveloperConnectionConnectInput = ServerFunctionData<
-  typeof connectDeveloperConnection
->;
-type DeveloperConnectionStartAuthInput = ServerFunctionData<
-  typeof startSentryDeveloperConnectionAuth
->;
-type DeveloperConnectionCompleteAuthInput = ServerFunctionData<
-  typeof completeSentryDeveloperConnectionAuth
->;
-type DeveloperConnectionSetSandboxEnabledInput = ServerFunctionData<
-  typeof setDeveloperConnectionSandboxEnabled
->;
-type DeveloperConnectionProviderInput = ServerFunctionData<
-  typeof disconnectDeveloperConnection
->;
-type StartSentryDeveloperConnectionAuthResult = Awaited<
-  ReturnType<typeof startSentryDeveloperConnectionAuth>
->;
 
 export const developerConnectionQueryKeys = {
   all: ["developer-connections"] as const,
@@ -52,7 +34,7 @@ export function connectDeveloperConnectionMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to connect developer provider" },
-    mutationFn: (data: DeveloperConnectionConnectInput) =>
+    mutationFn: (data: ConnectDeveloperConnectionInput) =>
       connectDeveloperConnection({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -63,7 +45,7 @@ export function startSentryDeveloperConnectionAuthMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to start Sentry authorization" },
-    mutationFn: (data: DeveloperConnectionStartAuthInput) =>
+    mutationFn: (data: StartSentryDeveloperConnectionAuthInput) =>
       startSentryDeveloperConnectionAuth({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -74,7 +56,7 @@ export function completeSentryDeveloperConnectionAuthMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to complete Sentry authorization" },
-    mutationFn: (data: DeveloperConnectionCompleteAuthInput) =>
+    mutationFn: (data: CompleteSentryDeveloperConnectionAuthInput) =>
       completeSentryDeveloperConnectionAuth({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -85,7 +67,7 @@ export function setDeveloperConnectionSandboxEnabledMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to update sandbox access" },
-    mutationFn: (data: DeveloperConnectionSetSandboxEnabledInput) =>
+    mutationFn: (data: SetDeveloperConnectionSandboxEnabledInput) =>
       setDeveloperConnectionSandboxEnabled({ data }),
     onSuccess: input?.onSuccess,
   });
@@ -96,7 +78,7 @@ export function disconnectDeveloperConnectionMutationOptions(input?: {
 }) {
   return mutationOptions({
     meta: { errorTitle: "Failed to disconnect developer provider" },
-    mutationFn: (data: DeveloperConnectionProviderInput) =>
+    mutationFn: (data: DisconnectDeveloperConnectionInput) =>
       disconnectDeveloperConnection({ data }),
     onSuccess: input?.onSuccess,
   });

--- a/apps/app/src/people/people-queries.ts
+++ b/apps/app/src/people/people-queries.ts
@@ -1,5 +1,7 @@
 import {
+  type GetPersonInput,
   getPerson,
+  type ListPeopleInput,
   type ListPeopleResult,
   listPeople,
   type PersonDetailResult,
@@ -10,15 +12,6 @@ import {
   queryOptions,
 } from "@tanstack/react-query";
 
-type ServerFunctionData<TFn> = TFn extends (args: {
-  data: infer TData;
-}) => unknown
-  ? TData
-  : never;
-
-type PeopleListInput = ServerFunctionData<typeof listPeople>;
-type PersonDetailInput = ServerFunctionData<typeof getPerson>;
-
 export type PeopleList = ListPeopleResult;
 export type PersonRow = PeopleList["items"][number];
 export type PersonDetail = PersonDetailResult;
@@ -26,17 +19,17 @@ export type PersonDetail = PersonDetailResult;
 export const peopleQueryKeys = {
   all: ["people"] as const,
   detail: (publicId: string) => ["people", "detail", publicId] as const,
-  list: (input: Omit<PeopleListInput, "cursor">) =>
+  list: (input: Omit<ListPeopleInput, "cursor">) =>
     ["people", "list", input] as const,
 };
 
 export function peopleListInfiniteQueryOptions(
-  input: Omit<PeopleListInput, "cursor">
+  input: Omit<ListPeopleInput, "cursor">
 ) {
   return infiniteQueryOptions({
     enabled: typeof window !== "undefined",
     getNextPageParam: (lastPage: PeopleList) => lastPage.nextCursor,
-    initialPageParam: undefined as PeopleListInput["cursor"],
+    initialPageParam: undefined as ListPeopleInput["cursor"],
     placeholderData: keepPreviousData,
     queryFn: ({ pageParam }) =>
       listPeople({
@@ -58,7 +51,7 @@ export function personDetailQueryOptions(input: {
     enabled: typeof window !== "undefined" && input.enabled,
     queryFn: () =>
       getPerson({
-        data: { publicId: input.publicId } satisfies PersonDetailInput,
+        data: { publicId: input.publicId } satisfies GetPersonInput,
       }),
     queryKey: peopleQueryKeys.detail(input.publicId),
   });


### PR DESCRIPTION
## Summary
- export explicit TanStack adapter input contracts for people, decisions, connectors, and developer connections
- remove app-local ServerFunctionData conditional helpers from query option modules
- add a source ratchet to keep app query helpers consuming explicit @api/app/tanstack contracts

## Verification
- pnpm --filter @lightfast/app test -- src/__tests__/tanstack-query-input-types-source.test.ts
- pnpm --filter @api/app test -- src/__tests__/connectors-tanstack-adapter-source.test.ts src/__tests__/developer-connections-tanstack-adapter-source.test.ts src/__tests__/people-tanstack-adapter-source.test.ts src/__tests__/decisions-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck