### PR TITLE
refactor: hide api app service internals

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -189,34 +189,6 @@
       "types": "./src/adapters/tanstack/people.ts",
       "default": "./src/adapters/tanstack/people.ts"
     },
-    "./services/github": {
-      "types": "./src/services/github/index.ts",
-      "default": "./src/services/github/index.ts"
-    },
-    "./services/skills": {
-      "types": "./src/services/skills/index.ts",
-      "default": "./src/services/skills/index.ts"
-    },
-    "./services/connectors": {
-      "types": "./src/services/connectors/index.ts",
-      "default": "./src/services/connectors/index.ts"
-    },
-    "./services/connectors/chat-routines": {
-      "types": "./src/services/connectors/chat-routines.ts",
-      "default": "./src/services/connectors/chat-routines.ts"
-    },
-    "./services/connectors/runtime": {
-      "types": "./src/services/connectors/runtime.ts",
-      "default": "./src/services/connectors/runtime.ts"
-    },
-    "./services/user-connectors": {
-      "types": "./src/services/user-connectors/index.ts",
-      "default": "./src/services/user-connectors/index.ts"
-    },
-    "./services/user-connectors/runtime": {
-      "types": "./src/services/user-connectors/runtime.ts",
-      "default": "./src/services/user-connectors/runtime.ts"
-    },
     "./signals/service": {
       "types": "./src/signals/service.ts",
       "default": "./src/signals/service.ts"

--- a/api/app/src/__tests__/api-app-service-exports-source.test.ts
+++ b/api/app/src/__tests__/api-app-service-exports-source.test.ts
@@ -1,0 +1,43 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiAppRoot = resolve(import.meta.dirname, "../..");
+
+function apiSourceFiles(dir = resolve(apiAppRoot, "src")): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absPath = resolve(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return entry.name === "__tests__" ? [] : apiSourceFiles(absPath);
+    }
+
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [absPath] : [];
+  });
+}
+
+describe("api app service internals", () => {
+  it("does not expose backend services as package entrypoints", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(apiAppRoot, "package.json"), "utf8")
+    ) as { exports?: Record<string, unknown> };
+
+    const serviceExports = Object.keys(packageJson.exports ?? {}).filter(
+      (entrypoint) =>
+        entrypoint === "./services" || entrypoint.startsWith("./services/")
+    );
+
+    expect(serviceExports).toEqual([]);
+  });
+
+  it("keeps service imports relative inside api/app", () => {
+    const offenders = apiSourceFiles()
+      .map((path) => ({
+        path: relative(apiAppRoot, path),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ source }) => source.includes("@api/app/services/"));
+
+    expect(offenders.map(({ path }) => path)).toEqual([]);
+  });
+});

--- a/api/app/src/__tests__/workspace-assistant-route.test.ts
+++ b/api/app/src/__tests__/workspace-assistant-route.test.ts
@@ -31,7 +31,7 @@ vi.mock("../auth/identity", () => ({
   resolveIdentityFromClerk: resolveIdentityFromClerkMock,
 }));
 
