### PR TITLE
fix: keep internal route adapters server-only

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1465,8 +1465,12 @@ describe("app authenticated route migration", () => {
     expect(skillsIndexEventsRouteSource).toContain(
       "handleSkillIndexEventsRequest"
     );
+    expect(skillsIndexEventsRouteSource).toContain("await import(");
     expect(skillsIndexEventsRouteSource).toContain(
-      'from "@api/app/internal-api/skills-events"'
+      '"@api/app/internal-api/skills-events"'
+    );
+    expect(skillsIndexEventsRouteSource).not.toContain(
+      'import { handleSkillIndexEventsRequest } from "@api/app/internal-api/skills-events"'
     );
     expect(skillsIndexEventsRouteSource).not.toContain(
       "@api/app/services/skills/events"

--- a/apps/app/src/__tests__/health.test.ts
+++ b/apps/app/src/__tests__/health.test.ts
@@ -27,8 +27,12 @@ describe("app health route", () => {
     };
 
     expect(routeSource).not.toContain('from "~/env"');
+    expect(routeSource).toContain("await import(");
     expect(routeSource).toContain('@api/app/internal-api/health"');
     expect(routeSource).toContain("handleAppHealthRequest");
+    expect(routeSource).not.toContain(
+      'import { handleAppHealthRequest } from "@api/app/internal-api/health"'
+    );
     expect(routeSource).not.toContain('import("~/server/health")');
     expect(existsSync(serverPath)).toBe(false);
     expect(apiPackageJson.exports["./internal-api/health"]).toEqual({

--- a/apps/app/src/routes/api/health.ts
+++ b/apps/app/src/routes/api/health.ts
@@ -1,10 +1,17 @@
-import { handleAppHealthRequest } from "@api/app/internal-api/health";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleAppHealthRouteRequest(request: Request) {
+  const { handleAppHealthRequest } = await import(
+    "@api/app/internal-api/health"
+  );
+
+  return handleAppHealthRequest(request);
+}
 
 export const Route = createFileRoute("/api/health")({
   server: {
     handlers: {
-      GET: ({ request }) => handleAppHealthRequest(request),
+      GET: ({ request }) => handleAppHealthRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/skills/index/events.ts
+++ b/apps/app/src/routes/api/skills/index/events.ts
@@ -1,10 +1,17 @@
-import { handleSkillIndexEventsRequest } from "@api/app/internal-api/skills-events";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleSkillIndexEventsRouteRequest(request: Request) {
+  const { handleSkillIndexEventsRequest } = await import(
+    "@api/app/internal-api/skills-events"
+  );
+
+  return handleSkillIndexEventsRequest(request);
+}
 
 export const Route = createFileRoute("/api/skills/index/events")({
   server: {
     handlers: {
-      GET: ({ request }) => handleSkillIndexEventsRequest(request),
+      GET: ({ request }) => handleSkillIndexEventsRouteRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Lazy-load the app health and skill index events internal adapters from their TanStack route handlers.
- Extend source ratchets to prevent top-level imports of these server-only adapters from returning.
- Keep both route files as explicit GET mounts while avoiding eager env/DB/Redis imports in the route graph.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/health.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- git diff --check
- curl smoke: GET /api/health returned 200 app health JSON
- curl smoke: GET /api/skills/index/events returned controlled 401 Unauthorized JSON
- agent-browser smoke: /api/health rendered app health JSON