### PR TITLE
refactor: move github webhook route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -77,6 +77,10 @@
       "types": "./src/adapters/internal/github-oauth.ts",
       "default": "./src/adapters/internal/github-oauth.ts"
     },
+    "./internal-api/github-webhook": {
+      "types": "./src/adapters/internal/github-webhook.ts",
+      "default": "./src/adapters/internal/github-webhook.ts"
+    },
     "./internal-api/workspace-assistant": {
       "types": "./src/adapters/internal/workspace-assistant/index.ts",
       "default": "./src/adapters/internal/workspace-assistant/index.ts"

--- a/api/app/src/adapters/internal/github-webhook.ts
+++ b/api/app/src/adapters/internal/github-webhook.ts
@@ -1,0 +1,7 @@
+import { handleGitHubWebhook as handleGitHubWebhookServiceRequest } from "../../services/github";
+
+export async function handleGitHubWebhookRequest(
+  request: Request
+): Promise<Response> {
+  return handleGitHubWebhookServiceRequest({ request });
+}

--- a/apps/app/src/__tests__/github-routes.test.ts
+++ b/apps/app/src/__tests__/github-routes.test.ts
@@ -14,6 +14,32 @@ function repoSource(path: string) {
 }
 
 describe("app GitHub API routes", () => {
+  it("mounts the GitHub webhook through an explicit api/app internal handler", () => {
+    const webhookRouteSource = source("src/routes/api/github/webhook.ts");
+    const githubWebhookAdapterSource = repoSource(
+      "api/app/src/adapters/internal/github-webhook.ts"
+    );
+    const apiPackageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
+
+    expect(webhookRouteSource).toContain(
+      'createFileRoute("/api/github/webhook")'
+    );
+    expect(webhookRouteSource).toContain(
+      '@api/app/internal-api/github-webhook"'
+    );
+    expect(webhookRouteSource).toContain("handleGitHubWebhookRequest");
+    expect(webhookRouteSource).not.toContain("@api/app/services/github");
+    expect(webhookRouteSource).not.toContain("handleGitHubWebhook({");
+
+    expect(apiPackageJson.exports["./internal-api/github-webhook"]).toEqual({
+      default: "./src/adapters/internal/github-webhook.ts",
+      types: "./src/adapters/internal/github-webhook.ts",
+    });
+    expect(githubWebhookAdapterSource).toContain("handleGitHubWebhook");
+  });
+
   it("mounts GitHub OAuth callbacks through explicit api/app handlers", () => {
     const setupCallbackSource = source("src/routes/api/github/setup.ts");
     const oauthCallbackSource = source(

--- a/apps/app/src/routes/api/github/webhook.ts
+++ b/apps/app/src/routes/api/github/webhook.ts
@@ -1,14 +1,10 @@
+import { handleGitHubWebhookRequest } from "@api/app/internal-api/github-webhook";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/github/webhook")({
   server: {
     handlers: {
-      POST: async ({ request }) => {
-        const { handleGitHubWebhook } = await import(
-          "@api/app/services/github"
-        );
-        return handleGitHubWebhook({ request });
-      },
+      POST: ({ request }) => handleGitHubWebhookRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- add an explicit `@api/app/internal-api/github-webhook` adapter surface
- make `apps/app` GitHub webhook route a thin mount over the api/app handler
- add a source ratchet so the route cannot import `@api/app/services/github` directly

## Test Plan
- [x] RED: `pnpm --filter @lightfast/app test -- src/__tests__/github-routes.test.ts` failed before the adapter existed
- [x] GREEN: `pnpm --filter @lightfast/app test -- src/__tests__/github-routes.test.ts`
- [x] `pnpm --filter @api/app test -- src/__tests__/github-webhook.test.ts`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts src/__tests__/github-routes.test.ts`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `git diff --check`
- [x] `pnpm check`
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`
- [x] Runtime smoke: `POST https://github-webhook-route-boundary.app.lightfast.localhost/api/github/webhook` returned `401 {"ok":false}` and logged `missing_signature`
- [x] agent-browser opened `https://github-webhook-route-boundary.app.lightfast.localhost/api/github/webhook` without route/runtime errors