-vi.mock("@api/app/services/skills", () => ({
+vi.mock("../services/skills", () => ({
   getSkillIndexSnapshot: getSkillIndexSnapshotMock,
   getVerifiedLightfastSkillSourceRepositoryId:
     getVerifiedLightfastSkillSourceRepositoryIdMock,
@@ -94,12 +94,12 @@ vi.mock("@repo/api-contract", () => ({
   userConnectorFindOutputSchema: { kind: "user-connector-find-output" },
 }));
 
-vi.mock("@api/app/services/connectors/chat-routines", () => ({
+vi.mock("../services/connectors/chat-routines", () => ({
   callChatProviderRoutine: callProviderRoutineMock,
   findChatProviderRoutines: findProviderRoutinesMock,
 }));
 
-vi.mock("@api/app/services/user-connectors/runtime", () => ({
+vi.mock("../services/user-connectors/runtime", () => ({
   callUserConnectorTool: callUserConnectorToolMock,
   findUserConnectorTools: findUserConnectorToolsMock,
 }));

--- a/api/app/src/adapters/internal/mcp-proxy.ts
+++ b/api/app/src/adapters/internal/mcp-proxy.ts
@@ -163,7 +163,7 @@ function providerRoutineContext(
       connectors: {
         loadTools: async () => {
           const { loadAgentConnectorRuntimeTools } = await import(
-            "@api/app/services/connectors/runtime"
+            "../../services/connectors/runtime"
           );
           return await loadAgentConnectorRuntimeTools({
             calledByUserId: command.actor.userId,

--- a/api/app/src/adapters/internal/workspace-assistant/chat-route.ts
+++ b/api/app/src/adapters/internal/workspace-assistant/chat-route.ts
@@ -582,7 +582,7 @@ function createWorkspaceAssistantProviderRoutineToolDefinitions(input: {
           outputSchema: providerRoutineCallSuccessSchema,
           execute: async (toolInput) => {
             const { callChatProviderRoutine } = await import(
-              "@api/app/services/connectors/chat-routines"
+              "../../../services/connectors/chat-routines"
             );
             return callChatProviderRoutine(
               providerRoutineContext(input),
@@ -602,7 +602,7 @@ function createWorkspaceAssistantProviderRoutineToolDefinitions(input: {
           outputSchema: providerRoutineFindOutputSchema,
           execute: async (toolInput) => {
             const { findChatProviderRoutines } = await import(
-              "@api/app/services/connectors/chat-routines"
+              "../../../services/connectors/chat-routines"
             );
             return findChatProviderRoutines(
               providerRoutineContext(input),
@@ -631,7 +631,7 @@ function createWorkspaceAssistantUserConnectorToolDefinitions(input: {
           outputSchema: userConnectorCallSuccessSchema,
           execute: async (toolInput) => {
             const { callUserConnectorTool } = await import(
-              "@api/app/services/user-connectors/runtime"
+              "../../../services/user-connectors/runtime"
             );
             return callUserConnectorTool(
               userConnectorContext(input),
@@ -651,7 +651,7 @@ function createWorkspaceAssistantUserConnectorToolDefinitions(input: {
           outputSchema: userConnectorFindOutputSchema,
           execute: async (toolInput) => {
             const { findUserConnectorTools } = await import(
-              "@api/app/services/user-connectors/runtime"
+              "../../../services/user-connectors/runtime"
             );
             return findUserConnectorTools(
               userConnectorContext(input),
@@ -857,7 +857,7 @@ async function getSkillContext(clerkOrgId: string) {
     const {
       getSkillIndexSnapshot,
       getVerifiedLightfastSkillSourceRepositoryId,
-    } = await import("@api/app/services/skills");
+    } = await import("../../../services/skills");
     const sourceControlRepositoryId =
       await getVerifiedLightfastSkillSourceRepositoryId(db, { clerkOrgId });
     const result = await getSkillIndexSnapshot({

--- a/api/app/src/adapters/native-provider-proxy.ts
+++ b/api/app/src/adapters/native-provider-proxy.ts
@@ -63,7 +63,7 @@ async function createNativeProviderRoutineContext(
     "@api/app/auth/identity"
   );
   const { loadAgentConnectorRuntimeTools } = await import(
-    "@api/app/services/connectors/runtime"
+    "../services/connectors/runtime"
   );
   const auth = await resolveAuthContextFromClerk({
     db,

--- a/apps/app/src/__tests__/chat-api-source.test.ts
+++ b/apps/app/src/__tests__/chat-api-source.test.ts
@@ -71,7 +71,7 @@ describe("app chat API route migration", () => {
     expect(chatSource).toContain("safeValidateUIMessages");
     expect(chatSource).toContain("streamText");
     expect(chatSource).toContain("toUIMessageStreamResponse");
-    expect(chatSource).toContain('await import("@api/app/services/skills")');
+    expect(chatSource).toContain('await import("../../../services/skills")');
     expect(chatSource).toContain(
       "setWorkspaceAssistantConversationActiveStream"
     );
@@ -94,6 +94,7 @@ describe("app chat API route migration", () => {
       expect(nextFreeSource).not.toContain('from "~/server');
       expect(nextFreeSource).not.toContain("@vendor/observability/log/next");
       expect(nextFreeSource).not.toContain("@api/app/auth/identity");
+      expect(nextFreeSource).not.toContain("@api/app/services/");
     }
     expect(chatSource).not.toContain('from "@api/app/services/skills"');
   });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -27,6 +27,7 @@
     "@db/app": "workspace:*",
     "@repo/api-contract": "workspace:*",
     "@repo/app-encryption": "workspace:*",
+    "@repo/service-jwt": "workspace:*",
     "drizzle-orm": "catalog:",
     "lightfast": "workspace:*"
   },

--- a/e2e/src/decisions/real-clerk-smoke.test.ts
+++ b/e2e/src/decisions/real-clerk-smoke.test.ts
@@ -1,10 +1,26 @@
+import { providerRoutineId } from "@repo/api-contract";
+import { verifyServiceJWT } from "@repo/service-jwt";
 import { describe, expect, it } from "vitest";
 
 import {
   buildDecisionsSmokeConfig,
+  callRuntimeDecisionThroughAppProxy,
   createUniqueDecisionsOrgSlug,
   formatCommandForError,
 } from "./real-clerk-smoke";
+
+const serviceJwtSecret = "test-service-jwt-secret-at-least-32-chars";
+
+function appProxySuccessResponse() {
+  return Response.json({
+    provider: "linear",
+    providerRoutineCallId: "provider_routine_call_smoke",
+    providerToolName: "get_team",
+    result: { marker: "get_team" },
+    routineId: providerRoutineId("linear", "get_team"),
+    status: "succeeded",
+  });
+}
 
 describe("real Clerk Decisions smoke helpers", () => {
   it("creates stable slug-safe org names from a timestamp", () => {
@@ -46,6 +62,7 @@ describe("real Clerk Decisions smoke helpers", () => {
     const config = buildDecisionsSmokeConfig({
       env: {
         CLERK_SECRET_KEY: "sk_test_123",
+        SERVICE_JWT_SECRET: serviceJwtSecret,
       },
       getPortlessUrl: (name) =>
         `https://integration-call-ledger.${name}.localhost`,
@@ -58,6 +75,19 @@ describe("real Clerk Decisions smoke helpers", () => {
       runtimeDecisionEnabled: true,
       sessionName: "lightfast-decisions-smoke-1780372800000",
     });
+  });
+
+  it("requires a service JWT secret before runtime Decision proof setup starts", () => {
+    expect(() =>
+      buildDecisionsSmokeConfig({
+        env: {
+          CLERK_SECRET_KEY: "sk_test_123",
+          SERVICE_JWT_SECRET: "too-short",
+        },
+        getPortlessUrl: (name) => `https://${name}.localhost`,
+        nowMs: Date.parse("2026-06-02T04:00:00.000Z"),
+      })
+    ).toThrow("SERVICE_JWT_SECRET must be at least 32 characters");
   });
 
   it("redacts agent-browser eval scripts from command failure messages", () => {
@@ -80,5 +110,120 @@ describe("real Clerk Decisions smoke helpers", () => {
         nowMs: Date.parse("2026-06-02T04:00:00.000Z"),
       })
     ).toThrow("CLERK_SECRET_KEY");
+  });
+
+  it("calls the app-owned internal MCP proxy with service auth and routine input", async () => {
+    const calls: Array<{
+      init?: RequestInit;
+      request: RequestInfo | URL;
+    }> = [];
+    const fetchFn: typeof fetch = async (request, init) => {
+      calls.push({ init, request });
+      return appProxySuccessResponse();
+    };
+
+    await callRuntimeDecisionThroughAppProxy({
+      appOrigin: "https://app.lightfast.localhost",
+      fetchFn,
+      orgId: "org_123",
+      serviceJwtSecret,
+      timeoutMs: 5000,
+      userId: "user_123",
+    });
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(String(call.request)).toBe(
+      "https://app.lightfast.localhost/api/internal/mcp/proxy/call"
+    );
+    expect(call.init?.method).toBe("POST");
+    expect(call.init?.signal).toBeInstanceOf(AbortSignal);
+
+    const headers = new Headers(call.init?.headers);
+    expect(headers.get("content-type")).toBe("application/json");
+    const authorization = headers.get("authorization");
+    expect(authorization).toMatch(/^Bearer /);
+    const token = authorization!.replace(/^Bearer\s+/, "");
+    await expect(
+      verifyServiceJWT({
+        allowedCallers: ["mcp"],
+        audience: "lightfast-app",
+        jwtSecret: serviceJwtSecret,
+        token,
+      })
+    ).resolves.toEqual({
+      audience: "lightfast-app",
+      caller: "mcp",
+    });
+
+    expect(typeof call.init?.body).toBe("string");
+    expect(JSON.parse(call.init?.body as string)).toEqual({
+      actor: {
+        clientId: "decisions-runtime-smoke",
+        grantId: "decisions-runtime-smoke:org_123",
+        kind: "mcp",
+        orgId: "org_123",
+        userId: "user_123",
+      },
+      input: {
+        input: { id: "team-lightfast" },
+        routineId: providerRoutineId("linear", "get_team"),
+      },
+      scopes: {
+        providerRoutineRead: true,
+        providerRoutineWrite: true,
+      },
+    });
+  });
+
+  it("reports non-OK app proxy responses", async () => {
+    const fetchFn: typeof fetch = async () =>
+      Response.json({ error: "service_not_configured" }, { status: 500 });
+
+    await expect(
+      callRuntimeDecisionThroughAppProxy({
+        appOrigin: "https://app.lightfast.localhost",
+        fetchFn,
+        orgId: "org_123",
+        serviceJwtSecret,
+        userId: "user_123",
+      })
+    ).rejects.toThrow("Runtime Decision proof failed through app proxy");
+  });
+
+  it("rejects invalid app proxy response bodies", async () => {
+    const fetchFn: typeof fetch = async () => new Response("not-json");
+
+    await expect(
+      callRuntimeDecisionThroughAppProxy({
+        appOrigin: "https://app.lightfast.localhost",
+        fetchFn,
+        orgId: "org_123",
+        serviceJwtSecret,
+        userId: "user_123",
+      })
+    ).rejects.toThrow("invalid response");
+  });
+
+  it("times out stalled app proxy calls", async () => {
+    const fetchFn: typeof fetch = async (_request, init) =>
+      await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("Aborted", "AbortError")),
+          { once: true }
+        );
+      });
+
+    await expect(
+      callRuntimeDecisionThroughAppProxy({
+        appOrigin: "https://app.lightfast.localhost",
+        fetchFn,
+        orgId: "org_123",
+        serviceJwtSecret,
+        timeoutMs: 1,
+        userId: "user_123",
+      })
+    ).rejects.toThrow("timed out after 1ms");
   });
 });

--- a/e2e/src/decisions/real-clerk-smoke.ts
+++ b/e2e/src/decisions/real-clerk-smoke.ts
@@ -5,6 +5,12 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import {
+  providerRoutineCallSuccessSchema,
+  providerRoutineId,
+} from "@repo/api-contract";
+import { signServiceJWT } from "@repo/service-jwt";
+
+import {
   allowLocalhostTls,
   normalizeUrl,
   trimTrailingSlash,
@@ -23,6 +29,8 @@ const LINEAR_EMULATOR_ACTOR_NAME = "Lightfast Local";
 const LINEAR_EMULATOR_WORKSPACE_ID = "linear_workspace_lightfast_emulated";
 const LINEAR_EMULATOR_WORKSPACE_NAME = "lightfast-emulated";
 const RUNTIME_DECISION_TOOL_NAME = "get_team";
+const RUNTIME_DECISION_PROXY_TIMEOUT_MS = 30_000;
+const SERVICE_JWT_SECRET_MIN_LENGTH = 32;
 
 type Env = Record<string, string | undefined>;
 
@@ -34,6 +42,7 @@ export interface DecisionsSmokeConfig {
   orgSlug: string;
   runtimeDecisionEnabled: boolean;
   screenshotPath?: string;
+  serviceJwtSecret?: string;
   sessionName: string;
 }
 
@@ -83,6 +92,12 @@ export function buildDecisionsSmokeConfig(
   const emailAddress =
     env.LIGHTFAST_E2E_DECISIONS_EMAIL?.trim() ||
     `${slugPart(env.LIGHTFAST_E2E_DECISIONS_EMAIL_PREFIX ?? "decisions-smoke")}-${nowMs}@${DEFAULT_EMAIL_DOMAIN}`;
+  const runtimeDecisionEnabled =
+    env.LIGHTFAST_E2E_DECISIONS_RUNTIME_CALL !== "0";
+  const serviceJwtSecret = env.SERVICE_JWT_SECRET?.trim() || undefined;
+  if (runtimeDecisionEnabled) {
+    requireRuntimeServiceJwtSecret(serviceJwtSecret);
+  }
 
   return {
     appOrigin: normalizeUrl(
@@ -98,12 +113,22 @@ export function buildDecisionsSmokeConfig(
       "LIGHTFAST_E2E_LINEAR_MCP_ENDPOINT"
     ),
     orgSlug,
-    runtimeDecisionEnabled: env.LIGHTFAST_E2E_DECISIONS_RUNTIME_CALL !== "0",
+    runtimeDecisionEnabled,
     screenshotPath: env.LIGHTFAST_E2E_DECISIONS_SCREENSHOT?.trim() || undefined,
+    serviceJwtSecret,
     sessionName:
       env.LIGHTFAST_E2E_AGENT_BROWSER_SESSION?.trim() ||
       `${DEFAULT_SESSION_NAME}-${nowMs}`,
   };
+}
+
+function requireRuntimeServiceJwtSecret(secret: string | undefined): string {
+  if (!secret || secret.length < SERVICE_JWT_SECRET_MIN_LENGTH) {
+    throw new Error(
+      `SERVICE_JWT_SECRET must be at least ${SERVICE_JWT_SECRET_MIN_LENGTH} characters when runtime Decision proof is enabled. Set LIGHTFAST_E2E_DECISIONS_RUNTIME_CALL=0 to skip that proof.`
+    );
+  }
+  return secret;
 }
 
 function slugPart(value: string) {
@@ -428,29 +453,100 @@ async function createActiveLinearRuntimeConnection(input: {
 async function recordRuntimeDecision(input: {
   config: DecisionsSmokeConfig;
   orgId: string;
+  userId: string;
 }) {
   configureLinearRuntimeEnv(input.config);
   allowLocalhostTls(input.config.linearMcpEndpoint);
 
-  const { loadConnectorRuntimeTools } = await import(
-    "@api/app/services/connectors/runtime"
-  );
-  const tools = await loadConnectorRuntimeTools({
-    automationPublicId: "automation_decisions_runtime_smoke",
-    clerkOrgId: input.orgId,
-    runPublicId: "run_decisions_runtime_smoke",
+  await callRuntimeDecisionThroughAppProxy({
+    appOrigin: input.config.appOrigin,
+    orgId: input.orgId,
+    serviceJwtSecret: requireRuntimeServiceJwtSecret(
+      input.config.serviceJwtSecret
+    ),
+    userId: input.userId,
   });
-  const tool = tools.find(
-    (item) => item.providerToolName === RUNTIME_DECISION_TOOL_NAME
-  );
-  if (!tool) {
+}
+
+export async function callRuntimeDecisionThroughAppProxy(input: {
+  appOrigin: string;
+  fetchFn?: typeof fetch;
+  orgId: string;
+  serviceJwtSecret: string;
+  timeoutMs?: number;
+  userId: string;
+}) {
+  const token = await signServiceJWT({
+    audience: "lightfast-app",
+    caller: "mcp",
+    jwtSecret: input.serviceJwtSecret,
+  });
+  const timeoutMs = input.timeoutMs ?? RUNTIME_DECISION_PROXY_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const fetchFn = input.fetchFn ?? fetch;
+
+  let response: Response;
+  try {
+    response = await fetchFn(
+      new URL("/api/internal/mcp/proxy/call", input.appOrigin),
+      {
+        body: JSON.stringify({
+          actor: {
+            clientId: "decisions-runtime-smoke",
+            grantId: `decisions-runtime-smoke:${input.orgId}`,
+            kind: "mcp",
+            orgId: input.orgId,
+            userId: input.userId,
+          },
+          input: {
+            input: { id: "team-lightfast" },
+            routineId: providerRoutineId("linear", RUNTIME_DECISION_TOOL_NAME),
+          },
+          scopes: {
+            providerRoutineRead: true,
+            providerRoutineWrite: true,
+          },
+        }),
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        method: "POST",
+        signal: timeoutSignal,
+      }
+    );
+  } catch (error) {
+    if (timeoutSignal.aborted) {
+      throw new Error(
+        `Runtime Decision proof through app proxy timed out after ${timeoutMs}ms.`,
+        { cause: error }
+      );
+    }
+    throw error;
+  }
+
+  const body = await response.json().catch(() => undefined);
+  if (!response.ok) {
     throw new Error(
-      `Linear runtime tool ${RUNTIME_DECISION_TOOL_NAME} was not loaded.`
+      `Runtime Decision proof failed through app proxy: ${JSON.stringify(body)}`
     );
   }
 
-  const result = await tool.call({ id: "team-lightfast" });
-  const serialized = JSON.stringify(result);
+  const parsed = providerRoutineCallSuccessSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error(
+      `Runtime Decision proof through app proxy returned an invalid response: ${parsed.error.message}`
+    );
+  }
+
+  const result = parsed.data;
+  if (result.providerToolName !== RUNTIME_DECISION_TOOL_NAME) {
+    throw new Error(
+      `Runtime Decision proof returned ${result.providerToolName}, expected ${RUNTIME_DECISION_TOOL_NAME}.`
+    );
+  }
+
+  const serialized = JSON.stringify(result.result);
   if (!serialized.includes(RUNTIME_DECISION_TOOL_NAME)) {
     throw new Error(
       `Linear runtime tool result did not include ${RUNTIME_DECISION_TOOL_NAME}: ${serialized}`
@@ -631,7 +727,7 @@ export async function runRealClerkDecisionsSmoke(
         orgId: org.id,
         userId: user.id,
       });
-      await recordRuntimeDecision({ config, orgId: org.id });
+      await recordRuntimeDecision({ config, orgId: org.id, userId: user.id });
     }
     await seedDecisionRows({
       orgId: org.id,

--- a/e2e/src/helpers/api-app-boundaries.test.ts
+++ b/e2e/src/helpers/api-app-boundaries.test.ts
@@ -1,0 +1,33 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const e2eRoot = resolve(import.meta.dirname, "../..");
+const forbiddenApiAppServicesSpecifier = `@api/app/${"services"}/`;
+
+function e2eSourceFiles(dir = resolve(e2eRoot, "src")): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absPath = resolve(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return e2eSourceFiles(absPath);
+    }
+
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [absPath] : [];
+  });
+}
+
+describe("e2e architecture boundaries", () => {
+  it("does not import api/app backend service internals", () => {
+    const offenders = e2eSourceFiles()
+      .map((path) => ({
+        path: relative(e2eRoot, path),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ source }) =>
+        source.includes(forbiddenApiAppServicesSpecifier)
+      );
+
+    expect(offenders.map(({ path }) => path)).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1700,6 +1700,9 @@ importers:
       '@repo/app-encryption':
         specifier: workspace:*
         version: link:../packages/app-encryption
+      '@repo/service-jwt':
+        specifier: workspace:*
+        version: link:../packages/service-jwt
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.1)(@planetscale/database@1.20.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)


### PR DESCRIPTION
## Summary
- remove `@api/app/services/*` package exports so backend services stay private to `api/app`
- switch app-owned adapters and tests to relative service imports inside `api/app`
- move the Decisions e2e runtime proof through `/api/internal/mcp/proxy/call` with service JWT auth and add boundary ratchets

## Test Plan
- [x] `pnpm --filter @api/app test -- src/__tests__/api-app-service-exports-source.test.ts src/__tests__/workspace-assistant-route.test.ts`
- [x] `pnpm --filter @lightfast/e2e exec vitest run src/decisions/real-clerk-smoke.test.ts src/helpers/api-app-boundaries.test.ts`
- [x] `pnpm --filter @lightfast/e2e typecheck`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/chat-api-source.test.ts src/__tests__/internal-mcp-routes-source.test.ts src/__tests__/authenticated-routes-source.test.ts`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits on the known unused-file backlog; this slice's new files are not listed

## Notes
- `SERVICE_JWT_SECRET` is now required up front for Decisions runtime proof runs unless `LIGHTFAST_E2E_DECISIONS_RUNTIME_CALL=0` disables that live proxy proof.
