### PR TITLE
Move connector OAuth route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -65,6 +65,10 @@
       "types": "./src/adapters/internal/health.ts",
       "default": "./src/adapters/internal/health.ts"
     },
+    "./internal-api/connector-oauth": {
+      "types": "./src/adapters/internal/connector-oauth.ts",
+      "default": "./src/adapters/internal/connector-oauth.ts"
+    },
     "./internal-api/workspace-assistant": {
       "types": "./src/adapters/internal/workspace-assistant/index.ts",
       "default": "./src/adapters/internal/workspace-assistant/index.ts"

--- a/api/app/src/adapters/internal/connector-oauth.ts
+++ b/api/app/src/adapters/internal/connector-oauth.ts
@@ -1,0 +1,54 @@
+import {
+  completeLinearConnectorOAuth,
+  completeXConnectorOAuth,
+} from "../../services/connectors";
+import { completeGranolaUserConnectorOAuth } from "../../services/user-connectors";
+
+export async function handleLinearConnectorOAuthCallbackRequest(
+  request: Request
+): Promise<Response> {
+  const result = await completeLinearConnectorOAuth({
+    requestUrl: request.url,
+  });
+  return Response.redirect(result.redirectUrl);
+}
+
+export async function handleXConnectorOAuthCallbackRequest(
+  request: Request
+): Promise<Response> {
+  const result = await completeXConnectorOAuth({
+    requestUrl: request.url,
+  });
+  return Response.redirect(result.redirectUrl);
+}
+
+export async function handleGranolaUserConnectorOAuthCallbackRequest(
+  request: Request
+): Promise<Response> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error) {
+    return accountSettingsRedirect(request.url, error);
+  }
+
+  if (!(code && state)) {
+    return accountSettingsRedirect(request.url, "missing_oauth_code");
+  }
+
+  const result = await completeGranolaUserConnectorOAuth({
+    code,
+    requestUrl: request.url,
+    state,
+  });
+  return Response.redirect(result.redirectUrl);
+}
+
+function accountSettingsRedirect(requestUrl: string, error: string): Response {
+  const url = new URL("/account/settings", requestUrl);
+  url.searchParams.set("connector", "granola");
+  url.searchParams.set("error", error);
+  return Response.redirect(url.toString());
+}

