### PR TITLE
refactor: inline org settings mutation options

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1227,12 +1227,22 @@ describe("app authenticated route migration", () => {
     );
     expect(memberListSource).toContain('from "@clerk/tanstack-react-start"');
     expect(existsSync(resolve(appRoot, memberInviteActionsPath))).toBe(false);
-    expect(memberInviteSource).toContain("inviteOrgMemberMutationOptions");
+    expect(memberInviteSource).toContain('@api/app/tanstack/org-members"');
+    expect(memberInviteSource).toContain("inviteOrgMember");
+    expect(memberInviteSource).not.toContain("inviteOrgMemberMutationOptions");
     expect(memberInviteSource).not.toContain("useOrgMemberInviteAction");
     expect(existsSync(resolve(appRoot, memberListActionsPath))).toBe(false);
-    expect(memberListSource).toContain("updateOrgMemberRoleMutationOptions");
-    expect(memberListSource).toContain("revokeOrgInvitationMutationOptions");
-    expect(memberListSource).toContain("removeOrgMemberMutationOptions");
+    expect(memberListSource).toContain('@api/app/tanstack/org-members"');
+    expect(memberListSource).toContain("updateOrgMemberRole");
+    expect(memberListSource).toContain("revokeOrgInvitation");
+    expect(memberListSource).toContain("removeOrgMember");
+    expect(memberListSource).not.toContain(
+      "updateOrgMemberRoleMutationOptions"
+    );
+    expect(memberListSource).not.toContain(
+      "revokeOrgInvitationMutationOptions"
+    );
+    expect(memberListSource).not.toContain("removeOrgMemberMutationOptions");
     expect(memberListSource).not.toContain("useOrgMemberListActions");
     expect(memberQueriesSource).toContain("orgMemberQueryKeys");
     expect(memberQueriesSource).not.toContain("useTRPC");
@@ -1244,12 +1254,18 @@ describe("app authenticated route migration", () => {
     );
     expect(apiKeyListSource).toContain('from "@clerk/tanstack-react-start"');
     expect(existsSync(resolve(appRoot, apiKeyCreateActionsPath))).toBe(false);
-    expect(apiKeyCreateSource).toContain("createOrgApiKeyMutationOptions");
+    expect(apiKeyCreateSource).toContain('@api/app/tanstack/org-api-keys"');
+    expect(apiKeyCreateSource).toContain("createOrgApiKey");
+    expect(apiKeyCreateSource).not.toContain("createOrgApiKeyMutationOptions");
     expect(apiKeyCreateSource).not.toContain("useOrgApiKeyCreateAction");
     expect(existsSync(resolve(appRoot, apiKeyListActionsPath))).toBe(false);
-    expect(apiKeyListSource).toContain("revokeOrgApiKeyMutationOptions");
-    expect(apiKeyListSource).toContain("deleteOrgApiKeyMutationOptions");
-    expect(apiKeyListSource).toContain("rotateOrgApiKeyMutationOptions");
+    expect(apiKeyListSource).toContain('@api/app/tanstack/org-api-keys"');
+    expect(apiKeyListSource).toContain("revokeOrgApiKey");
+    expect(apiKeyListSource).toContain("deleteOrgApiKey");
+    expect(apiKeyListSource).toContain("rotateOrgApiKey");
+    expect(apiKeyListSource).not.toContain("revokeOrgApiKeyMutationOptions");
+    expect(apiKeyListSource).not.toContain("deleteOrgApiKeyMutationOptions");
+    expect(apiKeyListSource).not.toContain("rotateOrgApiKeyMutationOptions");
     expect(apiKeyListSource).not.toContain("useOrgApiKeyListActions");
     expect(apiKeyCacheSource).toContain("OrgApiKeyListData");
     expect(apiKeyQueriesSource).toContain('@api/app/tanstack/org-api-keys"');
@@ -1415,7 +1431,9 @@ describe("app authenticated route migration", () => {
     expect(billingClientSource).toContain("orgBillingQueryKeys.overview");
     expect(billingClientSource).not.toContain("useBillingOverviewRefresh");
     expect(existsSync(resolve(appRoot, billingCancellationPath))).toBe(false);
-    expect(billingClientSource).toContain(
+    expect(billingClientSource).toContain('@api/app/tanstack/org-billing"');
+    expect(billingClientSource).toContain("cancelOrgBillingSubscriptionItem");
+    expect(billingClientSource).not.toContain(
       "cancelOrgBillingSubscriptionItemMutationOptions"
     );
     expect(billingClientSource).not.toContain(

--- a/apps/app/src/__tests__/org-api-key-queries-source.test.ts
+++ b/apps/app/src/__tests__/org-api-key-queries-source.test.ts
@@ -14,10 +14,11 @@ describe("org API key query helpers", () => {
     expect(source).toContain('@api/app/tanstack/org-api-keys"');
     expect(source).toContain("orgApiKeyQueryKeys");
     expect(source).toContain("orgApiKeysQueryOptions");
-    expect(source).toContain("createOrgApiKeyMutationOptions");
-    expect(source).toContain("revokeOrgApiKeyMutationOptions");
-    expect(source).toContain("deleteOrgApiKeyMutationOptions");
-    expect(source).toContain("rotateOrgApiKeyMutationOptions");
+    expect(source).not.toContain("mutationOptions");
+    expect(source).not.toContain("createOrgApiKeyMutationOptions");
+    expect(source).not.toContain("revokeOrgApiKeyMutationOptions");
+    expect(source).not.toContain("deleteOrgApiKeyMutationOptions");
+    expect(source).not.toContain("rotateOrgApiKeyMutationOptions");
     expect(source).not.toContain("useTRPC");
   });
 
@@ -30,9 +31,11 @@ describe("org API key query helpers", () => {
       "src/org/settings/api-keys/org-api-key-create-action.ts";
 
     expect(existsSync(resolve(appRoot, actionsPath))).toBe(false);
+    expect(createSource).toContain('@api/app/tanstack/org-api-keys"');
+    expect(createSource).toContain("createOrgApiKey");
     expect(createSource).toContain("useMutation");
     expect(createSource).toContain("useQueryClient");
-    expect(createSource).toContain("createOrgApiKeyMutationOptions");
+    expect(createSource).not.toContain("createOrgApiKeyMutationOptions");
     expect(createSource).not.toContain("useOrgApiKeyCreateAction");
     expect(createSource).not.toContain("org-api-key-create-action");
   });
@@ -45,11 +48,15 @@ describe("org API key query helpers", () => {
     const actionsPath = "src/org/settings/api-keys/org-api-key-list-actions.ts";
 
     expect(existsSync(resolve(appRoot, actionsPath))).toBe(false);
+    expect(listSource).toContain('@api/app/tanstack/org-api-keys"');
+    expect(listSource).toContain("revokeOrgApiKey");
+    expect(listSource).toContain("deleteOrgApiKey");
+    expect(listSource).toContain("rotateOrgApiKey");
     expect(listSource).toContain("useMutation");
     expect(listSource).toContain("useQueryClient");
-    expect(listSource).toContain("revokeOrgApiKeyMutationOptions");
-    expect(listSource).toContain("deleteOrgApiKeyMutationOptions");
-    expect(listSource).toContain("rotateOrgApiKeyMutationOptions");
+    expect(listSource).not.toContain("revokeOrgApiKeyMutationOptions");
+    expect(listSource).not.toContain("deleteOrgApiKeyMutationOptions");
+    expect(listSource).not.toContain("rotateOrgApiKeyMutationOptions");
     expect(listSource).toContain("orgApiKeyQueryKeys.list()");
     expect(listSource).toContain("revokeApiKey");
     expect(listSource).toContain("removeApiKey");

--- a/apps/app/src/__tests__/org-billing-queries-source.test.ts
+++ b/apps/app/src/__tests__/org-billing-queries-source.test.ts
@@ -13,7 +13,10 @@ describe("org billing app data access", () => {
 
     expect(source).toContain('@api/app/tanstack/org-billing"');
     expect(source).toContain("queryOptions");
-    expect(source).toContain("mutationOptions");
+    expect(source).not.toContain("mutationOptions");
+    expect(source).not.toContain(
+      "cancelOrgBillingSubscriptionItemMutationOptions"
+    );
     expect(source).toContain('["org-billing", "overview", orgId ?? "no-org"]');
     expect(source).toContain("enabled: Boolean(input.orgId)");
     expect(source).not.toContain("useTRPC");
@@ -61,8 +64,10 @@ describe("org billing app data access", () => {
       "src/org/settings/billing/billing-cancellation-mutation.ts";
 
     expect(existsSync(resolve(appRoot, mutationPath))).toBe(false);
+    expect(clientSource).toContain('@api/app/tanstack/org-billing"');
+    expect(clientSource).toContain("cancelOrgBillingSubscriptionItem");
     expect(clientSource).toContain("useMutation");
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "cancelOrgBillingSubscriptionItemMutationOptions"
     );
     expect(clientSource).toContain("orgBillingQueryKeys.overview(auth.orgId)");

--- a/apps/app/src/__tests__/org-members-queries-source.test.ts
+++ b/apps/app/src/__tests__/org-members-queries-source.test.ts
@@ -13,7 +13,11 @@ describe("org members app data access", () => {
 
     expect(source).toContain('@api/app/tanstack/org-members"');
     expect(source).toContain("queryOptions");
-    expect(source).toContain("mutationOptions");
+    expect(source).not.toContain("mutationOptions");
+    expect(source).not.toContain("inviteOrgMemberMutationOptions");
+    expect(source).not.toContain("updateOrgMemberRoleMutationOptions");
+    expect(source).not.toContain("removeOrgMemberMutationOptions");
+    expect(source).not.toContain("revokeOrgInvitationMutationOptions");
     expect(source).toContain('["org-members", "list", orgId ?? "no-org"]');
     expect(source).toContain("enabled: Boolean(input.orgId)");
     expect(source).not.toContain("useTRPC");
@@ -44,9 +48,11 @@ describe("org members app data access", () => {
     const actionsPath = "src/org/settings/members/org-member-invite-actions.ts";
 
     expect(existsSync(resolve(appRoot, actionsPath))).toBe(false);
+    expect(inviteSource).toContain('@api/app/tanstack/org-members"');
+    expect(inviteSource).toContain("inviteOrgMember");
     expect(inviteSource).toContain("useMutation");
     expect(inviteSource).toContain("useQueryClient");
-    expect(inviteSource).toContain("inviteOrgMemberMutationOptions");
+    expect(inviteSource).not.toContain("inviteOrgMemberMutationOptions");
     expect(inviteSource).toContain("orgMemberQueryKeys.list(orgId)");
     expect(inviteSource).toContain("createOptimisticInvitation");
     expect(inviteSource).not.toContain("useOrgMemberInviteAction");
@@ -61,11 +67,15 @@ describe("org members app data access", () => {
     const actionsPath = "src/org/settings/members/org-member-list-actions.ts";
 
     expect(existsSync(resolve(appRoot, actionsPath))).toBe(false);
+    expect(listSource).toContain('@api/app/tanstack/org-members"');
+    expect(listSource).toContain("updateOrgMemberRole");
+    expect(listSource).toContain("removeOrgMember");
+    expect(listSource).toContain("revokeOrgInvitation");
     expect(listSource).toContain("useMutation");
     expect(listSource).toContain("useQueryClient");
-    expect(listSource).toContain("updateOrgMemberRoleMutationOptions");
-    expect(listSource).toContain("removeOrgMemberMutationOptions");
-    expect(listSource).toContain("revokeOrgInvitationMutationOptions");
+    expect(listSource).not.toContain("updateOrgMemberRoleMutationOptions");
+    expect(listSource).not.toContain("removeOrgMemberMutationOptions");
+    expect(listSource).not.toContain("revokeOrgInvitationMutationOptions");
     expect(listSource).toContain("orgMemberQueryKeys.list(orgId)");
     expect(listSource).toContain("updateMemberRole");
     expect(listSource).toContain("restoreMember");

--- a/apps/app/src/org/settings/api-keys/org-api-key-create.tsx
+++ b/apps/app/src/org/settings/api-keys/org-api-key-create.tsx
@@ -1,3 +1,4 @@
+import { createOrgApiKey } from "@api/app/tanstack/org-api-keys";
 import { useAuth } from "@clerk/tanstack-react-start";
 import {
   Tick02Icon as Check,
@@ -6,6 +7,7 @@ import {
   Add01Icon as Plus,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import type { createOrgApiKeySchema } from "@repo/app-validation/schemas";
 import { Button } from "@repo/ui/components/ui/button";
 import {
   Dialog,
@@ -19,7 +21,10 @@ import {
 import { Input } from "@repo/ui/components/ui/input";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
-import { createOrgApiKeyMutationOptions } from "./org-api-key-queries";
+import type { z } from "zod";
+import { orgApiKeyQueryKeys } from "./org-api-key-queries";
+
+type CreateOrgApiKeyInput = z.infer<typeof createOrgApiKeySchema>;
 
 export function OrgApiKeyCreate() {
   const { has, isLoaded } = useAuth();
@@ -45,12 +50,16 @@ export function OrgApiKeyCreate() {
     setName("");
   }, []);
 
-  const createMutation = useMutation(
-    createOrgApiKeyMutationOptions({
-      onCreated: handleCreated,
-      queryClient,
-    })
-  );
+  const createMutation = useMutation({
+    meta: { errorTitle: "Failed to create API key" },
+    mutationFn: (data: CreateOrgApiKeyInput) => createOrgApiKey({ data }),
+    onSuccess: (data) => {
+      handleCreated(data.key ?? null);
+      void queryClient.invalidateQueries({
+        queryKey: orgApiKeyQueryKeys.list(),
+      });
+    },
+  });
 
   const handleCreate = useCallback(() => {
     const trimmed = name.trim();

--- a/apps/app/src/org/settings/api-keys/org-api-key-list.tsx
+++ b/apps/app/src/org/settings/api-keys/org-api-key-list.tsx
@@ -1,3 +1,8 @@
+import {
+  deleteOrgApiKey,
+  revokeOrgApiKey,
+  rotateOrgApiKey,
+} from "@api/app/tanstack/org-api-keys";
 import { useAuth } from "@clerk/tanstack-react-start";
 import {
   Tick02Icon as Check,
@@ -9,6 +14,11 @@ import {
   Delete02Icon as Trash2,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import type {
+  deleteOrgApiKeySchema,
+  revokeOrgApiKeySchema,
+  rotateOrgApiKeySchema,
+} from "@repo/app-validation/schemas";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,6 +48,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatRelativeTimeToNow } from "@vendor/lib/time";
 import { memo, useCallback, useState } from "react";
+import type { z } from "zod";
 import {
   type OrgApiKey,
   type OrgApiKeyListData,
@@ -46,11 +57,8 @@ import {
   revokeApiKey,
 } from "./org-api-key-cache";
 import {
-  deleteOrgApiKeyMutationOptions,
   orgApiKeyQueryKeys,
   orgApiKeysQueryOptions,
-  revokeOrgApiKeyMutationOptions,
-  rotateOrgApiKeyMutationOptions,
 } from "./org-api-key-queries";
 
 interface AlertAction {
@@ -58,6 +66,9 @@ interface AlertAction {
   keyName: string;
   type: "revoke" | "delete" | "rotate";
 }
+type RevokeOrgApiKeyInput = z.infer<typeof revokeOrgApiKeySchema>;
+type DeleteOrgApiKeyInput = z.infer<typeof deleteOrgApiKeySchema>;
+type RotateOrgApiKeyInput = z.input<typeof rotateOrgApiKeySchema>;
 
 export function OrgApiKeyList() {
   const { has, isLoaded } = useAuth();
@@ -83,7 +94,8 @@ export function OrgApiKeyList() {
   const [copiedRotatedKey, setCopiedRotatedKey] = useState(false);
 
   const revokeMutation = useMutation({
-    ...revokeOrgApiKeyMutationOptions(),
+    meta: { errorTitle: "Failed to revoke API key" },
+    mutationFn: (data: RevokeOrgApiKeyInput) => revokeOrgApiKey({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: listQueryKey });
 
@@ -114,7 +126,8 @@ export function OrgApiKeyList() {
       void queryClient.invalidateQueries({ queryKey: listQueryKey }),
   });
   const deleteMutation = useMutation({
-    ...deleteOrgApiKeyMutationOptions(),
+    meta: { errorTitle: "Failed to delete API key" },
+    mutationFn: (data: DeleteOrgApiKeyInput) => deleteOrgApiKey({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: listQueryKey });
 
@@ -149,7 +162,8 @@ export function OrgApiKeyList() {
       void queryClient.invalidateQueries({ queryKey: listQueryKey }),
   });
   const rotateMutation = useMutation({
-    ...rotateOrgApiKeyMutationOptions(),
+    meta: { errorTitle: "Failed to rotate API key" },
+    mutationFn: (data: RotateOrgApiKeyInput) => rotateOrgApiKey({ data }),
     onSuccess: (data, input) => {
       const key = data.key ?? null;
       if (!key) {

--- a/apps/app/src/org/settings/api-keys/org-api-key-queries.ts
+++ b/apps/app/src/org/settings/api-keys/org-api-key-queries.ts
@@ -1,30 +1,11 @@
 import {
-  createOrgApiKey,
-  deleteOrgApiKey,
   type ListOrgApiKeysResult,
   listOrgApiKeys,
-  revokeOrgApiKey,
-  rotateOrgApiKey,
 } from "@api/app/tanstack/org-api-keys";
-import type {
-  createOrgApiKeySchema,
-  deleteOrgApiKeySchema,
-  revokeOrgApiKeySchema,
-  rotateOrgApiKeySchema,
-} from "@repo/app-validation/schemas";
-import {
-  mutationOptions,
-  type QueryClient,
-  queryOptions,
-} from "@tanstack/react-query";
-import type { z } from "zod";
+import { queryOptions } from "@tanstack/react-query";
 
 export type OrgApiKeyListData = ListOrgApiKeysResult;
 export type OrgApiKey = OrgApiKeyListData[number];
-type CreateOrgApiKeyInput = z.infer<typeof createOrgApiKeySchema>;
-type RevokeOrgApiKeyInput = z.infer<typeof revokeOrgApiKeySchema>;
-type DeleteOrgApiKeyInput = z.infer<typeof deleteOrgApiKeySchema>;
-type RotateOrgApiKeyInput = z.input<typeof rotateOrgApiKeySchema>;
 
 export const orgApiKeyQueryKeys = {
   all: ["org-api-keys"] as const,
@@ -37,42 +18,5 @@ export function orgApiKeysQueryOptions() {
     queryFn: () => listOrgApiKeys(),
     queryKey: orgApiKeyQueryKeys.list(),
     staleTime: 5 * 60 * 1000,
-  });
-}
-
-export function createOrgApiKeyMutationOptions(input: {
-  onCreated: (key: string | null) => void;
-  queryClient: QueryClient;
-}) {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to create API key" },
-    mutationFn: (data: CreateOrgApiKeyInput) => createOrgApiKey({ data }),
-    onSuccess: (data) => {
-      input.onCreated(data.key ?? null);
-      void input.queryClient.invalidateQueries({
-        queryKey: orgApiKeyQueryKeys.list(),
-      });
-    },
-  });
-}
-
-export function revokeOrgApiKeyMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to revoke API key" },
-    mutationFn: (data: RevokeOrgApiKeyInput) => revokeOrgApiKey({ data }),
-  });
-}
-
-export function deleteOrgApiKeyMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to delete API key" },
-    mutationFn: (data: DeleteOrgApiKeyInput) => deleteOrgApiKey({ data }),
-  });
-}
-
-export function rotateOrgApiKeyMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to rotate API key" },
-    mutationFn: (data: RotateOrgApiKeyInput) => rotateOrgApiKey({ data }),
   });
 }

--- a/apps/app/src/org/settings/billing/billing-queries.ts
+++ b/apps/app/src/org/settings/billing/billing-queries.ts
@@ -1,22 +1,14 @@
 import {
-  type CancelOrgBillingSubscriptionItemResult,
-  cancelOrgBillingSubscriptionItem,
   getOrgBillingOverview,
   type OrgBillingOverviewResult,
 } from "@api/app/tanstack/org-billing";
-import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 
 export type BillingOverview = OrgBillingOverviewResult;
 export type BillingPlan = BillingOverview["plans"][number];
 export type BillingSubscription = BillingOverview["subscription"];
 export type BillingSubscriptionItem =
   BillingSubscription["subscriptionItems"][number];
-export type CancelOrgBillingSubscriptionItemData =
-  CancelOrgBillingSubscriptionItemResult;
-
-interface CancelOrgBillingSubscriptionItemInput {
-  subscriptionItemId: string;
-}
 
 export const orgBillingQueryKeys = {
   all: ["org-billing"] as const,
@@ -32,15 +24,5 @@ export function billingOverviewQueryOptions(input: {
     queryFn: () => getOrgBillingOverview(),
     queryKey: orgBillingQueryKeys.overview(input.orgId),
     staleTime: 5 * 60 * 1000,
-  });
-}
-
-export function cancelOrgBillingSubscriptionItemMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to schedule cancellation" },
-    mutationFn: (
-      data: CancelOrgBillingSubscriptionItemInput
-    ): Promise<CancelOrgBillingSubscriptionItemData> =>
-      cancelOrgBillingSubscriptionItem({ data }),
   });
 }

--- a/apps/app/src/org/settings/billing/billing-settings-client.tsx
+++ b/apps/app/src/org/settings/billing/billing-settings-client.tsx
@@ -1,3 +1,4 @@
+import { cancelOrgBillingSubscriptionItem } from "@api/app/tanstack/org-billing";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   BillingPaymentMethodResource,
@@ -9,7 +10,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { BillingCheckoutDialog } from "./billing-checkout-dialog";
 import {
   billingOverviewQueryOptions,
-  cancelOrgBillingSubscriptionItemMutationOptions,
   orgBillingQueryKeys,
 } from "./billing-queries";
 import {
@@ -35,6 +35,9 @@ import { StatementDetailsDialog } from "./statement-details-dialog";
 type BillingPlan = BillingOverview["plans"][number];
 type BillingSubscriptionItem =
   BillingOverview["subscription"]["subscriptionItems"][number];
+interface CancelOrgBillingSubscriptionItemInput {
+  subscriptionItemId: string;
+}
 
 const PRICING_HASH = "#pricing";
 const EMPTY_PAYMENT_METHODS: BillingPaymentMethodResource[] = [];
@@ -145,7 +148,9 @@ export function BillingSettingsClient() {
     useState<BillingStatementResource | null>(null);
 
   const { mutate: cancelSubscriptionItem } = useMutation({
-    ...cancelOrgBillingSubscriptionItemMutationOptions(),
+    meta: { errorTitle: "Failed to schedule cancellation" },
+    mutationFn: (data: CancelOrgBillingSubscriptionItemInput) =>
+      cancelOrgBillingSubscriptionItem({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: overviewQueryKey });
 

--- a/apps/app/src/org/settings/members/org-member-invite.tsx
+++ b/apps/app/src/org/settings/members/org-member-invite.tsx
@@ -1,9 +1,11 @@
+import { inviteOrgMember } from "@api/app/tanstack/org-members";
 import { useAuth } from "@clerk/tanstack-react-start";
 import {
   Loading03Icon as Loader2,
   UserAdd01Icon as UserPlus,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import type { inviteOrgMemberSchema } from "@repo/app-validation/schemas";
 import { Button } from "@repo/ui/components/ui/button";
 import {
   Dialog,
@@ -26,6 +28,7 @@ import {
 import { toast } from "@repo/ui/components/ui/sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+import type { z } from "zod";
 import {
   createOptimisticInvitation,
   insertInvitation,
@@ -34,10 +37,9 @@ import {
   removeInvitation,
   replaceInvitation,
 } from "./org-member-cache";
-import {
-  inviteOrgMemberMutationOptions,
-  orgMemberQueryKeys,
-} from "./org-member-queries";
+import { orgMemberQueryKeys } from "./org-member-queries";
+
+type InviteOrgMemberInput = z.input<typeof inviteOrgMemberSchema>;
 
 export function OrgMemberInvite() {
   const { has, isLoaded, orgId } = useAuth();
@@ -65,7 +67,8 @@ export function OrgMemberInvite() {
   }, []);
 
   const inviteMutation = useMutation({
-    ...inviteOrgMemberMutationOptions(),
+    meta: { errorTitle: "Failed to send invitation" },
+    mutationFn: (data: InviteOrgMemberInput) => inviteOrgMember({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: listQueryKey });
 

--- a/apps/app/src/org/settings/members/org-member-list.tsx
+++ b/apps/app/src/org/settings/members/org-member-list.tsx
@@ -1,3 +1,8 @@
+import {
+  removeOrgMember as removeOrgMemberServerFn,
+  revokeOrgInvitation,
+  updateOrgMemberRole,
+} from "@api/app/tanstack/org-members";
 import { useAuth } from "@clerk/tanstack-react-start";
 import {
   Mail01Icon as Mail,
@@ -8,6 +13,11 @@ import {
   UserGroupIcon as Users,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import type {
+  removeOrgMemberSchema,
+  revokeOrgInvitationSchema,
+  updateOrgMemberRoleSchema,
+} from "@repo/app-validation/schemas";
 import { Avatar, AvatarFallback } from "@repo/ui/components/ui/avatar";
 import { Badge } from "@repo/ui/components/ui/badge";
 import { Button } from "@repo/ui/components/ui/button";
@@ -29,6 +39,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatRelativeTimeToNow } from "@vendor/lib/time";
 import { memo, type ReactNode, useCallback, useMemo } from "react";
+import type { z } from "zod";
 import {
   isOptimisticInvitation,
   type OrgInvitation,
@@ -44,10 +55,11 @@ import {
 import {
   orgMemberQueryKeys,
   orgMembersQueryOptions,
-  removeOrgMemberMutationOptions,
-  revokeOrgInvitationMutationOptions,
-  updateOrgMemberRoleMutationOptions,
 } from "./org-member-queries";
+
+type UpdateOrgMemberRoleInput = z.infer<typeof updateOrgMemberRoleSchema>;
+type RemoveOrgMemberInput = z.infer<typeof removeOrgMemberSchema>;
+type RevokeOrgInvitationInput = z.infer<typeof revokeOrgInvitationSchema>;
 
 function initials(name: string) {
   const letters = name
@@ -145,7 +157,9 @@ export function OrgMemberList({ searchQuery = "" }: { searchQuery?: string }) {
     ...orgMembersQueryOptions({ orgId }),
   });
   const updateRoleMutation = useMutation({
-    ...updateOrgMemberRoleMutationOptions(),
+    meta: { errorTitle: "Failed to update role" },
+    mutationFn: (data: UpdateOrgMemberRoleInput) =>
+      updateOrgMemberRole({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: listQueryKey });
 
@@ -179,7 +193,9 @@ export function OrgMemberList({ searchQuery = "" }: { searchQuery?: string }) {
       void queryClient.invalidateQueries({ queryKey: listQueryKey }),
   });
   const removeMutation = useMutation({
-    ...removeOrgMemberMutationOptions(),
+    meta: { errorTitle: "Failed to remove member" },
+    mutationFn: (data: RemoveOrgMemberInput) =>
+      removeOrgMemberServerFn({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: listQueryKey });
 
@@ -213,7 +229,9 @@ export function OrgMemberList({ searchQuery = "" }: { searchQuery?: string }) {
       void queryClient.invalidateQueries({ queryKey: listQueryKey }),
   });
   const revokeInvitationMutation = useMutation({
-    ...revokeOrgInvitationMutationOptions(),
+    meta: { errorTitle: "Failed to revoke invitation" },
+    mutationFn: (data: RevokeOrgInvitationInput) =>
+      revokeOrgInvitation({ data }),
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: listQueryKey });
 

--- a/apps/app/src/org/settings/members/org-member-queries.ts
+++ b/apps/app/src/org/settings/members/org-member-queries.ts
@@ -1,28 +1,13 @@
 import {
-  inviteOrgMember,
   type ListOrgMembersResult,
   listOrgMembers,
-  removeOrgMember,
-  revokeOrgInvitation,
-  updateOrgMemberRole,
 } from "@api/app/tanstack/org-members";
-import type {
-  inviteOrgMemberSchema,
-  removeOrgMemberSchema,
-  revokeOrgInvitationSchema,
-  updateOrgMemberRoleSchema,
-} from "@repo/app-validation/schemas";
-import { mutationOptions, queryOptions } from "@tanstack/react-query";
-import type { z } from "zod";
+import { queryOptions } from "@tanstack/react-query";
 
 export type OrgMembersListData = ListOrgMembersResult;
 export type OrgMember = OrgMembersListData["members"][number];
 export type OrgInvitation = OrgMembersListData["invitations"][number];
 export type OrgRole = "org:admin" | "org:member";
-type InviteOrgMemberInput = z.input<typeof inviteOrgMemberSchema>;
-type UpdateOrgMemberRoleInput = z.infer<typeof updateOrgMemberRoleSchema>;
-type RemoveOrgMemberInput = z.infer<typeof removeOrgMemberSchema>;
-type RevokeOrgInvitationInput = z.infer<typeof revokeOrgInvitationSchema>;
 
 export const orgMemberQueryKeys = {
   all: ["org-members"] as const,
@@ -38,35 +23,5 @@ export function orgMembersQueryOptions(input: {
     queryFn: () => listOrgMembers(),
     queryKey: orgMemberQueryKeys.list(input.orgId),
     staleTime: 5 * 60 * 1000,
-  });
-}
-
-export function inviteOrgMemberMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to send invitation" },
-    mutationFn: (data: InviteOrgMemberInput) => inviteOrgMember({ data }),
-  });
-}
-
-export function updateOrgMemberRoleMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to update role" },
-    mutationFn: (data: UpdateOrgMemberRoleInput) =>
-      updateOrgMemberRole({ data }),
-  });
-}
-
-export function removeOrgMemberMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to remove member" },
-    mutationFn: (data: RemoveOrgMemberInput) => removeOrgMember({ data }),
-  });
-}
-
-export function revokeOrgInvitationMutationOptions() {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to revoke invitation" },
-    mutationFn: (data: RevokeOrgInvitationInput) =>
-      revokeOrgInvitation({ data }),
   });
 }


### PR DESCRIPTION
## Summary
- Inline org settings mutation options for members, API keys, and billing at their component call sites.
- Keep read query keys/options centralized while leaving local optimistic updates and invalidation in the owning components.
- Ratchet source tests so these shallow wrappers do not come back.

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/org-api-key-queries-source.test.ts src/__tests__/org-members-queries-source.test.ts src/__tests__/org-billing-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm check
- pnpm --filter @lightfast/app typecheck
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- agent-browser smoke: /lightfast/settings/members, /lightfast/settings/api-keys, and /lightfast/settings/billing redirect to Clerk sign-in with expected redirect_url values