### PR TITLE
Refactor user connector command context

### DIFF
--- a/api/app/src/__tests__/account-connector-domain-commands.test.ts
+++ b/api/app/src/__tests__/account-connector-domain-commands.test.ts
@@ -17,8 +17,8 @@ import {
 const listMcpOauthGrantConnectionsForUserMock = vi.fn();
 const getMcpOauthGrantByPublicIdMock = vi.fn();
 const revokeMcpOauthGrantMock = vi.fn();
-const startUserConnectorOAuthMock = vi.fn();
-const disconnectUserConnectorMock = vi.fn();
+const startGranolaUserConnectorOAuthMock = vi.fn();
+const disconnectGranolaUserConnectorMock = vi.fn();
 
 const pendingIdentity: AuthIdentity = {
   type: "pending",
@@ -30,10 +30,6 @@ const activeIdentity: AuthIdentity = {
   userId: "user_current",
   orgId: "org_acme",
   orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
-};
-
-const unauthenticatedIdentity: AuthIdentity = {
-  type: "unauthenticated",
 };
 
 const now = new Date("2026-06-01T00:00:00.000Z");
@@ -96,12 +92,12 @@ function mcpDeps() {
   });
 }
 
-function userConnectorDeps(headers = new Headers()) {
+function userConnectorDeps(referer?: string | null) {
   return createDefaultUserConnectorCommandDeps({
     db: {} as Database,
-    disconnectUserConnector: disconnectUserConnectorMock,
-    headers,
-    startUserConnectorOAuth: startUserConnectorOAuthMock,
+    disconnectGranolaUserConnector: disconnectGranolaUserConnectorMock,
+    request: { referer },
+    startGranolaUserConnectorOAuth: startGranolaUserConnectorOAuthMock,
   });
 }
 
@@ -109,17 +105,17 @@ beforeEach(() => {
   listMcpOauthGrantConnectionsForUserMock.mockReset();
   getMcpOauthGrantByPublicIdMock.mockReset();
   revokeMcpOauthGrantMock.mockReset();
-  startUserConnectorOAuthMock.mockReset();
-  disconnectUserConnectorMock.mockReset();
+  startGranolaUserConnectorOAuthMock.mockReset();
+  disconnectGranolaUserConnectorMock.mockReset();
 
   listMcpOauthGrantConnectionsForUserMock.mockResolvedValue([connection()]);
   getMcpOauthGrantByPublicIdMock.mockResolvedValue(grant());
   revokeMcpOauthGrantMock.mockResolvedValue(true);
-  startUserConnectorOAuthMock.mockResolvedValue({
+  startGranolaUserConnectorOAuthMock.mockResolvedValue({
     authorizationUrl: "https://granola.test/oauth/authorize",
     mode: "connect",
   });
-  disconnectUserConnectorMock.mockResolvedValue({ disconnected: true });
+  disconnectGranolaUserConnectorMock.mockResolvedValue({ disconnected: true });
 });
 
 describe("account MCP connection domain commands", () => {
@@ -190,14 +186,12 @@ describe("account MCP connection domain commands", () => {
 
 describe("user connector domain commands", () => {
   it("starts a user connector OAuth flow for pending Clerk users", async () => {
-    const headers = new Headers({
-      referer: "https://app.lightfast.localhost/connectors?scope=personal",
-    });
+    const referer = "https://app.lightfast.localhost/connectors?scope=personal";
 
     await expect(
       startUserConnectorCommand.run({
         ctx: ctx(),
-        deps: userConnectorDeps(headers),
+        deps: userConnectorDeps(referer),
         input: { provider: "granola" },
       })
     ).resolves.toEqual({
@@ -205,14 +199,11 @@ describe("user connector domain commands", () => {
       mode: "connect",
     });
 
-    expect(startUserConnectorOAuthMock).toHaveBeenCalledWith(
-      {
-        auth: { identity: pendingIdentity },
-        db: expect.anything(),
-        headers,
-      },
-      { provider: "granola" }
-    );
+    expect(startGranolaUserConnectorOAuthMock).toHaveBeenCalledWith({
+      db: expect.anything(),
+      request: { referer },
+      viewer: { userId: "user_current" },
+    });
   });
 
   it("disconnects a user connector with the same credential-blind viewer identity shape", async () => {
@@ -224,25 +215,31 @@ describe("user connector domain commands", () => {
       })
     ).resolves.toEqual({ disconnected: true });
 
-    expect(disconnectUserConnectorMock).toHaveBeenCalledWith(
-      {
-        auth: { identity: activeIdentity },
-        db: expect.anything(),
-        headers: expect.any(Headers),
-      },
-      { provider: "granola" }
-    );
+    expect(disconnectGranolaUserConnectorMock).toHaveBeenCalledWith({
+      db: expect.anything(),
+      request: {},
+      viewer: { userId: "user_current" },
+    });
   });
 
-  it("rejects unauthenticated actors before user connector services run", async () => {
-    expect(() => ctx(unauthenticatedIdentity)).toThrowError(
+  it("rejects non-Clerk actors before user connector services run", async () => {
+    await expect(
+      startUserConnectorCommand.run({
+        ctx: {
+          actor: { kind: "service", service: "system" },
+          request: { id: "req_test", source: "tanstack" },
+        },
+        deps: userConnectorDeps(),
+        input: { provider: "granola" },
+      })
+    ).rejects.toThrowError(
       expect.objectContaining({
-        code: "AUTH_REQUIRED",
+        code: "CLERK_USER_REQUIRED",
         kind: "authz",
       })
     );
 
-    expect(startUserConnectorOAuthMock).not.toHaveBeenCalled();
-    expect(disconnectUserConnectorMock).not.toHaveBeenCalled();
+    expect(startGranolaUserConnectorOAuthMock).not.toHaveBeenCalled();
+    expect(disconnectGranolaUserConnectorMock).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -51,8 +51,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/developer-connections/leases.ts",
       "services/developer-sandbox-runs/index.ts",
       "services/user-connectors/catalog.ts",
-      "services/user-connectors/granola-flow.ts",
-      "services/user-connectors/index.ts",
     ]) {
       const fileSource = source(file);
 
@@ -60,6 +58,18 @@ describe("api/app app-facing tRPC root", () => {
       expect(fileSource, file).not.toContain("../trpc");
       expect(fileSource, file).toContain("../../auth/identity");
       expect(fileSource, file).toContain("ResolvedAuthContext");
+    }
+
+    for (const file of [
+      "services/user-connectors/granola-flow.ts",
+      "services/user-connectors/index.ts",
+    ]) {
+      const fileSource = source(file);
+
+      expect(fileSource, file).not.toContain("../../trpc");
+      expect(fileSource, file).not.toContain("../trpc");
+      expect(fileSource, file).not.toContain("../../auth/identity");
+      expect(fileSource, file).not.toContain("ResolvedAuthContext");
     }
   });
 });

--- a/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
@@ -13,7 +13,6 @@ describe("connector service domain errors", () => {
     for (const file of [
       "services/connectors/index.ts",
       "services/connectors/config.ts",
-      "services/user-connectors/index.ts",
     ]) {
       const fileSource = source(file);
 
@@ -21,6 +20,13 @@ describe("connector service domain errors", () => {
       expect(fileSource, file).not.toContain("@trpc/server");
       expect(fileSource, file).not.toContain("TRPCError");
     }
+
+    const userConnectorIndexSource = source(
+      "services/user-connectors/index.ts"
+    );
+    expect(userConnectorIndexSource).not.toContain("../../domain/errors");
+    expect(userConnectorIndexSource).not.toContain("switch");
+    expect(userConnectorIndexSource).not.toContain("unsupportedProvider");
   });
 
   it("keeps connector provider flow errors framework-neutral", () => {

--- a/api/app/src/__tests__/user-connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/user-connectors-domain-commands.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import type { Database } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,17 +8,13 @@ import { actorFromAuthIdentity } from "../domain";
 import { ValidationError } from "../domain/errors";
 import {
   createDefaultUserConnectorCommandDeps,
+  disconnectUserConnectorCommand,
   startUserConnectorCommand,
 } from "../domain/user-connectors";
 
 const serviceMocks = vi.hoisted(() => ({
-  disconnectUserConnector: vi.fn(),
-  startUserConnectorOAuth: vi.fn(),
-}));
-
-vi.mock("../services/user-connectors", () => ({
-  disconnectUserConnector: serviceMocks.disconnectUserConnector,
-  startUserConnectorOAuth: serviceMocks.startUserConnectorOAuth,
+  disconnectGranolaUserConnector: vi.fn(),
+  startGranolaUserConnectorOAuth: vi.fn(),
 }));
 
 const pendingIdentity = {
@@ -34,9 +32,9 @@ function ctx() {
 function deps() {
   return createDefaultUserConnectorCommandDeps({
     db: {} as Database,
-    disconnectUserConnector: serviceMocks.disconnectUserConnector,
-    headers: new Headers(),
-    startUserConnectorOAuth: serviceMocks.startUserConnectorOAuth,
+    disconnectGranolaUserConnector: serviceMocks.disconnectGranolaUserConnector,
+    request: {},
+    startGranolaUserConnectorOAuth: serviceMocks.startGranolaUserConnectorOAuth,
   });
 }
 
@@ -45,8 +43,29 @@ describe("user connector domain commands", () => {
     vi.clearAllMocks();
   });
 
+  it("keeps user connector commands free of raw auth and transport types", () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, "../domain/user-connectors/commands.ts"),
+      "utf8"
+    );
+
+    expect(source).not.toContain("../../auth/identity");
+    expect(source).not.toContain("AuthIdentity");
+    expect(source).not.toContain("Headers");
+  });
+
+  it("keeps direct Granola commands pinned to the Granola provider", () => {
+    expect(
+      startUserConnectorCommand.input.safeParse({ provider: "notion" }).success
+    ).toBe(false);
+    expect(
+      disconnectUserConnectorCommand.input.safeParse({ provider: "notion" })
+        .success
+    ).toBe(false);
+  });
+
   it("preserves domain errors raised by user connector services", async () => {
-    serviceMocks.startUserConnectorOAuth.mockRejectedValueOnce(
+    serviceMocks.startGranolaUserConnectorOAuth.mockRejectedValueOnce(
       new ValidationError(
         "USER_CONNECTOR_UNSUPPORTED_PROVIDER",
         "Unsupported user connector provider: fake"

--- a/api/app/src/__tests__/user-connectors-flow.test.ts
+++ b/api/app/src/__tests__/user-connectors-flow.test.ts
@@ -182,17 +182,9 @@ function userConnection(
   };
 }
 
-function ctx(
-  input: {
-    identity?: "active" | "pending" | "unauthenticated";
-    referer?: string;
-  } = {}
-) {
-  const headers = new Headers();
-  if (input.referer) {
-    headers.set("referer", input.referer);
-  }
-
+function authIdentity(input: {
+  identity?: "active" | "pending" | "unauthenticated";
+}) {
   const identity =
     input.identity === "unauthenticated"
       ? ({ type: "unauthenticated" } as const)
@@ -205,10 +197,25 @@ function ctx(
             userId: "user_current",
           } as const);
 
+  return identity;
+}
+
+function catalogCtx(
+  input: { identity?: "active" | "pending" | "unauthenticated" } = {}
+) {
+  const identity = authIdentity(input);
+
   return {
     auth: { identity },
     db: {} as Database,
-    headers,
+  };
+}
+
+function oauthCtx(input: { referer?: string; userId?: string } = {}) {
+  return {
+    db: {} as Database,
+    request: { referer: input.referer },
+    viewer: { userId: input.userId ?? "user_current" },
   };
 }
 
@@ -235,7 +242,7 @@ describe("user connector catalog services", () => {
 
   it("returns an empty user connector catalog for unauthenticated viewers", async () => {
     await expect(
-      listUserConnectorsForViewer(ctx({ identity: "unauthenticated" }))
+      listUserConnectorsForViewer(catalogCtx({ identity: "unauthenticated" }))
     ).resolves.toEqual([]);
 
     expect(listCurrentUserConnectorConnectionsMock).not.toHaveBeenCalled();
@@ -243,7 +250,7 @@ describe("user connector catalog services", () => {
 
   it("lists Granola as a private user connector for signed-in pending viewers", async () => {
     await expect(
-      listUserConnectorsForViewer(ctx({ identity: "pending" }))
+      listUserConnectorsForViewer(catalogCtx({ identity: "pending" }))
     ).resolves.toEqual([
       expect.objectContaining({
         canManage: true,
@@ -267,7 +274,7 @@ describe("user connector catalog services", () => {
       userConnection({ providerAccountName: "Granola" }),
     ]);
 
-    const rows = await listUserConnectorsForViewer(ctx());
+    const rows = await listUserConnectorsForViewer(catalogCtx());
 
     expect(rows).toEqual([
       expect.objectContaining({
@@ -370,7 +377,7 @@ describe("Granola user connector OAuth flow", () => {
   it("starts OAuth and stores the attempt under the provider-generated state", async () => {
     await expect(
       startGranolaUserConnectorOAuth(
-        ctx({
+        oauthCtx({
           referer:
             "https://app.lightfast.localhost/account/settings?section=connectors",
         })
@@ -402,17 +409,6 @@ describe("Granola user connector OAuth flow", () => {
     );
   });
 
-  it("throws a domain authz error when Granola starts without authentication", async () => {
-    await expect(
-      startGranolaUserConnectorOAuth(ctx({ identity: "unauthenticated" }))
-    ).rejects.toThrowError(
-      expect.objectContaining({
-        code: "AUTH_REQUIRED",
-        kind: "authz",
-      })
-    );
-  });
-
   it("adds a Lightfast state when the provider authorization URL lacks state", async () => {
     listGranolaMcpToolsMock.mockImplementationOnce(
       async ({
@@ -432,7 +428,7 @@ describe("Granola user connector OAuth flow", () => {
       }
     );
 
-    const result = await startGranolaUserConnectorOAuth(ctx());
+    const result = await startGranolaUserConnectorOAuth(oauthCtx());
 
     expect(result.authorizationUrl).toBe(
       "https://granola.test/oauth/authorize?state=attempt_123456789012345678901234"
@@ -447,7 +443,9 @@ describe("Granola user connector OAuth flow", () => {
   it("returns reconnect mode when Granola is already connected", async () => {
     getCurrentUserConnectorConnectionMock.mockResolvedValue(userConnection());
 
-    await expect(startGranolaUserConnectorOAuth(ctx())).resolves.toMatchObject({
+    await expect(
+      startGranolaUserConnectorOAuth(oauthCtx())
+    ).resolves.toMatchObject({
       mode: "reconnect",
     });
   });
@@ -561,7 +559,7 @@ describe("Granola user connector OAuth flow", () => {
   it("disconnects the current Granola connector with observed-current guards", async () => {
     getCurrentUserConnectorConnectionMock.mockResolvedValue(userConnection());
 
-    await expect(disconnectGranolaUserConnector(ctx())).resolves.toEqual({
+    await expect(disconnectGranolaUserConnector(oauthCtx())).resolves.toEqual({
       disconnected: true,
     });
 

--- a/api/app/src/adapters/tanstack/user-connectors.ts
+++ b/api/app/src/adapters/tanstack/user-connectors.ts
@@ -14,8 +14,7 @@ function requestId() {
   return crypto.randomUUID();
 }
 
-async function createTanStackUserConnectorContext() {
-  const request = getRequest();
+async function createTanStackUserConnectorContext(request: Request) {
   const auth = await resolveAuthContextFromClerk({
     db,
     headers: new Headers(request.headers),
@@ -46,10 +45,10 @@ export const startUserConnector = createServerFn({ method: "POST" })
     noStore();
     try {
       return await startUserConnectorCommand.run({
-        ctx: await createTanStackUserConnectorContext(),
+        ctx: await createTanStackUserConnectorContext(request),
         deps: createDefaultUserConnectorCommandDeps({
           db,
-          headers: new Headers(request.headers),
+          request: { referer: request.headers.get("referer") },
         }),
         input: data,
       });
@@ -65,10 +64,10 @@ export const disconnectUserConnector = createServerFn({ method: "POST" })
     noStore();
     try {
       return await disconnectUserConnectorCommand.run({
-        ctx: await createTanStackUserConnectorContext(),
+        ctx: await createTanStackUserConnectorContext(request),
         deps: createDefaultUserConnectorCommandDeps({
           db,
-          headers: new Headers(request.headers),
+          request: { referer: request.headers.get("referer") },
         }),
         input: data,
       });

--- a/api/app/src/domain/user-connectors/commands.ts
+++ b/api/app/src/domain/user-connectors/commands.ts
@@ -1,12 +1,10 @@
 import type { Database } from "@db/app";
-import { userConnectorProviderSchema } from "@repo/api-contract";
 import { z } from "zod";
 
-import type { AuthIdentity } from "../../auth/identity";
 import {
-  disconnectUserConnector,
-  startUserConnectorOAuth,
-} from "../../services/user-connectors";
+  disconnectGranolaUserConnector,
+  startGranolaUserConnectorOAuth,
+} from "../../services/user-connectors/granola-flow";
 import type { Actor } from "../actor";
 import { defineCommand } from "../command";
 import {
@@ -17,32 +15,36 @@ import {
 } from "../errors";
 import { requireClerkUserActor } from "../gates";
 
+interface UserConnectorRequestContext {
+  referer?: string | null;
+}
+
 interface UserConnectorServiceContext {
-  auth: { identity: Exclude<AuthIdentity, { type: "unauthenticated" }> };
   db: Database;
-  headers: Headers;
+  request: UserConnectorRequestContext;
+  viewer: { userId: string };
 }
 
 interface UserConnectorCommandDeps {
   db: Database;
-  disconnectUserConnector: typeof disconnectUserConnector;
-  headers: Headers;
-  startUserConnectorOAuth: typeof startUserConnectorOAuth;
+  disconnectGranolaUserConnector: typeof disconnectGranolaUserConnector;
+  request: UserConnectorRequestContext;
+  startGranolaUserConnectorOAuth: typeof startGranolaUserConnectorOAuth;
 }
 
 export function createDefaultUserConnectorCommandDeps(input: {
   db: Database;
-  disconnectUserConnector?: typeof disconnectUserConnector;
-  headers: Headers;
-  startUserConnectorOAuth?: typeof startUserConnectorOAuth;
+  disconnectGranolaUserConnector?: typeof disconnectGranolaUserConnector;
+  request: UserConnectorRequestContext;
+  startGranolaUserConnectorOAuth?: typeof startGranolaUserConnectorOAuth;
 }): UserConnectorCommandDeps {
   return {
     db: input.db,
-    disconnectUserConnector:
-      input.disconnectUserConnector ?? disconnectUserConnector,
-    headers: input.headers,
-    startUserConnectorOAuth:
-      input.startUserConnectorOAuth ?? startUserConnectorOAuth,
+    disconnectGranolaUserConnector:
+      input.disconnectGranolaUserConnector ?? disconnectGranolaUserConnector,
+    request: input.request,
+    startGranolaUserConnectorOAuth:
+      input.startGranolaUserConnectorOAuth ?? startGranolaUserConnectorOAuth,
   };
 }
 
@@ -55,10 +57,10 @@ const disconnectUserConnectorOutput = z.object({
   disconnected: z.boolean(),
 });
 const userConnectorStartConnectInputSchema = z.object({
-  provider: userConnectorProviderSchema,
+  provider: z.literal("granola"),
 });
 const userConnectorProviderInputSchema = z.object({
-  provider: userConnectorProviderSchema,
+  provider: z.literal("granola"),
 });
 
 export const startUserConnectorCommand = defineCommand<
@@ -70,13 +72,12 @@ export const startUserConnectorCommand = defineCommand<
   name: "userConnectors.start",
   input: userConnectorStartConnectInputSchema,
   output: startUserConnectorOutput,
-  run: async ({ ctx, deps, input }) => {
+  run: async ({ ctx, deps }) => {
     const actor = requireClerkUserActor(ctx);
 
     try {
-      return await deps.startUserConnectorOAuth(
-        serviceContextForActor(actor, deps),
-        input
+      return await deps.startGranolaUserConnectorOAuth(
+        serviceContextForActor(actor, deps)
       );
     } catch (error) {
       throw mapUserConnectorServiceError(
@@ -97,13 +98,12 @@ export const disconnectUserConnectorCommand = defineCommand<
   name: "userConnectors.disconnect",
   input: userConnectorProviderInputSchema,
   output: disconnectUserConnectorOutput,
-  run: async ({ ctx, deps, input }) => {
+  run: async ({ ctx, deps }) => {
     const actor = requireClerkUserActor(ctx);
 
     try {
-      return await deps.disconnectUserConnector(
-        serviceContextForActor(actor, deps),
-        input
+      return await deps.disconnectGranolaUserConnector(
+        serviceContextForActor(actor, deps)
       );
     } catch (error) {
       throw mapUserConnectorServiceError(
@@ -120,27 +120,9 @@ function serviceContextForActor(
   deps: UserConnectorCommandDeps
 ): UserConnectorServiceContext {
   return {
-    auth: { identity: identityForActor(actor) },
     db: deps.db,
-    headers: deps.headers,
-  };
-}
-
-function identityForActor(
-  actor: Extract<Actor, { kind: "clerkUser" }>
-): Exclude<AuthIdentity, { type: "unauthenticated" }> {
-  if (actor.orgId && actor.orgGate) {
-    return {
-      type: "active",
-      userId: actor.userId,
-      orgId: actor.orgId,
-      orgGate: actor.orgGate,
-    };
-  }
-
-  return {
-    type: "pending",
-    userId: actor.userId,
+    request: deps.request,
+    viewer: { userId: actor.userId },
   };
 }
 

--- a/api/app/src/services/user-connectors/granola-flow.ts
+++ b/api/app/src/services/user-connectors/granola-flow.ts
@@ -17,8 +17,7 @@ import { auth } from "@vendor/clerk/server";
 import type { OAuthClientInformationMixed, OAuthTokens } from "@vendor/mcp";
 import { StreamableHTTPClientTransport } from "@vendor/mcp";
 import { log } from "@vendor/observability/log/next";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
-import { AuthzError, InternalDomainError } from "../../domain/errors";
+import { InternalDomainError } from "../../domain/errors";
 import { env } from "../../env";
 import {
   consumeUserConnectorOAuthAttempt,
@@ -31,21 +30,17 @@ export const GRANOLA_OAUTH_CALLBACK_PATH =
   "/api/connectors/granola/oauth/callback";
 
 interface GranolaUserConnectorServiceContext {
-  auth: AuthContext;
   db: Database;
-  headers: Headers;
+  request: {
+    referer?: string | null;
+  };
+  viewer: {
+    userId: string;
+  };
 }
 
 export interface GranolaRedirectResult {
   redirectUrl: string;
-}
-
-function signedInIdentity(ctx: GranolaUserConnectorServiceContext) {
-  const identity = ctx.auth.identity;
-  if (identity.type === "unauthenticated") {
-    throw new AuthzError("AUTH_REQUIRED", "Authentication required.");
-  }
-  return identity;
 }
 
 function resolveUserConnectorAppOrigin() {
@@ -83,8 +78,8 @@ function signInRedirect(input: {
   return { redirectUrl: signInUrl.toString() };
 }
 
-function safeReturnTo(input: { appOrigin: string; headers: Headers }) {
-  const referer = input.headers.get("referer");
+function safeReturnTo(input: { appOrigin: string; referer?: string | null }) {
+  const referer = input.referer;
   if (!referer) {
     return "/account/settings?connector=granola";
   }
@@ -214,14 +209,13 @@ function createGranolaOAuthProvider(input: {
 export async function startGranolaUserConnectorOAuth(
   ctx: GranolaUserConnectorServiceContext
 ): Promise<{ authorizationUrl: string; mode: "connect" | "reconnect" }> {
-  const identity = signedInIdentity(ctx);
   const appOrigin = resolveUserConnectorAppOrigin();
   const redirectUrl = new URL(
     GRANOLA_OAUTH_CALLBACK_PATH,
     appOrigin
   ).toString();
   const current = await getCurrentUserConnectorConnection(ctx.db, {
-    clerkUserId: identity.userId,
+    clerkUserId: ctx.viewer.userId,
     provider: "granola",
   });
   const mode = current ? "reconnect" : "connect";
@@ -261,12 +255,15 @@ export async function startGranolaUserConnectorOAuth(
   const providerState = authorizationUrl.searchParams.get("state") ?? undefined;
   const snapshot = provider.snapshot();
   const attempt = await issueUserConnectorOAuthAttempt({
-    clerkUserId: identity.userId,
+    clerkUserId: ctx.viewer.userId,
     clientInformation: snapshot.clientInformation,
     codeVerifier: snapshot.codeVerifier,
     provider: "granola",
     redirectUrl,
-    returnTo: safeReturnTo({ appOrigin, headers: ctx.headers }),
+    returnTo: safeReturnTo({
+      appOrigin,
+      referer: ctx.request.referer,
+    }),
     state: providerState,
   });
 
@@ -275,7 +272,7 @@ export async function startGranolaUserConnectorOAuth(
   }
 
   log.info("[user-connectors] granola oauth started", {
-    clerkUserId: identity.userId,
+    clerkUserId: ctx.viewer.userId,
     mode,
     provider: "granola",
   });
@@ -416,12 +413,10 @@ export async function completeGranolaUserConnectorOAuth(input: {
 export async function disconnectGranolaUserConnector(
   ctx: GranolaUserConnectorServiceContext
 ): Promise<{ disconnected: boolean }> {
-  const identity = signedInIdentity(ctx);
-
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const connection: UserConnectorConnection | undefined =
       await getCurrentUserConnectorConnection(ctx.db, {
-        clerkUserId: identity.userId,
+        clerkUserId: ctx.viewer.userId,
         provider: "granola",
       });
     if (!connection) {
@@ -429,7 +424,7 @@ export async function disconnectGranolaUserConnector(
     }
 
     const revoked = await markCurrentUserConnectorConnectionRevoked(ctx.db, {
-      clerkUserId: identity.userId,
+      clerkUserId: ctx.viewer.userId,
       observedCurrentConnectionId: connection.id,
       observedEncryptedAccessToken: connection.encryptedAccessToken,
       observedEncryptedRefreshToken: connection.encryptedRefreshToken,

--- a/api/app/src/services/user-connectors/index.ts
+++ b/api/app/src/services/user-connectors/index.ts
@@ -1,57 +1,6 @@
-import type { Database } from "@db/app";
-import type { UserConnectorProvider } from "@repo/api-contract";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
-import { ValidationError } from "../../domain/errors";
-import {
-  disconnectGranolaUserConnector,
-  startGranolaUserConnectorOAuth,
-} from "./granola-flow";
-
-interface UserConnectorOAuthServiceContext {
-  auth: AuthContext;
-  db: Database;
-  headers: Headers;
-}
-
-interface UserConnectorProviderInput {
-  provider: UserConnectorProvider;
-}
-type UserConnectorStartConnectInput = UserConnectorProviderInput;
-
 export { listUserConnectorsForViewer } from "./catalog";
 export {
   completeGranolaUserConnectorOAuth,
   disconnectGranolaUserConnector,
   startGranolaUserConnectorOAuth,
 } from "./granola-flow";
-
-function unsupportedProvider(provider: string): never {
-  throw new ValidationError(
-    "USER_CONNECTOR_UNSUPPORTED_PROVIDER",
-    `Unsupported user connector provider: ${provider}`
-  );
-}
-
-export async function startUserConnectorOAuth(
-  ctx: UserConnectorOAuthServiceContext,
-  input: UserConnectorStartConnectInput
-) {
-  switch (input.provider) {
-    case "granola":
-      return await startGranolaUserConnectorOAuth(ctx);
-    default:
-      return unsupportedProvider(input.provider);
-  }
-}
-
-export async function disconnectUserConnector(
-  ctx: UserConnectorOAuthServiceContext,
-  input: UserConnectorProviderInput
-) {
-  switch (input.provider) {
-    case "granola":
-      return await disconnectGranolaUserConnector(ctx);
-    default:
-      return unsupportedProvider(input.provider);
-  }
-}


### PR DESCRIPTION
## Summary

- Move user connector start/disconnect command deps from raw auth/header context to `{ db, request, viewer }`.
- Wire user connector commands directly to Granola service functions and keep `services/user-connectors/index.ts` as a pure barrel.
- Keep TanStack adapter responsible for Clerk/header resolution and pin direct commands to the Granola provider literal.
- Add/adjust ratchets for transport-free command boundaries and pure service barrels.

## Verification

- `pnpm --filter @api/app test -- src/__tests__/user-connectors-domain-commands.test.ts src/__tests__/account-connector-domain-commands.test.ts src/__tests__/user-connectors-flow.test.ts src/__tests__/app-trpc-root-source.test.ts src/__tests__/connector-service-domain-errors-source.test.ts` (121 files, 866 tests)
- `pnpm --filter @api/app typecheck`
- `pnpm check`
- `pnpm turbo boundaries`
- `pnpm typecheck`
- `git diff --check`
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` still exits 1 on the known unused-file backlog; no touched files are listed.

## Reviews

- Spec subagent: PASS, no findings.
- Quality subagent: PASS after fixes, no remaining findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored user connector service architecture to simplify authentication context handling.
  * Updated OAuth flow implementation and dependency injection patterns.

* **Tests**
  * Enhanced test coverage for user connector domain commands, services, and OAuth flows with improved mocking and assertion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->