### PR TITLE
refactor(app): inline workspace assistant queries

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -334,7 +334,9 @@ describe("app authenticated route migration", () => {
     expect(teamSwitcherSource).toContain('to="/$slug"');
     expect(teamSwitcherSource).not.toContain("next/navigation");
     expect(teamSwitcherSource).not.toContain("next/link");
-    expect(recentChatsMenuSource).toContain(
+    expect(recentChatsMenuSource).toContain("listConversations");
+    expect(recentChatsMenuSource).toContain("assistantConversationsQueryKey");
+    expect(recentChatsMenuSource).not.toContain(
       "assistantConversationsQueryOptions"
     );
     expect(recentChatsMenuSource).toContain('to="/$slug/chat/$conversationId"');
@@ -873,7 +875,9 @@ describe("app authenticated route migration", () => {
     expect(chatIndexRouteSource).toContain("WorkspaceAssistantClient");
     expect(chatIndexRouteSource).toContain("key={conversationId}");
     expect(chatRouteSource).not.toContain("WorkspacePage");
-    expect(conversationRouteSource).toContain(
+    expect(conversationRouteSource).toContain("getConversation");
+    expect(conversationRouteSource).toContain("assistantConversationQueryKey");
+    expect(conversationRouteSource).not.toContain(
       "assistantConversationQueryOptions"
     );
     expect(conversationRouteSource).toContain("WorkspaceAssistantClient");
@@ -891,6 +895,10 @@ describe("app authenticated route migration", () => {
     );
     expect(assistantClientSource).toContain("createConversation({ data })");
     expect(assistantClientSource).toContain("assistantConversationsQueryKey");
+    expect(assistantClientSource).toContain("assistantConversationQueryKey");
+    expect(assistantClientSource).not.toContain(
+      "assistantConversationQueryOptions"
+    );
     expect(composerSource).toContain("PromptInput");
     expect(composerSource).toContain("PromptInputSubmit");
     expect(messageSource).toContain("ChatMessage");

--- a/apps/app/src/__tests__/workspace-assistant-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/workspace-assistant-no-trpc-source.test.ts
@@ -25,8 +25,17 @@ describe("migrated workspace assistant data access", () => {
     );
 
     expect(queryHelperSource).toMatch(assistantAdapterImport);
-    expect(queryHelperSource).toContain("assistantConversationsQueryOptions");
-    expect(queryHelperSource).toContain("assistantConversationQueryOptions");
+    expect(queryHelperSource).toContain("assistantConversationsQueryKey");
+    expect(queryHelperSource).toContain("assistantConversationQueryKey");
+    expect(queryHelperSource).not.toContain("queryOptions");
+    expect(queryHelperSource).not.toContain(
+      "assistantConversationsQueryOptions"
+    );
+    expect(queryHelperSource).not.toContain(
+      "assistantConversationQueryOptions"
+    );
+    expect(queryHelperSource).not.toContain("listConversations");
+    expect(queryHelperSource).not.toContain("getConversation");
 
     for (const fileSource of [
       queryHelperSource,
@@ -40,11 +49,11 @@ describe("migrated workspace assistant data access", () => {
       expect(fileSource).not.toContain("AppRouterOutputs");
     }
 
-    expect(recentChatsMenuSource).toContain(
-      "assistantConversationsQueryOptions"
-    );
+    expect(recentChatsMenuSource).toContain("listConversations");
+    expect(recentChatsMenuSource).toContain("assistantConversationsQueryKey");
     expect(clientSource).toContain("createConversation");
     expect(clientSource).toContain("assistantConversationsQueryKey");
+    expect(clientSource).toContain("assistantConversationQueryKey");
     expect(newConversationRouteSource).toContain(
       'from "~/chat/conversation-id"'
     );
@@ -54,7 +63,9 @@ describe("migrated workspace assistant data access", () => {
     );
     expect(newConversationRouteSource).not.toContain("createServerFn");
     expect(newConversationRouteSource).not.toContain("@db/app");
-    expect(conversationRouteSource).toContain(
+    expect(conversationRouteSource).toContain("getConversation");
+    expect(conversationRouteSource).toContain("assistantConversationQueryKey");
+    expect(conversationRouteSource).not.toContain(
       "assistantConversationQueryOptions"
     );
   });

--- a/apps/app/src/chat/workspace-assistant-client.tsx
+++ b/apps/app/src/chat/workspace-assistant-client.tsx
@@ -29,7 +29,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatComposer } from "./chat-composer";
 import { ChatMessage } from "./chat-message";
 import {
-  assistantConversationQueryOptions,
+  assistantConversationQueryKey,
   assistantConversationsQueryKey,
   type WorkspaceAssistantConversationResult,
 } from "./workspace-assistant-queries";
@@ -64,8 +64,8 @@ export function WorkspaceAssistantClient({
       title: string;
     }) => createConversation({ data }),
   });
-  const getConversationQueryOptions = useMemo(
-    () => assistantConversationQueryOptions({ conversationId }),
+  const conversationQueryKey = useMemo(
+    () => assistantConversationQueryKey(conversationId),
     [conversationId]
   );
   const initialMessages = useMemo(
@@ -223,7 +223,7 @@ export function WorkspaceAssistantClient({
         setOptimisticFirstMessage(null);
       }
       if (createdConversationDuringSubmit && createdConversation) {
-        queryClient.setQueryData(getConversationQueryOptions.queryKey, {
+        queryClient.setQueryData(conversationQueryKey, {
           conversation: createdConversation,
           messages: toSeededConversationMessages(
             messagesRef.current,
@@ -245,7 +245,7 @@ export function WorkspaceAssistantClient({
     [
       conversationId,
       createConversationMutation.mutateAsync,
-      getConversationQueryOptions.queryKey,
+      conversationQueryKey,
       orgSlug,
       queryClient,
       router,

--- a/apps/app/src/chat/workspace-assistant-queries.ts
+++ b/apps/app/src/chat/workspace-assistant-queries.ts
@@ -1,10 +1,7 @@
-import {
-  type GetConversationResult,
-  getConversation,
-  type ListConversationsResult,
-  listConversations,
+import type {
+  GetConversationResult,
+  ListConversationsResult,
 } from "@api/app/tanstack/assistant";
-import { queryOptions } from "@tanstack/react-query";
 
 export type WorkspaceAssistantConversationResult = GetConversationResult;
 export type WorkspaceAssistantConversationList = ListConversationsResult;
@@ -16,27 +13,11 @@ export const assistantConversationsQueryKey = [
   "conversations",
 ] as const;
 
-const assistantConversationQueryKey = [
+const assistantConversationQueryKeyPrefix = [
   "workspace-assistant",
   "conversation",
 ] as const;
 
-export function assistantConversationsQueryOptions(input: { limit: number }) {
-  return queryOptions({
-    enabled: typeof window !== "undefined",
-    queryFn: () => listConversations({ data: input }),
-    queryKey: [...assistantConversationsQueryKey, input] as const,
-    staleTime: 0,
-  });
-}
-
-export function assistantConversationQueryOptions(input: {
-  conversationId: string;
-}) {
-  return queryOptions({
-    enabled: typeof window !== "undefined",
-    queryFn: () => getConversation({ data: { id: input.conversationId } }),
-    queryKey: [...assistantConversationQueryKey, input.conversationId] as const,
-    retry: false,
-  });
+export function assistantConversationQueryKey(conversationId: string) {
+  return [...assistantConversationQueryKeyPrefix, conversationId] as const;
 }

--- a/apps/app/src/components/recent-chats-menu.tsx
+++ b/apps/app/src/components/recent-chats-menu.tsx
@@ -1,3 +1,4 @@
+import { listConversations } from "@api/app/tanstack/assistant";
 import {
   CollapseIcon,
   ExpandIcon,
@@ -20,9 +21,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
 import {
-  assistantConversationsQueryOptions,
+  assistantConversationsQueryKey,
   type WorkspaceAssistantConversationListItem,
 } from "~/chat/workspace-assistant-queries";
+
+const recentChatsInput = { limit: 20 } as const;
 
 export function RecentChatsMenu({
   onConversationSelect,
@@ -37,8 +40,10 @@ export function RecentChatsMenu({
 }) {
   const [expanded, setExpanded] = useState(false);
   const { data, error, isPending } = useQuery({
-    ...assistantConversationsQueryOptions({ limit: 20 }),
     enabled: typeof window !== "undefined" && Boolean(orgSlug),
+    queryFn: () => listConversations({ data: recentChatsInput }),
+    queryKey: [...assistantConversationsQueryKey, recentChatsInput] as const,
+    staleTime: 0,
   });
 
   const conversations = data?.items ?? [];

--- a/apps/app/src/routes/_authenticated/$slug/chat/$conversationId.tsx
+++ b/apps/app/src/routes/_authenticated/$slug/chat/$conversationId.tsx
@@ -1,10 +1,11 @@
 // biome-ignore-all lint/style/useFilenamingConvention: TanStack route params use camelCase file names for camelCase params.
 
+import { getConversation } from "@api/app/tanstack/assistant";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { ChatLoading } from "~/chat/chat-loading";
 import { WorkspaceAssistantClient } from "~/chat/workspace-assistant-client";
-import { assistantConversationQueryOptions } from "~/chat/workspace-assistant-queries";
+import { assistantConversationQueryKey } from "~/chat/workspace-assistant-queries";
 import { WorkspaceRouteErrorPanel } from "~/components/route-boundaries";
 
 const conversationNotFoundCode = "WORKSPACE_ASSISTANT_CONVERSATION_NOT_FOUND";
@@ -53,7 +54,10 @@ function ChatRouteError({
 function WorkspaceConversationPage() {
   const { conversationId } = Route.useParams();
   const conversationQuery = useQuery({
-    ...assistantConversationQueryOptions({ conversationId }),
+    enabled: typeof window !== "undefined",
+    queryFn: () => getConversation({ data: { id: conversationId } }),
+    queryKey: assistantConversationQueryKey(conversationId),
+    retry: false,
   });
 
   if (conversationQuery.isPending) {


### PR DESCRIPTION
## Summary
- convert `workspace-assistant-queries` into shared result types and cache-key primitives only
- inline workspace assistant list/detail TanStack Query options at the direct UI consumers
- update source ratchets so the single-hop assistant query-option wrappers stay gone

## Test Plan
- pnpm --filter @lightfast/app test -- src/__tests__/workspace-assistant-no-trpc-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/chat-workspace-assistant-client.test.tsx
- pnpm --filter @lightfast/app typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check

## Notes
- Plain local `pnpm knip` is blocked by missing local env; with app env plus MCP URL placeholders it runs but reports the existing repo-wide Knip baseline and exits nonzero, so merge-queue Knip remains authoritative.