### PR TITLE
Move assistant chat ID allocation into API adapter

### DIFF
--- a/api/app/src/__tests__/workspace-assistant-source.test.ts
+++ b/api/app/src/__tests__/workspace-assistant-source.test.ts
@@ -39,6 +39,9 @@ describe("workspace assistant TanStack migration", () => {
     expect(adapterSource).toMatch(
       /export\s+const\s+createConversation\s*=\s*createServerFn/
     );
+    expect(adapterSource).toMatch(
+      /export\s+const\s+createNewWorkspaceAssistantConversationId\s*=\s*createServerFn/
+    );
     expect(adapterSource).not.toContain("TRPCError");
   });
 

--- a/api/app/src/adapters/tanstack/assistant.ts
+++ b/api/app/src/adapters/tanstack/assistant.ts
@@ -227,12 +227,7 @@ export const createNewWorkspaceAssistantConversationId = createServerFn({
   method: "GET",
 }).handler(async () => {
   noStore();
-  try {
-    await getBoundActor();
-    return createWorkspaceAssistantConversationId();
-  } catch (error) {
-    mapTanStackError(error);
-  }
+  return createWorkspaceAssistantConversationId();
 });
 
 export const createConversation = createServerFn({ method: "POST" })

--- a/api/app/src/adapters/tanstack/assistant.ts
+++ b/api/app/src/adapters/tanstack/assistant.ts
@@ -1,4 +1,5 @@
 import {
+  createWorkspaceAssistantConversationId,
   createWorkspaceAssistantConversation as createWorkspaceAssistantConversationInDb,
   getWorkspaceAssistantConversationByPublicId,
   listWorkspaceAssistantConversations,
@@ -221,6 +222,18 @@ function serializeConversationList(
     items: conversations.items.map(serializeConversation),
   };
 }
+
+export const createNewWorkspaceAssistantConversationId = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  noStore();
+  try {
+    await getBoundActor();
+    return createWorkspaceAssistantConversationId();
+  } catch (error) {
+    mapTanStackError(error);
+  }
+});
 
 export const createConversation = createServerFn({ method: "POST" })
   .inputValidator(createConversationInput)

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -743,8 +743,10 @@ describe("app authenticated route migration", () => {
       'createFileRoute("/_authenticated/$slug/chat/")'
     );
     expect(chatIndexRouteSource).toContain(
-      "createWorkspaceAssistantConversationId"
+      "createNewWorkspaceAssistantConversationId"
     );
+    expect(chatIndexRouteSource).toContain('@api/app/tanstack/assistant"');
+    expect(chatIndexRouteSource).not.toContain("@db/app");
     expect(chatIndexRouteSource).toContain("WorkspaceAssistantClient");
     expect(chatIndexRouteSource).toContain("key={conversationId}");
     expect(chatRouteSource).not.toContain("WorkspacePage");

--- a/apps/app/src/__tests__/workspace-assistant-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/workspace-assistant-no-trpc-source.test.ts
@@ -17,6 +17,9 @@ describe("migrated workspace assistant data access", () => {
       "src/components/recent-chats-menu.tsx"
     );
     const clientSource = source("src/chat/workspace-assistant-client.tsx");
+    const newConversationRouteSource = source(
+      "src/routes/_authenticated/$slug/chat/index.tsx"
+    );
     const conversationRouteSource = source(
       "src/routes/_authenticated/$slug/chat/$conversationId.tsx"
     );
@@ -42,6 +45,12 @@ describe("migrated workspace assistant data access", () => {
     );
     expect(clientSource).toContain("createConversation");
     expect(clientSource).toContain("assistantConversationsQueryKey");
+    expect(newConversationRouteSource).toMatch(assistantAdapterImport);
+    expect(newConversationRouteSource).toContain(
+      "createNewWorkspaceAssistantConversationId"
+    );
+    expect(newConversationRouteSource).not.toContain("createServerFn");
+    expect(newConversationRouteSource).not.toContain("@db/app");
     expect(conversationRouteSource).toContain(
       "assistantConversationQueryOptions"
     );

--- a/apps/app/src/routes/_authenticated/$slug/chat/index.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/chat/index.tsx
@@ -1,17 +1,10 @@
+import { createNewWorkspaceAssistantConversationId } from "@api/app/tanstack/assistant";
 import { createFileRoute } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
 import { WorkspaceAssistantClient } from "~/chat/workspace-assistant-client";
 import {
   WorkspaceRouteErrorPanel,
   WorkspaceRoutePending,
 } from "~/components/route-boundaries";
-
-const createNewWorkspaceAssistantConversationId = createServerFn({
-  method: "GET",
-}).handler(async () => {
-  const { createWorkspaceAssistantConversationId } = await import("@db/app");
-  return createWorkspaceAssistantConversationId();
-});
 
 export const Route = createFileRoute("/_authenticated/$slug/chat/")({
   loader: () => createNewWorkspaceAssistantConversationId(),


### PR DESCRIPTION
## Summary
- expose the new workspace assistant conversation ID allocator from @api/app/tanstack/assistant
- remove the local createServerFn and @db/app dynamic import from the app chat index route
- enforce the assistant adapter auth gate before allocating a pre-created chat ID
- add source ratchets for the app route and API adapter boundary

## Verification
- pnpm --filter @lightfast/app test -- src/__tests__/workspace-assistant-no-trpc-source.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @api/app test -- src/__tests__/workspace-assistant-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck