### PR TITLE
Keep desktop native auth tokens out of renderer

### DIFF
--- a/apps/desktop/src/main/native-auth/__tests__/flow.test.ts
+++ b/apps/desktop/src/main/native-auth/__tests__/flow.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const openExternalMock = vi.fn(async () => undefined);
-const setSessionMock = vi.fn(() => true);
+const setSessionMock = vi.fn((_session: unknown) => true);
 const getSessionMock = vi.fn(() => null);
+const getAuthSnapshotMock = vi.fn(
+  (): {
+    isSignedIn: boolean;
+    organizationId?: string;
+    organizationName?: string;
+    organizationSlug?: string | null;
+    userEmail?: string | null;
+  } => ({ isSignedIn: false })
+);
 const createDesktopNativeAuthClientMock = vi.fn();
 const startLoopbackServerMock = vi.fn();
 const exchangeAuthorizationCodeMock = vi.fn();
@@ -33,6 +42,7 @@ vi.mock("../app-client", () => ({
 }));
 
 vi.mock("../store", () => ({
+  getAuthSnapshot: getAuthSnapshotMock,
   getSession: getSessionMock,
   setSession: setSessionMock,
 }));
@@ -53,6 +63,21 @@ describe("desktop native auth flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSessionMock.mockReturnValue(null);
+    getAuthSnapshotMock.mockReturnValue({ isSignedIn: false });
+    setSessionMock.mockImplementation((session: unknown) => {
+      const nativeSession = session as {
+        organization: { id: string; name: string; slug?: string | null };
+        user: { email?: string | null };
+      };
+      getAuthSnapshotMock.mockReturnValue({
+        isSignedIn: true,
+        organizationId: nativeSession.organization.id,
+        organizationName: nativeSession.organization.name,
+        organizationSlug: nativeSession.organization.slug,
+        userEmail: nativeSession.user.email,
+      });
+      return true;
+    });
     createDesktopNativeAuthClientMock.mockReturnValue({
       getOAuthConfig: vi.fn(async () => ({
         authorizationEndpoint: "https://clerk.example.com/oauth/authorize",
@@ -92,7 +117,13 @@ describe("desktop native auth flow", () => {
       waitForCallback: vi.fn(async () => ({ code: "code_123", state })),
     });
 
-    await expect(beginSignIn()).resolves.toBe("access");
+    await expect(beginSignIn()).resolves.toMatchObject({
+      isSignedIn: true,
+      organizationId: "org_1",
+      organizationName: "Acme",
+      organizationSlug: "acme",
+      userEmail: "dev@example.com",
+    });
 
     const openCalls = openExternalMock.mock.calls as unknown as [string][];
     const signinUrl = new URL(openCalls[0]?.[0] ?? "");
@@ -120,7 +151,7 @@ describe("desktop native auth flow", () => {
   it.each([
     ["missing organization", "Native auth organization required"],
     ["wrong organization", "Native auth organization mismatch"],
-  ])("returns null when finalize rejects %s", async (_name, message) => {
+  ])("returns a signed-out snapshot when finalize rejects %s", async (_name, message) => {
     const state = Buffer.from(
       JSON.stringify({
         attemptId: "attempt_123456789",
@@ -150,12 +181,12 @@ describe("desktop native auth flow", () => {
       waitForCallback: vi.fn(async () => ({ code: "code_123", state })),
     });
 
-    await expect(beginSignIn()).resolves.toBeNull();
+    await expect(beginSignIn()).resolves.toEqual({ isSignedIn: false });
     expect(setSessionMock).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledOnce();
   });
 
-  it("returns null when token exchange yields an expired token", async () => {
+  it("returns a signed-out snapshot when token exchange yields an expired token", async () => {
     const state = Buffer.from(
       JSON.stringify({
         attemptId: "attempt_123456789",
@@ -176,7 +207,7 @@ describe("desktop native auth flow", () => {
       tokenType: "Bearer",
     });
 
-    await expect(beginSignIn()).resolves.toBeNull();
+    await expect(beginSignIn()).resolves.toEqual({ isSignedIn: false });
     expect(setSessionMock).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledOnce();
   });
@@ -198,7 +229,7 @@ describe("desktop native auth flow", () => {
       }),
     });
 
-    await expect(beginSignIn()).resolves.toBeNull();
+    await expect(beginSignIn()).resolves.toEqual({ isSignedIn: false });
 
     const events = stdout.mock.calls.map(([line]) =>
       JSON.parse(String(line))
@@ -227,7 +258,10 @@ describe("desktop native auth flow", () => {
       waitForCallback: vi.fn(async () => ({ code: "code_123", state })),
     });
 
-    await expect(beginSignIn()).resolves.toBe("access");
+    await expect(beginSignIn()).resolves.toMatchObject({
+      isSignedIn: true,
+      organizationId: "org_1",
+    });
     expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/main/native-auth/flow.ts
+++ b/apps/desktop/src/main/native-auth/flow.ts
@@ -16,7 +16,12 @@ import { shell } from "electron";
 import { logger } from "../logger";
 import { getRuntimeConfig } from "../runtime-config";
 import { createDesktopNativeAuthClient } from "./app-client";
-import { getSession, setSession } from "./store";
+import {
+  type AuthSnapshot,
+  getAuthSnapshot,
+  getSession,
+  setSession,
+} from "./store";
 
 const DEFAULT_SIGNIN_TIMEOUT_MS = 5 * 60_000;
 
@@ -55,7 +60,7 @@ function emitAgentEvent(payload: AuthEvent): void {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
 
-let inflight: Promise<string | null> | null = null;
+let inflight: Promise<AuthSnapshot> | null = null;
 let pendingSigninUrl: string | null = null;
 const urlListeners = new Set<(url: string | null) => void>();
 
@@ -117,7 +122,7 @@ function agentFailureReason(error: unknown): AgentAuthFailureReason {
   }
 }
 
-export function beginSignIn(): Promise<string | null> {
+export function beginSignIn(): Promise<AuthSnapshot> {
   if (inflight) {
     return inflight;
   }
@@ -143,7 +148,7 @@ export function maybeAutoBeginSignIn(): void {
   void beginSignIn();
 }
 
-async function runSignIn(): Promise<string | null> {
+async function runSignIn(): Promise<AuthSnapshot> {
   const appUrl = getRuntimeConfig().appOrigin;
   const client = createDesktopNativeAuthClient();
   const config = await client.getOAuthConfig();
@@ -199,17 +204,17 @@ async function runSignIn(): Promise<string | null> {
     };
     if (!setSession(session)) {
       emitAgentEvent({ event: "auth_signin_failed", reason: "persist_failed" });
-      return null;
+      return getAuthSnapshot();
     }
     emitAgentEvent({ event: "auth_signed_in" });
-    return tokens.accessToken;
+    return getAuthSnapshot();
   } catch (error) {
     logger.error("[native-auth] sign-in failed", error);
     emitAgentEvent({
       event: "auth_signin_failed",
       reason: agentFailureReason(error),
     });
-    return null;
+    return getAuthSnapshot();
   } finally {
     try {
       await loopback.close();

--- a/apps/desktop/src/main/native-auth/store.ts
+++ b/apps/desktop/src/main/native-auth/store.ts
@@ -127,10 +127,6 @@ export function getSession(): DesktopNativeSession | null {
   return globalStore.getSession();
 }
 
-export function getToken(): string | null {
-  return getSession()?.tokens.accessToken ?? null;
-}
-
 export function setSession(session: NativeSession): boolean {
   const ok = globalStore.setSession(session);
   if (ok) {

--- a/apps/desktop/src/preload/build-bridge.ts
+++ b/apps/desktop/src/preload/build-bridge.ts
@@ -53,7 +53,8 @@ export function buildBridge(): LightfastBridge {
     appOrigin: runtimeConfig.appOrigin,
     auth: {
       snapshot: authSnapshot,
-      signIn: () => ipcRenderer.invoke(IpcChannels.authSignIn),
+      signIn: () =>
+        ipcRenderer.invoke(IpcChannels.authSignIn) as Promise<AuthSnapshot>,
       signOut: () => ipcRenderer.invoke(IpcChannels.authSignOut),
       onChanged: (listener) => {
         const handler = (_event: IpcRendererEvent, snap: AuthSnapshot) =>

--- a/apps/desktop/src/renderer/__tests__/desktop-auth-boundary-source.test.ts
+++ b/apps/desktop/src/renderer/__tests__/desktop-auth-boundary-source.test.ts
@@ -18,9 +18,16 @@ describe("desktop native auth boundary", () => {
     expect(ipcSource).not.toContain("getToken:");
     expect(ipcSource).not.toContain("getRequestHeaders:");
     expect(ipcSource).not.toContain("Authorization?:");
+    expect(ipcSource).not.toContain("signIn: () => Promise<string | null>");
     expect(preloadSource).not.toContain("authGetToken");
     expect(preloadSource).not.toContain("authGetRequestHeaders");
     expect(preloadSource).not.toContain("getRequestHeaders");
+
+    const flowSource = source("src/main/native-auth/flow.ts");
+    const appShellSource = source("src/renderer/src/react/app-shell.tsx");
+    expect(flowSource).not.toContain("return tokens.accessToken");
+    expect(flowSource).not.toContain("Promise<string | null>");
+    expect(appShellSource).not.toContain(".then((token)");
   });
 
   it("exposes a typed desktop API bridge over IPC", () => {

--- a/apps/desktop/src/renderer/src/react/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/react/app-shell.tsx
@@ -44,8 +44,8 @@ export function AppShell() {
         <SignedOutShell
           onLearnMore={() => void window.lightfastBridge.openApp()}
           onSignIn={() => {
-            void window.lightfastBridge.auth.signIn().then((token) => {
-              if (token) {
+            void window.lightfastBridge.auth.signIn().then((snapshot) => {
+              if (snapshot.isSignedIn) {
                 signoutFailureReported = false;
                 return;
               }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -140,7 +140,7 @@ export interface LightfastBridge {
   appOrigin: string;
   auth: {
     snapshot: AuthSnapshot;
-    signIn: () => Promise<string | null>;
+    signIn: () => Promise<AuthSnapshot>;
     signOut: () => Promise<boolean>;
     onChanged: (listener: (snapshot: AuthSnapshot) => void) => () => void;
     pendingSigninUrl: () => Promise<string | null>;


### PR DESCRIPTION
## Summary
- Change desktop native sign-in to return an `AuthSnapshot` instead of an access token.
- Update the preload/renderer bridge so renderer code checks `snapshot.isSignedIn` and never receives the bearer token.
- Strengthen desktop auth source tests to reject token-returning sign-in contracts.

## Test Plan
- `pnpm --filter @lightfast/desktop test -- src/main/native-auth/__tests__/flow.test.ts src/renderer/__tests__/desktop-auth-boundary-source.test.ts`
- `pnpm --filter @lightfast/desktop typecheck`
- `pnpm check`
- `pnpm typecheck`
- `pnpm turbo boundaries`
- `git diff --check`
