### PR TITLE
refactor: inline signal create mutation

### DIFF
--- a/api/app/src/adapters/tanstack/signals.ts
+++ b/api/app/src/adapters/tanstack/signals.ts
@@ -1,6 +1,7 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import type { z } from "zod";
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
@@ -106,4 +107,5 @@ export type ListWorkingSetSignalsResult = Awaited<
   ReturnType<typeof listWorkingSetSignals>
 >;
 export type SignalDetailResult = Awaited<ReturnType<typeof getSignal>>;
+export type CreateSignalInput = z.input<typeof createSignalCommand.input>;
 export type CreateSignalResult = Awaited<ReturnType<typeof createSignal>>;

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -501,7 +501,10 @@ describe("app authenticated route migration", () => {
     expect(clientSource).toContain("SignalsViewSwitcher");
     expect(clientSource).not.toContain("viewsSlot=");
     expect(clientSource).toContain("signalDetailQueryOptions");
-    expect(createDialogSource).toContain("createSignalMutationOptions");
+    expect(createDialogSource).toContain('@api/app/tanstack/signals"');
+    expect(createDialogSource).toContain("createSignal");
+    expect(createDialogSource).toContain("signalQueryKeys");
+    expect(createDialogSource).not.toContain("createSignalMutationOptions");
     expect(createDialogSource).toContain("listUserOrganizationsQueryOptions");
     expect(searchSource).toContain("validateSignalsSearch");
     expect(searchSource).toContain("parseSignalDispositions");

--- a/apps/app/src/__tests__/signals-queries-source.test.ts
+++ b/apps/app/src/__tests__/signals-queries-source.test.ts
@@ -3,9 +3,10 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const appRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(appRoot, "../..");
 
 describe("signals query helpers", () => {
-  it("centralizes migrated signal query keys and server function calls", () => {
+  it("centralizes migrated signal query keys and read server function calls", () => {
     const source = readFileSync(
       resolve(appRoot, "src/signals/signals-queries.ts"),
       "utf8"
@@ -16,7 +17,31 @@ describe("signals query helpers", () => {
     expect(source).toContain("workingSetSignalsQueryOptions");
     expect(source).toContain("processingSignalsQueryOptions");
     expect(source).toContain("signalDetailQueryOptions");
-    expect(source).toContain("createSignalMutationOptions");
+    expect(source).not.toContain("createSignalMutationOptions");
+    expect(source).not.toContain("createSignal,");
     expect(source).not.toContain("useTRPC");
+  });
+
+  it("keeps signal creation on a direct api/app server function import", () => {
+    const source = readFileSync(
+      resolve(appRoot, "src/signals/signal-create-dialog.tsx"),
+      "utf8"
+    );
+
+    expect(source).toContain('@api/app/tanstack/signals"');
+    expect(source).toContain("createSignal");
+    expect(source).toContain("type CreateSignalInput");
+    expect(source).toContain("signalQueryKeys");
+    expect(source).not.toContain("createSignalMutationOptions");
+  });
+
+  it("exports explicit signal creation contracts from api/app", () => {
+    const source = readFileSync(
+      resolve(repoRoot, "api/app/src/adapters/tanstack/signals.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("export type CreateSignalInput");
+    expect(source).toContain("export type CreateSignalResult");
   });
 });

--- a/apps/app/src/signals/signal-create-dialog.tsx
+++ b/apps/app/src/signals/signal-create-dialog.tsx
@@ -1,3 +1,7 @@
+import {
+  type CreateSignalInput,
+  createSignal,
+} from "@api/app/tanstack/signals";
 import { Loading03Icon as Loader2 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { SIGNAL_INPUT_MAX_LENGTH } from "@repo/api-contract";
@@ -17,7 +21,7 @@ import { useLocation } from "@tanstack/react-router";
 import type { ChangeEvent, FormEvent, KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { listUserOrganizationsQueryOptions } from "~/organization/organization-queries";
-import { createSignalMutationOptions } from "./signals-queries";
+import { signalQueryKeys } from "./signals-queries";
 
 interface SignalCreateDialogProps {
   onOpenChange: (open: boolean) => void;
@@ -124,22 +128,28 @@ export function SignalCreateDialog({
   const formattedInputLength = inputLength.toLocaleString();
   const formattedInputLimit = SIGNAL_INPUT_MAX_LENGTH.toLocaleString();
 
-  const createMutation = useMutation(
-    createSignalMutationOptions({
-      draftStorageKey,
-      onClose: () => onOpenChange(false),
-      onCreateMore: () =>
-        requestAnimationFrame(() => textareaRef.current?.focus()),
-      queryClient,
-      removeDraft: removeSignalDraft,
-      resetInput: () => setInput(""),
-      shouldCreateMore: () => createMore,
-      toastSuccess: () =>
-        toast.success("Signal queued", {
-          description: "Classification will start shortly.",
-        }),
-    })
-  );
+  const createMutation = useMutation({
+    meta: { errorTitle: "Failed to create signal" },
+    mutationFn: (data: CreateSignalInput) => createSignal({ data }),
+    onSuccess: () => {
+      removeSignalDraft(draftStorageKey);
+      void queryClient.invalidateQueries({
+        queryKey: signalQueryKeys.workingSet(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: signalQueryKeys.processing(),
+      });
+      toast.success("Signal queued", {
+        description: "Classification will start shortly.",
+      });
+      setInput("");
+      if (createMore) {
+        requestAnimationFrame(() => textareaRef.current?.focus());
+        return;
+      }
+      onOpenChange(false);
+    },
+  });
 
   useEffect(() => {
     setCreateMore(readCreateMore());

--- a/apps/app/src/signals/signals-queries.ts
+++ b/apps/app/src/signals/signals-queries.ts
@@ -1,5 +1,4 @@
 import {
-  createSignal,
   getSignal,
   type ListProcessingSignalsResult,
   type ListWorkingSetSignalsResult,
@@ -7,11 +6,7 @@ import {
   listWorkingSetSignals,
   type SignalDetailResult,
 } from "@api/app/tanstack/signals";
-import {
-  keepPreviousData,
-  type QueryClient,
-  queryOptions,
-} from "@tanstack/react-query";
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 import {
   PROCESSING_SIGNALS_LIMIT,
   signalProcessingStatuses,
@@ -73,36 +68,4 @@ export function signalDetailQueryOptions(input: {
     queryFn: () => getSignal({ data: { publicId: input.publicId } }),
     queryKey: signalQueryKeys.detail(input.publicId),
   });
-}
-
-export function createSignalMutationOptions(input: {
-  draftStorageKey: string;
-  onClose: () => void;
-  onCreateMore: () => void;
-  queryClient: QueryClient;
-  removeDraft: (storageKey: string) => void;
-  resetInput: () => void;
-  shouldCreateMore: () => boolean;
-  toastSuccess: () => void;
-}) {
-  return {
-    meta: { errorTitle: "Failed to create signal" },
-    mutationFn: (data: { input: string }) => createSignal({ data }),
-    onSuccess: () => {
-      input.removeDraft(input.draftStorageKey);
-      void input.queryClient.invalidateQueries({
-        queryKey: signalQueryKeys.workingSet(),
-      });
-      void input.queryClient.invalidateQueries({
-        queryKey: signalQueryKeys.processing(),
-      });
-      input.toastSuccess();
-      input.resetInput();
-      if (input.shouldCreateMore()) {
-        input.onCreateMore();
-        return;
-      }
-      input.onClose();
-    },
-  };
 }


### PR DESCRIPTION
## Summary
- inline the signal create mutation behavior into its only UI caller
- keep `signals-queries.ts` focused on signal query keys and read query options
- export an explicit `CreateSignalInput` contract from the TanStack signals adapter

## Test Plan
- `pnpm --filter @lightfast/app test -- src/__tests__/signals-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts`
- `pnpm --filter @api/app test -- src/__tests__/signals-tanstack-adapter-source.test.ts`
- `pnpm check`
- `pnpm --filter @lightfast/app typecheck`
- `SKIP_ENV_VALIDATION=true pnpm typecheck`
- `pnpm turbo boundaries`
- `git diff --check`
- agent-browser smoke: unauthenticated `/lightfast/signals` redirects to `/sign-in?redirect_url=%2Flightfast%2Fsignals`
