### PR TITLE
Move native provider proxy boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -41,6 +41,10 @@
       "types": "./src/adapters/cli-api.ts",
       "default": "./src/adapters/cli-api.ts"
     },
+    "./native-provider-proxy": {
+      "types": "./src/adapters/native-provider-proxy.ts",
+      "default": "./src/adapters/native-provider-proxy.ts"
+    },
     "./internal-api/mcp-signals": {
       "types": "./src/adapters/internal/mcp-signals.ts",
       "default": "./src/adapters/internal/mcp-signals.ts"

--- a/api/app/src/adapters/native-provider-proxy.ts
+++ b/api/app/src/adapters/native-provider-proxy.ts
@@ -1,9 +1,13 @@
 import { db } from "@db/app/client";
-import type {
-  ProviderRoutineCallInput,
-  ProviderRoutineCallSuccess,
-  ProviderRoutineFindInput,
-  ProviderRoutineFindOutput,
+import {
+  type ProviderRoutineCallInput,
+  type ProviderRoutineCallSuccess,
+  type ProviderRoutineFindInput,
+  type ProviderRoutineFindOutput,
+  providerRoutineCallInputSchema,
+  providerRoutineCallSuccessSchema,
+  providerRoutineFindInputSchema,
+  providerRoutineFindOutputSchema,
 } from "@lightfast/connector-core/provider-routines";
 import type { ProviderRoutineServiceContext } from "@repo/provider-routines";
 import { z } from "zod";
@@ -17,14 +21,14 @@ const log = {
     console.warn(message, metadata),
 };
 
-export type NativeProviderRoutineServiceContext = ProviderRoutineServiceContext;
+type NativeProviderRoutineServiceContext = ProviderRoutineServiceContext;
 
-export type NativeFindProviderRoutines = (
+type NativeFindProviderRoutines = (
   context: NativeProviderRoutineServiceContext,
   input: ProviderRoutineFindInput
 ) => Promise<ProviderRoutineFindOutput>;
 
-export type NativeCallProviderRoutine = (
+type NativeCallProviderRoutine = (
   context: NativeProviderRoutineServiceContext,
   input: ProviderRoutineCallInput
 ) => Promise<ProviderRoutineCallSuccess>;
@@ -46,7 +50,7 @@ class NativeProxyRouteError extends Error {
   }
 }
 
-export function jsonResponse(data: unknown, init: ResponseInit = {}) {
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
   const headers = new Headers(init.headers);
   headers.set("cache-control", "no-store");
   headers.set("content-type", "application/json");
@@ -54,7 +58,7 @@ export function jsonResponse(data: unknown, init: ResponseInit = {}) {
   return Response.json(data, { ...init, headers });
 }
 
-export function errorResponse(error: unknown) {
+function errorResponse(error: unknown) {
   const normalized = normalizeRouteError(error);
   return jsonResponse(
     {
@@ -67,7 +71,7 @@ export function errorResponse(error: unknown) {
   );
 }
 
-export async function createNativeProviderRoutineContext(
+async function createNativeProviderRoutineContext(
   req: Request
 ): Promise<NativeProviderRoutineServiceContext> {
   const { resolveAuthContextFromClerk } = await import(
@@ -129,10 +133,51 @@ export async function createNativeProviderRoutineContext(
   };
 }
 
-export async function loadNativeProviderRoutineServices() {
+async function loadNativeProviderRoutineServices() {
   return (await import(
     "@repo/provider-routines"
   )) as NativeProviderRoutineServices;
+}
+
+export async function handleNativeProviderRoutineCallRequest(
+  request: Request
+): Promise<Response> {
+  try {
+    const input = providerRoutineCallInputSchema.parse(
+      await request.json().catch(() => null)
+    );
+    const context = await createNativeProviderRoutineContext(request);
+    const { callProviderRoutine } = await loadNativeProviderRoutineServices();
+    const result = await callProviderRoutine(context, input);
+    return jsonResponse(providerRoutineCallSuccessSchema.parse(result));
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function handleNativeProviderRoutineFindRequest(
+  request: Request
+): Promise<Response> {
+  try {
+    const searchParams = new URL(request.url).searchParams;
+    const input = providerRoutineFindInputSchema.parse({
+      includeSchema:
+        searchParams.get("includeSchema") === "true" ? true : undefined,
+      limit: searchParams.get("limit")
+        ? Number(searchParams.get("limit"))
+        : undefined,
+      provider: searchParams.get("provider") ?? undefined,
+      query: searchParams.get("query") ?? undefined,
+      readOnly: searchParams.get("readOnly") === "true" ? true : undefined,
+      routineId: searchParams.get("routineId") ?? undefined,
+    });
+    const context = await createNativeProviderRoutineContext(request);
+    const { findProviderRoutines } = await loadNativeProviderRoutineServices();
+    const result = await findProviderRoutines(context, input);
+    return jsonResponse(providerRoutineFindOutputSchema.parse(result));
+  } catch (error) {
+    return errorResponse(error);
+  }
 }
 
 function normalizeRouteError(error: unknown): {

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1385,7 +1385,13 @@ describe("app authenticated route migration", () => {
     const skillsEventsAdapterSource = repoSource(
       "api/app/src/services/skills/events.ts"
     );
-    const nativeProxyServerSource = source("src/server/native-proxy.ts");
+    const nativeProxyServerPath = resolve(
+      appRoot,
+      "src/server/native-proxy.ts"
+    );
+    const nativeProxyAdapterSource = repoSource(
+      "api/app/src/adapters/native-provider-proxy.ts"
+    );
     const nativeProxyCallRouteSource = source(
       "src/routes/api/native/proxy/call.ts"
     );
@@ -1460,22 +1466,37 @@ describe("app authenticated route migration", () => {
     expect(skillsEventsAdapterSource).toContain("@db/app/client");
     expect(skillsEventsAdapterSource).toContain("createSkillIndexEventStream");
     expect(skillsEventsAdapterSource).toContain("redis.subscribe");
-    expect(nativeProxyServerSource).toContain(
+    expect(existsSync(nativeProxyServerPath)).toBe(false);
+    expect(nativeProxyAdapterSource).toContain(
       "createNativeProviderRoutineContext"
     );
-    expect(nativeProxyServerSource).toContain("loadAgentConnectorRuntimeTools");
-    expect(nativeProxyServerSource).toContain("adapters");
-    expect(nativeProxyServerSource).toContain('sourceSurface: "native_cli"');
+    expect(nativeProxyAdapterSource).toContain(
+      "loadAgentConnectorRuntimeTools"
+    );
+    expect(nativeProxyAdapterSource).toContain("adapters");
+    expect(nativeProxyAdapterSource).toContain('sourceSurface: "native_cli"');
     expect(nativeProxyCallRouteSource).toContain(
       'createFileRoute("/api/native/proxy/call")'
     );
     expect(nativeProxyCallRouteSource).toContain(
+      "handleNativeProviderRoutineCallRequest"
+    );
+    expect(nativeProxyCallRouteSource).toContain(
+      'from "@api/app/native-provider-proxy"'
+    );
+    expect(nativeProxyCallRouteSource).not.toContain(
       "providerRoutineCallInputSchema"
     );
     expect(nativeProxyRoutinesRouteSource).toContain(
       'createFileRoute("/api/native/proxy/routines")'
     );
     expect(nativeProxyRoutinesRouteSource).toContain(
+      "handleNativeProviderRoutineFindRequest"
+    );
+    expect(nativeProxyRoutinesRouteSource).toContain(
+      'from "@api/app/native-provider-proxy"'
+    );
+    expect(nativeProxyRoutinesRouteSource).not.toContain(
       "providerRoutineFindInputSchema"
     );
     expect(mcpServiceAuthSource).toContain("verifyMcpServiceRequest");
@@ -1510,7 +1531,6 @@ describe("app authenticated route migration", () => {
     );
 
     for (const startupSensitiveFile of [
-      nativeProxyServerSource,
       mcpServiceAuthSource,
       mcpProxyServerSource,
       mcpSignalsRouteSource,
@@ -1530,7 +1550,7 @@ describe("app authenticated route migration", () => {
       githubWebhookRouteSource,
       skillsIndexEventsRouteSource,
       skillsEventsAdapterSource,
-      nativeProxyServerSource,
+      nativeProxyAdapterSource,
       nativeProxyCallRouteSource,
       nativeProxyRoutinesRouteSource,
       mcpServiceAuthSource,

--- a/apps/app/src/__tests__/native-rpc-routes-source.test.ts
+++ b/apps/app/src/__tests__/native-rpc-routes-source.test.ts
@@ -61,7 +61,7 @@ describe("native RPC route boundaries", () => {
     expect(sharedAdapter).not.toContain("/api/v1/rpc");
   });
 
-  it("leaves native provider proxy routes as separate CLI plumbing", () => {
+  it("mounts native provider proxy routes through an explicit api/app adapter", () => {
     expect(
       existsSync(resolve(appRoot, "src/routes/api/native/proxy/call.ts"))
     ).toBe(true);
@@ -71,14 +71,34 @@ describe("native RPC route boundaries", () => {
 
     const proxyCallRoute = appSource("src/routes/api/native/proxy/call.ts");
     const proxyFindRoute = appSource("src/routes/api/native/proxy/routines.ts");
+    const nativeProviderProxyAdapter = repoSource(
+      "api/app/src/adapters/native-provider-proxy.ts"
+    );
+    const packageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports?: Record<string, unknown>;
+    };
 
-    expect(proxyCallRoute).toContain(
-      "@lightfast/connector-core/provider-routines"
-    );
-    expect(proxyFindRoute).toContain(
-      "@lightfast/connector-core/provider-routines"
-    );
+    expect(packageJson.exports).toHaveProperty("./native-provider-proxy");
+    expect(proxyCallRoute).toContain("@api/app/native-provider-proxy");
+    expect(proxyCallRoute).toContain("handleNativeProviderRoutineCallRequest");
+    expect(proxyFindRoute).toContain("@api/app/native-provider-proxy");
+    expect(proxyFindRoute).toContain("handleNativeProviderRoutineFindRequest");
     expect(proxyCallRoute).not.toContain('@api/app/cli-api"');
     expect(proxyFindRoute).not.toContain('@api/app/cli-api"');
+    expect(proxyCallRoute).not.toContain(
+      "@lightfast/connector-core/provider-routines"
+    );
+    expect(proxyFindRoute).not.toContain(
+      "@lightfast/connector-core/provider-routines"
+    );
+    expect(proxyCallRoute).not.toContain("~/server/native-proxy");
+    expect(proxyFindRoute).not.toContain("~/server/native-proxy");
+    expect(nativeProviderProxyAdapter).toContain(
+      "createNativeProviderRoutineContext"
+    );
+    expect(nativeProviderProxyAdapter).toContain(
+      "loadAgentConnectorRuntimeTools"
+    );
+    expect(nativeProviderProxyAdapter).toContain('sourceSurface: "native_cli"');
   });
 });

--- a/apps/app/src/routes/api/native/proxy/call.ts
+++ b/apps/app/src/routes/api/native/proxy/call.ts
@@ -1,32 +1,10 @@
-import {
-  providerRoutineCallInputSchema,
-  providerRoutineCallSuccessSchema,
-} from "@lightfast/connector-core/provider-routines";
+import { handleNativeProviderRoutineCallRequest } from "@api/app/native-provider-proxy";
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  createNativeProviderRoutineContext,
-  errorResponse,
-  jsonResponse,
-  loadNativeProviderRoutineServices,
-} from "~/server/native-proxy";
 
 export const Route = createFileRoute("/api/native/proxy/call")({
   server: {
     handlers: {
-      POST: async ({ request }) => {
-        try {
-          const input = providerRoutineCallInputSchema.parse(
-            await request.json().catch(() => null)
-          );
-          const context = await createNativeProviderRoutineContext(request);
-          const { callProviderRoutine } =
-            await loadNativeProviderRoutineServices();
-          const result = await callProviderRoutine(context, input);
-          return jsonResponse(providerRoutineCallSuccessSchema.parse(result));
-        } catch (error) {
-          return errorResponse(error);
-        }
-      },
+      POST: ({ request }) => handleNativeProviderRoutineCallRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/native/proxy/routines.ts
+++ b/apps/app/src/routes/api/native/proxy/routines.ts
@@ -1,42 +1,10 @@
-import {
-  providerRoutineFindInputSchema,
-  providerRoutineFindOutputSchema,
-} from "@lightfast/connector-core/provider-routines";
+import { handleNativeProviderRoutineFindRequest } from "@api/app/native-provider-proxy";
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  createNativeProviderRoutineContext,
-  errorResponse,
-  jsonResponse,
-  loadNativeProviderRoutineServices,
-} from "~/server/native-proxy";
 
 export const Route = createFileRoute("/api/native/proxy/routines")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        try {
-          const searchParams = new URL(request.url).searchParams;
-          const input = providerRoutineFindInputSchema.parse({
-            includeSchema:
-              searchParams.get("includeSchema") === "true" ? true : undefined,
-            limit: searchParams.get("limit")
-              ? Number(searchParams.get("limit"))
-              : undefined,
-            provider: searchParams.get("provider") ?? undefined,
-            query: searchParams.get("query") ?? undefined,
-            readOnly:
-              searchParams.get("readOnly") === "true" ? true : undefined,
-            routineId: searchParams.get("routineId") ?? undefined,
-          });
-          const context = await createNativeProviderRoutineContext(request);
-          const { findProviderRoutines } =
-            await loadNativeProviderRoutineServices();
-          const result = await findProviderRoutines(context, input);
-          return jsonResponse(providerRoutineFindOutputSchema.parse(result));
-        } catch (error) {
-          return errorResponse(error);
-        }
-      },
+      GET: ({ request }) => handleNativeProviderRoutineFindRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- move native provider routine proxy auth/context and route parsing into @api/app/native-provider-proxy
- leave /api/native/proxy/call and /api/native/proxy/routines as thin TanStack route mounts
- ratchet source tests so the old apps/app server proxy file stays gone and route files avoid provider-routine plumbing

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/native-rpc-routes-source.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- SKIP_ENV_VALIDATION=true pnpm knip, then rg for native-provider-proxy/native-proxy symbols in the Knip output
- curl -i --max-time 15 https://native-provider-proxy-boundary.lightfast.localhost/api/native/proxy/routines
- agent-browser open/get text for https://native-provider-proxy-boundary.lightfast.localhost/api/native/proxy/routines