### PR TITLE
fix: keep native oauth routes server-only

### DIFF
--- a/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
+++ b/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
@@ -49,6 +49,24 @@ const mcpOAuthProtocolRouteExpectations = [
   },
 ] as const;
 
+const nativeOAuthFacadeRouteExpectations = [
+  {
+    staticImport:
+      'import { handleNativeOAuthClientConfigRequest } from "@api/app/native-auth/server-routes"',
+    getSource: () => source("src/routes/api/oauth/$client/config.ts"),
+  },
+  {
+    staticImport:
+      'import { handleNativeOAuthFinalizeRequest } from "@api/app/native-auth/server-routes"',
+    getSource: () => source("src/routes/api/oauth/finalize.ts"),
+  },
+  {
+    staticImport:
+      'import { handleNativeOAuthDesktopSessionRequest } from "@api/app/native-auth/server-routes"',
+    getSource: () => source("src/routes/api/oauth/desktop/session.ts"),
+  },
+] as const;
+
 describe("app OAuth protocol route migration", () => {
   it("ports MCP OAuth protocol endpoints as TanStack server routes", () => {
     const metadataSource = source(
@@ -233,6 +251,14 @@ describe("app OAuth protocol route migration", () => {
       expect(routeSource).not.toContain("next/");
       expect(routeSource).not.toContain("server-only");
       expect(routeSource).not.toContain('"use server"');
+    }
+
+    for (const expectation of nativeOAuthFacadeRouteExpectations) {
+      const routeSource = expectation.getSource();
+
+      expect(routeSource).toContain("await import(");
+      expect(routeSource).toContain('@api/app/native-auth/server-routes"');
+      expect(routeSource).not.toContain(expectation.staticImport);
     }
   });
 });

--- a/apps/app/src/routes/api/oauth/$client/config.ts
+++ b/apps/app/src/routes/api/oauth/$client/config.ts
@@ -1,10 +1,18 @@
-import { handleNativeOAuthClientConfigRequest } from "@api/app/native-auth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleNativeOAuthClientConfigRouteRequest(client: string) {
+  const { handleNativeOAuthClientConfigRequest } = await import(
+    "@api/app/native-auth/server-routes"
+  );
+
+  return handleNativeOAuthClientConfigRequest(client);
+}
 
 export const Route = createFileRoute("/api/oauth/$client/config")({
   server: {
     handlers: {
-      GET: ({ params }) => handleNativeOAuthClientConfigRequest(params.client),
+      GET: ({ params }) =>
+        handleNativeOAuthClientConfigRouteRequest(params.client),
     },
   },
 });

--- a/apps/app/src/routes/api/oauth/desktop/session.ts
+++ b/apps/app/src/routes/api/oauth/desktop/session.ts
@@ -1,10 +1,18 @@
-import { handleNativeOAuthDesktopSessionRequest } from "@api/app/native-auth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleNativeOAuthDesktopSessionRouteRequest(request: Request) {
+  const { handleNativeOAuthDesktopSessionRequest } = await import(
+    "@api/app/native-auth/server-routes"
+  );
+
+  return handleNativeOAuthDesktopSessionRequest(request);
+}
 
 export const Route = createFileRoute("/api/oauth/desktop/session")({
   server: {
     handlers: {
-      GET: ({ request }) => handleNativeOAuthDesktopSessionRequest(request),
+      GET: ({ request }) =>
+        handleNativeOAuthDesktopSessionRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/oauth/finalize.ts
+++ b/apps/app/src/routes/api/oauth/finalize.ts
@@ -1,10 +1,17 @@
-import { handleNativeOAuthFinalizeRequest } from "@api/app/native-auth/server-routes";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleNativeOAuthFinalizeRouteRequest(request: Request) {
+  const { handleNativeOAuthFinalizeRequest } = await import(
+    "@api/app/native-auth/server-routes"
+  );
+
+  return handleNativeOAuthFinalizeRequest(request);
+}
 
 export const Route = createFileRoute("/api/oauth/finalize")({
   server: {
     handlers: {
-      POST: ({ request }) => handleNativeOAuthFinalizeRequest(request),
+      POST: ({ request }) => handleNativeOAuthFinalizeRouteRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Lazy-load native OAuth facade handlers from @api/app inside TanStack server route handlers.
- Add a source ratchet so native OAuth route files keep server-only @api/app imports out of module scope.
- Preserve explicit route mounts for native client config, native finalize, and desktop session endpoints.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/oauth-protocol-routes-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- rg -n '^import .*@api/app/native-auth/server-routes' apps/app/src/routes
- git diff --check
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- curl native config/finalize/session against https://native-oauth-route-server-only-boundary.app.lightfast.localhost
- agent-browser open/get text for /api/oauth/desktop/config