### PR TITLE
refactor: trim api app private exports

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -13,18 +13,6 @@
       "types": "./src/mcp-oauth/server-routes.ts",
       "default": "./src/mcp-oauth/server-routes.ts"
     },
-    "./mcp-oauth/resource-access": {
-      "types": "./src/mcp-oauth/resource-access.ts",
-      "default": "./src/mcp-oauth/resource-access.ts"
-    },
-    "./env": {
-      "types": "./src/env.ts",
-      "default": "./src/env.ts"
-    },
-    "./domain": {
-      "types": "./src/domain/index.ts",
-      "default": "./src/domain/index.ts"
-    },
     "./native-auth": {
       "types": "./src/native-auth/index.ts",
       "default": "./src/native-auth/index.ts"
@@ -188,22 +176,6 @@
     "./tanstack/people": {
       "types": "./src/adapters/tanstack/people.ts",
       "default": "./src/adapters/tanstack/people.ts"
-    },
-    "./signals/service": {
-      "types": "./src/signals/service.ts",
-      "default": "./src/signals/service.ts"
-    },
-    "./inngest": {
-      "types": "./src/inngest/index.ts",
-      "default": "./src/inngest/index.ts"
-    },
-    "./inngest/client": {
-      "types": "./src/inngest/client.ts",
-      "default": "./src/inngest/client.ts"
-    },
-    "./auth/identity": {
-      "types": "./src/auth/identity.ts",
-      "default": "./src/auth/identity.ts"
     }
   },
   "license": "Apache-2.0",