--- a/apps/app/src/__tests__/connectors-routes.test.ts
+++ b/apps/app/src/__tests__/connectors-routes.test.ts
@@ -3,9 +3,14 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const appRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(appRoot, "../..");
 
 function source(path: string) {
   return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
 }
 
 describe("app connector API routes", () => {
@@ -19,34 +24,64 @@ describe("app connector API routes", () => {
     const granolaCallbackSource = source(
       "src/routes/api/connectors/granola/oauth/callback.ts"
     );
+    const connectorOAuthAdapterSource = repoSource(
+      "api/app/src/adapters/internal/connector-oauth.ts"
+    );
+    const apiPackageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
 
     expect(linearCallbackSource).toContain(
       'createFileRoute("/api/connectors/linear/oauth/callback")'
     );
-    expect(linearCallbackSource).toContain("completeLinearConnectorOAuth");
     expect(linearCallbackSource).toContain(
-      "Response.redirect(result.redirectUrl)"
+      '@api/app/internal-api/connector-oauth"'
     );
+    expect(linearCallbackSource).toContain(
+      "handleLinearConnectorOAuthCallbackRequest"
+    );
+    expect(linearCallbackSource).not.toContain("completeLinearConnectorOAuth");
+    expect(linearCallbackSource).not.toContain("Response.redirect");
     expect(xCallbackSource).toContain(
       'createFileRoute("/api/connectors/x/oauth/callback")'
     );
-    expect(xCallbackSource).toContain("completeXConnectorOAuth");
-    expect(xCallbackSource).toContain("Response.redirect(result.redirectUrl)");
+    expect(xCallbackSource).toContain('@api/app/internal-api/connector-oauth"');
+    expect(xCallbackSource).toContain("handleXConnectorOAuthCallbackRequest");
+    expect(xCallbackSource).not.toContain("completeXConnectorOAuth");
+    expect(xCallbackSource).not.toContain("Response.redirect");
     expect(granolaCallbackSource).toContain(
       'createFileRoute("/api/connectors/granola/oauth/callback")'
     );
     expect(granolaCallbackSource).toContain(
+      '@api/app/internal-api/connector-oauth"'
+    );
+    expect(granolaCallbackSource).toContain(
+      "handleGranolaUserConnectorOAuthCallbackRequest"
+    );
+    expect(granolaCallbackSource).not.toContain(
       "completeGranolaUserConnectorOAuth"
     );
-    expect(granolaCallbackSource).toContain("missing_oauth_code");
-    expect(granolaCallbackSource).toContain(
-      "Response.redirect(result.redirectUrl)"
+    expect(granolaCallbackSource).not.toContain("missing_oauth_code");
+    expect(granolaCallbackSource).not.toContain("Response.redirect");
+    expect(apiPackageJson.exports["./internal-api/connector-oauth"]).toEqual({
+      default: "./src/adapters/internal/connector-oauth.ts",
+      types: "./src/adapters/internal/connector-oauth.ts",
+    });
+    expect(connectorOAuthAdapterSource).toContain(
+      "completeLinearConnectorOAuth"
     );
+    expect(connectorOAuthAdapterSource).toContain("completeXConnectorOAuth");
+    expect(connectorOAuthAdapterSource).toContain(
+      "completeGranolaUserConnectorOAuth"
+    );
+    expect(connectorOAuthAdapterSource).toContain("missing_oauth_code");
+    expect(connectorOAuthAdapterSource).toContain("Response.redirect");
 
     for (const routeSource of [
       linearCallbackSource,
       xCallbackSource,
       granolaCallbackSource,
+      connectorOAuthAdapterSource,
     ]) {
       expect(routeSource).not.toContain("next/");
     }

--- a/apps/app/src/routes/api/connectors/granola/oauth/callback.ts
+++ b/apps/app/src/routes/api/connectors/granola/oauth/callback.ts
@@ -1,39 +1,11 @@
+import { handleGranolaUserConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth";
 import { createFileRoute } from "@tanstack/react-router";
-
-function accountSettingsRedirect(requestUrl: string, error: string) {
-  const url = new URL("/account/settings", requestUrl);
-  url.searchParams.set("connector", "granola");
-  url.searchParams.set("error", error);
-  return Response.redirect(url.toString());
-}
 
 export const Route = createFileRoute("/api/connectors/granola/oauth/callback")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const url = new URL(request.url);
-        const code = url.searchParams.get("code");
-        const state = url.searchParams.get("state");
-        const error = url.searchParams.get("error");
-
-        if (error) {
-          return accountSettingsRedirect(request.url, error);
-        }
-
-        if (!(code && state)) {
-          return accountSettingsRedirect(request.url, "missing_oauth_code");
-        }
-
-        const { completeGranolaUserConnectorOAuth } = await import(
-          "@api/app/services/user-connectors"
-        );
-        const result = await completeGranolaUserConnectorOAuth({
-          code,
-          requestUrl: request.url,
-          state,
-        });
-        return Response.redirect(result.redirectUrl);
-      },
+      GET: ({ request }) =>
+        handleGranolaUserConnectorOAuthCallbackRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/connectors/linear/oauth/callback.ts
+++ b/apps/app/src/routes/api/connectors/linear/oauth/callback.ts
@@ -1,17 +1,10 @@
+import { handleLinearConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/connectors/linear/oauth/callback")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { completeLinearConnectorOAuth } = await import(
-          "@api/app/services/connectors"
-        );
-        const result = await completeLinearConnectorOAuth({
-          requestUrl: request.url,
-        });
-        return Response.redirect(result.redirectUrl);
-      },
+      GET: ({ request }) => handleLinearConnectorOAuthCallbackRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/connectors/x/oauth/callback.ts
+++ b/apps/app/src/routes/api/connectors/x/oauth/callback.ts
@@ -1,17 +1,10 @@
+import { handleXConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/connectors/x/oauth/callback")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { completeXConnectorOAuth } = await import(
-          "@api/app/services/connectors"
-        );
-        const result = await completeXConnectorOAuth({
-          requestUrl: request.url,
-        });
-        return Response.redirect(result.redirectUrl);
-      },
+      GET: ({ request }) => handleXConnectorOAuthCallbackRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add an explicit `@api/app/internal-api/connector-oauth` adapter surface for Linear, X, and Granola OAuth callback responses.
- Keep TanStack app route files as thin mounts that delegate to named `api/app` handlers.
- Ratchet route-boundary tests so connector service imports and redirect composition stay out of `apps/app`.

## Test Plan
- [x] Red: `pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts` failed before the adapter export existed.
- [x] Green: `pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts`.
- [x] Green: `pnpm --filter @api/app test -- src/__tests__/connectors-flow.test.ts src/__tests__/user-connectors-flow.test.ts`.
- [x] `pnpm check`.
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`.
- [x] `git diff --check`.
- [x] `curl -sk -I https://connector-oauth-route-boundary.app.lightfast.localhost/api/connectors/granola/oauth/callback` returns `302` with `error=missing_oauth_code`.
- [x] `agent-browser open https://connector-oauth-route-boundary.app.lightfast.localhost/api/connectors/linear/oauth/callback` lands on the expected sign-in redirect for `/account/teams?connector=linear&error=expired_state`.

Note: Granola's missing-code route redirects to the raw local backend URL in dev, matching existing behavior; curl verifies the route, while a browser follows that redirect into an HTTPS protocol mismatch on `127.0.0.1`.
