### PR TITLE
refactor: inline workspace assistant id boundary

### DIFF
--- a/api/app/src/__tests__/workspace-assistant-source.test.ts
+++ b/api/app/src/__tests__/workspace-assistant-source.test.ts
@@ -39,8 +39,8 @@ describe("workspace assistant TanStack migration", () => {
     expect(adapterSource).toMatch(
       /export\s+const\s+createConversation\s*=\s*createServerFn/
     );
-    expect(adapterSource).toMatch(
-      /export\s+const\s+createNewWorkspaceAssistantConversationId\s*=\s*createServerFn/
+    expect(adapterSource).not.toContain(
+      "createNewWorkspaceAssistantConversationId"
     );
     expect(adapterSource).not.toContain("TRPCError");
   });

--- a/api/app/src/adapters/tanstack/assistant.ts
+++ b/api/app/src/adapters/tanstack/assistant.ts
@@ -1,5 +1,4 @@
 import {
-  createWorkspaceAssistantConversationId,
   createWorkspaceAssistantConversation as createWorkspaceAssistantConversationInDb,
   getWorkspaceAssistantConversationByPublicId,
   listWorkspaceAssistantConversations,
@@ -222,13 +221,6 @@ function serializeConversationList(
     items: conversations.items.map(serializeConversation),
   };
 }
-
-export const createNewWorkspaceAssistantConversationId = createServerFn({
-  method: "GET",
-}).handler(async () => {
-  noStore();
-  return createWorkspaceAssistantConversationId();
-});
 
 export const createConversation = createServerFn({ method: "POST" })
   .inputValidator(createConversationInput)

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -807,7 +807,7 @@ describe("app authenticated route migration", () => {
     const chatStreamRouteSource = repoSource(
       "api/app/src/adapters/internal/workspace-assistant/stream-route.ts"
     );
-    const conversationIdPath = resolve(appRoot, "src/chat/conversation-id.ts");
+    const conversationIdSource = source("src/chat/conversation-id.ts");
     const resumableConfigPath = resolve(
       appRoot,
       "src/chat/resumable-stream-config.ts"
@@ -820,10 +820,15 @@ describe("app authenticated route migration", () => {
       'createFileRoute("/_authenticated/$slug/chat/")'
     );
     expect(chatIndexRouteSource).toContain(
-      "createNewWorkspaceAssistantConversationId"
+      "createWorkspaceAssistantConversationId"
     );
-    expect(chatIndexRouteSource).toContain('@api/app/tanstack/assistant"');
+    expect(chatIndexRouteSource).toContain('from "~/chat/conversation-id"');
+    expect(chatIndexRouteSource).not.toContain('@api/app/tanstack/assistant"');
     expect(chatIndexRouteSource).not.toContain("@db/app");
+    expect(conversationIdSource).toContain(
+      'WORKSPACE_ASSISTANT_CONVERSATION_ID_PREFIX = "conv_"'
+    );
+    expect(conversationIdSource).toContain("crypto.randomUUID()");
     expect(chatIndexRouteSource).toContain("WorkspaceAssistantClient");
     expect(chatIndexRouteSource).toContain("key={conversationId}");
     expect(chatRouteSource).not.toContain("WorkspacePage");
@@ -850,7 +855,9 @@ describe("app authenticated route migration", () => {
     expect(messageSource).toContain("ChatMessage");
     expect(messagePartSource).toContain("WorkspaceAssistantMessagePart");
     expect(copyButtonSource).toContain("extractMessageText");
-    expect(existsSync(conversationIdPath)).toBe(false);
+    expect(conversationIdSource).toContain(
+      "createWorkspaceAssistantConversationId"
+    );
     expect(existsSync(resumableConfigPath)).toBe(false);
     expect(assistantClientSource).toContain("isResumableStreamEnabled");
     expect(assistantClientSource).toContain("VITE_VERCEL_ENV");

--- a/apps/app/src/__tests__/workspace-assistant-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/workspace-assistant-no-trpc-source.test.ts
@@ -45,9 +45,12 @@ describe("migrated workspace assistant data access", () => {
     );
     expect(clientSource).toContain("createConversation");
     expect(clientSource).toContain("assistantConversationsQueryKey");
-    expect(newConversationRouteSource).toMatch(assistantAdapterImport);
     expect(newConversationRouteSource).toContain(
-      "createNewWorkspaceAssistantConversationId"
+      'from "~/chat/conversation-id"'
+    );
+    expect(newConversationRouteSource).not.toMatch(assistantAdapterImport);
+    expect(newConversationRouteSource).toContain(
+      "createWorkspaceAssistantConversationId"
     );
     expect(newConversationRouteSource).not.toContain("createServerFn");
     expect(newConversationRouteSource).not.toContain("@db/app");

--- a/apps/app/src/chat/conversation-id.ts
+++ b/apps/app/src/chat/conversation-id.ts
@@ -1,0 +1,5 @@
+export const WORKSPACE_ASSISTANT_CONVERSATION_ID_PREFIX = "conv_";
+
+export function createWorkspaceAssistantConversationId() {
+  return `${WORKSPACE_ASSISTANT_CONVERSATION_ID_PREFIX}${crypto.randomUUID()}`;
+}

--- a/apps/app/src/routes/_authenticated/$slug/chat/index.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/chat/index.tsx
@@ -1,5 +1,5 @@
-import { createNewWorkspaceAssistantConversationId } from "@api/app/tanstack/assistant";
 import { createFileRoute } from "@tanstack/react-router";
+import { createWorkspaceAssistantConversationId } from "~/chat/conversation-id";
 import { WorkspaceAssistantClient } from "~/chat/workspace-assistant-client";
 import {
   WorkspaceRouteErrorPanel,
@@ -7,7 +7,7 @@ import {
 } from "~/components/route-boundaries";
 
 export const Route = createFileRoute("/_authenticated/$slug/chat/")({
-  loader: () => createNewWorkspaceAssistantConversationId(),
+  loader: () => createWorkspaceAssistantConversationId(),
   pendingMs: 0,
   pendingMinMs: 0,
   pendingComponent: ChatRoutePending,


### PR DESCRIPTION
## Summary
- move new workspace chat conversation ID generation into a tiny app-local helper
- stop the new-chat route from importing the full assistant TanStack adapter just to mint an ID
- remove the now-unused unauthenticated ID server function from the assistant adapter and update source ratchets

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts src/__tests__/workspace-assistant-no-trpc-source.test.ts
- pnpm --filter @api/app test -- src/__tests__/workspace-assistant-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @api/app typecheck
- git diff --check
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- curl -k -I https://tanstack-route-boundary-ratchets.app.lightfast.localhost/lightfast/chat
- agent-browser open https://tanstack-route-boundary-ratchets.app.lightfast.localhost/lightfast/chat && agent-browser wait --load networkidle && agent-browser get url && agent-browser get title && agent-browser get text body
