### PR TITLE
refactor: move skills events route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -81,6 +81,10 @@
       "types": "./src/adapters/internal/github-webhook.ts",
       "default": "./src/adapters/internal/github-webhook.ts"
     },
+    "./internal-api/skills-events": {
+      "types": "./src/adapters/internal/skills-events.ts",
+      "default": "./src/adapters/internal/skills-events.ts"
+    },
     "./internal-api/workspace-assistant": {
       "types": "./src/adapters/internal/workspace-assistant/index.ts",
       "default": "./src/adapters/internal/workspace-assistant/index.ts"
@@ -196,10 +200,6 @@
     "./services/skills": {
       "types": "./src/services/skills/index.ts",
       "default": "./src/services/skills/index.ts"
-    },
-    "./services/skills/events": {
-      "types": "./src/services/skills/events.ts",
-      "default": "./src/services/skills/events.ts"
     },
     "./services/connectors": {
       "types": "./src/services/connectors/index.ts",

--- a/api/app/src/adapters/internal/skills-events.ts
+++ b/api/app/src/adapters/internal/skills-events.ts
@@ -1,0 +1,7 @@
+import { handleSkillIndexEventsRequest as handleSkillIndexEventsServiceRequest } from "../../services/skills/events";
+
+export async function handleSkillIndexEventsRequest(
+  request: Request
+): Promise<Response> {
+  return handleSkillIndexEventsServiceRequest(request);
+}

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1385,8 +1385,14 @@ describe("app authenticated route migration", () => {
       "src/server/skills/skill-index-event-stream.ts"
     );
     const skillsEventsAdapterSource = repoSource(
+      "api/app/src/adapters/internal/skills-events.ts"
+    );
+    const skillsEventsServiceSource = repoSource(
       "api/app/src/services/skills/events.ts"
     );
+    const apiPackageJson = JSON.parse(repoSource("api/app/package.json")) as {
+      exports: Record<string, { default: string; types: string }>;
+    };
     const nativeProxyServerPath = resolve(
       appRoot,
       "src/server/native-proxy.ts"
@@ -1460,20 +1466,29 @@ describe("app authenticated route migration", () => {
       "handleSkillIndexEventsRequest"
     );
     expect(skillsIndexEventsRouteSource).toContain(
-      'from "@api/app/services/skills/events"'
+      'from "@api/app/internal-api/skills-events"'
+    );
+    expect(skillsIndexEventsRouteSource).not.toContain(
+      "@api/app/services/skills/events"
     );
     expect(skillsIndexEventsRouteSource).not.toContain("@db/app");
     expect(skillsIndexEventsRouteSource).not.toContain(
       "resolveAuthContextFromClerk"
     );
+    expect(apiPackageJson.exports["./internal-api/skills-events"]).toEqual({
+      default: "./src/adapters/internal/skills-events.ts",
+      types: "./src/adapters/internal/skills-events.ts",
+    });
+    expect(apiPackageJson.exports["./services/skills/events"]).toBeUndefined();
     expect(existsSync(skillsIndexEventStreamPath)).toBe(false);
     expect(skillsEventsAdapterSource).toContain(
       "handleSkillIndexEventsRequest"
     );
-    expect(skillsEventsAdapterSource).toContain("resolveAuthContextFromClerk");
-    expect(skillsEventsAdapterSource).toContain("@db/app/client");
-    expect(skillsEventsAdapterSource).toContain("createSkillIndexEventStream");
-    expect(skillsEventsAdapterSource).toContain("redis.subscribe");
+    expect(skillsEventsAdapterSource).toContain("../../services/skills/events");
+    expect(skillsEventsServiceSource).toContain("resolveAuthContextFromClerk");
+    expect(skillsEventsServiceSource).toContain("@db/app/client");
+    expect(skillsEventsServiceSource).toContain("createSkillIndexEventStream");
+    expect(skillsEventsServiceSource).toContain("redis.subscribe");
     expect(existsSync(nativeProxyServerPath)).toBe(false);
     expect(nativeProxyAdapterSource).toContain(
       "createNativeProviderRoutineContext"

--- a/apps/app/src/routes/api/skills/index/events.ts
+++ b/apps/app/src/routes/api/skills/index/events.ts
@@ -1,4 +1,4 @@
-import { handleSkillIndexEventsRequest } from "@api/app/services/skills/events";
+import { handleSkillIndexEventsRequest } from "@api/app/internal-api/skills-events";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/skills/index/events")({


### PR DESCRIPTION
## Summary
- add `@api/app/internal-api/skills-events` as the route-facing skills event stream adapter
- move the app route import from `@api/app/services/skills/events` to the explicit internal API surface
- remove the now-stale `./services/skills/events` package export and update source ratchets

## Test Plan
- [x] RED: `pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts` failed before the adapter existed
- [x] GREEN: `pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts`
- [x] `pnpm --filter @api/app test -- src/__tests__/skills-index-events-route.test.ts` (package suite passed)
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `git diff --check`
- [x] `pnpm check`
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`
- [x] Runtime smoke: `GET https://skills-events-internal-api-boundary.app.lightfast.localhost/api/skills/index/events` returned `401 {"error":"Unauthorized"}`
- [x] agent-browser opened `https://skills-events-internal-api-boundary.app.lightfast.localhost/api/skills/index/events` without route/runtime errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Updated the public API export path for skills events functionality. Code importing from `@api/app/services/skills/events` must now import from `@api/app/internal-api/skills-events` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->