### PR TITLE
chore(mcp): narrow env boundary

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -13,10 +13,10 @@
     "start": "pnpm preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "with-env": "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
-    "with-env:local": "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
-    "with-env:vercel": "dotenv -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --",
-    "with-related-projects": "MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast) INNGEST_DEV=$(portless get inngest.lightfast) QSTASH_URL=$(portless get qstash.lightfast)"
+    "with-env": "dotenv -e ./.vercel/.env.development.local --",
+    "with-env:local": "dotenv -e ./.vercel/.env.development.local --",
+    "with-env:vercel": "dotenv -e ./.vercel/.env.development.local --",
+    "with-related-projects": "MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast)"
   },
   "dependencies": {
     "@api/app": "workspace:*",

--- a/apps/mcp/src/__tests__/env-config.test.ts
+++ b/apps/mcp/src/__tests__/env-config.test.ts
@@ -5,17 +5,38 @@ import { createSentryBuildOptions } from "../../vite.config";
 
 const appRoot = resolve(import.meta.dirname, "../..");
 
+const forbiddenAppRuntimeEnvNames = [
+  "CLERK_SECRET_KEY",
+  "CONNECTOR_MCP_AUTH_SECRET",
+  "DATABASE_HOST",
+  "DATABASE_USERNAME",
+  "DATABASE_PASSWORD",
+  "GITHUB_APP_CLIENT_SECRET",
+  "INNGEST_APP_NAME",
+  "INNGEST_DEV",
+  "INNGEST_EVENT_KEY",
+  "INNGEST_SERVE_ORIGIN",
+  "INNGEST_SIGNING_KEY",
+  "LINEAR_CLIENT_SECRET",
+  "QSTASH_URL",
+  "X_CLIENT_SECRET",
+] as const;
+
+function expectNoForbiddenAppRuntimeEnv(source: string) {
+  for (const envName of forbiddenAppRuntimeEnvNames) {
+    expect(source).not.toContain(envName);
+  }
+}
+
 describe("MCP environment validation wiring", () => {
-  it("keeps DB env requirements out of the MCP env schema", () => {
+  it("keeps app runtime env requirements out of the MCP env schema", () => {
     const envSource = readFileSync(resolve(appRoot, "src/env.ts"), "utf8");
 
     expect(envSource).toContain('import "@tanstack/react-start/server-only"');
     expect(envSource).not.toContain("@db/app/env");
-    expect(envSource).not.toContain("DATABASE_HOST");
-    expect(envSource).not.toContain("DATABASE_USERNAME");
-    expect(envSource).not.toContain("DATABASE_PASSWORD");
     expect(envSource).not.toContain("@vendor/observability/sentry-env");
     expect(envSource).toContain('from "@t3-oss/env-core"');
+    expectNoForbiddenAppRuntimeEnv(envSource);
   });
 
   it("evaluates the MCP env schema during Vite config loading", () => {
@@ -78,13 +99,72 @@ describe("MCP environment validation wiring", () => {
     );
   });
 
-  it("loads shared app env before app-specific MCP env", () => {
+  it("loads only MCP-owned env files", () => {
     const packageJson = JSON.parse(
       readFileSync(resolve(appRoot, "package.json"), "utf8")
     ) as { scripts: Record<string, string> };
 
-    expect(packageJson.scripts["with-env"]).toBe(
-      "dotenv -e ../app/.env.overrides.local -e ../app/.vercel/.env.development.local -e ./.vercel/.env.development.local --"
+    const envScripts = [
+      packageJson.scripts["with-env"],
+      packageJson.scripts["with-env:local"],
+      packageJson.scripts["with-env:vercel"],
+    ];
+
+    expect(envScripts).toEqual([
+      "dotenv -e ./.vercel/.env.development.local --",
+      "dotenv -e ./.vercel/.env.development.local --",
+      "dotenv -e ./.vercel/.env.development.local --",
+    ]);
+
+    for (const script of envScripts) {
+      expect(script).not.toContain("../app/.env");
+      expect(script).not.toContain("../app/.vercel");
+      expectNoForbiddenAppRuntimeEnv(script ?? "");
+    }
+
+    const relatedProjectsScript = packageJson.scripts["with-related-projects"];
+
+    expect(relatedProjectsScript).toBe(
+      "MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast)"
     );
+    expectNoForbiddenAppRuntimeEnv(relatedProjectsScript ?? "");
+  });
+
+  it("keeps app runtime envs out of the Turbo build boundary", () => {
+    const turboConfig = JSON.parse(
+      readFileSync(resolve(appRoot, "turbo.json"), "utf8")
+    ) as {
+      tasks: {
+        build: {
+          env?: string[];
+          passThroughEnv?: string[];
+          inputs?: string[];
+        };
+      };
+    };
+
+    expect(turboConfig.tasks.build.env ?? []).toEqual(
+      expect.not.arrayContaining([...forbiddenAppRuntimeEnvNames])
+    );
+    expect(turboConfig.tasks.build.passThroughEnv ?? []).toEqual(
+      expect.arrayContaining(["HOST", "PORT"])
+    );
+    expect(turboConfig.tasks.build.passThroughEnv ?? []).toEqual(
+      expect.not.arrayContaining([...forbiddenAppRuntimeEnvNames])
+    );
+
+    for (const input of turboConfig.tasks.build.inputs ?? []) {
+      expect(input).not.toContain("../app/.env");
+      expect(input).not.toContain("../app/.vercel");
+    }
+  });
+
+  it("does not seed app runtime envs in the MCP test bootstrap", () => {
+    const setupSource = readFileSync(
+      resolve(appRoot, "src/__tests__/setup-env.ts"),
+      "utf8"
+    );
+
+    expectNoForbiddenAppRuntimeEnv(setupSource);
   });
 });

--- a/apps/mcp/src/__tests__/setup-env.ts
+++ b/apps/mcp/src/__tests__/setup-env.ts
@@ -1,6 +1,3 @@
-process.env.DATABASE_HOST ||= "localhost";
-process.env.DATABASE_USERNAME ||= "test";
-process.env.DATABASE_PASSWORD ||= "test";
 process.env.MCP_AUTH_ISSUER ||= "https://mcp.lightfast.test";
 process.env.MCP_RESOURCE_URL ||= "https://mcp.lightfast.test/mcp";
 process.env.SERVICE_JWT_SECRET ||=

--- a/apps/mcp/turbo.json
+++ b/apps/mcp/turbo.json
@@ -17,19 +17,8 @@
         "VITE_*",
         "VERCEL_ENV"
       ],
-      "passThroughEnv": [
-        "DATABASE_HOST",
-        "DATABASE_USERNAME",
-        "DATABASE_PASSWORD",
-        "HOST",
-        "PORT"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "../app/.env.overrides.local",
-        "../app/.vercel/.env*",
-        ".vercel/.env*"
-      ],
+      "passThroughEnv": ["HOST", "PORT"],
+      "inputs": ["$TURBO_DEFAULT$", ".vercel/.env*"],
       "outputs": [".output/**", "dist/**", "src/routeTree.gen.ts"]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- stop apps/mcp from loading apps/app env files or app workflow envs during local/dev/build flows
- remove DB env pass-through and app env file inputs from the MCP Turbo build boundary
- add source ratchets covering app runtime env leaks in MCP package scripts, Turbo config, env schema, and test bootstrap

## Test Plan
- pnpm --filter @lightfast/mcp test -- src/__tests__/env-config.test.ts src/__tests__/mcp-app-boundary-source.test.ts
- pnpm --filter @lightfast/mcp test
- pnpm --filter @lightfast/mcp typecheck
- pnpm --filter @lightfast/mcp build
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- git diff --check
- agent-browser smoke: /api/health, /.well-known/oauth-protected-resource, and unauthenticated /mcp on https://auth-boundary-ratchets.mcp.lightfast.localhost