--- a/api/app/src/__tests__/api-app-service-exports-source.test.ts
+++ b/api/app/src/__tests__/api-app-service-exports-source.test.ts
@@ -17,27 +17,51 @@ function apiSourceFiles(dir = resolve(apiAppRoot, "src")): string[] {
 }
 
 describe("api app service internals", () => {
-  it("does not expose backend services as package entrypoints", () => {
+  it("does not expose backend internals as package entrypoints", () => {
     const packageJson = JSON.parse(
       readFileSync(resolve(apiAppRoot, "package.json"), "utf8")
     ) as { exports?: Record<string, unknown> };
+    const privateExports = new Set([
+      "./auth/identity",
+      "./domain",
+      "./env",
+      "./inngest",
+      "./inngest/client",
+      "./mcp-oauth/resource-access",
+      "./signals/service",
+    ]);
 
-    const serviceExports = Object.keys(packageJson.exports ?? {}).filter(
+    const forbiddenExports = Object.keys(packageJson.exports ?? {}).filter(
       (entrypoint) =>
-        entrypoint === "./services" || entrypoint.startsWith("./services/")
+        entrypoint === "./services" ||
+        entrypoint.startsWith("./services/") ||
+        privateExports.has(entrypoint)
     );
 
-    expect(serviceExports).toEqual([]);
+    expect(forbiddenExports).toEqual([]);
   });
 
-  it("keeps service imports relative inside api/app", () => {
+  it("keeps private imports relative inside api/app", () => {
+    const privateSpecifiers = [
+      "@api/app/auth/identity",
+      "@api/app/domain",
+      "@api/app/env",
+      "@api/app/inngest",
+      "@api/app/mcp-oauth/resource-access",
+      "@api/app/services/",
+      "@api/app/signals/service",
+    ];
     const offenders = apiSourceFiles()
       .map((path) => ({
         path: relative(apiAppRoot, path),
         source: readFileSync(path, "utf8"),
       }))
-      .filter(({ source }) => source.includes("@api/app/services/"));
+      .flatMap(({ path, source }) =>
+        privateSpecifiers
+          .filter((specifier) => source.includes(specifier))
+          .map((specifier) => ({ path, specifier }))
+      );
 
-    expect(offenders.map(({ path }) => path)).toEqual([]);
+    expect(offenders).toEqual([]);
   });
 });

--- a/api/app/src/adapters/internal/mcp-proxy.ts
+++ b/api/app/src/adapters/internal/mcp-proxy.ts
@@ -93,7 +93,7 @@ export async function handleMcpProxyFindRequest(
 
   try {
     const { assertHostedMcpOrgAccess } = await import(
-      "@api/app/mcp-oauth/resource-access"
+      "../../mcp-oauth/resource-access"
     );
     await assertHostedMcpOrgAccess(db, {
       orgId: parsed.data.actor.orgId,
@@ -131,7 +131,7 @@ export async function handleMcpProxyCallRequest(
 
   try {
     const { assertHostedMcpOrgAccess } = await import(
-      "@api/app/mcp-oauth/resource-access"
+      "../../mcp-oauth/resource-access"
     );
     await assertHostedMcpOrgAccess(db, {
       orgId: parsed.data.actor.orgId,

--- a/api/app/src/adapters/native-provider-proxy.ts
+++ b/api/app/src/adapters/native-provider-proxy.ts
@@ -59,9 +59,7 @@ function errorResponse(error: unknown) {
 async function createNativeProviderRoutineContext(
   req: Request
 ): Promise<NativeProviderRoutineServiceContext> {
-  const { resolveAuthContextFromClerk } = await import(
-    "@api/app/auth/identity"
-  );
+  const { resolveAuthContextFromClerk } = await import("../auth/identity");
   const { loadAgentConnectorRuntimeTools } = await import(
     "../services/connectors/runtime"
   );

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -72,7 +72,6 @@ function dependencies(
 describe("hosted MCP tools", () => {
   afterEach(() => {
     vi.doUnmock("@api/app/mcp-oauth");
-    vi.doUnmock("@api/app/signals/service");
     vi.doUnmock("../tools/app-audit-intake");
     vi.doUnmock("../tools/app-proxy-intake");
     vi.doUnmock("../tools/app-signal-intake");
@@ -406,9 +405,6 @@ describe("hosted MCP tools", () => {
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for system health");
     });
-    vi.doMock("@api/app/signals/service", () => {
-      throw new Error("signal service should not load for system health");
-    });
     vi.doMock("../tools/app-signal-intake", () => {
       throw new Error("app signal intake should not load for system health");
     });
@@ -432,7 +428,7 @@ describe("hosted MCP tools", () => {
     );
   });
 
-  it("does not load app signal service or OAuth for signal creation", async () => {
+  it("does not load app OAuth for signal creation", async () => {
     const createSignalForActor = vi.fn().mockResolvedValue({
       id: signalId,
       status: "queued",
@@ -445,9 +441,6 @@ describe("hosted MCP tools", () => {
     }));
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for signal creation");
-    });
-    vi.doMock("@api/app/signals/service", () => {
-      throw new Error("signal service should not load for signal creation");
     });
     vi.doMock("../tools/app-signal-intake", () => ({
       createSignalForActorViaApp: createSignalForActor,
@@ -496,9 +489,6 @@ describe("hosted MCP tools", () => {
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for signal get");
     });
-    vi.doMock("@api/app/signals/service", () => {
-      throw new Error("signal service should not load for signal get");
-    });
     vi.doMock("../tools/app-signal-intake", () => ({
       getSignalForActorViaApp: getSignalForActor,
     }));
@@ -543,9 +533,6 @@ describe("hosted MCP tools", () => {
     }));
     vi.doMock("@api/app/mcp-oauth", () => {
       throw new Error("mcp-oauth should not load for proxy calls");
-    });
-    vi.doMock("@api/app/signals/service", () => {
-      throw new Error("signal service should not load for proxy calls");
     });
     vi.doMock("../tools/app-signal-intake", () => {
       throw new Error("app signal intake should not load for proxy calls");


### PR DESCRIPTION
## Summary
- remove unused implementation-shaped `@api/app` package exports (`auth/identity`, `domain`, `env`, `inngest*`, `mcp-oauth/resource-access`, `signals/service`)
- convert `api/app` self-imports for auth identity and MCP resource access to relative internals
- extend the package/source ratchet and remove stale MCP test mocks for the deleted signal-service export

## Test Plan
- [x] `pnpm --filter @api/app test -- src/__tests__/api-app-service-exports-source.test.ts src/__tests__/mcp-signals-internal-adapter.test.ts`
- [x] `pnpm --filter @api/app test -- src/__tests__/api-app-service-exports-source.test.ts src/__tests__/workspace-signals-router-source.test.ts src/__tests__/mcp-signals-internal-adapter.test.ts`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/internal-mcp-routes-source.test.ts src/__tests__/inngest-route.test.ts src/__tests__/native-rpc-routes-source.test.ts src/__tests__/authenticated-routes-source.test.ts src/__tests__/chat-api-source.test.ts`
- [x] `pnpm --filter @lightfast/mcp test -- src/__tests__/tools.test.ts src/__tests__/app-signal-intake.test.ts src/__tests__/env-config.test.ts`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm --filter @lightfast/mcp typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits on the known unused-file backlog; touched files are not listed

## Reviews
- Spec review: no findings; confirmed this is seam deletion, not a new abstraction.
- Code quality review: no Critical/Important/Minor findings; CodeRabbit uncommitted review returned 0 findings.
