### PR TITLE
Move X connector MCP route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -69,6 +69,10 @@
       "types": "./src/adapters/internal/connector-oauth.ts",
       "default": "./src/adapters/internal/connector-oauth.ts"
     },
+    "./internal-api/connector-mcp": {
+      "types": "./src/adapters/internal/connector-mcp.ts",
+      "default": "./src/adapters/internal/connector-mcp.ts"
+    },
     "./internal-api/github-oauth": {
       "types": "./src/adapters/internal/github-oauth.ts",
       "default": "./src/adapters/internal/github-oauth.ts"

--- a/api/app/src/adapters/internal/connector-mcp.ts
+++ b/api/app/src/adapters/internal/connector-mcp.ts
@@ -1,0 +1,7 @@
+import { handleXConnectorMcpRequest as handleXConnectorMcpServiceRequest } from "../../services/connectors";
+
+export async function handleXConnectorMcpRequest(
+  request: Request
+): Promise<Response> {
+  return handleXConnectorMcpServiceRequest({ request });
+}

--- a/apps/app/src/__tests__/connectors-routes.test.ts
+++ b/apps/app/src/__tests__/connectors-routes.test.ts
@@ -89,12 +89,29 @@ describe("app connector API routes", () => {
 
   it("mounts the X MCP bridge on the app API surface", () => {
     const xMcpSource = source("src/routes/api/connectors/x/mcp.ts");
+    const connectorMcpAdapterSource = repoSource(
+      "api/app/src/adapters/internal/connector-mcp.ts"
+    );
+    const apiPackageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
 
     expect(xMcpSource).toContain('createFileRoute("/api/connectors/x/mcp")');
+    expect(xMcpSource).toContain('@api/app/internal-api/connector-mcp"');
     expect(xMcpSource).toContain("handleXConnectorMcpRequest");
     expect(xMcpSource).toContain("GET:");
     expect(xMcpSource).toContain("POST:");
     expect(xMcpSource).toContain("DELETE:");
-    expect(xMcpSource).not.toContain("next/");
+    expect(xMcpSource).not.toContain("@api/app/services/connectors");
+    expect(apiPackageJson.exports["./internal-api/connector-mcp"]).toEqual({
+      default: "./src/adapters/internal/connector-mcp.ts",
+      types: "./src/adapters/internal/connector-mcp.ts",
+    });
+    expect(connectorMcpAdapterSource).toContain("../../services/connectors");
+    expect(connectorMcpAdapterSource).toContain("handleXConnectorMcpRequest");
+
+    for (const routeSource of [xMcpSource, connectorMcpAdapterSource]) {
+      expect(routeSource).not.toContain("next/");
+    }
   });
 });

--- a/apps/app/src/routes/api/connectors/x/mcp.ts
+++ b/apps/app/src/routes/api/connectors/x/mcp.ts
@@ -1,18 +1,12 @@
+import { handleXConnectorMcpRequest } from "@api/app/internal-api/connector-mcp";
 import { createFileRoute } from "@tanstack/react-router";
-
-async function handleXConnectorMcpRequest(request: Request) {
-  const { handleXConnectorMcpRequest: handleRequest } = await import(
-    "@api/app/services/connectors"
-  );
-  return handleRequest({ request });
-}
 
 export const Route = createFileRoute("/api/connectors/x/mcp")({
   server: {
     handlers: {
-      GET: async ({ request }) => handleXConnectorMcpRequest(request),
-      POST: async ({ request }) => handleXConnectorMcpRequest(request),
-      DELETE: async ({ request }) => handleXConnectorMcpRequest(request),
+      GET: ({ request }) => handleXConnectorMcpRequest(request),
+      POST: ({ request }) => handleXConnectorMcpRequest(request),
+      DELETE: ({ request }) => handleXConnectorMcpRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add an explicit `@api/app/internal-api/connector-mcp` adapter surface for the X connector MCP bridge.
- Keep `/api/connectors/x/mcp` as a thin TanStack route mount for GET, POST, and DELETE.
- Ratchet the route source so app routes no longer import `@api/app/services/connectors` directly.

## Test Plan
- [x] Red: `pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts` failed because `api/app/src/adapters/internal/connector-mcp.ts` did not exist.
- [x] Green: `pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts`.
- [x] Green: `pnpm --filter @api/app test -- src/__tests__/connectors-x-mcp-bridge.test.ts`.
- [x] `pnpm check`.
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`.
- [x] `git diff --check`.
- [x] `curl -sk -o - -D - https://x-connector-mcp-route-boundary.app.lightfast.localhost/api/connectors/x/mcp` returns `401 Unauthorized` from the bridge.
- [x] `curl -sk -o - -D - -X POST https://x-connector-mcp-route-boundary.app.lightfast.localhost/api/connectors/x/mcp -H 'content-type: application/json' --data '{"jsonrpc":"2.0","id":"test","method":"tools/list","params":{}}'` returns `401 Unauthorized` from the bridge.
- [x] `agent-browser open https://x-connector-mcp-route-boundary.app.lightfast.localhost/api/connectors/x/mcp` opened the endpoint without route/runtime errors.

Note: local `pnpm dev` emitted the repo's known app proxy port collision noise.
