### PR TITLE
refactor: move inngest route boundary to api

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -81,6 +81,10 @@
       "types": "./src/adapters/internal/github-webhook.ts",
       "default": "./src/adapters/internal/github-webhook.ts"
     },
+    "./internal-api/inngest": {
+      "types": "./src/adapters/internal/inngest.ts",
+      "default": "./src/adapters/internal/inngest.ts"
+    },
     "./internal-api/skills-events": {
       "types": "./src/adapters/internal/skills-events.ts",
       "default": "./src/adapters/internal/skills-events.ts"

--- a/api/app/src/__tests__/inngest-route.test.ts
+++ b/api/app/src/__tests__/inngest-route.test.ts
@@ -112,6 +112,7 @@ vi.mock("../inngest/workflow/queue-skill-refresh-from-source-control", () => ({
 }));
 
 const { createInngestRouteContext, inngest } = await import("../inngest");
+const { handleInngestRequest } = await import("../adapters/internal/inngest");
 
 describe("createInngestRouteContext", () => {
   it("serves the app Inngest client with automation and production health workflows", () => {
@@ -173,5 +174,15 @@ describe("createInngestRouteContext", () => {
       serveOrigin: "https://lightfast.localhost",
       servePath: "/api/inngest",
     });
+  });
+
+  it("adapts app route requests to the selected Inngest handler", async () => {
+    const request = new Request("https://lightfast.localhost/api/inngest");
+    const response = new Response("ok");
+    routeHandlers.POST.mockResolvedValueOnce(response);
+
+    await expect(handleInngestRequest(request, "POST")).resolves.toBe(response);
+
+    expect(routeHandlers.POST).toHaveBeenCalledWith(request, {});
   });
 });

--- a/api/app/src/adapters/internal/inngest.ts
+++ b/api/app/src/adapters/internal/inngest.ts
@@ -1,0 +1,16 @@
+import { createInngestRouteContext } from "../../inngest";
+
+export type InngestMethod = "GET" | "POST" | "PUT";
+
+export async function handleInngestRequest(
+  request: Request,
+  method: InngestMethod
+): Promise<Response> {
+  const handlers = createInngestRouteContext();
+  const handler = handlers[method] as (
+    request: Request,
+    context: unknown
+  ) => Promise<Response>;
+
+  return handler(request, {});
+}

--- a/apps/app/src/__tests__/inngest-route.test.ts
+++ b/apps/app/src/__tests__/inngest-route.test.ts
@@ -3,21 +3,39 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const appRoot = resolve(import.meta.dirname, "../..");
+const apiRoot = resolve(appRoot, "../../api/app");
 
-function source(path: string) {
+function appSource(path: string) {
   return readFileSync(resolve(appRoot, path), "utf8");
 }
 
+function apiSource(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
 describe("app Inngest route", () => {
-  it("serves app Inngest handlers through a TanStack server route", () => {
-    const routeSource = source("src/routes/api/inngest.ts");
+  it("mounts app Inngest through the api internal adapter boundary", () => {
+    const routeSource = appSource("src/routes/api/inngest.ts");
+    const adapterSource = apiSource("src/adapters/internal/inngest.ts");
+    const apiPackageJson = JSON.parse(apiSource("package.json")) as {
+      exports: Record<string, unknown>;
+    };
 
     expect(routeSource).toContain('createFileRoute("/api/inngest")');
-    expect(routeSource).toContain("createInngestRouteContext");
-    expect(routeSource).toContain("handler(request, {})");
+    expect(routeSource).toContain("handleInngestRequest");
+    expect(routeSource).toContain('from "@api/app/internal-api/inngest"');
+    expect(routeSource).not.toContain("@api/app/inngest");
+    expect(routeSource).not.toContain("createInngestRouteContext");
+    expect(routeSource).not.toContain("handler(request, {})");
     expect(routeSource).toContain("GET:");
     expect(routeSource).toContain("POST:");
     expect(routeSource).toContain("PUT:");
     expect(routeSource).not.toContain("next/");
+    expect(apiPackageJson.exports["./internal-api/inngest"]).toEqual({
+      default: "./src/adapters/internal/inngest.ts",
+      types: "./src/adapters/internal/inngest.ts",
+    });
+    expect(adapterSource).toContain("createInngestRouteContext");
+    expect(adapterSource).toContain("handler(request, {})");
   });
 });

--- a/apps/app/src/__tests__/inngest-route.test.ts
+++ b/apps/app/src/__tests__/inngest-route.test.ts
@@ -23,7 +23,11 @@ describe("app Inngest route", () => {
 
     expect(routeSource).toContain('createFileRoute("/api/inngest")');
     expect(routeSource).toContain("handleInngestRequest");
-    expect(routeSource).toContain('from "@api/app/internal-api/inngest"');
+    expect(routeSource).toContain("await import(");
+    expect(routeSource).toContain('"@api/app/internal-api/inngest"');
+    expect(routeSource).not.toContain(
+      'import { handleInngestRequest } from "@api/app/internal-api/inngest"'
+    );
     expect(routeSource).not.toContain("@api/app/inngest");
     expect(routeSource).not.toContain("createInngestRouteContext");
     expect(routeSource).not.toContain("handler(request, {})");

--- a/apps/app/src/routes/api/inngest.ts
+++ b/apps/app/src/routes/api/inngest.ts
@@ -1,16 +1,5 @@
+import { handleInngestRequest } from "@api/app/internal-api/inngest";
 import { createFileRoute } from "@tanstack/react-router";
-
-type InngestMethod = "GET" | "POST" | "PUT";
-
-async function handleInngestRequest(request: Request, method: InngestMethod) {
-  const { createInngestRouteContext } = await import("@api/app/inngest");
-  const handlers = createInngestRouteContext();
-  const handler = handlers[method] as (
-    request: Request,
-    context: unknown
-  ) => Promise<Response>;
-  return handler(request, {});
-}
 
 export const Route = createFileRoute("/api/inngest")({
   server: {

--- a/apps/app/src/routes/api/inngest.ts
+++ b/apps/app/src/routes/api/inngest.ts
@@ -1,12 +1,24 @@
-import { handleInngestRequest } from "@api/app/internal-api/inngest";
 import { createFileRoute } from "@tanstack/react-router";
+
+type InngestMethod = "GET" | "POST" | "PUT";
+
+async function handleInngestRouteRequest(
+  request: Request,
+  method: InngestMethod
+) {
+  const { handleInngestRequest } = await import(
+    "@api/app/internal-api/inngest"
+  );
+
+  return handleInngestRequest(request, method);
+}
 
 export const Route = createFileRoute("/api/inngest")({
   server: {
     handlers: {
-      GET: async ({ request }) => handleInngestRequest(request, "GET"),
-      POST: async ({ request }) => handleInngestRequest(request, "POST"),
-      PUT: async ({ request }) => handleInngestRequest(request, "PUT"),
+      GET: async ({ request }) => handleInngestRouteRequest(request, "GET"),
+      POST: async ({ request }) => handleInngestRouteRequest(request, "POST"),
+      PUT: async ({ request }) => handleInngestRouteRequest(request, "PUT"),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add an explicit `@api/app/internal-api/inngest` adapter for app Inngest route handling.
- Keep `apps/app/src/routes/api/inngest.ts` as a thin TanStack route mount.
- Add source and behavior ratchets so the route no longer reassembles the backend Inngest context directly.

## Test Plan
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/inngest-route.test.ts` (red first, then green)
- [x] `pnpm --filter @api/app test -- src/__tests__/inngest-route.test.ts` (red first, then green)
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] route scan: no `@api/app/services`, `@api/app/inngest`, or `createInngestRouteContext` in `apps/app/src/routes/api`
- [x] `pnpm check`
- [x] `SKIP_ENV_VALIDATION=true pnpm typecheck`
- [x] `pnpm turbo boundaries`
- [x] runtime curl: `GET /api/inngest` returned `200` with Inngest metadata and `x-inngest-sdk-handled: true`
- [x] agent-browser opened `/api/inngest` and read the expected JSON body

Note: `SKIP_ENV_VALIDATION=true pnpm knip` still reports the repo's existing Knip backlog; it did not report the new Inngest adapter as unused.