### PR TITLE
fix: keep internal connector routes server-only

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -34,6 +34,65 @@ function appSourceFiles(dir = resolve(appRoot, "src")): string[] {
   });
 }
 
+const internalApiRouteLazyImportExpectations = [
+  {
+    handlerName: "handleGitHubWebhookRequest",
+    moduleSpecifier: "@api/app/internal-api/github-webhook",
+    path: "src/routes/api/github/webhook.ts",
+    staticImport:
+      'import { handleGitHubWebhookRequest } from "@api/app/internal-api/github-webhook"',
+  },
+  {
+    handlerName: "handleGitHubInstallationSetupRequest",
+    moduleSpecifier: "@api/app/internal-api/github-oauth",
+    path: "src/routes/api/github/setup.ts",
+    staticImport:
+      'import { handleGitHubInstallationSetupRequest } from "@api/app/internal-api/github-oauth"',
+  },
+  {
+    handlerName: "handleGitHubOAuthCallbackRequest",
+    moduleSpecifier: "@api/app/internal-api/github-oauth",
+    path: "src/routes/api/github/oauth/callback.ts",
+    staticImport:
+      'import { handleGitHubOAuthCallbackRequest } from "@api/app/internal-api/github-oauth"',
+  },
+  {
+    handlerName: "handleGitHubUserAccountOAuthCallbackRequest",
+    moduleSpecifier: "@api/app/internal-api/github-oauth",
+    path: "src/routes/api/github/user/oauth/callback.ts",
+    staticImport:
+      'import { handleGitHubUserAccountOAuthCallbackRequest } from "@api/app/internal-api/github-oauth"',
+  },
+  {
+    handlerName: "handleXConnectorMcpRequest",
+    moduleSpecifier: "@api/app/internal-api/connector-mcp",
+    path: "src/routes/api/connectors/x/mcp.ts",
+    staticImport:
+      'import { handleXConnectorMcpRequest } from "@api/app/internal-api/connector-mcp"',
+  },
+  {
+    handlerName: "handleXConnectorOAuthCallbackRequest",
+    moduleSpecifier: "@api/app/internal-api/connector-oauth",
+    path: "src/routes/api/connectors/x/oauth/callback.ts",
+    staticImport:
+      'import { handleXConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth"',
+  },
+  {
+    handlerName: "handleLinearConnectorOAuthCallbackRequest",
+    moduleSpecifier: "@api/app/internal-api/connector-oauth",
+    path: "src/routes/api/connectors/linear/oauth/callback.ts",
+    staticImport:
+      'import { handleLinearConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth"',
+  },
+  {
+    handlerName: "handleGranolaUserConnectorOAuthCallbackRequest",
+    moduleSpecifier: "@api/app/internal-api/connector-oauth",
+    path: "src/routes/api/connectors/granola/oauth/callback.ts",
+    staticImport:
+      'import { handleGranolaUserConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth"',
+  },
+] as const;
+
 describe("app authenticated route migration", () => {
   it("mounts a plain TanStack Query provider at the root route", () => {
     const rootSource = source("src/routes/__root.tsx");
@@ -953,6 +1012,20 @@ describe("app authenticated route migration", () => {
       accountGithubIndexRouteSource,
     ]) {
       expect(routeFile).not.toContain("next/");
+    }
+  });
+
+  it("keeps internal GitHub and connector route handlers server-only", () => {
+    for (const expectation of internalApiRouteLazyImportExpectations) {
+      const routeSource = source(expectation.path);
+
+      expect(routeSource).toContain("await import(");
+      expect(routeSource).toContain(`"${expectation.moduleSpecifier}"`);
+      expect(routeSource).toContain(expectation.handlerName);
+      expect(routeSource).not.toContain(expectation.staticImport);
+      expect(routeSource).not.toContain("@db/app");
+      expect(routeSource).not.toContain("next/");
+      expect(routeSource).not.toContain('"use server"');
     }
   });
 

--- a/apps/app/src/routes/api/connectors/granola/oauth/callback.ts
+++ b/apps/app/src/routes/api/connectors/granola/oauth/callback.ts
@@ -1,11 +1,20 @@
-import { handleGranolaUserConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleGranolaUserConnectorOAuthCallbackRouteRequest(
+  request: Request
+) {
+  const { handleGranolaUserConnectorOAuthCallbackRequest } = await import(
+    "@api/app/internal-api/connector-oauth"
+  );
+
+  return handleGranolaUserConnectorOAuthCallbackRequest(request);
+}
 
 export const Route = createFileRoute("/api/connectors/granola/oauth/callback")({
   server: {
     handlers: {
       GET: ({ request }) =>
-        handleGranolaUserConnectorOAuthCallbackRequest(request),
+        handleGranolaUserConnectorOAuthCallbackRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/connectors/linear/oauth/callback.ts
+++ b/apps/app/src/routes/api/connectors/linear/oauth/callback.ts
@@ -1,10 +1,20 @@
-import { handleLinearConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleLinearConnectorOAuthCallbackRouteRequest(
+  request: Request
+) {
+  const { handleLinearConnectorOAuthCallbackRequest } = await import(
+    "@api/app/internal-api/connector-oauth"
+  );
+
+  return handleLinearConnectorOAuthCallbackRequest(request);
+}
 
 export const Route = createFileRoute("/api/connectors/linear/oauth/callback")({
   server: {
     handlers: {
-      GET: ({ request }) => handleLinearConnectorOAuthCallbackRequest(request),
+      GET: ({ request }) =>
+        handleLinearConnectorOAuthCallbackRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/connectors/x/mcp.ts
+++ b/apps/app/src/routes/api/connectors/x/mcp.ts
@@ -1,12 +1,19 @@
-import { handleXConnectorMcpRequest } from "@api/app/internal-api/connector-mcp";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleXConnectorMcpRouteRequest(request: Request) {
+  const { handleXConnectorMcpRequest } = await import(
+    "@api/app/internal-api/connector-mcp"
+  );
+
+  return handleXConnectorMcpRequest(request);
+}
 
 export const Route = createFileRoute("/api/connectors/x/mcp")({
   server: {
     handlers: {
-      GET: ({ request }) => handleXConnectorMcpRequest(request),
-      POST: ({ request }) => handleXConnectorMcpRequest(request),
-      DELETE: ({ request }) => handleXConnectorMcpRequest(request),
+      GET: ({ request }) => handleXConnectorMcpRouteRequest(request),
+      POST: ({ request }) => handleXConnectorMcpRouteRequest(request),
+      DELETE: ({ request }) => handleXConnectorMcpRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/connectors/x/oauth/callback.ts
+++ b/apps/app/src/routes/api/connectors/x/oauth/callback.ts
@@ -1,10 +1,17 @@
-import { handleXConnectorOAuthCallbackRequest } from "@api/app/internal-api/connector-oauth";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleXConnectorOAuthCallbackRouteRequest(request: Request) {
+  const { handleXConnectorOAuthCallbackRequest } = await import(
+    "@api/app/internal-api/connector-oauth"
+  );
+
+  return handleXConnectorOAuthCallbackRequest(request);
+}
 
 export const Route = createFileRoute("/api/connectors/x/oauth/callback")({
   server: {
     handlers: {
-      GET: ({ request }) => handleXConnectorOAuthCallbackRequest(request),
+      GET: ({ request }) => handleXConnectorOAuthCallbackRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/github/oauth/callback.ts
+++ b/apps/app/src/routes/api/github/oauth/callback.ts
@@ -1,10 +1,17 @@
-import { handleGitHubOAuthCallbackRequest } from "@api/app/internal-api/github-oauth";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleGitHubOAuthCallbackRouteRequest(request: Request) {
+  const { handleGitHubOAuthCallbackRequest } = await import(
+    "@api/app/internal-api/github-oauth"
+  );
+
+  return handleGitHubOAuthCallbackRequest(request);
+}
 
 export const Route = createFileRoute("/api/github/oauth/callback")({
   server: {
     handlers: {
-      GET: ({ request }) => handleGitHubOAuthCallbackRequest(request),
+      GET: ({ request }) => handleGitHubOAuthCallbackRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/github/setup.ts
+++ b/apps/app/src/routes/api/github/setup.ts
@@ -1,10 +1,17 @@
-import { handleGitHubInstallationSetupRequest } from "@api/app/internal-api/github-oauth";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleGitHubInstallationSetupRouteRequest(request: Request) {
+  const { handleGitHubInstallationSetupRequest } = await import(
+    "@api/app/internal-api/github-oauth"
+  );
+
+  return handleGitHubInstallationSetupRequest(request);
+}
 
 export const Route = createFileRoute("/api/github/setup")({
   server: {
     handlers: {
-      GET: ({ request }) => handleGitHubInstallationSetupRequest(request),
+      GET: ({ request }) => handleGitHubInstallationSetupRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/github/user/oauth/callback.ts
+++ b/apps/app/src/routes/api/github/user/oauth/callback.ts
@@ -1,11 +1,20 @@
-import { handleGitHubUserAccountOAuthCallbackRequest } from "@api/app/internal-api/github-oauth";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleGitHubUserAccountOAuthCallbackRouteRequest(
+  request: Request
+) {
+  const { handleGitHubUserAccountOAuthCallbackRequest } = await import(
+    "@api/app/internal-api/github-oauth"
+  );
+
+  return handleGitHubUserAccountOAuthCallbackRequest(request);
+}
 
 export const Route = createFileRoute("/api/github/user/oauth/callback")({
   server: {
     handlers: {
       GET: ({ request }) =>
-        handleGitHubUserAccountOAuthCallbackRequest(request),
+        handleGitHubUserAccountOAuthCallbackRouteRequest(request),
     },
   },
 });

--- a/apps/app/src/routes/api/github/webhook.ts
+++ b/apps/app/src/routes/api/github/webhook.ts
@@ -1,10 +1,17 @@
-import { handleGitHubWebhookRequest } from "@api/app/internal-api/github-webhook";
 import { createFileRoute } from "@tanstack/react-router";
+
+async function handleGitHubWebhookRouteRequest(request: Request) {
+  const { handleGitHubWebhookRequest } = await import(
+    "@api/app/internal-api/github-webhook"
+  );
+
+  return handleGitHubWebhookRequest(request);
+}
 
 export const Route = createFileRoute("/api/github/webhook")({
   server: {
     handlers: {
-      POST: ({ request }) => handleGitHubWebhookRequest(request),
+      POST: ({ request }) => handleGitHubWebhookRouteRequest(request),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Lazy-load internal GitHub and connector route handlers from @api/app inside TanStack server route handlers.
- Add a source ratchet for GitHub webhook/setup/callbacks, X MCP, and connector OAuth callbacks so internal-api imports stay out of route module scope.
- Preserve explicit app route mounts for each internal HTTP endpoint.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/oauth-protocol-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- rg -n '^import .*@api/app/internal-api' apps/app/src/routes
- git diff --check
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- curl GitHub webhook, GitHub OAuth callback, X MCP, and X connector OAuth callback against https://internal-connector-routes-server-only-boundary.app.lightfast.localhost
- agent-browser open/get text for /api/connectors/x/mcp