### PR TITLE
test(mcp): ratchet connector runtime boundary

### DIFF
--- a/apps/mcp/src/__tests__/mcp-app-boundary-source.test.ts
+++ b/apps/mcp/src/__tests__/mcp-app-boundary-source.test.ts
@@ -32,6 +32,18 @@ function productionSources() {
     .filter((path) => !/\.test\.[tj]sx?$/.test(path));
 }
 
+function importSpecifiers(source: string): string[] {
+  return [
+    ...source.matchAll(/\bimport\s+["']([^"']+)["']/g),
+    ...source.matchAll(/\bfrom\s+["']([^"']+)["']/g),
+    ...source.matchAll(/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g),
+    ...source.matchAll(/\brequire\s*\(\s*["']([^"']+)["']\s*\)/g),
+  ].flatMap((match) => {
+    const specifier = match[1];
+    return specifier ? [specifier] : [];
+  });
+}
+
 describe("hosted MCP app boundary", () => {
   it("does not import app backend packages in production MCP code", () => {
     const packageJson = JSON.parse(source("package.json")) as {
@@ -64,5 +76,32 @@ describe("hosted MCP app boundary", () => {
       .sort();
 
     expect(staleSources).toEqual([]);
+  });
+
+  it("does not import connector provider runtime code in production MCP code", () => {
+    const packageJson = JSON.parse(source("package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(
+      packageJson.dependencies?.["@repo/provider-routines"]
+    ).toBeUndefined();
+
+    const forbiddenRuntimeImport = new RegExp(
+      [
+        "^@repo/provider-routines($|/)",
+        "^@lightfast/connector-(github|granola|linear|x)/(node|oauth|mcp|operations|tools)($|/)",
+      ].join("|")
+    );
+    const staleImports = productionSources()
+      .flatMap((path) => {
+        const relativePath = relative(appRoot, path);
+        return importSpecifiers(readFileSync(path, "utf8"))
+          .filter((specifier) => forbiddenRuntimeImport.test(specifier))
+          .map((specifier) => `${relativePath}: ${specifier}`);
+      })
+      .sort();
+
+    expect(staleImports).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add an MCP source ratchet that forbids production imports of connector provider runtime entrypoints (`node`, `oauth`, `mcp`, `operations`, `tools`) and `@repo/provider-routines`
- Keep client-safe connector contracts possible by avoiding whole provider-package bans
- Extend import scanning to side-effect, static, dynamic, and require imports

## Test Plan
- pnpm --filter @lightfast/mcp test -- src/__tests__/mcp-app-boundary-source.test.ts
- pnpm --filter @lightfast/mcp typecheck
- pnpm --filter @lightfast/mcp build
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- git diff --check
- agent-browser smoke: health, OAuth protected-resource metadata, unauthenticated /mcp invalid-token response

## Notes
- `pnpm run knip` requires `SKIP_ENV_VALIDATION=true`; with that set, it reports broad pre-existing repo drift unrelated to this one-file ratchet.