### PR TITLE
Refactor user connector catalog context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -50,7 +50,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/developer-connections/index.ts",
       "services/developer-connections/leases.ts",
       "services/developer-sandbox-runs/index.ts",
-      "services/user-connectors/catalog.ts",
     ]) {
       const fileSource = source(file);
 
@@ -61,6 +60,7 @@ describe("api/app app-facing tRPC root", () => {
     }
 
     for (const file of [
+      "services/user-connectors/catalog.ts",
       "services/user-connectors/granola-flow.ts",
       "services/user-connectors/index.ts",
     ]) {

--- a/api/app/src/__tests__/connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/connectors-domain-commands.test.ts
@@ -140,9 +140,10 @@ describe("connector domain commands", () => {
         }),
       })
     );
-    expect(serviceMocks.listUserConnectorsForViewer).toHaveBeenCalledWith(
-      expect.anything()
-    );
+    expect(serviceMocks.listUserConnectorsForViewer).toHaveBeenCalledWith({
+      db: expect.anything(),
+      viewer: { userId: "user_current" },
+    });
   });
 
   it("marks admin actors as matching Clerk-session admins for catalog canManage checks", async () => {

--- a/api/app/src/__tests__/user-connectors-flow.test.ts
+++ b/api/app/src/__tests__/user-connectors-flow.test.ts
@@ -182,32 +182,10 @@ function userConnection(
   };
 }
 
-function authIdentity(input: {
-  identity?: "active" | "pending" | "unauthenticated";
-}) {
-  const identity =
-    input.identity === "unauthenticated"
-      ? ({ type: "unauthenticated" } as const)
-      : input.identity === "pending"
-        ? ({ type: "pending", userId: "user_current" } as const)
-        : ({
-            orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
-            orgId: "org_acme",
-            type: "active",
-            userId: "user_current",
-          } as const);
-
-  return identity;
-}
-
-function catalogCtx(
-  input: { identity?: "active" | "pending" | "unauthenticated" } = {}
-) {
-  const identity = authIdentity(input);
-
+function catalogCtx(input: { userId?: string } = {}) {
   return {
-    auth: { identity },
     db: {} as Database,
+    viewer: { userId: input.userId ?? "user_current" },
   };
 }
 
@@ -240,18 +218,8 @@ describe("user connector catalog services", () => {
     listCurrentUserConnectorConnectionsMock.mockResolvedValue([]);
   });
 
-  it("returns an empty user connector catalog for unauthenticated viewers", async () => {
-    await expect(
-      listUserConnectorsForViewer(catalogCtx({ identity: "unauthenticated" }))
-    ).resolves.toEqual([]);
-
-    expect(listCurrentUserConnectorConnectionsMock).not.toHaveBeenCalled();
-  });
-
-  it("lists Granola as a private user connector for signed-in pending viewers", async () => {
-    await expect(
-      listUserConnectorsForViewer(catalogCtx({ identity: "pending" }))
-    ).resolves.toEqual([
+  it("lists Granola as a private user connector for the viewer", async () => {
+    await expect(listUserConnectorsForViewer(catalogCtx())).resolves.toEqual([
       expect.objectContaining({
         canManage: true,
         catalogStatus: "available",

--- a/api/app/src/domain/connectors/commands.ts
+++ b/api/app/src/domain/connectors/commands.ts
@@ -159,7 +159,10 @@ export const listConnectorSectionsCommand = defineCommand<
     try {
       return {
         teamConnectors: await deps.listConnectorsForOrg(serviceContext),
-        yourConnectors: await deps.listUserConnectorsForViewer(serviceContext),
+        yourConnectors: await deps.listUserConnectorsForViewer({
+          db: deps.db,
+          viewer: { userId: actor.userId },
+        }),
       };
     } catch (error) {
       throw mapConnectorServiceError(

--- a/api/app/src/services/user-connectors/catalog.ts
+++ b/api/app/src/services/user-connectors/catalog.ts
@@ -1,10 +1,11 @@
 import type { Database, UserConnectorConnection } from "@db/app";
 import { listCurrentUserConnectorConnections } from "@db/app";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
 
 export interface UserConnectorServiceContext {
-  auth: AuthContext;
   db: Database;
+  viewer: {
+    userId: string;
+  };
 }
 
 export interface UserConnectorCatalogRow {
@@ -56,13 +57,8 @@ const USER_CONNECTOR_CATALOG = [
 export async function listUserConnectorsForViewer(
   ctx: UserConnectorServiceContext
 ): Promise<UserConnectorCatalogRow[]> {
-  const identity = ctx.auth.identity;
-  if (identity.type === "unauthenticated") {
-    return [];
-  }
-
   const connections = await listCurrentUserConnectorConnections(ctx.db, {
-    clerkUserId: identity.userId,
+    clerkUserId: ctx.viewer.userId,
   });
   const byProvider = new Map(connections.map((row) => [row.provider, row]));
 


### PR DESCRIPTION
## Summary

- Make `services/user-connectors/catalog.ts` credential-blind by replacing `ResolvedAuthContext` with `{ db, viewer: { userId } }`.
- Pass that personal catalog context from connector sections while leaving team/org connector service context unchanged.
- Move the catalog source ratchet into the raw-auth-free group and keep behavior tests on viewer-driven DB lookup.

## Verification

- `pnpm --filter @api/app test -- src/__tests__/connectors-domain-commands.test.ts src/__tests__/user-connectors-flow.test.ts src/__tests__/app-trpc-root-source.test.ts` (121 files, 865 tests)
- `pnpm --filter @api/app typecheck`
- `pnpm check`
- `pnpm turbo boundaries`
- `pnpm typecheck`
- `git diff --check`
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` still exits 1 on the known unused-file backlog; no touched files are listed.

## Reviews

- Spec subagent: PASS, no findings.
- Quality subagent: PASS, no findings. Applied its optional simplification to remove the duplicate source-string guard from the flow test.
