### PR TITLE
Move skills events route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -161,6 +161,10 @@
       "types": "./src/services/skills/index.ts",
       "default": "./src/services/skills/index.ts"
     },
+    "./services/skills/events": {
+      "types": "./src/services/skills/events.ts",
+      "default": "./src/services/skills/events.ts"
+    },
     "./services/connectors": {
       "types": "./src/services/connectors/index.ts",
       "default": "./src/services/connectors/index.ts"

--- a/api/app/src/services/skills/events.ts
+++ b/api/app/src/services/skills/events.ts
@@ -1,6 +1,7 @@
-import "@tanstack/react-start/server-only";
-
+import { db } from "@db/app/client";
 import { redis } from "@vendor/upstash";
+
+import { resolveAuthContextFromClerk } from "../../auth/identity";
 
 type UpstashSubscription = ReturnType<typeof redis.subscribe<string>>;
 
@@ -11,7 +12,45 @@ interface SubscriberRecord {
 
 const subscribers = new Map<string, SubscriberRecord>();
 
-export function createSkillIndexEventStream(input: {
+export async function handleSkillIndexEventsRequest(
+  request: Request
+): Promise<Response> {
+  const authContext = await resolveAuthContextFromClerk({
+    db,
+    headers: request.headers,
+  });
+  const identity = authContext.identity;
+
+  if (identity.type === "unauthenticated") {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (identity.type !== "active") {
+    return Response.json({ error: "Organization required" }, { status: 403 });
+  }
+  if (identity.orgGate.bindingStatus !== "bound") {
+    return Response.json(
+      { error: "Organization setup required" },
+      { status: 403 }
+    );
+  }
+
+  return new Response(
+    createSkillIndexEventStream({
+      clerkOrgId: identity.orgId,
+      signal: request.signal,
+    }),
+    {
+      headers: {
+        "cache-control": "no-store, no-cache, no-transform",
+        connection: "keep-alive",
+        "content-type": "text/event-stream",
+        "x-accel-buffering": "no",
+      },
+    }
+  );
+}
+
+function createSkillIndexEventStream(input: {
   clerkOrgId: string;
   signal?: AbortSignal;
 }) {

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1378,8 +1378,12 @@ describe("app authenticated route migration", () => {
     const skillsIndexEventsRouteSource = source(
       "src/routes/api/skills/index/events.ts"
     );
-    const skillsIndexEventStreamSource = source(
+    const skillsIndexEventStreamPath = resolve(
+      appRoot,
       "src/server/skills/skill-index-event-stream.ts"
+    );
+    const skillsEventsAdapterSource = repoSource(
+      "api/app/src/services/skills/events.ts"
     );
     const nativeProxyServerSource = source("src/server/native-proxy.ts");
     const nativeProxyCallRouteSource = source(
@@ -1439,11 +1443,23 @@ describe("app authenticated route migration", () => {
       'createFileRoute("/api/skills/index/events")'
     );
     expect(skillsIndexEventsRouteSource).toContain(
-      "createSkillIndexEventStream"
+      "handleSkillIndexEventsRequest"
     );
-    expect(skillsIndexEventStreamSource).toContain(
-      "createSkillIndexEventStream"
+    expect(skillsIndexEventsRouteSource).toContain(
+      'from "@api/app/services/skills/events"'
     );
+    expect(skillsIndexEventsRouteSource).not.toContain("@db/app");
+    expect(skillsIndexEventsRouteSource).not.toContain(
+      "resolveAuthContextFromClerk"
+    );
+    expect(existsSync(skillsIndexEventStreamPath)).toBe(false);
+    expect(skillsEventsAdapterSource).toContain(
+      "handleSkillIndexEventsRequest"
+    );
+    expect(skillsEventsAdapterSource).toContain("resolveAuthContextFromClerk");
+    expect(skillsEventsAdapterSource).toContain("@db/app/client");
+    expect(skillsEventsAdapterSource).toContain("createSkillIndexEventStream");
+    expect(skillsEventsAdapterSource).toContain("redis.subscribe");
     expect(nativeProxyServerSource).toContain(
       "createNativeProviderRoutineContext"
     );
@@ -1494,7 +1510,6 @@ describe("app authenticated route migration", () => {
     );
 
     for (const startupSensitiveFile of [
-      skillsIndexEventsRouteSource,
       nativeProxyServerSource,
       mcpServiceAuthSource,
       mcpProxyServerSource,
@@ -1514,7 +1529,7 @@ describe("app authenticated route migration", () => {
       xCompleteClientSource,
       githubWebhookRouteSource,
       skillsIndexEventsRouteSource,
-      skillsIndexEventStreamSource,
+      skillsEventsAdapterSource,
       nativeProxyServerSource,
       nativeProxyCallRouteSource,
       nativeProxyRoutinesRouteSource,

--- a/apps/app/src/routes/api/skills/index/events.ts
+++ b/apps/app/src/routes/api/skills/index/events.ts
@@ -1,51 +1,10 @@
-import { db } from "@db/app/client";
+import { handleSkillIndexEventsRequest } from "@api/app/services/skills/events";
 import { createFileRoute } from "@tanstack/react-router";
-import { createSkillIndexEventStream } from "~/server/skills/skill-index-event-stream";
 
 export const Route = createFileRoute("/api/skills/index/events")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { resolveAuthContextFromClerk } = await import(
-          "@api/app/auth/identity"
-        );
-        const authContext = await resolveAuthContextFromClerk({
-          db,
-          headers: request.headers,
-        });
-        const identity = authContext.identity;
-
-        if (identity.type === "unauthenticated") {
-          return Response.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        if (identity.type !== "active") {
-          return Response.json(
-            { error: "Organization required" },
-            { status: 403 }
-          );
-        }
-        if (identity.orgGate.bindingStatus !== "bound") {
-          return Response.json(
-            { error: "Organization setup required" },
-            { status: 403 }
-          );
-        }
-
-        return new Response(
-          createSkillIndexEventStream({
-            clerkOrgId: identity.orgId,
-            signal: request.signal,
-          }),
-          {
-            headers: {
-              "cache-control": "no-store, no-cache, no-transform",
-              connection: "keep-alive",
-              "content-type": "text/event-stream",
-              "x-accel-buffering": "no",
-            },
-          }
-        );
-      },
+      GET: ({ request }) => handleSkillIndexEventsRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- move /api/skills/index/events auth and SSE handling into @api/app/services/skills/events
- leave the TanStack app route as a thin server-route mount
- ratchet the app source test so DB/Clerk auth logic stays out of the app route

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- SKIP_ENV_VALIDATION=true pnpm knip, then rg for skills/events symbols in the Knip output
- curl -i --max-time 15 https://skills-events-route-boundary.lightfast.localhost/api/skills/index/events
- agent-browser open/get text for https://skills-events-route-boundary.lightfast.localhost/api/skills/index/events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized skills index events API handler into a dedicated service module, centralizing authentication, organization validation, and event streaming logic for improved code organization and maintainability.

* **Tests**
  * Updated test assertions to verify correct handler implementation and service module integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->