### PR TITLE
Split MCP app internal URL from issuer

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -16,7 +16,7 @@
     "with-env": "dotenv -e ./.vercel/.env.development.local --",
     "with-env:local": "dotenv -e ./.vercel/.env.development.local --",
     "with-env:vercel": "dotenv -e ./.vercel/.env.development.local --",
-    "with-related-projects": "MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast)"
+    "with-related-projects": "APP_INTERNAL_URL=$(portless get lightfast) MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast)"
   },
   "dependencies": {
     "@lightfast/connector-core": "workspace:*",

--- a/apps/mcp/src/__tests__/app-proxy-intake.test.ts
+++ b/apps/mcp/src/__tests__/app-proxy-intake.test.ts
@@ -4,7 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const jwtSecret = "test-service-jwt-secret-at-least-32-chars";
 
 async function importAdapter() {
-  vi.stubEnv("MCP_AUTH_ISSUER", "https://lightfast.ai");
+  vi.stubEnv("APP_INTERNAL_URL", "https://app-internal.lightfast.ai");
+  vi.stubEnv("MCP_AUTH_ISSUER", "https://issuer.lightfast.ai");
   vi.stubEnv("MCP_RESOURCE_URL", "https://mcp.lightfast.ai/mcp");
   vi.stubEnv("SERVICE_JWT_SECRET", jwtSecret);
   return await import("../tools/app-proxy-intake");
@@ -73,7 +74,7 @@ describe("app proxy intake adapter", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://lightfast.ai/api/internal/mcp/proxy/find",
+      "https://app-internal.lightfast.ai/api/internal/mcp/proxy/find",
       expect.objectContaining({
         method: "POST",
       })
@@ -141,7 +142,7 @@ describe("app proxy intake adapter", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://lightfast.ai/api/internal/mcp/proxy/call",
+      "https://app-internal.lightfast.ai/api/internal/mcp/proxy/call",
       expect.objectContaining({
         method: "POST",
       })

--- a/apps/mcp/src/__tests__/app-signal-intake.test.ts
+++ b/apps/mcp/src/__tests__/app-signal-intake.test.ts
@@ -4,7 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const jwtSecret = "test-service-jwt-secret-at-least-32-chars";
 
 async function importAdapter() {
-  vi.stubEnv("MCP_AUTH_ISSUER", "https://lightfast.ai");
+  vi.stubEnv("APP_INTERNAL_URL", "https://app-internal.lightfast.ai");
+  vi.stubEnv("MCP_AUTH_ISSUER", "https://issuer.lightfast.ai");
   vi.stubEnv("MCP_RESOURCE_URL", "https://mcp.lightfast.ai/mcp");
   vi.stubEnv("SERVICE_JWT_SECRET", jwtSecret);
   return await import("../tools/app-signal-intake");
@@ -50,7 +51,7 @@ describe("app signal intake adapter", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://lightfast.ai/api/internal/mcp/signals",
+      "https://app-internal.lightfast.ai/api/internal/mcp/signals",
       expect.objectContaining({
         method: "POST",
       })
@@ -187,7 +188,7 @@ describe("app signal intake adapter", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://lightfast.ai/api/internal/mcp/signals/get",
+      "https://app-internal.lightfast.ai/api/internal/mcp/signals/get",
       expect.objectContaining({
         method: "POST",
       })

--- a/apps/mcp/src/__tests__/env-config.test.ts
+++ b/apps/mcp/src/__tests__/env-config.test.ts
@@ -36,6 +36,7 @@ describe("MCP environment validation wiring", () => {
     expect(envSource).not.toContain("@db/app/env");
     expect(envSource).not.toContain("@vendor/observability/sentry-env");
     expect(envSource).toContain('from "@t3-oss/env-core"');
+    expect(envSource).toContain("APP_INTERNAL_URL");
     expectNoForbiddenAppRuntimeEnv(envSource);
   });
 
@@ -95,6 +96,7 @@ describe("MCP environment validation wiring", () => {
         "SENTRY_ORG",
         "SENTRY_PROJECT",
         "VITE_*",
+        "APP_INTERNAL_URL",
       ])
     );
   });
@@ -125,9 +127,22 @@ describe("MCP environment validation wiring", () => {
     const relatedProjectsScript = packageJson.scripts["with-related-projects"];
 
     expect(relatedProjectsScript).toBe(
-      "MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast)"
+      "APP_INTERNAL_URL=$(portless get lightfast) MCP_RESOURCE_URL=$(portless get mcp.lightfast)/mcp MCP_AUTH_ISSUER=$(portless get lightfast)"
     );
     expectNoForbiddenAppRuntimeEnv(relatedProjectsScript ?? "");
+  });
+
+  it("uses a distinct app internal URL for app-owned MCP intake calls", () => {
+    const intakeSource = [
+      "src/tools/app-audit-intake.ts",
+      "src/tools/app-proxy-intake.ts",
+      "src/tools/app-signal-intake.ts",
+    ]
+      .map((path) => readFileSync(resolve(appRoot, path), "utf8"))
+      .join("\n");
+
+    expect(intakeSource).toContain("appInternalUrl");
+    expect(intakeSource).not.toContain("env.MCP_AUTH_ISSUER");
   });
 
   it("keeps app runtime envs out of the Turbo build boundary", () => {

--- a/apps/mcp/src/env.ts
+++ b/apps/mcp/src/env.ts
@@ -12,6 +12,7 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(["development", "production", "test"])
       .default("development"),
+    APP_INTERNAL_URL: z.string().url().optional(),
     MCP_AUTH_ISSUER: z.string().url(),
     MCP_RESOURCE_URL: z.string().url(),
     SERVICE_JWT_SECRET: z.string().min(32),
@@ -25,6 +26,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
+    APP_INTERNAL_URL: process.env.APP_INTERNAL_URL,
     MCP_AUTH_ISSUER: process.env.MCP_AUTH_ISSUER,
     MCP_RESOURCE_URL: process.env.MCP_RESOURCE_URL,
     SERVICE_JWT_SECRET: process.env.SERVICE_JWT_SECRET,
@@ -40,3 +42,5 @@ export const env = createEnv({
     process.env.npm_lifecycle_event === "lint",
   emptyStringAsUndefined: true,
 });
+
+export const appInternalUrl = env.APP_INTERNAL_URL ?? env.MCP_AUTH_ISSUER;

--- a/apps/mcp/src/tools/app-audit-intake.ts
+++ b/apps/mcp/src/tools/app-audit-intake.ts
@@ -1,5 +1,5 @@
 import { signServiceJWT } from "@repo/service-jwt";
-import { env } from "../env";
+import { appInternalUrl, env } from "../env";
 
 type Fetch = typeof fetch;
 
@@ -35,7 +35,7 @@ async function readJson(response: Response): Promise<unknown> {
 }
 
 function appAuditUrl(): string {
-  return new URL("/api/internal/mcp/audit", env.MCP_AUTH_ISSUER).toString();
+  return new URL("/api/internal/mcp/audit", appInternalUrl).toString();
 }
 
 function messageFromBody(body: unknown): string {

--- a/apps/mcp/src/tools/app-proxy-intake.ts
+++ b/apps/mcp/src/tools/app-proxy-intake.ts
@@ -12,7 +12,7 @@ import {
 } from "@lightfast/connector-core/provider-routines";
 import { signServiceJWT } from "@repo/service-jwt";
 
-import { env } from "../env";
+import { appInternalUrl, env } from "../env";
 
 type Fetch = typeof fetch;
 
@@ -61,7 +61,7 @@ async function readJson(response: Response): Promise<unknown> {
 }
 
 function appProxyUrl(pathname: string): string {
-  return new URL(pathname, env.MCP_AUTH_ISSUER).toString();
+  return new URL(pathname, appInternalUrl).toString();
 }
 
 function commandActorFromContext(

--- a/apps/mcp/src/tools/app-signal-intake.ts
+++ b/apps/mcp/src/tools/app-signal-intake.ts
@@ -8,7 +8,7 @@ import {
 } from "@repo/api-contract";
 import { signServiceJWT } from "@repo/service-jwt";
 
-import { env } from "../env";
+import { appInternalUrl, env } from "../env";
 
 type Fetch = typeof fetch;
 
@@ -32,7 +32,7 @@ async function readJson(response: Response): Promise<unknown> {
 }
 
 function appSignalUrl(pathname = "/api/internal/mcp/signals"): string {
-  return new URL(pathname, env.MCP_AUTH_ISSUER).toString();
+  return new URL(pathname, appInternalUrl).toString();
 }
 
 function messageFromBody(body: unknown): string {

--- a/apps/mcp/turbo.json
+++ b/apps/mcp/turbo.json
@@ -6,6 +6,7 @@
     "build": {
       "dependsOn": ["^build"],
       "env": [
+        "APP_INTERNAL_URL",
         "MCP_AUTH_ISSUER",
         "MCP_RESOURCE_URL",
         "SERVICE_JWT_SECRET",


### PR DESCRIPTION
## Summary
- Add optional APP_INTERNAL_URL to the MCP runtime env and turbo build allowlist.
- Route app-owned MCP intake calls through appInternalUrl instead of coupling them to MCP_AUTH_ISSUER.
- Add tests that lock the distinct internal URL wiring and related project script.

## Test Plan
- pnpm --filter @lightfast/mcp test -- src/__tests__/env-config.test.ts src/__tests__/app-signal-intake.test.ts src/__tests__/app-proxy-intake.test.ts
- pnpm --filter @lightfast/mcp typecheck
- pnpm --filter @lightfast/mcp build
- pnpm check
- SKIP_ENV_VALIDATION=true pnpm typecheck
- pnpm turbo boundaries
- git diff --check
- agent-browser smoke: /api/health, /.well-known/oauth-protected-resource, unauthenticated /mcp

## Notes
- SKIP_ENV_VALIDATION=true pnpm run knip still reports broad pre-existing repo drift, so this PR leaves Knip cleanup out of scope.