### PR TITLE
fix: keep native rpc adapters server-only

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1504,8 +1504,12 @@ describe("app authenticated route migration", () => {
     expect(nativeProxyCallRouteSource).toContain(
       "handleNativeProviderRoutineCallRequest"
     );
+    expect(nativeProxyCallRouteSource).toContain("await import(");
     expect(nativeProxyCallRouteSource).toContain(
-      'from "@api/app/native-provider-proxy"'
+      '"@api/app/native-provider-proxy"'
+    );
+    expect(nativeProxyCallRouteSource).not.toContain(
+      'import { handleNativeProviderRoutineCallRequest } from "@api/app/native-provider-proxy"'
     );
     expect(nativeProxyCallRouteSource).not.toContain(
       "providerRoutineCallInputSchema"
@@ -1516,8 +1520,12 @@ describe("app authenticated route migration", () => {
     expect(nativeProxyRoutinesRouteSource).toContain(
       "handleNativeProviderRoutineFindRequest"
     );
+    expect(nativeProxyRoutinesRouteSource).toContain("await import(");
     expect(nativeProxyRoutinesRouteSource).toContain(
-      'from "@api/app/native-provider-proxy"'
+      '"@api/app/native-provider-proxy"'
+    );
+    expect(nativeProxyRoutinesRouteSource).not.toContain(
+      'import { handleNativeProviderRoutineFindRequest } from "@api/app/native-provider-proxy"'
     );
     expect(nativeProxyRoutinesRouteSource).not.toContain(
       "providerRoutineFindInputSchema"

--- a/apps/app/src/__tests__/native-rpc-routes-source.test.ts
+++ b/apps/app/src/__tests__/native-rpc-routes-source.test.ts
@@ -25,10 +25,18 @@ describe("native RPC route boundaries", () => {
     const cliRoute = appSource("src/routes/api/cli/rpc.ts");
 
     expect(desktopRoute).toContain('createFileRoute("/api/desktop/rpc")');
-    expect(desktopRoute).toContain('@api/app/desktop-api"');
+    expect(desktopRoute).toContain("await import(");
+    expect(desktopRoute).toContain('"@api/app/desktop-api"');
+    expect(desktopRoute).not.toContain(
+      'import { handleDesktopNativeRpcRequest } from "@api/app/desktop-api"'
+    );
     expect(desktopRoute).toContain("handleDesktopNativeRpcRequest");
     expect(cliRoute).toContain('createFileRoute("/api/cli/rpc")');
-    expect(cliRoute).toContain('@api/app/cli-api"');
+    expect(cliRoute).toContain("await import(");
+    expect(cliRoute).toContain('"@api/app/cli-api"');
+    expect(cliRoute).not.toContain(
+      'import { handleCliNativeRpcRequest } from "@api/app/cli-api"'
+    );
     expect(cliRoute).toContain("handleCliNativeRpcRequest");
 
     for (const source of [desktopRoute, cliRoute]) {
@@ -79,9 +87,17 @@ describe("native RPC route boundaries", () => {
     };
 
     expect(packageJson.exports).toHaveProperty("./native-provider-proxy");
-    expect(proxyCallRoute).toContain("@api/app/native-provider-proxy");
+    expect(proxyCallRoute).toContain("await import(");
+    expect(proxyCallRoute).toContain('"@api/app/native-provider-proxy"');
+    expect(proxyCallRoute).not.toContain(
+      'import { handleNativeProviderRoutineCallRequest } from "@api/app/native-provider-proxy"'
+    );
     expect(proxyCallRoute).toContain("handleNativeProviderRoutineCallRequest");
-    expect(proxyFindRoute).toContain("@api/app/native-provider-proxy");
+    expect(proxyFindRoute).toContain("await import(");
+    expect(proxyFindRoute).toContain('"@api/app/native-provider-proxy"');
+    expect(proxyFindRoute).not.toContain(
+      'import { handleNativeProviderRoutineFindRequest } from "@api/app/native-provider-proxy"'
+    );
     expect(proxyFindRoute).toContain("handleNativeProviderRoutineFindRequest");
     expect(proxyCallRoute).not.toContain('@api/app/cli-api"');
     expect(proxyFindRoute).not.toContain('@api/app/cli-api"');

--- a/apps/app/src/routes/api/cli/rpc.ts
+++ b/apps/app/src/routes/api/cli/rpc.ts
@@ -1,10 +1,15 @@
-import { handleCliNativeRpcRequest } from "@api/app/cli-api";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleCliRpcRouteRequest(request: Request) {
+  const { handleCliNativeRpcRequest } = await import("@api/app/cli-api");
+
+  return handleCliNativeRpcRequest(request);
+}
 
 export const Route = createFileRoute("/api/cli/rpc")({
   server: {
     handlers: {
-      POST: async ({ request }) => handleCliNativeRpcRequest(request),
+      POST: async ({ request }) => handleCliRpcRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/desktop/rpc.ts
+++ b/apps/app/src/routes/api/desktop/rpc.ts
@@ -1,10 +1,17 @@
-import { handleDesktopNativeRpcRequest } from "@api/app/desktop-api";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleDesktopRpcRouteRequest(request: Request) {
+  const { handleDesktopNativeRpcRequest } = await import(
+    "@api/app/desktop-api"
+  );
+
+  return handleDesktopNativeRpcRequest(request);
+}
 
 export const Route = createFileRoute("/api/desktop/rpc")({
   server: {
     handlers: {
-      POST: async ({ request }) => handleDesktopNativeRpcRequest(request),
+      POST: async ({ request }) => handleDesktopRpcRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/native/proxy/call.ts
+++ b/apps/app/src/routes/api/native/proxy/call.ts
@@ -1,10 +1,18 @@
-import { handleNativeProviderRoutineCallRequest } from "@api/app/native-provider-proxy";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleNativeProviderRoutineCallRouteRequest(request: Request) {
+  const { handleNativeProviderRoutineCallRequest } = await import(
+    "@api/app/native-provider-proxy"
+  );
+
+  return handleNativeProviderRoutineCallRequest(request);
+}
 
 export const Route = createFileRoute("/api/native/proxy/call")({
   server: {
     handlers: {
-      POST: ({ request }) => handleNativeProviderRoutineCallRequest(request),
+      POST: ({ request }) =>
+        handleNativeProviderRoutineCallRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/native/proxy/routines.ts
+++ b/apps/app/src/routes/api/native/proxy/routines.ts
@@ -1,10 +1,18 @@
-import { handleNativeProviderRoutineFindRequest } from "@api/app/native-provider-proxy";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleNativeProviderRoutineFindRouteRequest(request: Request) {
+  const { handleNativeProviderRoutineFindRequest } = await import(
+    "@api/app/native-provider-proxy"
+  );
+
+  return handleNativeProviderRoutineFindRequest(request);
+}
 
 export const Route = createFileRoute("/api/native/proxy/routines")({
   server: {
     handlers: {
-      GET: ({ request }) => handleNativeProviderRoutineFindRequest(request),
+      GET: ({ request }) =>
+        handleNativeProviderRoutineFindRouteRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Lazy-load desktop, CLI, and native provider proxy API adapters inside TanStack server route handlers.
- Extend app route source ratchets so native RPC/proxy routes cannot reintroduce top-level server-only adapter imports.
- Preserve explicit route-local boundaries without adding a generic adapter layer.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/native-rpc-routes-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- git diff --check
- curl smoke: /api/desktop/rpc returned controlled 401 JSON
- curl smoke: /api/cli/rpc returned controlled 401 JSON
- curl smoke: /api/native/proxy/call returned controlled 400 JSON
- curl smoke: /api/native/proxy/routines returned controlled 401 JSON
- agent-browser smoke: /api/native/proxy/routines rendered controlled unauthorized JSON