### PR TITLE
refactor: inline developer connection mutation options

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -612,17 +612,25 @@ describe("app authenticated route migration", () => {
     );
     expect(routeSource).toContain("setSearchParams");
     expect(clientSource).toContain("developerConnectionsQueryOptions");
-    expect(clientSource).toContain("connectDeveloperConnectionMutationOptions");
-    expect(clientSource).toContain(
+    expect(clientSource).toContain('@api/app/tanstack/developer-connections"');
+    expect(clientSource).toContain("connectDeveloperConnection");
+    expect(clientSource).toContain("startSentryDeveloperConnectionAuth");
+    expect(clientSource).toContain("completeSentryDeveloperConnectionAuth");
+    expect(clientSource).toContain("setDeveloperConnectionSandboxEnabled");
+    expect(clientSource).toContain("disconnectDeveloperConnection");
+    expect(clientSource).not.toContain(
+      "connectDeveloperConnectionMutationOptions"
+    );
+    expect(clientSource).not.toContain(
       "startSentryDeveloperConnectionAuthMutationOptions"
     );
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "completeSentryDeveloperConnectionAuthMutationOptions"
     );
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "setDeveloperConnectionSandboxEnabledMutationOptions"
     );
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "disconnectDeveloperConnectionMutationOptions"
     );
     expect(searchSource).toContain("validateDeveloperConnectionsSearch");

