### PR TITLE
Move app health route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -61,6 +61,10 @@
       "types": "./src/adapters/internal/mcp-proxy.ts",
       "default": "./src/adapters/internal/mcp-proxy.ts"
     },
+    "./internal-api/health": {
+      "types": "./src/adapters/internal/health.ts",
+      "default": "./src/adapters/internal/health.ts"
+    },
     "./internal-api/workspace-assistant": {
       "types": "./src/adapters/internal/workspace-assistant/index.ts",
       "default": "./src/adapters/internal/workspace-assistant/index.ts"

--- a/api/app/src/adapters/internal/health.ts
+++ b/api/app/src/adapters/internal/health.ts
@@ -1,4 +1,4 @@
-export function getHealth(request: Request): Response {
+export function handleAppHealthRequest(request: Request): Response {
   const authToken = process.env.HEALTH_CHECK_AUTH_TOKEN;
 
   if (authToken) {

--- a/apps/app/src/__tests__/health.test.ts
+++ b/apps/app/src/__tests__/health.test.ts
@@ -1,8 +1,17 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const appRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(appRoot, "../..");
+
+function appSource(path: string): string {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
 
 describe("app health route", () => {
   afterEach(() => {
@@ -11,20 +20,32 @@ describe("app health route", () => {
   });
 
   it("keeps the file route wrapper browser-safe", () => {
-    const routeSource = readFileSync(
-      resolve(appRoot, "src/routes/api/health.ts"),
-      "utf8"
-    );
+    const routeSource = appSource("src/routes/api/health.ts");
+    const serverPath = resolve(appRoot, "src/server/health.ts");
+    const apiPackageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
 
     expect(routeSource).not.toContain('from "~/env"');
-    expect(routeSource).toContain('import("~/server/health")');
+    expect(routeSource).toContain('@api/app/internal-api/health"');
+    expect(routeSource).toContain("handleAppHealthRequest");
+    expect(routeSource).not.toContain('import("~/server/health")');
+    expect(existsSync(serverPath)).toBe(false);
+    expect(apiPackageJson.exports["./internal-api/health"]).toEqual({
+      default: "./src/adapters/internal/health.ts",
+      types: "./src/adapters/internal/health.ts",
+    });
   });
 
   it("returns an unauthenticated health payload when no token is configured", async () => {
     vi.stubEnv("HEALTH_CHECK_AUTH_TOKEN", "");
-    const { getHealth } = await import("../server/health");
+    const { handleAppHealthRequest } = await import(
+      "@api/app/internal-api/health"
+    );
 
-    const response = getHealth(new Request("https://app.test/api/health"));
+    const response = handleAppHealthRequest(
+      new Request("https://app.test/api/health")
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe(
@@ -42,9 +63,13 @@ describe("app health route", () => {
       "HEALTH_CHECK_AUTH_TOKEN",
       "test-health-token-test-health-token"
     );
-    const { getHealth } = await import("../server/health");
+    const { handleAppHealthRequest } = await import(
+      "@api/app/internal-api/health"
+    );
 
-    const response = getHealth(new Request("https://app.test/api/health"));
+    const response = handleAppHealthRequest(
+      new Request("https://app.test/api/health")
+    );
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({
@@ -57,9 +82,11 @@ describe("app health route", () => {
       "HEALTH_CHECK_AUTH_TOKEN",
       "test-health-token-test-health-token"
     );
-    const { getHealth } = await import("../server/health");
+    const { handleAppHealthRequest } = await import(
+      "@api/app/internal-api/health"
+    );
 
-    const response = getHealth(
+    const response = handleAppHealthRequest(
       new Request("https://app.test/api/health", {
         headers: { authorization: "Bearer wrong-token" },
       })
@@ -74,9 +101,11 @@ describe("app health route", () => {
       "HEALTH_CHECK_AUTH_TOKEN",
       "test-health-token-test-health-token"
     );
-    const { getHealth } = await import("../server/health");
+    const { handleAppHealthRequest } = await import(
+      "@api/app/internal-api/health"
+    );
 
-    const response = getHealth(
+    const response = handleAppHealthRequest(
       new Request("https://app.test/api/health", {
         headers: {
           authorization: "Bearer test-health-token-test-health-token",

--- a/apps/app/src/routes/api/health.ts
+++ b/apps/app/src/routes/api/health.ts
@@ -1,12 +1,10 @@
+import { handleAppHealthRequest } from "@api/app/internal-api/health";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/health")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { getHealth } = await import("~/server/health");
-        return getHealth(request);
-      },
+      GET: ({ request }) => handleAppHealthRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add @api/app/internal-api/health as the explicit app health route adapter.
- Mount /api/health directly from apps/app using the api/app handler.
- Remove the final apps/app/src/server helper and ratchet the source boundary.

## Test Plan
- [x] pnpm --filter @lightfast/app test -- src/__tests__/health.test.ts (red first, then green)
- [x] pnpm --filter @api/app test -- src/__tests__/mcp-internal-adapters-source.test.ts
- [x] pnpm check
- [x] git diff --check
- [x] SKIP_ENV_VALIDATION=true pnpm typecheck
- [x] SKIP_ENV_VALIDATION=true pnpm knip captured to /tmp/lightfast-knip-app-health-route-boundary.txt; no health route-boundary matches
- [x] curl direct app /api/health via https://app-health-route-boundary.app.lightfast.localhost/api/health
- [x] agent-browser verified direct app /api/health response
