### PR TITLE
fix: keep internal mcp proxy routes server-only

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1541,15 +1541,23 @@ describe("app authenticated route migration", () => {
     expect(mcpProxyCallRouteSource).toContain(
       'createFileRoute("/api/internal/mcp/proxy/call")'
     );
+    expect(mcpProxyCallRouteSource).toContain("await import(");
     expect(mcpProxyCallRouteSource).toContain(
-      'from "@api/app/internal-api/mcp-proxy"'
+      '"@api/app/internal-api/mcp-proxy"'
+    );
+    expect(mcpProxyCallRouteSource).not.toContain(
+      'import { handleMcpProxyCallRequest } from "@api/app/internal-api/mcp-proxy"'
     );
     expect(mcpProxyCallRouteSource).not.toContain("~/server/mcp-proxy");
     expect(mcpProxyFindRouteSource).toContain(
       'createFileRoute("/api/internal/mcp/proxy/find")'
     );
+    expect(mcpProxyFindRouteSource).toContain("await import(");
     expect(mcpProxyFindRouteSource).toContain(
-      'from "@api/app/internal-api/mcp-proxy"'
+      '"@api/app/internal-api/mcp-proxy"'
+    );
+    expect(mcpProxyFindRouteSource).not.toContain(
+      'import { handleMcpProxyFindRequest } from "@api/app/internal-api/mcp-proxy"'
     );
     expect(mcpProxyFindRouteSource).not.toContain("~/server/mcp-proxy");
     expect(mcpAuditRouteSource).toContain(

--- a/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
+++ b/apps/app/src/__tests__/internal-mcp-routes-source.test.ts
@@ -44,15 +44,26 @@ describe("internal MCP app routes", () => {
     expect(existsSync(resolve(appRoot, "src/server/mcp-proxy.ts"))).toBe(false);
 
     expect(createRoute).toContain('@api/app/internal-api/mcp-signals"');
+    expect(createRoute).toContain("await import(");
     expect(createRoute).toContain("handleCreateMcpSignalInternalRequest");
     expect(getRoute).toContain('@api/app/internal-api/mcp-signals"');
+    expect(getRoute).toContain("await import(");
     expect(getRoute).toContain("handleGetMcpSignalInternalRequest");
     expect(auditRoute).toContain('@api/app/internal-api/mcp-audit"');
+    expect(auditRoute).toContain("await import(");
     expect(auditRoute).toContain("handleRecordMcpAuditInternalRequest");
     expect(proxyCallRoute).toContain('@api/app/internal-api/mcp-proxy"');
+    expect(proxyCallRoute).toContain("await import(");
     expect(proxyCallRoute).toContain("handleMcpProxyCallRequest");
+    expect(proxyCallRoute).not.toContain(
+      'import { handleMcpProxyCallRequest } from "@api/app/internal-api/mcp-proxy"'
+    );
     expect(proxyFindRoute).toContain('@api/app/internal-api/mcp-proxy"');
+    expect(proxyFindRoute).toContain("await import(");
     expect(proxyFindRoute).toContain("handleMcpProxyFindRequest");
+    expect(proxyFindRoute).not.toContain(
+      'import { handleMcpProxyFindRequest } from "@api/app/internal-api/mcp-proxy"'
+    );
 
     for (const source of [
       createRoute,

--- a/apps/app/src/routes/api/internal/mcp/proxy/call.ts
+++ b/apps/app/src/routes/api/internal/mcp/proxy/call.ts
@@ -1,10 +1,17 @@
-import { handleMcpProxyCallRequest } from "@api/app/internal-api/mcp-proxy";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleMcpProxyCallRouteRequest(request: Request) {
+  const { handleMcpProxyCallRequest } = await import(
+    "@api/app/internal-api/mcp-proxy"
+  );
+
+  return handleMcpProxyCallRequest(request);
+}
 
 export const Route = createFileRoute("/api/internal/mcp/proxy/call")({
   server: {
     handlers: {
-      POST: async ({ request }) => handleMcpProxyCallRequest(request),
+      POST: async ({ request }) => handleMcpProxyCallRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/internal/mcp/proxy/find.ts
+++ b/apps/app/src/routes/api/internal/mcp/proxy/find.ts
@@ -1,10 +1,17 @@
-import { handleMcpProxyFindRequest } from "@api/app/internal-api/mcp-proxy";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleMcpProxyFindRouteRequest(request: Request) {
+  const { handleMcpProxyFindRequest } = await import(
+    "@api/app/internal-api/mcp-proxy"
+  );
+
+  return handleMcpProxyFindRequest(request);
+}
 
 export const Route = createFileRoute("/api/internal/mcp/proxy/find")({
   server: {
     handlers: {
-      POST: async ({ request }) => handleMcpProxyFindRequest(request),
+      POST: async ({ request }) => handleMcpProxyFindRouteRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Lazy-load MCP proxy call/find internal API handlers from the TanStack route server handlers.
- Extend internal MCP and authenticated-route source ratchets to block top-level MCP proxy adapter imports.
- Keep the route mounts explicit while avoiding eager DB/service-JWT/provider-runtime imports in the route module graph.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/internal-mcp-routes-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- git diff --check
- curl smoke: POST /api/internal/mcp/proxy/call returned controlled 401 missing_token JSON
- curl smoke: POST /api/internal/mcp/proxy/find returned controlled 401 missing_token JSON
- agent-browser smoke: same-origin fetch POST /api/internal/mcp/proxy/find returned controlled 401 missing_token JSON