### PR TITLE
refactor(app): inline signal list queries

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -508,8 +508,12 @@ describe("app authenticated route migration", () => {
     expect(createDialogSource).toContain("listUserOrganizationsQueryOptions");
     expect(searchSource).toContain("validateSignalsSearch");
     expect(searchSource).toContain("parseSignalDispositions");
-    expect(workspaceDataSource).toContain("workingSetSignalsQueryOptions");
-    expect(workspaceDataSource).toContain("processingSignalsQueryOptions");
+    expect(workspaceDataSource).toContain("listWorkingSetSignals");
+    expect(workspaceDataSource).toContain("listProcessingSignals");
+    expect(workspaceDataSource).toContain("signalQueryKeys.workingSet()");
+    expect(workspaceDataSource).toContain("signalQueryKeys.processing()");
+    expect(workspaceDataSource).not.toContain("workingSetSignalsQueryOptions");
+    expect(workspaceDataSource).not.toContain("processingSignalsQueryOptions");
     expect(workspaceDataSource).toContain("filterClassifiedSignals");
     expect(workspaceDataSource).toContain("compareSignalsByRecency");
     expect(workspaceDataSource).not.toContain("useWorkingSetQuery");

--- a/apps/app/src/__tests__/signals-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/signals-no-trpc-source.test.ts
@@ -46,8 +46,13 @@ describe("migrated signal UI data access", () => {
     }
     expect(workspaceDataSource).toContain('from "@tanstack/react-query"');
     expect(workspaceDataSource).toContain("useQuery");
-    expect(workspaceDataSource).toContain("workingSetSignalsQueryOptions");
-    expect(workspaceDataSource).toContain("processingSignalsQueryOptions");
+    expect(workspaceDataSource).toContain('@api/app/tanstack/signals"');
+    expect(workspaceDataSource).toContain("listWorkingSetSignals");
+    expect(workspaceDataSource).toContain("listProcessingSignals");
+    expect(workspaceDataSource).toContain("signalQueryKeys.workingSet()");
+    expect(workspaceDataSource).toContain("signalQueryKeys.processing()");
+    expect(workspaceDataSource).not.toContain("workingSetSignalsQueryOptions");
+    expect(workspaceDataSource).not.toContain("processingSignalsQueryOptions");
     expect(workspaceDataSource).toContain("filterClassifiedSignals");
     expect(workspaceDataSource).toContain("compareSignalsByRecency");
     expect(workspaceDataSource).not.toContain("useWorkingSetQuery");

--- a/apps/app/src/__tests__/signals-queries-source.test.ts
+++ b/apps/app/src/__tests__/signals-queries-source.test.ts
@@ -6,7 +6,7 @@ const appRoot = resolve(import.meta.dirname, "../..");
 const repoRoot = resolve(appRoot, "../..");
 
 describe("signals query helpers", () => {
-  it("centralizes migrated signal query keys and read server function calls", () => {
+  it("keeps signal keys, result types, and shared detail query options", () => {
     const source = readFileSync(
       resolve(appRoot, "src/signals/signals-queries.ts"),
       "utf8"
@@ -14,9 +14,11 @@ describe("signals query helpers", () => {
 
     expect(source).toContain('@api/app/tanstack/signals"');
     expect(source).toContain("signalQueryKeys");
-    expect(source).toContain("workingSetSignalsQueryOptions");
-    expect(source).toContain("processingSignalsQueryOptions");
     expect(source).toContain("signalDetailQueryOptions");
+    expect(source).not.toContain("workingSetSignalsQueryOptions");
+    expect(source).not.toContain("processingSignalsQueryOptions");
+    expect(source).not.toContain("listWorkingSetSignals,");
+    expect(source).not.toContain("listProcessingSignals,");
     expect(source).not.toContain("createSignalMutationOptions");
     expect(source).not.toContain("createSignal,");
     expect(source).not.toContain("useTRPC");

--- a/apps/app/src/__tests__/signals-queries-source.test.ts
+++ b/apps/app/src/__tests__/signals-queries-source.test.ts
@@ -17,8 +17,8 @@ describe("signals query helpers", () => {
     expect(source).toContain("signalDetailQueryOptions");
     expect(source).not.toContain("workingSetSignalsQueryOptions");
     expect(source).not.toContain("processingSignalsQueryOptions");
-    expect(source).not.toContain("listWorkingSetSignals,");
-    expect(source).not.toContain("listProcessingSignals,");
+    expect(source).not.toContain("listWorkingSetSignals");
+    expect(source).not.toContain("listProcessingSignals");
     expect(source).not.toContain("createSignalMutationOptions");
     expect(source).not.toContain("createSignal,");
     expect(source).not.toContain("useTRPC");

--- a/apps/app/src/signals/signals-queries.ts
+++ b/apps/app/src/signals/signals-queries.ts
@@ -2,18 +2,13 @@ import {
   getSignal,
   type ListProcessingSignalsResult,
   type ListWorkingSetSignalsResult,
-  listProcessingSignals,
-  listWorkingSetSignals,
   type SignalDetailResult,
 } from "@api/app/tanstack/signals";
-import { keepPreviousData, queryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import {
   PROCESSING_SIGNALS_LIMIT,
   signalProcessingStatuses,
 } from "./signals-model";
-
-const WORKING_SET_REFETCH_MS = 30_000;
-const PROCESSING_REFETCH_MS = 5000;
 
 export type ProcessingSignalsResult = ListProcessingSignalsResult;
 export type WorkingSetSignalsResult = ListWorkingSetSignalsResult;
@@ -30,34 +25,6 @@ export const signalQueryKeys = {
     ] as const,
   workingSet: () => ["signals", "working-set"] as const,
 };
-
-export function workingSetSignalsQueryOptions() {
-  return queryOptions({
-    enabled: typeof window !== "undefined",
-    placeholderData: keepPreviousData,
-    queryFn: () => listWorkingSetSignals(),
-    queryKey: signalQueryKeys.workingSet(),
-    refetchInterval: WORKING_SET_REFETCH_MS,
-    staleTime: WORKING_SET_REFETCH_MS,
-  });
-}
-
-export function processingSignalsQueryOptions() {
-  return queryOptions({
-    enabled: typeof window !== "undefined",
-    placeholderData: keepPreviousData,
-    queryFn: () =>
-      listProcessingSignals({
-        data: {
-          limit: PROCESSING_SIGNALS_LIMIT,
-          statuses: [...signalProcessingStatuses],
-        },
-      }),
-    queryKey: signalQueryKeys.processing(),
-    refetchInterval: PROCESSING_REFETCH_MS,
-    staleTime: PROCESSING_REFETCH_MS,
-  });
-}
 
 export function signalDetailQueryOptions(input: {
   enabled: boolean;

--- a/apps/app/src/signals/use-signals-workspace-data.ts
+++ b/apps/app/src/signals/use-signals-workspace-data.ts
@@ -1,28 +1,54 @@
-import { useQuery } from "@tanstack/react-query";
+import {
+  listProcessingSignals,
+  listWorkingSetSignals,
+} from "@api/app/tanstack/signals";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
   adaptProcessingRow,
   compareSignalsByRecency,
   filterClassifiedSignals,
+  PROCESSING_SIGNALS_LIMIT,
   type SignalClassificationFilters,
   type SignalListItem,
   type SignalRow,
   type SignalSection,
+  signalProcessingStatuses,
 } from "./signals-model";
-import {
-  processingSignalsQueryOptions,
-  workingSetSignalsQueryOptions,
-} from "./signals-queries";
+import { signalQueryKeys } from "./signals-queries";
+
+const WORKING_SET_REFETCH_MS = 30_000;
+const PROCESSING_REFETCH_MS = 5000;
 
 export function useSignalsWorkspaceData({
   filters,
 }: {
   filters: SignalClassificationFilters;
 }) {
-  const workingSetOptions = workingSetSignalsQueryOptions();
-  const processingOptions = processingSignalsQueryOptions();
-  const workingSetQuery = useQuery(workingSetOptions);
-  const processingQuery = useQuery(processingOptions);
+  const workingSetQueryKey = signalQueryKeys.workingSet();
+  const processingQueryKey = signalQueryKeys.processing();
+  const workingSetQuery = useQuery({
+    enabled: typeof window !== "undefined",
+    placeholderData: keepPreviousData,
+    queryFn: () => listWorkingSetSignals(),
+    queryKey: workingSetQueryKey,
+    refetchInterval: WORKING_SET_REFETCH_MS,
+    staleTime: WORKING_SET_REFETCH_MS,
+  });
+  const processingQuery = useQuery({
+    enabled: typeof window !== "undefined",
+    placeholderData: keepPreviousData,
+    queryFn: () =>
+      listProcessingSignals({
+        data: {
+          limit: PROCESSING_SIGNALS_LIMIT,
+          statuses: [...signalProcessingStatuses],
+        },
+      }),
+    queryKey: processingQueryKey,
+    refetchInterval: PROCESSING_REFETCH_MS,
+    staleTime: PROCESSING_REFETCH_MS,
+  });
 
   const classifiedRows = useMemo<SignalListItem[]>(
     () => workingSetQuery.data?.items ?? [],
@@ -98,12 +124,12 @@ export function useSignalsWorkspaceData({
     isInitialPending:
       !hasAnyRows && (workingSetQuery.isPending || processingQuery.isPending),
     limit: workingSetQuery.data?.limit ?? 2000,
-    processingQueryKey: processingOptions.queryKey,
+    processingQueryKey,
     signalsByPublicId,
     totalCount: workingSetQuery.data?.totalCount ?? classifiedRows.length,
     truncated: workingSetQuery.data?.truncated ?? false,
     visibleListSections,
     windowDays: workingSetQuery.data?.windowDays ?? 30,
-    workingSetQueryKey: workingSetOptions.queryKey,
+    workingSetQueryKey,
   };
 }


### PR DESCRIPTION
## Summary
- inline working-set and processing signal list queries in `useSignalsWorkspaceData`
- keep `signals-queries` focused on shared result types, query keys, and signal detail options
- update source ratchets so the single-use list query wrappers stay gone

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/signals-queries-source.test.ts src/__tests__/signals-no-trpc-source.test.ts src/__tests__/authenticated-routes-source.test.ts
- pnpm --filter @lightfast/app typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized signals data fetching architecture for improved efficiency and maintainability.
  * Streamlined query handling for workspace signal operations while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->