### PR TITLE
fix: keep mcp oauth routes server-only

### DIFF
--- a/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
+++ b/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
@@ -15,6 +15,40 @@ function repoSource(path: string) {
 
 const rootApiAppImportPattern = /from\s+["@']@api\/app["@']/;
 
+const mcpOAuthProtocolRouteExpectations = [
+  {
+    staticImport:
+      'import { handleMcpOAuthAuthorizationServerMetadataRequest } from "@api/app/mcp-oauth/server-routes"',
+    getSource: () =>
+      source("src/routes/[.]well-known/oauth-authorization-server.ts"),
+  },
+  {
+    staticImport:
+      'import { handleMcpOAuthJwksRequest } from "@api/app/mcp-oauth/server-routes"',
+    getSource: () => source("src/routes/oauth/jwks.ts"),
+  },
+  {
+    staticImport:
+      'import { handleRegisterMcpOAuthClientRequest } from "@api/app/mcp-oauth/server-routes"',
+    getSource: () => source("src/routes/oauth/register.ts"),
+  },
+  {
+    staticImport:
+      'import { handleGetRegisteredMcpOAuthClientRequest } from "@api/app/mcp-oauth/server-routes"',
+    getSource: () => source("src/routes/oauth/register/$clientId.ts"),
+  },
+  {
+    staticImport:
+      'import { handleMcpOAuthTokenRequest } from "@api/app/mcp-oauth/server-routes"',
+    getSource: () => source("src/routes/oauth/token.ts"),
+  },
+  {
+    staticImport:
+      'import { handleMcpOAuthRevokeRequest } from "@api/app/mcp-oauth/server-routes"',
+    getSource: () => source("src/routes/oauth/revoke.ts"),
+  },
+] as const;
+
 describe("app OAuth protocol route migration", () => {
   it("ports MCP OAuth protocol endpoints as TanStack server routes", () => {
     const metadataSource = source(
@@ -119,6 +153,14 @@ describe("app OAuth protocol route migration", () => {
     ]) {
       expect(appRouteSource).not.toContain("@db/app");
       expect(appRouteSource).not.toContain("~/server/oauth/mcp-response");
+    }
+
+    for (const expectation of mcpOAuthProtocolRouteExpectations) {
+      const routeSource = expectation.getSource();
+
+      expect(routeSource).toContain("await import(");
+      expect(routeSource).toContain('@api/app/mcp-oauth/server-routes"');
+      expect(routeSource).not.toContain(expectation.staticImport);
     }
   });
 

--- a/apps/app/src/routes/[.]well-known/oauth-authorization-server.ts
+++ b/apps/app/src/routes/[.]well-known/oauth-authorization-server.ts
@@ -1,11 +1,18 @@
-import { handleMcpOAuthAuthorizationServerMetadataRequest } from "@api/app/mcp-oauth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleMcpOAuthAuthorizationServerMetadataRouteRequest() {
+  const { handleMcpOAuthAuthorizationServerMetadataRequest } = await import(
+    "@api/app/mcp-oauth/server-routes"
+  );
+
+  return handleMcpOAuthAuthorizationServerMetadataRequest();
+}
 
 export const Route = createFileRoute("/.well-known/oauth-authorization-server")(
   {
     server: {
       handlers: {
-        GET: () => handleMcpOAuthAuthorizationServerMetadataRequest(),
+        GET: () => handleMcpOAuthAuthorizationServerMetadataRouteRequest(),
       },
     },
   }

--- a/apps/app/src/routes/oauth/jwks.ts
+++ b/apps/app/src/routes/oauth/jwks.ts
@@ -1,10 +1,17 @@
-import { handleMcpOAuthJwksRequest } from "@api/app/mcp-oauth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleMcpOAuthJwksRouteRequest() {
+  const { handleMcpOAuthJwksRequest } = await import(
+    "@api/app/mcp-oauth/server-routes"
+  );
+
+  return handleMcpOAuthJwksRequest();
+}
 
 export const Route = createFileRoute("/oauth/jwks")({
   server: {
     handlers: {
-      GET: () => handleMcpOAuthJwksRequest(),
+      GET: () => handleMcpOAuthJwksRouteRequest(),
     },
   },
 });

--- a/apps/app/src/routes/oauth/register.ts
+++ b/apps/app/src/routes/oauth/register.ts
@@ -1,10 +1,17 @@
-import { handleRegisterMcpOAuthClientRequest } from "@api/app/mcp-oauth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleRegisterMcpOAuthClientRouteRequest(request: Request) {
+  const { handleRegisterMcpOAuthClientRequest } = await import(
+    "@api/app/mcp-oauth/server-routes"
+  );
+
+  return handleRegisterMcpOAuthClientRequest(request);
+}
 
 export const Route = createFileRoute("/oauth/register")({
   server: {
     handlers: {
-      POST: ({ request }) => handleRegisterMcpOAuthClientRequest(request),
+      POST: ({ request }) => handleRegisterMcpOAuthClientRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/oauth/register/$clientId.ts
+++ b/apps/app/src/routes/oauth/register/$clientId.ts
@@ -1,12 +1,22 @@
 // biome-ignore-all lint/style/useFilenamingConvention: TanStack route params must be valid JavaScript identifiers.
-import { handleGetRegisteredMcpOAuthClientRequest } from "@api/app/mcp-oauth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleGetRegisteredMcpOAuthClientRouteRequest(
+  request: Request,
+  input: { clientId: string }
+) {
+  const { handleGetRegisteredMcpOAuthClientRequest } = await import(
+    "@api/app/mcp-oauth/server-routes"
+  );
+
+  return handleGetRegisteredMcpOAuthClientRequest(request, input);
+}
 
 export const Route = createFileRoute("/oauth/register/$clientId")({
   server: {
     handlers: {
       GET: ({ params, request }) =>
-        handleGetRegisteredMcpOAuthClientRequest(request, {
+        handleGetRegisteredMcpOAuthClientRouteRequest(request, {
           clientId: params.clientId,
         }),
     },

--- a/apps/app/src/routes/oauth/revoke.ts
+++ b/apps/app/src/routes/oauth/revoke.ts
@@ -1,10 +1,17 @@
-import { handleMcpOAuthRevokeRequest } from "@api/app/mcp-oauth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleMcpOAuthRevokeRouteRequest(request: Request) {
+  const { handleMcpOAuthRevokeRequest } = await import(
+    "@api/app/mcp-oauth/server-routes"
+  );
+
+  return handleMcpOAuthRevokeRequest(request);
+}
 
 export const Route = createFileRoute("/oauth/revoke")({
   server: {
     handlers: {
-      POST: ({ request }) => handleMcpOAuthRevokeRequest(request),
+      POST: ({ request }) => handleMcpOAuthRevokeRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/oauth/token.ts
+++ b/apps/app/src/routes/oauth/token.ts
@@ -1,10 +1,17 @@
-import { handleMcpOAuthTokenRequest } from "@api/app/mcp-oauth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleMcpOAuthTokenRouteRequest(request: Request) {
+  const { handleMcpOAuthTokenRequest } = await import(
+    "@api/app/mcp-oauth/server-routes"
+  );
+
+  return handleMcpOAuthTokenRequest(request);
+}
 
 export const Route = createFileRoute("/oauth/token")({
   server: {
     handlers: {
-      POST: ({ request }) => handleMcpOAuthTokenRequest(request),
+      POST: ({ request }) => handleMcpOAuthTokenRouteRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Lazy-load MCP OAuth protocol handlers from @api/app inside TanStack server route handlers.
- Add a source ratchet so OAuth protocol route files keep server-only @api/app imports out of module scope.
- Preserve explicit app route mounts for metadata, JWKS, register, registered client lookup, token, and revoke endpoints.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/oauth-protocol-routes-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- rg -n '^import .*@api/app/mcp-oauth/server-routes' apps/app/src/routes
- git diff --check
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- curl metadata/JWKS/token/register against https://mcp-oauth-route-server-only-boundary.app.lightfast.localhost
- agent-browser open/get text for /.well-known/oauth-authorization-server