--- a/apps/app/src/__tests__/developer-connections-queries-source.test.ts
+++ b/apps/app/src/__tests__/developer-connections-queries-source.test.ts
@@ -17,17 +17,20 @@ describe("developer-connections app data access", () => {
     expect(querySource).toContain('@api/app/tanstack/developer-connections"');
     expect(querySource).toContain("developerConnectionQueryKeys");
     expect(querySource).toContain("developerConnectionsQueryOptions");
-    expect(querySource).toContain("connectDeveloperConnectionMutationOptions");
-    expect(querySource).toContain(
+    expect(querySource).not.toContain("mutationOptions");
+    expect(querySource).not.toContain(
+      "connectDeveloperConnectionMutationOptions"
+    );
+    expect(querySource).not.toContain(
       "startSentryDeveloperConnectionAuthMutationOptions"
     );
-    expect(querySource).toContain(
+    expect(querySource).not.toContain(
       "completeSentryDeveloperConnectionAuthMutationOptions"
     );
-    expect(querySource).toContain(
+    expect(querySource).not.toContain(
       "setDeveloperConnectionSandboxEnabledMutationOptions"
     );
-    expect(querySource).toContain(
+    expect(querySource).not.toContain(
       "disconnectDeveloperConnectionMutationOptions"
     );
     expect(querySource).not.toContain("useTRPC");
@@ -43,18 +46,26 @@ describe("developer-connections app data access", () => {
 
     expect(clientSource).not.toContain("useTRPC");
     expect(clientSource).not.toContain("org.workspace.developerConnections");
+    expect(clientSource).toContain('@api/app/tanstack/developer-connections"');
     expect(clientSource).toContain("developerConnectionsQueryOptions");
-    expect(clientSource).toContain("connectDeveloperConnectionMutationOptions");
-    expect(clientSource).toContain(
+    expect(clientSource).toContain("connectDeveloperConnection");
+    expect(clientSource).toContain("startSentryDeveloperConnectionAuth");
+    expect(clientSource).toContain("completeSentryDeveloperConnectionAuth");
+    expect(clientSource).toContain("setDeveloperConnectionSandboxEnabled");
+    expect(clientSource).toContain("disconnectDeveloperConnection");
+    expect(clientSource).not.toContain(
+      "connectDeveloperConnectionMutationOptions"
+    );
+    expect(clientSource).not.toContain(
       "startSentryDeveloperConnectionAuthMutationOptions"
     );
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "completeSentryDeveloperConnectionAuthMutationOptions"
     );
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "setDeveloperConnectionSandboxEnabledMutationOptions"
     );
-    expect(clientSource).toContain(
+    expect(clientSource).not.toContain(
       "disconnectDeveloperConnectionMutationOptions"
     );
     expect(modelSource).not.toContain("AppRouterOutputs");

--- a/apps/app/src/__tests__/tanstack-query-input-types-source.test.ts
+++ b/apps/app/src/__tests__/tanstack-query-input-types-source.test.ts
@@ -44,10 +44,10 @@ describe("TanStack query input type boundaries", () => {
       "type RefreshConnectorToolsInput"
     );
     expect(
-      appSource("src/developer-connections/developer-connections-queries.ts")
+      appSource("src/developer-connections/developer-connections-client.tsx")
     ).toContain("type ConnectDeveloperConnectionInput");
     expect(
-      appSource("src/developer-connections/developer-connections-queries.ts")
+      appSource("src/developer-connections/developer-connections-client.tsx")
     ).toContain("type StartSentryDeveloperConnectionAuthInput");
     expect(appSource("src/decisions/decisions-queries.ts")).toContain(
       "type ListDecisionsInput"

--- a/apps/app/src/developer-connections/developer-connections-client.tsx
+++ b/apps/app/src/developer-connections/developer-connections-client.tsx
@@ -1,4 +1,17 @@
 import {
+  type CompleteSentryDeveloperConnectionAuthInput,
+  type ConnectDeveloperConnectionInput,
+  completeSentryDeveloperConnectionAuth,
+  connectDeveloperConnection,
+  type DisconnectDeveloperConnectionInput,
+  disconnectDeveloperConnection,
+  type SetDeveloperConnectionSandboxEnabledInput,
+  type StartSentryDeveloperConnectionAuthInput,
+  type StartSentryDeveloperConnectionAuthResult,
+  setDeveloperConnectionSandboxEnabled,
+  startSentryDeveloperConnectionAuth,
+} from "@api/app/tanstack/developer-connections";
+import {
   ArrowUpRightIcon as ArrowUpRight,
   SidebarRightIcon as PanelRight,
   Search01Icon as Search,
@@ -35,13 +48,8 @@ import {
   displayDeveloperConnectionProvider,
 } from "./developer-connections-model";
 import {
-  completeSentryDeveloperConnectionAuthMutationOptions,
-  connectDeveloperConnectionMutationOptions,
   developerConnectionQueryKeys,
   developerConnectionsQueryOptions,
-  disconnectDeveloperConnectionMutationOptions,
-  setDeveloperConnectionSandboxEnabledMutationOptions,
-  startSentryDeveloperConnectionAuthMutationOptions,
 } from "./developer-connections-queries";
 import type { NormalizedDeveloperConnectionsSearch } from "./developer-connections-search-params";
 
@@ -125,44 +133,49 @@ export function DeveloperConnectionsClient({
     });
   };
 
-  const connectMutation = useMutation(
-    connectDeveloperConnectionMutationOptions({
-      onSuccess: () => {
-        setConnectRow(null);
-        invalidateList();
-      },
-    })
-  );
-  const startSentryAuthMutation = useMutation(
-    startSentryDeveloperConnectionAuthMutationOptions({
-      onSuccess: (result) => {
-        setSentryAuthAttempt({
-          attemptId: result.attemptId,
-          userCode: result.userCode,
-          verificationUri: result.verificationUri,
-        });
-      },
-    })
-  );
-  const completeSentryAuthMutation = useMutation(
-    completeSentryDeveloperConnectionAuthMutationOptions({
-      onSuccess: () => {
-        setConnectRow(null);
-        setSentryAuthAttempt(null);
-        invalidateList();
-      },
-    })
-  );
-  const setSandboxEnabledMutation = useMutation(
-    setDeveloperConnectionSandboxEnabledMutationOptions({
-      onSuccess: invalidateList,
-    })
-  );
-  const disconnectMutation = useMutation(
-    disconnectDeveloperConnectionMutationOptions({
-      onSuccess: invalidateList,
-    })
-  );
+  const connectMutation = useMutation({
+    meta: { errorTitle: "Failed to connect developer provider" },
+    mutationFn: (data: ConnectDeveloperConnectionInput) =>
+      connectDeveloperConnection({ data }),
+    onSuccess: () => {
+      setConnectRow(null);
+      invalidateList();
+    },
+  });
+  const startSentryAuthMutation = useMutation({
+    meta: { errorTitle: "Failed to start Sentry authorization" },
+    mutationFn: (data: StartSentryDeveloperConnectionAuthInput) =>
+      startSentryDeveloperConnectionAuth({ data }),
+    onSuccess: (result: StartSentryDeveloperConnectionAuthResult) => {
+      setSentryAuthAttempt({
+        attemptId: result.attemptId,
+        userCode: result.userCode,
+        verificationUri: result.verificationUri,
+      });
+    },
+  });
+  const completeSentryAuthMutation = useMutation({
+    meta: { errorTitle: "Failed to complete Sentry authorization" },
+    mutationFn: (data: CompleteSentryDeveloperConnectionAuthInput) =>
+      completeSentryDeveloperConnectionAuth({ data }),
+    onSuccess: () => {
+      setConnectRow(null);
+      setSentryAuthAttempt(null);
+      invalidateList();
+    },
+  });
+  const setSandboxEnabledMutation = useMutation({
+    meta: { errorTitle: "Failed to update sandbox access" },
+    mutationFn: (data: SetDeveloperConnectionSandboxEnabledInput) =>
+      setDeveloperConnectionSandboxEnabled({ data }),
+    onSuccess: invalidateList,
+  });
+  const disconnectMutation = useMutation({
+    meta: { errorTitle: "Failed to disconnect developer provider" },
+    mutationFn: (data: DisconnectDeveloperConnectionInput) =>
+      disconnectDeveloperConnection({ data }),
+    onSuccess: invalidateList,
+  });
 
   useEffect(() => {
     if (!search.error) {

--- a/apps/app/src/developer-connections/developer-connections-queries.ts
+++ b/apps/app/src/developer-connections/developer-connections-queries.ts
@@ -1,18 +1,5 @@
-import {
-  type CompleteSentryDeveloperConnectionAuthInput,
-  type ConnectDeveloperConnectionInput,
-  completeSentryDeveloperConnectionAuth,
-  connectDeveloperConnection,
-  type DisconnectDeveloperConnectionInput,
-  disconnectDeveloperConnection,
-  listDeveloperConnections,
-  type SetDeveloperConnectionSandboxEnabledInput,
-  type StartSentryDeveloperConnectionAuthInput,
-  type StartSentryDeveloperConnectionAuthResult,
-  setDeveloperConnectionSandboxEnabled,
-  startSentryDeveloperConnectionAuth,
-} from "@api/app/tanstack/developer-connections";
-import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import { listDeveloperConnections } from "@api/app/tanstack/developer-connections";
+import { queryOptions } from "@tanstack/react-query";
 
 export const developerConnectionQueryKeys = {
   all: ["developer-connections"] as const,
@@ -26,60 +13,5 @@ export function developerConnectionsQueryOptions(input?: {
     queryFn: () => listDeveloperConnections(),
     queryKey: developerConnectionQueryKeys.list(),
     staleTime: input?.staleTime,
-  });
-}
-
-export function connectDeveloperConnectionMutationOptions(input?: {
-  onSuccess?: () => void;
-}) {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to connect developer provider" },
-    mutationFn: (data: ConnectDeveloperConnectionInput) =>
-      connectDeveloperConnection({ data }),
-    onSuccess: input?.onSuccess,
-  });
-}
-
-export function startSentryDeveloperConnectionAuthMutationOptions(input?: {
-  onSuccess?: (result: StartSentryDeveloperConnectionAuthResult) => void;
-}) {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to start Sentry authorization" },
-    mutationFn: (data: StartSentryDeveloperConnectionAuthInput) =>
-      startSentryDeveloperConnectionAuth({ data }),
-    onSuccess: input?.onSuccess,
-  });
-}
-
-export function completeSentryDeveloperConnectionAuthMutationOptions(input?: {
-  onSuccess?: () => void;
-}) {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to complete Sentry authorization" },
-    mutationFn: (data: CompleteSentryDeveloperConnectionAuthInput) =>
-      completeSentryDeveloperConnectionAuth({ data }),
-    onSuccess: input?.onSuccess,
-  });
-}
-
-export function setDeveloperConnectionSandboxEnabledMutationOptions(input?: {
-  onSuccess?: () => void;
-}) {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to update sandbox access" },
-    mutationFn: (data: SetDeveloperConnectionSandboxEnabledInput) =>
-      setDeveloperConnectionSandboxEnabled({ data }),
-    onSuccess: input?.onSuccess,
-  });
-}
-
-export function disconnectDeveloperConnectionMutationOptions(input?: {
-  onSuccess?: () => void;
-}) {
-  return mutationOptions({
-    meta: { errorTitle: "Failed to disconnect developer provider" },
-    mutationFn: (data: DisconnectDeveloperConnectionInput) =>
-      disconnectDeveloperConnection({ data }),
-    onSuccess: input?.onSuccess,
   });
 }


### PR DESCRIPTION
## Summary
- Inline shallow developer-connections mutation options into the owning client component.
- Keep developer-connections read query keys/options centralized.
- Update source ratchets so mutation input contracts live with the direct server-function callers.

## Test Plan
- [x] pnpm --filter @lightfast/app test -- src/__tests__/developer-connections-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/tanstack-query-input-types-source.test.ts
- [x] pnpm check
- [x] pnpm --filter @lightfast/app typecheck
- [x] git diff --check
- [x] SKIP_ENV_VALIDATION=true pnpm typecheck
- [x] pnpm turbo boundaries
- [x] agent-browser smoke: https://inline-developer-connection-mutations.lightfast.localhost/lightfast/developer-connections redirects to /sign-in?redirect_url=%2Flightfast%2Fdeveloper-connections