### PR TITLE
test(api): keep auth identity transport neutral

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -36,6 +36,11 @@ describe("api/app app-facing tRPC root", () => {
   });
 
   it("keeps service auth context imports independent of tRPC", () => {
+    const identitySource = source("auth/identity.ts");
+
+    expect(identitySource).not.toContain("tRPC");
+    expect(identitySource).not.toContain("trpc");
+
     for (const file of [
       "services/connectors/catalog.ts",
       "services/connectors/index.ts",

--- a/api/app/src/auth/identity.ts
+++ b/api/app/src/auth/identity.ts
@@ -21,8 +21,8 @@ export type BindingStatus = OrgSetupGate["bindingStatus"];
 
 /**
  * Org-level gate signal carried on an `active` identity. Resolved from the
- * authoritative Lightfast DB binding; enforced server-side by tRPC's
- * `boundOrgProcedure`.
+ * authoritative Lightfast DB binding; enforced server-side by domain gates and
+ * adapter auth contexts.
  */
 export type OrgGate = OrgSetupGate;
 


### PR DESCRIPTION
## Summary
- remove the stale tRPC-specific auth identity comment from `auth/identity`
- add a source ratchet that keeps auth identity independent of tRPC language

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/app-trpc-root-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check