### PR TITLE
Enforce public API key scopes

### DIFF
--- a/api/app/src/__tests__/api-key-auth.test.ts
+++ b/api/app/src/__tests__/api-key-auth.test.ts
@@ -21,6 +21,7 @@ vi.mock("@vendor/unkey/server", () => ({
 const { resolveApiKeyAuth } = await import("../auth/api-key");
 
 const validKey = `lf_${"a".repeat(40)}`;
+const publicApiPermissionCheck = "api:signals:read OR api:signals:write";
 
 function verifyResult(
   overrides: Partial<{
@@ -28,6 +29,7 @@ function verifyResult(
     identity: { externalId?: string; id: string } | undefined;
     keyId: string | undefined;
     meta: Record<string, unknown> | undefined;
+    permissions: string[] | undefined;
     valid: boolean;
   }> = {}
 ) {
@@ -37,6 +39,7 @@ function verifyResult(
       identity: { externalId: "org_test", id: "identity_test" },
       keyId: "key_test",
       meta: { createdByUserId: "user_test" },
+      permissions: ["api:signals:read", "api:signals:write"],
       valid: true,
       ...overrides,
     },
@@ -114,7 +117,10 @@ describe("resolveApiKeyAuth", () => {
       reason: "invalid",
       status: 401,
     });
-    expect(mocks.verifyKey).toHaveBeenCalledWith({ key: validKey });
+    expect(mocks.verifyKey).toHaveBeenCalledWith({
+      key: validKey,
+      permissions: publicApiPermissionCheck,
+    });
     expect(mocks.getActiveOrgBinding).not.toHaveBeenCalled();
   });
 
@@ -137,6 +143,25 @@ describe("resolveApiKeyAuth", () => {
       reason: "expired",
       status: 401,
     });
+  });
+
+  it("rejects keys that have no public API permissions", async () => {
+    mocks.verifyKey.mockResolvedValueOnce(
+      verifyResult({
+        code: "INSUFFICIENT_PERMISSIONS",
+        permissions: [],
+        valid: false,
+      })
+    );
+
+    await expect(
+      resolveApiKeyAuth({ headers: headers(`Bearer ${validKey}`) })
+    ).rejects.toMatchObject({
+      message: "API key is missing required permissions",
+      reason: "insufficient-scope",
+      status: 403,
+    });
+    expect(mocks.getActiveOrgBinding).not.toHaveBeenCalled();
   });
 
   it("requires org-scoped identity and creator metadata", async () => {
@@ -173,11 +198,28 @@ describe("resolveApiKeyAuth", () => {
         type: "active",
         userId: "user_test",
       },
+      scopes: ["api:signals:read", "api:signals:write"],
+    });
+    expect(mocks.verifyKey).toHaveBeenCalledWith({
+      key: validKey,
+      permissions: publicApiPermissionCheck,
     });
     expect(mocks.getActiveOrgBinding).toHaveBeenCalledWith(
       expect.anything(),
       "org_test"
     );
+  });
+
+  it("exposes only the granted public API scopes returned by Unkey", async () => {
+    mocks.verifyKey.mockResolvedValueOnce(
+      verifyResult({ permissions: ["api:signals:read", "unrelated.scope"] })
+    );
+
+    await expect(
+      resolveApiKeyAuth({ headers: headers(`Bearer ${validKey}`) })
+    ).resolves.toMatchObject({
+      scopes: ["api:signals:read"],
+    });
   });
 
   it("keeps auth valid while exposing an unbound org gate", async () => {

--- a/api/app/src/__tests__/domain-core.test.ts
+++ b/api/app/src/__tests__/domain-core.test.ts
@@ -46,9 +46,10 @@ describe("actorFromApiKeyAuth", () => {
     const auth: ApiKeyAuthResult = {
       apiKeyId: "key_test",
       identity: boundIdentity,
+      scopes: ["api:signals:read"],
     };
 
-    expect(actorFromApiKeyAuth(auth, ["api:signals:read"])).toEqual({
+    expect(actorFromApiKeyAuth(auth)).toEqual({
       createdByUserId: "user_test",
       keyId: "key_test",
       kind: "apiKey",

--- a/api/app/src/__tests__/org-api-keys-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-api-keys-domain-commands.test.ts
@@ -151,6 +151,7 @@ describe("org API key domain commands", () => {
       externalId: "org_test",
       meta: { createdByUserId: "user_test", source: "dashboard" },
       name: "Test key",
+      permissions: ["api:signals:read", "api:signals:write"],
       prefix: "lf",
       recoverable: false,
     });

--- a/api/app/src/__tests__/public-signals-api.test.ts
+++ b/api/app/src/__tests__/public-signals-api.test.ts
@@ -47,6 +47,7 @@ function verifyResult(overrides: Partial<Record<string, unknown>> = {}) {
       identity: { externalId: "org_test", id: "identity_test" },
       keyId: "key_test",
       meta: { createdByUserId: "user_test" },
+      permissions: ["api:signals:read", "api:signals:write"],
       valid: true,
       ...overrides,
     },
@@ -196,6 +197,26 @@ describe("public signal API adapter", () => {
     });
   });
 
+  it("rejects signal list requests from write-only API keys", async () => {
+    mocks.verifyKey.mockResolvedValueOnce(
+      verifyResult({ permissions: ["api:signals:write"] })
+    );
+
+    const response = await handleListSignalsPublicApiRequest(
+      publicApiRequest({
+        method: "GET",
+        token: validKey,
+        url: "https://lightfast.test/api/v1/signals",
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "forbidden",
+    });
+    expect(mocks.listSignals).not.toHaveBeenCalled();
+  });
+
   it("creates a queued signal with API-key attribution", async () => {
     const response = await handleCreateSignalPublicApiRequest(
       publicApiRequest({
@@ -220,6 +241,25 @@ describe("public signal API adapter", () => {
       },
       input: "Reply to this relevant post",
     });
+  });
+
+  it("rejects signal creation from read-only API keys", async () => {
+    mocks.verifyKey.mockResolvedValueOnce(
+      verifyResult({ permissions: ["api:signals:read"] })
+    );
+
+    const response = await handleCreateSignalPublicApiRequest(
+      publicApiRequest({
+        body: { input: "Run the test plan" },
+        token: validKey,
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(responseJson(response)).resolves.toMatchObject({
+      error: "forbidden",
+    });
+    expect(mocks.createSignalForActor).not.toHaveBeenCalled();
   });
 
   it("rejects signal creation for unbound organizations", async () => {

--- a/api/app/src/__tests__/public-system-api.test.ts
+++ b/api/app/src/__tests__/public-system-api.test.ts
@@ -30,6 +30,7 @@ function verifyResult(overrides: Partial<Record<string, unknown>> = {}) {
       identity: { externalId: "org_test", id: "identity_test" },
       keyId: "key_test",
       meta: { createdByUserId: "user_test" },
+      permissions: ["api:signals:read", "api:signals:write"],
       valid: true,
       ...overrides,
     },

--- a/api/app/src/__tests__/signals-domain-commands.test.ts
+++ b/api/app/src/__tests__/signals-domain-commands.test.ts
@@ -220,6 +220,32 @@ describe("signal domain commands", () => {
     });
   });
 
+  it("rejects API-key signal creation without the write scope", async () => {
+    await expect(
+      createSignalCommand.run({
+        ctx: {
+          actor: {
+            createdByUserId: "user_test",
+            keyId: "key_test",
+            kind: "apiKey",
+            orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+            orgId: "org_test",
+            scopes: ["api:signals:read"],
+          },
+        },
+        deps: deps(),
+        input: { input: "new signal" },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "API_KEY_SCOPE_REQUIRED",
+        kind: "authz",
+      })
+    );
+
+    expect(createSignalForActorMock).not.toHaveBeenCalled();
+  });
+
   it("creates a signal as an MCP client actor with grant attribution", async () => {
     await expect(
       createSignalCommand.run({
@@ -280,6 +306,32 @@ describe("signal domain commands", () => {
         publicId: signalRow.publicId,
       }
     );
+  });
+
+  it("rejects API-key signal reads without the read scope", async () => {
+    await expect(
+      getSignalCommand.run({
+        ctx: {
+          actor: {
+            createdByUserId: "user_test",
+            keyId: "key_test",
+            kind: "apiKey",
+            orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+            orgId: "org_test",
+            scopes: ["api:signals:write"],
+          },
+        },
+        deps: deps(),
+        input: { publicId: signalRow.publicId },
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "API_KEY_SCOPE_REQUIRED",
+        kind: "authz",
+      })
+    );
+
+    expect(getVisibleSignalByPublicIdMock).not.toHaveBeenCalled();
   });
 
   it("loads signal detail as an MCP client actor using creator visibility", async () => {

--- a/api/app/src/adapters/public/signals.ts
+++ b/api/app/src/adapters/public/signals.ts
@@ -98,7 +98,7 @@ function requestId() {
 
 function publicSignalContext(auth: ApiKeyAuthResult) {
   return {
-    actor: actorFromApiKeyAuth(auth, ["api:signals:read", "api:signals:write"]),
+    actor: actorFromApiKeyAuth(auth),
     request: { id: requestId(), source: "public-api" as const },
   };
 }

--- a/api/app/src/auth/api-key.ts
+++ b/api/app/src/auth/api-key.ts
@@ -9,9 +9,20 @@ import { resolveOrgSetupGate } from "./org-setup-gate";
 
 export type ApiKeyAuthIdentity = Extract<AuthIdentity, { type: "active" }>;
 
+export const PUBLIC_API_KEY_SCOPES = [
+  "api:signals:read",
+  "api:signals:write",
+] as const;
+
+export type PublicApiKeyScope = (typeof PUBLIC_API_KEY_SCOPES)[number];
+
+export const PUBLIC_API_KEY_PERMISSION_CHECK =
+  PUBLIC_API_KEY_SCOPES.join(" OR ");
+
 export interface ApiKeyAuthResult {
   apiKeyId: string;
   identity: ApiKeyAuthIdentity;
+  scopes: PublicApiKeyScope[];
 }
 
 export type ApiKeyAuthFailure =
@@ -20,6 +31,7 @@ export type ApiKeyAuthFailure =
   | "invalid"
   | "disabled"
   | "expired"
+  | "insufficient-scope"
   | "not-org-scoped"
   | "missing-creator";
 
@@ -67,6 +79,14 @@ function parseBearerApiKey(headers: Headers): string {
   return token;
 }
 
+function parsePublicApiKeyScopes(permissions: unknown): PublicApiKeyScope[] {
+  if (!Array.isArray(permissions)) {
+    return [];
+  }
+
+  return PUBLIC_API_KEY_SCOPES.filter((scope) => permissions.includes(scope));
+}
+
 export async function resolveApiKeyAuth(input: {
   db?: Database;
   headers: Headers;
@@ -76,7 +96,10 @@ export async function resolveApiKeyAuth(input: {
   let verification;
 
   try {
-    verification = await unkey.keys.verifyKey({ key: token });
+    verification = await unkey.keys.verifyKey({
+      key: token,
+      permissions: PUBLIC_API_KEY_PERMISSION_CHECK,
+    });
   } catch {
     throw new ApiKeyAuthError("invalid", "Invalid API key", 401);
   }
@@ -89,7 +112,23 @@ export async function resolveApiKeyAuth(input: {
     if (key.code === "EXPIRED") {
       throw new ApiKeyAuthError("expired", "API key expired", 401);
     }
+    if (key.code === "FORBIDDEN" || key.code === "INSUFFICIENT_PERMISSIONS") {
+      throw new ApiKeyAuthError(
+        "insufficient-scope",
+        "API key is missing required permissions",
+        403
+      );
+    }
     throw new ApiKeyAuthError("invalid", "Invalid API key", 401);
+  }
+
+  const scopes = parsePublicApiKeyScopes(key.permissions);
+  if (scopes.length === 0) {
+    throw new ApiKeyAuthError(
+      "insufficient-scope",
+      "API key is missing required permissions",
+      403
+    );
   }
 
   const orgId = key.identity?.externalId;
@@ -125,5 +164,5 @@ export async function resolveApiKeyAuth(input: {
     throw new ApiKeyAuthError("invalid", "Invalid API key", 401);
   }
 
-  return { apiKeyId: key.keyId, identity };
+  return { apiKeyId: key.keyId, identity, scopes };
 }

--- a/api/app/src/domain/actor.ts
+++ b/api/app/src/domain/actor.ts
@@ -86,16 +86,13 @@ export function actorFromAuthIdentity(
   };
 }
 
-export function actorFromApiKeyAuth(
-  auth: ApiKeyAuthResult,
-  scopes: string[] = []
-): Actor {
+export function actorFromApiKeyAuth(auth: ApiKeyAuthResult): Actor {
   return {
     createdByUserId: auth.identity.userId,
     keyId: auth.apiKeyId,
     kind: "apiKey",
     orgGate: auth.identity.orgGate,
     orgId: auth.identity.orgId,
-    scopes,
+    scopes: auth.scopes,
   };
 }

--- a/api/app/src/domain/org-api-keys/commands.ts
+++ b/api/app/src/domain/org-api-keys/commands.ts
@@ -9,6 +9,7 @@ import type { KeyResponseData, UnkeyClient } from "@vendor/unkey";
 import { getUnkeyClient, unkeyEnv } from "@vendor/unkey/server";
 import { z } from "zod";
 
+import { PUBLIC_API_KEY_SCOPES } from "../../auth/api-key";
 import { UNKEY_API_KEY_PREFIX } from "../../auth/api-key-prefix";
 import { defineCommand } from "../command";
 import { NotFoundError } from "../errors";
@@ -169,6 +170,7 @@ export const createOrgApiKeyCommand = defineCommand<
         source: "dashboard",
       },
       name: input.name,
+      permissions: [...PUBLIC_API_KEY_SCOPES],
       prefix: UNKEY_API_KEY_PREFIX,
       recoverable: false,
     });

--- a/api/app/src/domain/signals/commands.ts
+++ b/api/app/src/domain/signals/commands.ts
@@ -12,6 +12,7 @@ import {
   signalStatusSchema,
 } from "@repo/api-contract";
 import { z } from "zod";
+import type { PublicApiKeyScope } from "../../auth/api-key";
 import { isSignalCreateQueueError } from "../../signals/create-signal";
 import { createSignalForActor } from "../../signals/service";
 import type { ExecutionContext } from "../actor";
@@ -144,7 +145,8 @@ type ResolvedSignalCommandActor =
     };
 
 function requireSignalCommandActor(
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
+  input: { apiKeyScope?: PublicApiKeyScope } = {}
 ): ResolvedSignalCommandActor {
   if (ctx.actor.kind === "clerkUser") {
     const actor = requireBoundClerkOrgActor(ctx);
@@ -152,6 +154,14 @@ function requireSignalCommandActor(
   }
 
   if (ctx.actor.kind === "apiKey") {
+    if (input.apiKeyScope && !ctx.actor.scopes.includes(input.apiKeyScope)) {
+      throw new AuthzError(
+        "API_KEY_SCOPE_REQUIRED",
+        `API key requires the ${input.apiKeyScope} scope.`,
+        { requiredScope: input.apiKeyScope }
+      );
+    }
+
     if (ctx.actor.orgGate?.bindingStatus !== "bound") {
       throw new AuthzError(
         "ORG_SETUP_REQUIRED",
@@ -210,7 +220,9 @@ export const listProcessingSignalsCommand = defineCommand({
     ListProcessingSignalsResult,
     SignalListProcessingCommandDeps
   >) => {
-    const actor = requireSignalCommandActor(ctx);
+    const actor = requireSignalCommandActor(ctx, {
+      apiKeyScope: "api:signals:read",
+    });
     return deps.listSignals(deps.db, {
       clerkOrgId: actor.orgId,
       createdByUserId: actor.userId,
@@ -233,7 +245,9 @@ export const listWorkingSetSignalsCommand = defineCommand({
     ListWorkingSetSignalsResult,
     SignalListWorkingSetCommandDeps
   >) => {
-    const actor = requireSignalCommandActor(ctx);
+    const actor = requireSignalCommandActor(ctx, {
+      apiKeyScope: "api:signals:read",
+    });
     return deps.listWorkspaceSignals(deps.db, {
       clerkOrgId: actor.orgId,
       createdByUserId: actor.userId,
@@ -254,7 +268,9 @@ export const getSignalCommand = defineCommand({
     SignalDetailResult,
     SignalGetCommandDeps
   >) => {
-    const actor = requireSignalCommandActor(ctx);
+    const actor = requireSignalCommandActor(ctx, {
+      apiKeyScope: "api:signals:read",
+    });
     const signal = await deps.getVisibleSignalByPublicId(deps.db, {
       clerkOrgId: actor.orgId,
       createdByUserId: actor.userId,
@@ -287,7 +303,9 @@ export const createSignalCommand = defineCommand({
     z.infer<typeof createSignalOutput>,
     SignalCreateCommandDeps
   >) => {
-    const actor = requireSignalCommandActor(ctx);
+    const actor = requireSignalCommandActor(ctx, {
+      apiKeyScope: "api:signals:write",
+    });
     try {
       return await deps.createSignalForActor(deps.db, {
         actor,


### PR DESCRIPTION
## Summary
- Verify public API keys with Unkey public signal permissions and carry granted scopes into `ApiKeyAuthResult`.
- Remove synthetic public signal scopes from the adapter and enforce read/write scopes in signal domain commands.
- Create dashboard org API keys with default public signal permissions.

## Test Plan
- `pnpm --filter @api/app test -- src/__tests__/api-key-auth.test.ts src/__tests__/domain-core.test.ts src/__tests__/signals-domain-commands.test.ts src/__tests__/public-signals-api.test.ts src/__tests__/public-system-api.test.ts src/__tests__/org-api-keys-domain-commands.test.ts`
- `pnpm --filter @api/app typecheck`
- `pnpm check`
- `pnpm typecheck`
- `pnpm turbo boundaries`
- `git diff --check`
