### PR TITLE
refactor: inline account organization mutation options

### DIFF
--- a/api/app/src/__tests__/account-tanstack-adapter-source.test.ts
+++ b/api/app/src/__tests__/account-tanstack-adapter-source.test.ts
@@ -28,7 +28,8 @@ describe("account TanStack adapter boundary", () => {
     expect(source).toContain("getGitHubAccountStatusCommand");
     expect(source).toContain("startGitHubAccountBindingCommand");
     expect(source).toContain("syncGitHubAccountCommand");
-    expect(source).toContain("disconnectGitHubAccountCommand");
+    expect(source).not.toContain("disconnectGitHubAccountCommand");
+    expect(source).not.toContain("disconnectGitHubAccount = createServerFn");
     expect(source).not.toContain("TRPCError");
     expect(source).not.toContain("ORPCError");
     expect(source).not.toContain("defineCommandSurface");

--- a/api/app/src/adapters/tanstack/account.ts
+++ b/api/app/src/adapters/tanstack/account.ts
@@ -7,7 +7,6 @@ import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
   createAccountUsernameCommand,
   createDefaultAccountCommandDeps,
-  disconnectGitHubAccountCommand,
   getAccountProfileCommand,
   getGitHubAccountStatusCommand,
   startGitHubAccountBindingCommand,
@@ -133,21 +132,6 @@ export const syncGitHubAccount = createServerFn({ method: "POST" }).handler(
     }
   }
 );
-
-export const disconnectGitHubAccount = createServerFn({
-  method: "POST",
-}).handler(async () => {
-  noStore();
-  try {
-    return await disconnectGitHubAccountCommand.run({
-      ctx: await createTanStackAccountContext(),
-      deps: await createDefaultAccountCommandDeps({ db }),
-      input: {},
-    });
-  } catch (error) {
-    mapTanStackError(error);
-  }
-});
 
 export type GitHubAccountStatusResult = Awaited<
   ReturnType<typeof getGitHubAccountStatus>

