### PR TITLE
Move GitHub OAuth route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -69,6 +69,10 @@
       "types": "./src/adapters/internal/connector-oauth.ts",
       "default": "./src/adapters/internal/connector-oauth.ts"
     },
+    "./internal-api/github-oauth": {
+      "types": "./src/adapters/internal/github-oauth.ts",
+      "default": "./src/adapters/internal/github-oauth.ts"
+    },
     "./internal-api/workspace-assistant": {
       "types": "./src/adapters/internal/workspace-assistant/index.ts",
       "default": "./src/adapters/internal/workspace-assistant/index.ts"

--- a/api/app/src/adapters/internal/github-oauth.ts
+++ b/api/app/src/adapters/internal/github-oauth.ts
@@ -1,0 +1,32 @@
+import {
+  completeGitHubInstallationSetup,
+  completeGitHubOAuthVerification,
+  completeGitHubUserAccountOAuth,
+} from "../../services/github";
+
+export async function handleGitHubInstallationSetupRequest(
+  request: Request
+): Promise<Response> {
+  const result = await completeGitHubInstallationSetup({
+    requestUrl: request.url,
+  });
+  return Response.redirect(result.redirectUrl);
+}
+
+export async function handleGitHubOAuthCallbackRequest(
+  request: Request
+): Promise<Response> {
+  const result = await completeGitHubOAuthVerification({
+    requestUrl: request.url,
+  });
+  return Response.redirect(result.redirectUrl);
+}
+
+export async function handleGitHubUserAccountOAuthCallbackRequest(
+  request: Request
+): Promise<Response> {
+  const result = await completeGitHubUserAccountOAuth({
+    requestUrl: request.url,
+  });
+  return Response.redirect(result.redirectUrl);
+}

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -934,8 +934,10 @@ describe("app authenticated route migration", () => {
     expect(completeRouteSource).toContain("GitHubBindCompleteClient");
     expect(completeClientSource).toContain('result.bindingStatus !== "bound"');
     expect(completeClientSource).toContain("setFailed(true)");
-    expect(setupCallbackSource).toContain("completeGitHubInstallationSetup");
-    expect(oauthCallbackSource).toContain("completeGitHubOAuthVerification");
+    expect(setupCallbackSource).toContain(
+      "handleGitHubInstallationSetupRequest"
+    );
+    expect(oauthCallbackSource).toContain("handleGitHubOAuthCallbackRequest");
 
     for (const routeFile of [
       bindRouteSource,

--- a/apps/app/src/__tests__/github-routes.test.ts
+++ b/apps/app/src/__tests__/github-routes.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(appRoot, "../..");
+
+function source(path: string) {
+  return readFileSync(resolve(appRoot, path), "utf8");
+}
+
+function repoSource(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("app GitHub API routes", () => {
+  it("mounts GitHub OAuth callbacks through explicit api/app handlers", () => {
+    const setupCallbackSource = source("src/routes/api/github/setup.ts");
+    const oauthCallbackSource = source(
+      "src/routes/api/github/oauth/callback.ts"
+    );
+    const userOAuthCallbackSource = source(
+      "src/routes/api/github/user/oauth/callback.ts"
+    );
+    const githubOAuthAdapterSource = repoSource(
+      "api/app/src/adapters/internal/github-oauth.ts"
+    );
+    const apiPackageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
+
+    expect(setupCallbackSource).toContain(
+      'createFileRoute("/api/github/setup")'
+    );
+    expect(setupCallbackSource).toContain(
+      '@api/app/internal-api/github-oauth"'
+    );
+    expect(setupCallbackSource).toContain(
+      "handleGitHubInstallationSetupRequest"
+    );
+    expect(setupCallbackSource).not.toContain(
+      "completeGitHubInstallationSetup"
+    );
+    expect(setupCallbackSource).not.toContain("Response.redirect");
+
+    expect(oauthCallbackSource).toContain(
+      'createFileRoute("/api/github/oauth/callback")'
+    );
+    expect(oauthCallbackSource).toContain(
+      '@api/app/internal-api/github-oauth"'
+    );
+    expect(oauthCallbackSource).toContain("handleGitHubOAuthCallbackRequest");
+    expect(oauthCallbackSource).not.toContain(
+      "completeGitHubOAuthVerification"
+    );
+    expect(oauthCallbackSource).not.toContain("Response.redirect");
+
+    expect(userOAuthCallbackSource).toContain(
+      'createFileRoute("/api/github/user/oauth/callback")'
+    );
+    expect(userOAuthCallbackSource).toContain(
+      '@api/app/internal-api/github-oauth"'
+    );
+    expect(userOAuthCallbackSource).toContain(
+      "handleGitHubUserAccountOAuthCallbackRequest"
+    );
+    expect(userOAuthCallbackSource).not.toContain(
+      "completeGitHubUserAccountOAuth"
+    );
+    expect(userOAuthCallbackSource).not.toContain("Response.redirect");
+
+    expect(apiPackageJson.exports["./internal-api/github-oauth"]).toEqual({
+      default: "./src/adapters/internal/github-oauth.ts",
+      types: "./src/adapters/internal/github-oauth.ts",
+    });
+    expect(githubOAuthAdapterSource).toContain(
+      "completeGitHubInstallationSetup"
+    );
+    expect(githubOAuthAdapterSource).toContain(
+      "completeGitHubOAuthVerification"
+    );
+    expect(githubOAuthAdapterSource).toContain(
+      "completeGitHubUserAccountOAuth"
+    );
+    expect(githubOAuthAdapterSource).toContain("Response.redirect");
+
+    for (const routeSource of [
+      setupCallbackSource,
+      oauthCallbackSource,
+      userOAuthCallbackSource,
+      githubOAuthAdapterSource,
+    ]) {
+      expect(routeSource).not.toContain("next/");
+    }
+  });
+});

--- a/apps/app/src/routes/api/github/oauth/callback.ts
+++ b/apps/app/src/routes/api/github/oauth/callback.ts
@@ -1,17 +1,10 @@
+import { handleGitHubOAuthCallbackRequest } from "@api/app/internal-api/github-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/github/oauth/callback")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { completeGitHubOAuthVerification } = await import(
-          "@api/app/services/github"
-        );
-        const result = await completeGitHubOAuthVerification({
-          requestUrl: request.url,
-        });
-        return Response.redirect(result.redirectUrl);
-      },
+      GET: ({ request }) => handleGitHubOAuthCallbackRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/github/setup.ts
+++ b/apps/app/src/routes/api/github/setup.ts
@@ -1,17 +1,10 @@
+import { handleGitHubInstallationSetupRequest } from "@api/app/internal-api/github-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/github/setup")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { completeGitHubInstallationSetup } = await import(
-          "@api/app/services/github"
-        );
-        const result = await completeGitHubInstallationSetup({
-          requestUrl: request.url,
-        });
-        return Response.redirect(result.redirectUrl);
-      },
+      GET: ({ request }) => handleGitHubInstallationSetupRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/github/user/oauth/callback.ts
+++ b/apps/app/src/routes/api/github/user/oauth/callback.ts
@@ -1,17 +1,11 @@
+import { handleGitHubUserAccountOAuthCallbackRequest } from "@api/app/internal-api/github-oauth";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/github/user/oauth/callback")({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const { completeGitHubUserAccountOAuth } = await import(
-          "@api/app/services/github"
-        );
-        const result = await completeGitHubUserAccountOAuth({
-          requestUrl: request.url,
-        });
-        return Response.redirect(result.redirectUrl);
-      },
+      GET: ({ request }) =>
+        handleGitHubUserAccountOAuthCallbackRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add an explicit `@api/app/internal-api/github-oauth` adapter surface for GitHub installation setup, org OAuth callback, and user-account OAuth callback responses.
- Keep the TanStack app route files as thin mounts that delegate to named `api/app` handlers.
- Add source ratchets so GitHub service imports and redirect composition stay out of `apps/app` route files.

