### PR TITLE
refactor: inline skills query options

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -711,10 +711,15 @@ describe("app authenticated route migration", () => {
     expect(skillsClientSource).toContain("SkillGrid");
     expect(skillsClientSource).toContain("SkillDialog");
     expect(skillsSearchSource).toContain("validateSkillsSearch");
-    expect(skillsQuerySource).toContain('@api/app/tanstack/skills"');
-    expect(skillsQuerySource).toContain(
+    expect(skillsClientSource).toContain('@api/app/tanstack/skills"');
+    expect(skillsClientSource).toContain("listSkills");
+    expect(skillsClientSource).toContain("skillsListQueryKey");
+    expect(skillsClientSource).toContain(
       'enabled: typeof window !== "undefined"'
     );
+    expect(skillsQuerySource).toContain("skillsListQueryKey");
+    expect(skillsQuerySource).not.toContain("skillsListQueryOptions");
+    expect(skillsQuerySource).not.toContain("@api/app/tanstack/skills");
     expect(skillsClientSource).not.toContain("useSkillsListQuery");
 
     expect(connectorsRouteSource).toContain("validateConnectorsSearch");

--- a/apps/app/src/__tests__/skills-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/skills-no-trpc-source.test.ts
@@ -11,13 +11,21 @@ function source(path: string) {
 describe("migrated skills data access", () => {
   it("uses TanStack server functions instead of tRPC", () => {
     const skillsAdapterImport = /from\s+["']@api\/app\/tanstack\/skills["']/;
+    const clientSource = source("src/skills/skills-client.tsx");
     const querySource = source("src/skills/skills-queries.ts");
     const controllerSource = source(
       "src/skills/use-skill-index-refresh-controller.ts"
     );
     const typesSource = source("src/skills/skills-types.ts");
 
-    expect(querySource).toMatch(skillsAdapterImport);
+    expect(clientSource).toMatch(skillsAdapterImport);
+    expect(clientSource).toContain("listSkills");
+    expect(clientSource).toContain("skillsListQueryKey");
+    expect(clientSource).not.toContain("skillsListQueryOptions");
+    expect(clientSource).not.toContain("useTRPC");
+    expect(clientSource).not.toContain("trpc.org.workspace.skills");
+    expect(querySource).toContain("skillsListQueryKey");
+    expect(querySource).not.toMatch(skillsAdapterImport);
     expect(querySource).not.toContain("useTRPC");
     expect(querySource).not.toContain("trpc.org.workspace.skills");
     expect(controllerSource).toMatch(skillsAdapterImport);

--- a/apps/app/src/__tests__/skills-queries-source.test.ts
+++ b/apps/app/src/__tests__/skills-queries-source.test.ts
@@ -9,12 +9,13 @@ function source(path: string) {
 }
 
 describe("skills app data access", () => {
-  it("uses local TanStack query helpers backed by api/app server functions", () => {
+  it("keeps only the shared skills list query key in the query module", () => {
     const querySource = source("src/skills/skills-queries.ts");
 
-    expect(querySource).toContain('@api/app/tanstack/skills"');
     expect(querySource).toContain("skillsListQueryKey");
-    expect(querySource).toContain("skillsListQueryOptions");
+    expect(querySource).not.toContain("skillsListQueryOptions");
+    expect(querySource).not.toContain("@api/app/tanstack/skills");
+    expect(querySource).not.toContain("queryOptions");
     expect(querySource).not.toContain("useTRPC");
   });
 
@@ -35,7 +36,10 @@ describe("skills app data access", () => {
     expect(existsSync(listHookPath)).toBe(false);
     expect(existsSync(topbarActionsPath)).toBe(false);
     expect(clientSource).toContain("useQuery");
-    expect(clientSource).toContain("skillsListQueryOptions");
+    expect(clientSource).toContain('@api/app/tanstack/skills"');
+    expect(clientSource).toContain("listSkills");
+    expect(clientSource).toContain("skillsListQueryKey");
+    expect(clientSource).not.toContain("skillsListQueryOptions");
     expect(clientSource).toContain("<SkillsActions");
     expect(clientSource).not.toContain("useSkillsListQuery");
     expect(clientSource).not.toContain("./use-skills-list-query");

--- a/apps/app/src/skills/skills-client.tsx
+++ b/apps/app/src/skills/skills-client.tsx
@@ -1,3 +1,4 @@
+import { listSkills } from "@api/app/tanstack/skills";
 import { Search01Icon as Search } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@repo/ui/components/ui/button";
@@ -18,7 +19,7 @@ import { SkillGrid } from "./skill-grid";
 import { SkillsActions } from "./skills-actions";
 import { SkillsLoading } from "./skills-loading";
 import { getVisibleSkills, type SkillFilter } from "./skills-model";
-import { skillsListQueryOptions } from "./skills-queries";
+import { skillsListQueryKey } from "./skills-queries";
 import type { NormalizedSkillsSearch } from "./skills-search-params";
 import type { SkillsListResult } from "./skills-types";
 import { useSkillIndexRefreshController } from "./use-skill-index-refresh-controller";
@@ -30,7 +31,13 @@ export function SkillsClient({
   search: NormalizedSkillsSearch;
   setSearchParams: (updates: Partial<NormalizedSkillsSearch>) => void;
 }) {
-  const skillsQuery = useQuery(skillsListQueryOptions());
+  const skillsQuery = useQuery({
+    enabled: typeof window !== "undefined",
+    queryFn: async (): Promise<SkillsListResult> =>
+      (await listSkills()) as SkillsListResult,
+    queryKey: skillsListQueryKey,
+    staleTime: 0,
+  });
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<SkillFilter>("all");
   const data = skillsQuery.data;

--- a/apps/app/src/skills/skills-queries.ts
+++ b/apps/app/src/skills/skills-queries.ts
@@ -1,14 +1,1 @@
-import { type ListSkillsResult, listSkills } from "@api/app/tanstack/skills";
-import { queryOptions } from "@tanstack/react-query";
-
 export const skillsListQueryKey = ["skills", "list"] as const;
-
-export function skillsListQueryOptions() {
-  return queryOptions({
-    enabled: typeof window !== "undefined",
-    queryFn: async (): Promise<ListSkillsResult> =>
-      (await listSkills()) as ListSkillsResult,
-    queryKey: skillsListQueryKey,
-    staleTime: 0,
-  });
-}


### PR DESCRIPTION
## Summary
- Inline the shallow skills list query options wrapper into SkillsClient.
- Keep skillsListQueryKey as the shared cache/invalidation boundary.
- Update source ratchets so the query module stays key-only while SkillsClient owns the server function call.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/skills-queries-source.test.ts src/__tests__/skills-refresh-controller-source.test.ts src/__tests__/skills-no-trpc-source.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm check
- git diff --check
- pnpm --filter @lightfast/app typecheck
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- Runtime smoke: pnpm dev, curl skills route, agent-browser opened https://inline-skills-query-options.lightfast.localhost/lightfast/skills and verified redirect to /sign-in?redirect_url=%2Flightfast%2Fskills