--- a/apps/app/src/__tests__/account-queries-source.test.ts
+++ b/apps/app/src/__tests__/account-queries-source.test.ts
@@ -15,22 +15,41 @@ const migratedFiles = [
 ] as const;
 
 describe("account query helpers", () => {
-  it("centralizes account query keys and server function calls", () => {
+  it("centralizes account query keys and read server function calls", () => {
     const querySource = source("src/account/account-queries.ts");
 
     expect(querySource).toContain('@api/app/tanstack/account"');
     expect(querySource).toContain("accountQueryKeys");
     expect(querySource).toContain("accountProfileQueryOptions");
-    expect(querySource).toContain("updateAccountNameMutationOptions");
-    expect(querySource).toContain("createAccountUsernameMutationOptions");
     expect(querySource).toContain("githubAccountStatusQueryOptions");
-    expect(querySource).toContain("startGitHubAccountBindingMutationOptions");
-    expect(querySource).toContain("syncGitHubAccountMutationOptions");
-    expect(querySource).toContain("disconnectGitHubAccountMutationOptions");
+    expect(querySource).not.toContain("mutationOptions");
+    expect(querySource).not.toContain("updateAccountNameMutationOptions");
+    expect(querySource).not.toContain("createAccountUsernameMutationOptions");
+    expect(querySource).not.toContain(
+      "startGitHubAccountBindingMutationOptions"
+    );
+    expect(querySource).not.toContain("syncGitHubAccountMutationOptions");
+    expect(querySource).not.toContain("disconnectGitHubAccountMutationOptions");
     expect(querySource).not.toContain("useTRPC");
   });
 
-  it("moves migrated account UI calls off tRPC", () => {
+  it("moves migrated account UI calls off tRPC and keeps shallow mutations local", () => {
+    const profileSource = source(
+      "src/account/settings/profile-data-display.tsx"
+    );
+    const usernameSource = source(
+      "src/account/tasks/username-account-task-client.tsx"
+    );
+
+    expect(profileSource).toContain('@api/app/tanstack/account"');
+    expect(profileSource).toContain("updateAccountName");
+    expect(profileSource).not.toContain("updateAccountNameMutationOptions");
+    expect(usernameSource).toContain('@api/app/tanstack/account"');
+    expect(usernameSource).toContain("createAccountUsername");
+    expect(usernameSource).not.toContain(
+      "createAccountUsernameMutationOptions"
+    );
+
     for (const file of migratedFiles) {
       const fileSource = source(file);
       expect(fileSource, file).not.toContain("viewer.account.get");
@@ -51,7 +70,16 @@ describe("account query helpers", () => {
 
     expect(querySource).toContain("@api/app/tanstack/mcp-connections");
     expect(querySource).toContain("accountMcpConnectionsQueryOptions");
-    expect(querySource).toContain("revokeAccountMcpConnectionMutationOptions");
+    expect(querySource).not.toContain(
+      "revokeAccountMcpConnectionMutationOptions"
+    );
+    expect(mcpConnectionsSource).toContain(
+      '@api/app/tanstack/mcp-connections"'
+    );
+    expect(mcpConnectionsSource).toContain("revokeAccountMcpConnection");
+    expect(mcpConnectionsSource).not.toContain(
+      "revokeAccountMcpConnectionMutationOptions"
+    );
     expect(userConnectorQuerySource).toContain(
       "@api/app/tanstack/user-connectors"
     );
@@ -82,9 +110,22 @@ describe("account query helpers", () => {
 
     for (const file of migratedGitHubAccountFiles) {
       const fileSource = source(file);
+      expect(fileSource, file).not.toContain(
+        "startGitHubAccountBindingMutationOptions"
+      );
+      expect(fileSource, file).not.toContain(
+        "syncGitHubAccountMutationOptions"
+      );
       expect(fileSource, file).not.toContain("useTRPC");
       expect(fileSource, file).not.toContain("viewer.githubAccount");
       expect(fileSource, file).not.toContain("AppRouterOutputs");
     }
+
+    expect(
+      source("src/account/tasks/github-account-task-client.tsx")
+    ).toContain("startGitHubAccountBinding");
+    expect(
+      source("src/account/tasks/github-account-complete-client.tsx")
+    ).toContain("syncGitHubAccount");
   });
 });

--- a/apps/app/src/__tests__/account-settings-routes-source.test.ts
+++ b/apps/app/src/__tests__/account-settings-routes-source.test.ts
@@ -49,7 +49,9 @@ describe("app account settings routes", () => {
 
     expect(clientSource).toContain("normalizeTeamSlug");
     expect(clientSource).toContain("createTeamIdempotencyKey");
-    expect(clientSource).toContain("createOrganizationMutationOptions");
+    expect(clientSource).toContain('@api/app/tanstack/organizations"');
+    expect(clientSource).toContain("createOrganization");
+    expect(clientSource).not.toContain("createOrganizationMutationOptions");
     expect(clientSource).toContain("organizationQueryKeys");
     expect(clientSource).not.toContain("viewer.organization.create");
     expect(clientSource).toContain('await navigate({ to: "/$slug"');
@@ -89,7 +91,9 @@ describe("app account settings routes", () => {
     const actionsPath = "src/account/settings/account-settings-actions.ts";
 
     expect(existsSync(resolve(appRoot, actionsPath))).toBe(false);
-    expect(profileSource).toContain("updateAccountNameMutationOptions");
+    expect(profileSource).toContain('@api/app/tanstack/account"');
+    expect(profileSource).toContain("updateAccountName");
+    expect(profileSource).not.toContain("updateAccountNameMutationOptions");
     expect(profileSource).toContain("accountQueryKeys.profile()");
     expect(profileSource).not.toContain("useAccountNameUpdate");
     expect(profileSource).not.toContain("account-settings-actions");

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -122,7 +122,9 @@ describe("app authenticated route migration", () => {
       'createFileRoute("/_authenticated/account/teams/new")'
     );
     expect(routeSource).toContain("CreateTeamClient");
-    expect(clientSource).toContain("createOrganizationMutationOptions");
+    expect(clientSource).toContain('@api/app/tanstack/organizations"');
+    expect(clientSource).toContain("createOrganization");
+    expect(clientSource).not.toContain("createOrganizationMutationOptions");
     expect(clientSource).toContain("organizationQueryKeys");
     expect(clientSource).toContain("normalizeTeamSlug");
     expect(clientSource).toContain("createTeamIdempotencyKey");
@@ -1375,9 +1377,14 @@ describe("app authenticated route migration", () => {
     expect(teamGeneralClientSource).toContain("useNavigate");
     expect(existsSync(resolve(appRoot, teamGeneralActionsPath))).toBe(false);
     expect(teamGeneralClientSource).toContain(
+      '@api/app/tanstack/organizations"'
+    );
+    expect(teamGeneralClientSource).toContain("updateOrganizationName");
+    expect(teamGeneralClientSource).toContain("updateOrganizationDomains");
+    expect(teamGeneralClientSource).not.toContain(
       "updateOrganizationNameMutationOptions"
     );
-    expect(teamGeneralClientSource).toContain(
+    expect(teamGeneralClientSource).not.toContain(
       "updateOrganizationDomainsMutationOptions"
     );
     expect(teamGeneralClientSource).toContain(

--- a/apps/app/src/__tests__/organization-queries-source.test.ts
+++ b/apps/app/src/__tests__/organization-queries-source.test.ts
@@ -22,7 +22,7 @@ const migratedFiles = [
 ] as const;
 
 describe("organization query helpers", () => {
-  it("centralizes organization query keys and server function calls", () => {
+  it("centralizes organization query keys and read server function calls", () => {
     const querySource = source("src/organization/organization-queries.ts");
 
     expect(querySource).toContain('@api/app/tanstack/organizations"');
@@ -30,9 +30,12 @@ describe("organization query helpers", () => {
     expect(querySource).toContain("listUserOrganizationsQueryOptions");
     expect(querySource).toContain("organizationBySlugQueryOptions");
     expect(querySource).toContain("organizationDomainsQueryOptions");
-    expect(querySource).toContain("createOrganizationMutationOptions");
-    expect(querySource).toContain("updateOrganizationDomainsMutationOptions");
-    expect(querySource).toContain("updateOrganizationNameMutationOptions");
+    expect(querySource).not.toContain("mutationOptions");
+    expect(querySource).not.toContain("createOrganizationMutationOptions");
+    expect(querySource).not.toContain(
+      "updateOrganizationDomainsMutationOptions"
+    );
+    expect(querySource).not.toContain("updateOrganizationNameMutationOptions");
     expect(querySource).not.toContain("useTRPC");
   });
 
@@ -78,8 +81,13 @@ describe("organization query helpers", () => {
     expect(existsSync(resolve(appRoot, actionsPath))).toBe(false);
     expect(clientSource).toContain("useMutation");
     expect(clientSource).toContain("useQueryClient");
-    expect(clientSource).toContain("updateOrganizationNameMutationOptions");
-    expect(clientSource).toContain("updateOrganizationDomainsMutationOptions");
+    expect(clientSource).toContain('@api/app/tanstack/organizations"');
+    expect(clientSource).toContain("updateOrganizationName");
+    expect(clientSource).toContain("updateOrganizationDomains");
+    expect(clientSource).not.toContain("updateOrganizationNameMutationOptions");
+    expect(clientSource).not.toContain(
+      "updateOrganizationDomainsMutationOptions"
+    );
     expect(clientSource).toContain("organizationQueryKeys.domains(slug)");
     expect(clientSource).toContain("renameOrganizationSlug");
     expect(clientSource).not.toContain("useTeamNameUpdate");

--- a/apps/app/src/account/account-queries.ts
+++ b/apps/app/src/account/account-queries.ts
@@ -1,19 +1,11 @@
 import {
-  createAccountUsername,
-  disconnectGitHubAccount,
   type GitHubAccountStatusResult,
   type GitHubUserAccount,
   getAccountProfile,
   getGitHubAccountStatus,
-  startGitHubAccountBinding,
-  syncGitHubAccount,
-  updateAccountName,
 } from "@api/app/tanstack/account";
-import {
-  listAccountMcpConnections,
-  revokeAccountMcpConnection,
-} from "@api/app/tanstack/mcp-connections";
-import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import { listAccountMcpConnections } from "@api/app/tanstack/mcp-connections";
+import { queryOptions } from "@tanstack/react-query";
 
 export const accountQueryKeys = {
   all: ["account"] as const,
@@ -36,21 +28,6 @@ export function accountProfileQueryOptions(input?: {
   });
 }
 
-export function updateAccountNameMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to update display name" },
-    mutationFn: (data: { displayName: string }) => updateAccountName({ data }),
-  });
-}
-
-export function createAccountUsernameMutationOptions() {
-  return mutationOptions({
-    meta: { suppressErrorToast: true },
-    mutationFn: (data: { idempotencyKey: string; username: string }) =>
-      createAccountUsername({ data }),
-  });
-}
-
 export function githubAccountStatusQueryOptions(input?: {
   enabled?: boolean;
   staleTime?: number;
@@ -63,28 +40,6 @@ export function githubAccountStatusQueryOptions(input?: {
   });
 }
 
-export function startGitHubAccountBindingMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to connect GitHub" },
-    mutationFn: (data: { returnTo?: string }) =>
-      startGitHubAccountBinding({ data }),
-  });
-}
-
-export function syncGitHubAccountMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to finish GitHub connection" },
-    mutationFn: () => syncGitHubAccount(),
-  });
-}
-
-export function disconnectGitHubAccountMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to disconnect GitHub" },
-    mutationFn: () => disconnectGitHubAccount(),
-  });
-}
-
 export function accountMcpConnectionsQueryOptions(input?: {
   enabled?: boolean;
   staleTime?: number;
@@ -94,13 +49,5 @@ export function accountMcpConnectionsQueryOptions(input?: {
     queryFn: () => listAccountMcpConnections(),
     queryKey: accountQueryKeys.mcpConnections(),
     staleTime: input?.staleTime,
-  });
-}
-
-export function revokeAccountMcpConnectionMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to revoke MCP connection" },
-    mutationFn: (data: { grantId: string }) =>
-      revokeAccountMcpConnection({ data }),
   });
 }

--- a/apps/app/src/account/mcp-connections-client.tsx
+++ b/apps/app/src/account/mcp-connections-client.tsx
@@ -1,3 +1,4 @@
+import { revokeAccountMcpConnection } from "@api/app/tanstack/mcp-connections";
 import {
   InformationCircleIcon as Info,
   SecurityCheckIcon as ShieldCheck,
@@ -31,7 +32,6 @@ import { useCallback, useState } from "react";
 import {
   accountMcpConnectionsQueryOptions,
   accountQueryKeys,
-  revokeAccountMcpConnectionMutationOptions,
 } from "./account-queries";
 
 interface McpConnection {
@@ -69,7 +69,9 @@ export function UserMcpConnectionsClient() {
     useState<McpConnection | null>(null);
 
   const revokeMutation = useMutation({
-    ...revokeAccountMcpConnectionMutationOptions(),
+    meta: { errorTitle: "Failed to revoke MCP connection" },
+    mutationFn: (data: { grantId: string }) =>
+      revokeAccountMcpConnection({ data }),
     onSuccess: () => toast.success("MCP connection revoked"),
     onSettled: () =>
       void queryClient.invalidateQueries({

--- a/apps/app/src/account/settings/profile-data-display.tsx
+++ b/apps/app/src/account/settings/profile-data-display.tsx
@@ -1,3 +1,4 @@
+import { updateAccountName as updateAccountNameServerFn } from "@api/app/tanstack/account";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loading03Icon as Loader2 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -27,7 +28,6 @@ import { SettingRow, SettingsGroup } from "~/components/settings-section";
 import {
   accountProfileQueryOptions,
   accountQueryKeys,
-  updateAccountNameMutationOptions,
 } from "../account-queries";
 import { ProfileDataLoading } from "./profile-data-loading";
 
@@ -51,7 +51,9 @@ export function ProfileDataDisplay() {
   });
 
   const { isPending: isUpdating, mutate: updateAccountName } = useMutation({
-    ...updateAccountNameMutationOptions(),
+    meta: { errorTitle: "Failed to update display name" },
+    mutationFn: (data: { displayName: string }) =>
+      updateAccountNameServerFn({ data }),
     onSuccess: (data) => {
       queryClient.setQueryData(accountQueryKeys.profile(), data);
       toast.success("Profile updated", {

--- a/apps/app/src/account/tasks/github-account-complete-client.tsx
+++ b/apps/app/src/account/tasks/github-account-complete-client.tsx
@@ -1,3 +1,4 @@
+import { syncGitHubAccount } from "@api/app/tanstack/account";
 import { Loading03Icon as Loader2 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { normalizeGitHubUserAccountReturnTo } from "@lightfast/connector-github/contract";
@@ -5,7 +6,6 @@ import { Button } from "@repo/ui/components/ui/button";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { TeamSwitcherSlot } from "~/components/team-switcher";
-import { syncGitHubAccountMutationOptions } from "../account-queries";
 
 interface GithubAccountCompleteClientProps {
   returnTo?: string;
@@ -23,7 +23,10 @@ export function GithubAccountCompleteClient({
   const [failed, setFailed] = useState(false);
   const hasStartedRef = useRef(false);
 
-  const syncMutation = useMutation(syncGitHubAccountMutationOptions());
+  const syncMutation = useMutation({
+    meta: { errorTitle: "Failed to finish GitHub connection" },
+    mutationFn: () => syncGitHubAccount(),
+  });
   const { mutateAsync } = syncMutation;
 
   const finish = useCallback(async () => {

--- a/apps/app/src/account/tasks/github-account-task-client.tsx
+++ b/apps/app/src/account/tasks/github-account-task-client.tsx
@@ -1,3 +1,4 @@
+import { startGitHubAccountBinding } from "@api/app/tanstack/account";
 import {
   CheckmarkCircle02Icon as CheckCircle2,
   Loading03Icon as Loader2,
@@ -9,10 +10,7 @@ import { Button } from "@repo/ui/components/ui/button";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { TeamSwitcherSlot } from "~/components/team-switcher";
-import {
-  githubAccountStatusQueryOptions,
-  startGitHubAccountBindingMutationOptions,
-} from "../account-queries";
+import { githubAccountStatusQueryOptions } from "../account-queries";
 
 interface GithubAccountTaskClientProps {
   githubError?: GitHubUserAccountBindErrorCode;
@@ -44,7 +42,11 @@ export function GithubAccountTaskClient({
 }: GithubAccountTaskClientProps) {
   const { data } = useQuery(githubAccountStatusQueryOptions());
 
-  const startMutation = useMutation(startGitHubAccountBindingMutationOptions());
+  const startMutation = useMutation({
+    meta: { errorTitle: "Failed to connect GitHub" },
+    mutationFn: (data: { returnTo?: string }) =>
+      startGitHubAccountBinding({ data }),
+  });
   const [isStarting, setIsStarting] = useState(false);
   const isStartingRef = useRef(false);
   const isConnecting = startMutation.isPending || isStarting;

--- a/apps/app/src/account/tasks/username-account-task-client.tsx
+++ b/apps/app/src/account/tasks/username-account-task-client.tsx
@@ -1,3 +1,4 @@
+import { createAccountUsername } from "@api/app/tanstack/account";
 import { Loading03Icon as Loader2 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Icons } from "@repo/ui/components/icons";
@@ -6,10 +7,7 @@ import { Input } from "@repo/ui/components/ui/input";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { TeamSwitcherSlot } from "~/components/team-switcher";
-import {
-  accountProfileQueryOptions,
-  createAccountUsernameMutationOptions,
-} from "../account-queries";
+import { accountProfileQueryOptions } from "../account-queries";
 
 interface UsernameAccountTaskClientProps {
   returnTo?: string;
@@ -75,7 +73,9 @@ export function UsernameAccountTaskClient({
   const targetPath = normalizeReturnTo(returnTo);
 
   const createUsernameMutation = useMutation({
-    ...createAccountUsernameMutationOptions(),
+    meta: { suppressErrorToast: true },
+    mutationFn: (data: { idempotencyKey: string; username: string }) =>
+      createAccountUsername({ data }),
     onSuccess: (data) => {
       idempotencyKeyRef.current = null;
       queryClient.setQueryData(accountQuery.queryKey, data);

--- a/apps/app/src/account/team-create-client.tsx
+++ b/apps/app/src/account/team-create-client.tsx
@@ -1,3 +1,4 @@
+import { createOrganization } from "@api/app/tanstack/organizations";
 import { Loading03Icon as Loader2 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Icons } from "@repo/ui/components/icons";
@@ -12,10 +13,7 @@ import {
 } from "~/account/team-name";
 import { useOrganizationList } from "~/compat/clerk";
 import { TeamSwitcherSlot } from "~/components/team-switcher";
-import {
-  createOrganizationMutationOptions,
-  organizationQueryKeys,
-} from "~/organization/organization-queries";
+import { organizationQueryKeys } from "~/organization/organization-queries";
 
 export function CreateTeamClient() {
   return (
@@ -46,7 +44,9 @@ function TeamNameForm() {
   const navigate = useNavigate({ from: "/account/teams/new" });
 
   const mutation = useMutation({
-    ...createOrganizationMutationOptions(),
+    meta: { suppressErrorToast: true },
+    mutationFn: (data: { idempotencyKey: string; slug: string }) =>
+      createOrganization({ data }),
     onSuccess: async (data) => {
       idempotencyKeyRef.current = null;
       if (setActive) {

--- a/apps/app/src/org/settings/general/team-general-settings-client.tsx
+++ b/apps/app/src/org/settings/general/team-general-settings-client.tsx
@@ -1,3 +1,7 @@
+import {
+  updateOrganizationDomains,
+  updateOrganizationName,
+} from "@api/app/tanstack/organizations";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Loading03Icon as Loader2,
@@ -28,8 +32,6 @@ import {
   organizationDomainsQueryOptions,
   organizationQueryKeys,
   type UserOrganizationsData,
-  updateOrganizationDomainsMutationOptions,
-  updateOrganizationNameMutationOptions,
 } from "~/organization/organization-queries";
 import {
   normalizeTeamDomainList,
@@ -129,7 +131,9 @@ export function TeamGeneralSettingsClient({
     [navigate, setActive]
   );
   const updateNameMutation = useMutation({
-    ...updateOrganizationNameMutationOptions(),
+    meta: { errorTitle: "Failed to update team name" },
+    mutationFn: (data: { name: string; slug: string }) =>
+      updateOrganizationName({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({
         queryKey: organizationQueryKeys.list(),
@@ -164,7 +168,9 @@ export function TeamGeneralSettingsClient({
     },
   });
   const updateDomainsMutation = useMutation({
-    ...updateOrganizationDomainsMutationOptions(),
+    meta: { errorTitle: "Failed to update domains" },
+    mutationFn: (data: { domains: string[]; slug: string }) =>
+      updateOrganizationDomains({ data }),
     onError: () => {
       setDraftDomains(currentDomainNames);
     },

--- a/apps/app/src/organization/organization-queries.ts
+++ b/apps/app/src/organization/organization-queries.ts
@@ -1,14 +1,11 @@
 import {
-  createOrganization,
   getOrganizationBySlug,
   type ListOrganizationDomainsResult,
   type ListUserOrganizationsResult,
   listOrganizationDomains,
   listUserOrganizations,
-  updateOrganizationDomains,
-  updateOrganizationName,
 } from "@api/app/tanstack/organizations";
-import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 
 export type UserOrganizationsData = ListUserOrganizationsResult;
 export type OrganizationDomainsData = ListOrganizationDomainsResult;
@@ -52,29 +49,5 @@ export function organizationDomainsQueryOptions(input: {
     queryFn: () => listOrganizationDomains({ data: { slug: input.slug } }),
     queryKey: organizationQueryKeys.domains(input.slug),
     staleTime: 5 * 60 * 1000,
-  });
-}
-
-export function createOrganizationMutationOptions() {
-  return mutationOptions({
-    meta: { suppressErrorToast: true },
-    mutationFn: (data: { idempotencyKey: string; slug: string }) =>
-      createOrganization({ data }),
-  });
-}
-
-export function updateOrganizationDomainsMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to update domains" },
-    mutationFn: (data: { domains: string[]; slug: string }) =>
-      updateOrganizationDomains({ data }),
-  });
-}
-
-export function updateOrganizationNameMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to update team name" },
-    mutationFn: (data: { name: string; slug: string }) =>
-      updateOrganizationName({ data }),
   });
 }


### PR DESCRIPTION
## Summary
- Inline shallow account and organization mutation option wrappers at their component call sites.
- Keep shared read query keys/options centralized while preserving local cache/invalidation behavior in clients.
- Remove the unused TanStack account adapter export for GitHub disconnect and ratchet the source tests.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/account-queries-source.test.ts src/__tests__/organization-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/account-settings-routes-source.test.ts
- pnpm --filter @api/app test -- src/__tests__/account-tanstack-adapter-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- git diff --check origin/main...HEAD
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- agent-browser smoke: /account/teams/new and /lightfast/settings/general redirect to signed-out Clerk auth boundaries with expected redirect_url values