### PR TITLE
refactor: inline signal detail query

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -488,6 +488,7 @@ describe("app authenticated route migration", () => {
     const routeSource = source("src/routes/_authenticated/$slug/signals.tsx");
     const clientSource = source("src/signals/signals-client.tsx");
     const createDialogSource = source("src/signals/signal-create-dialog.tsx");
+    const detailSheetSource = source("src/signals/signal-detail-sheet.tsx");
     const searchSource = source("src/signals/signals-search-params.ts");
     const workspaceDataSource = source(
       "src/signals/use-signals-workspace-data.ts"
@@ -504,13 +505,20 @@ describe("app authenticated route migration", () => {
     expect(clientSource).toContain("<SignalsViewHeader");
     expect(clientSource).toContain("SignalsViewSwitcher");
     expect(clientSource).not.toContain("viewsSlot=");
-    expect(clientSource).toContain("signalDetailQueryOptions");
+    expect(clientSource).toContain('@api/app/tanstack/signals"');
+    expect(clientSource).toContain("getSignal");
+    expect(clientSource).toContain("signalQueryKeys.detail");
+    expect(clientSource).not.toContain("signalDetailQueryOptions");
     expect(createDialogSource).toContain('@api/app/tanstack/signals"');
     expect(createDialogSource).toContain("createSignal");
     expect(createDialogSource).toContain("signalQueryKeys");
     expect(createDialogSource).not.toContain("createSignalMutationOptions");
     expect(createDialogSource).toContain("listUserOrganizations");
     expect(createDialogSource).toContain("organizationQueryKeys.list()");
+    expect(detailSheetSource).toContain('@api/app/tanstack/signals"');
+    expect(detailSheetSource).toContain("getSignal");
+    expect(detailSheetSource).toContain("signalQueryKeys.detail");
+    expect(detailSheetSource).not.toContain("signalDetailQueryOptions");
     expect(searchSource).toContain("validateSignalsSearch");
     expect(searchSource).toContain("parseSignalDispositions");
     expect(workspaceDataSource).toContain("listWorkingSetSignals");

--- a/apps/app/src/__tests__/signals-queries-source.test.ts
+++ b/apps/app/src/__tests__/signals-queries-source.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -6,22 +6,56 @@ const appRoot = resolve(import.meta.dirname, "../..");
 const repoRoot = resolve(appRoot, "../..");
 
 describe("signals query helpers", () => {
-  it("keeps signal keys, result types, and shared detail query options", () => {
-    const source = readFileSync(
-      resolve(appRoot, "src/signals/signals-queries.ts"),
+  it("keeps signal keys and result types without a query-options abstraction", () => {
+    const queriesPath = resolve(appRoot, "src/signals/signals-queries.ts");
+    const cacheSource = readFileSync(
+      resolve(appRoot, "src/signals/signals-cache.ts"),
       "utf8"
     );
 
-    expect(source).toContain('@api/app/tanstack/signals"');
-    expect(source).toContain("signalQueryKeys");
-    expect(source).toContain("signalDetailQueryOptions");
-    expect(source).not.toContain("workingSetSignalsQueryOptions");
-    expect(source).not.toContain("processingSignalsQueryOptions");
-    expect(source).not.toContain("listWorkingSetSignals");
-    expect(source).not.toContain("listProcessingSignals");
-    expect(source).not.toContain("createSignalMutationOptions");
-    expect(source).not.toContain("createSignal,");
-    expect(source).not.toContain("useTRPC");
+    expect(existsSync(queriesPath)).toBe(false);
+    expect(cacheSource).toContain('@api/app/tanstack/signals"');
+    expect(cacheSource).toContain("signalQueryKeys");
+    expect(cacheSource).toContain("ProcessingSignalsResult");
+    expect(cacheSource).toContain("WorkingSetSignalsResult");
+    expect(cacheSource).toContain("SignalDetailQueryResult");
+    expect(cacheSource).not.toContain("queryOptions");
+    expect(cacheSource).not.toContain("signalDetailQueryOptions");
+    expect(cacheSource).not.toContain("workingSetSignalsQueryOptions");
+    expect(cacheSource).not.toContain("processingSignalsQueryOptions");
+    expect(cacheSource).not.toContain("getSignal");
+    expect(cacheSource).not.toContain("listWorkingSetSignals");
+    expect(cacheSource).not.toContain("listProcessingSignals");
+    expect(cacheSource).not.toContain("createSignalMutationOptions");
+    expect(cacheSource).not.toContain("createSignal,");
+    expect(cacheSource).not.toContain("useTRPC");
+  });
+
+  it("keeps detail reads inline at the query call sites", () => {
+    const clientSource = readFileSync(
+      resolve(appRoot, "src/signals/signals-client.tsx"),
+      "utf8"
+    );
+    const detailSheetSource = readFileSync(
+      resolve(appRoot, "src/signals/signal-detail-sheet.tsx"),
+      "utf8"
+    );
+    const peopleDetailSource = readFileSync(
+      resolve(appRoot, "src/people/people-detail-content.tsx"),
+      "utf8"
+    );
+
+    for (const source of [
+      clientSource,
+      detailSheetSource,
+      peopleDetailSource,
+    ]) {
+      expect(source).toContain('@api/app/tanstack/signals"');
+      expect(source).toContain("getSignal");
+      expect(source).toContain("signalQueryKeys.detail");
+      expect(source).not.toContain("signalDetailQueryOptions");
+      expect(source).not.toContain("signals-queries");
+    }
   });
 
   it("keeps signal creation on a direct api/app server function import", () => {

--- a/apps/app/src/people/people-detail-content.tsx
+++ b/apps/app/src/people/people-detail-content.tsx
@@ -1,3 +1,4 @@
+import { getSignal } from "@api/app/tanstack/signals";
 import {
   AtSignIcon as AtSign,
   HashIcon as Hash,
@@ -13,7 +14,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { formatRelativeTimeToNow } from "@vendor/lib/time";
 import type { ReactNode } from "react";
-import { signalDetailQueryOptions } from "~/signals/signals-queries";
+import { signalQueryKeys } from "~/signals/signals-cache";
 import {
   formatPersonSignalRef,
   getPersonName,
@@ -71,9 +72,11 @@ function PersonSignalLink({
   signalId: string;
   slug: string;
 }) {
-  const query = useQuery(
-    signalDetailQueryOptions({ enabled: Boolean(signalId), publicId: signalId })
-  );
+  const query = useQuery({
+    enabled: typeof window !== "undefined" && Boolean(signalId),
+    queryFn: () => getSignal({ data: { publicId: signalId } }),
+    queryKey: signalQueryKeys.detail(signalId),
+  });
   const title = query.data
     ? (query.data.classification?.title ?? query.data.input)
     : null;

--- a/apps/app/src/signals/signal-create-dialog.tsx
+++ b/apps/app/src/signals/signal-create-dialog.tsx
@@ -25,7 +25,7 @@ import {
   ORGANIZATION_STALE_TIME,
   organizationQueryKeys,
 } from "~/organization/organization-cache";
-import { signalQueryKeys } from "./signals-queries";
+import { signalQueryKeys } from "./signals-cache";
 
 interface SignalCreateDialogProps {
   onOpenChange: (open: boolean) => void;

--- a/apps/app/src/signals/signal-detail-sheet.tsx
+++ b/apps/app/src/signals/signal-detail-sheet.tsx
@@ -1,3 +1,4 @@
+import { getSignal } from "@api/app/tanstack/signals";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { toast } from "@repo/ui/components/ui/sonner";
@@ -12,6 +13,7 @@ import {
 } from "@repo/ui-v2/components/ui/sheet";
 import { useQuery } from "@tanstack/react-query";
 import { SignalDetailContent } from "./signal-detail-content";
+import { signalQueryKeys } from "./signals-cache";
 import {
   getSignalSummary,
   getSignalTitle,
@@ -19,7 +21,6 @@ import {
   type SignalListItem,
   type SignalRow,
 } from "./signals-model";
-import { signalDetailQueryOptions } from "./signals-queries";
 
 function copySignalLink() {
   if (typeof window === "undefined") {
@@ -57,17 +58,18 @@ export function SignalDetailSheet({
   // Processing rows (and any already-fetched full rows) carry `input`, so their
   // body needs no `get`. Classified projection rows do.
   const hasBody = !!seededItem && "input" in seededItem;
+  const detailPublicId = publicId ?? "";
+  const shouldFetchDetail = open && !hasBody && detailPublicId.length > 0;
 
   const {
     data: fetchedDetail,
     isError,
     isLoading,
-  } = useQuery(
-    signalDetailQueryOptions({
-      enabled: open && !hasBody && Boolean(publicId),
-      publicId: publicId ?? "",
-    })
-  );
+  } = useQuery({
+    enabled: typeof window !== "undefined" && shouldFetchDetail,
+    queryFn: () => getSignal({ data: { publicId: detailPublicId } }),
+    queryKey: signalQueryKeys.detail(detailPublicId),
+  });
 
   // Header seed: the projection (or, for deep-links not in cache, the fetched row).
   const headerItem: SignalListItem | undefined = seededItem ?? fetchedDetail;

--- a/apps/app/src/signals/signals-cache.ts
+++ b/apps/app/src/signals/signals-cache.ts
@@ -1,10 +1,8 @@
-import {
-  getSignal,
-  type ListProcessingSignalsResult,
-  type ListWorkingSetSignalsResult,
-  type SignalDetailResult,
+import type {
+  ListProcessingSignalsResult,
+  ListWorkingSetSignalsResult,
+  SignalDetailResult,
 } from "@api/app/tanstack/signals";
-import { queryOptions } from "@tanstack/react-query";
 import {
   PROCESSING_SIGNALS_LIMIT,
   signalProcessingStatuses,
@@ -25,14 +23,3 @@ export const signalQueryKeys = {
     ] as const,
   workingSet: () => ["signals", "working-set"] as const,
 };
-
-export function signalDetailQueryOptions(input: {
-  enabled: boolean;
-  publicId: string;
-}) {
-  return queryOptions({
-    enabled: typeof window !== "undefined" && input.enabled,
-    queryFn: () => getSignal({ data: { publicId: input.publicId } }),
-    queryKey: signalQueryKeys.detail(input.publicId),
-  });
-}

--- a/apps/app/src/signals/signals-client.tsx
+++ b/apps/app/src/signals/signals-client.tsx
@@ -1,3 +1,4 @@
+import { getSignal } from "@api/app/tanstack/signals";
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@repo/ui-v2/components/ui/button";
@@ -13,10 +14,10 @@ import {
 import { WorkspaceSurface } from "~/components/workspace-surface";
 import { SignalCreateDialog } from "./signal-create-dialog";
 import { SignalDetailSheet } from "./signal-detail-sheet";
+import { signalQueryKeys } from "./signals-cache";
 import { SignalsListView } from "./signals-list-view";
 import { SignalsLoading } from "./signals-loading";
 import type { SignalClassificationFilters } from "./signals-model";
-import { signalDetailQueryOptions } from "./signals-queries";
 import {
   type NormalizedSignalsSearch,
   parseSignalDispositions,
@@ -83,9 +84,10 @@ export function SignalsClient({
       if (cached && "input" in cached) {
         return; // processing/full rows already carry the body
       }
-      void queryClient.prefetchQuery(
-        signalDetailQueryOptions({ enabled: true, publicId })
-      );
+      void queryClient.prefetchQuery({
+        queryFn: () => getSignal({ data: { publicId } }),
+        queryKey: signalQueryKeys.detail(publicId),
+      });
     },
     [queryClient, signalsByPublicId]
   );

--- a/apps/app/src/signals/signals-model.ts
+++ b/apps/app/src/signals/signals-model.ts
@@ -2,7 +2,7 @@ import type {
   ProcessingSignalsResult,
   SignalDetailQueryResult,
   WorkingSetSignalsResult,
-} from "./signals-queries";
+} from "./signals-cache";
 
 /** Full row from the cursor `list` query (processing path) — carries body fields. */
 export type SignalList = ProcessingSignalsResult;

--- a/apps/app/src/signals/use-signals-workspace-data.ts
+++ b/apps/app/src/signals/use-signals-workspace-data.ts
@@ -4,6 +4,7 @@ import {
 } from "@api/app/tanstack/signals";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { signalQueryKeys } from "./signals-cache";
 import {
   adaptProcessingRow,
   compareSignalsByRecency,
@@ -15,7 +16,6 @@ import {
   type SignalSection,
   signalProcessingStatuses,
 } from "./signals-model";
-import { signalQueryKeys } from "./signals-queries";
 
 const WORKING_SET_REFETCH_MS = 30_000;
 const PROCESSING_REFETCH_MS = 5000;


### PR DESCRIPTION
## Summary
- replace the shallow signals query-options wrapper with a keys/types-only signals cache module
- inline signal detail getSignal calls at the TanStack Query call sites
- update source tests to block reintroducing signals-queries and signalDetailQueryOptions

## Test Plan
- pnpm --filter @lightfast/app typecheck
- pnpm --filter @lightfast/app test -- src/__tests__/signals-queries-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/signals-no-trpc-source.test.ts
- pnpm check
- pnpm turbo boundaries
- pnpm typecheck
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known unrelated unused-file backlog; no signals-cache/signals-queries findings)