## Test Plan
- [x] Red: `pnpm --filter @lightfast/app test -- src/__tests__/github-routes.test.ts` failed because the adapter export/file was missing and app routes still imported GitHub services.
- [x] Green: `pnpm --filter @lightfast/app test -- src/__tests__/github-routes.test.ts`.
- [x] Green: `pnpm --filter @api/app test -- src/__tests__/github-setup-flow.test.ts src/__tests__/github-user-account-flow.test.ts`.
- [x] `pnpm check`.
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`.
- [x] `git diff --check`.
- [x] `curl -sk -o /dev/null -D - https://github-oauth-route-boundary.app.lightfast.localhost/api/github/setup` returns `302` to `/account/teams?github_error=expired_state`.
- [x] `curl -sk -o /dev/null -D - https://github-oauth-route-boundary.app.lightfast.localhost/api/github/oauth/callback` returns `302` to `/account/teams?github_error=expired_state`.
- [x] `curl -sk -o /dev/null -D - https://github-oauth-route-boundary.app.lightfast.localhost/api/github/user/oauth/callback` returns `302` to `/account/tasks/github?github_error=expired_state`.
- [x] `agent-browser open https://github-oauth-route-boundary.app.lightfast.localhost/api/github/setup` lands on the expected sign-in redirect for `/account/teams?github_error=expired_state`.

Note: local `pnpm dev` emitted the repo's known app proxy port collision noise, and the background Inngest scheduler logged unrelated local GitHub installation-token validation errors after the route checks had completed.
