### PR TITLE
Refactor developer connection catalog context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -46,7 +46,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/connectors/index.ts",
       "services/connectors/linear-flow.ts",
       "services/connectors/x-flow.ts",
-      "services/developer-connections/catalog.ts",
       "services/developer-connections/index.ts",
       "services/developer-connections/leases.ts",
       "services/developer-sandbox-runs/index.ts",
@@ -60,6 +59,7 @@ describe("api/app app-facing tRPC root", () => {
     }
 
     for (const file of [
+      "services/developer-connections/catalog.ts",
       "services/user-connectors/catalog.ts",
       "services/user-connectors/granola-flow.ts",
       "services/user-connectors/index.ts",

--- a/api/app/src/__tests__/developer-connections-domain-commands.test.ts
+++ b/api/app/src/__tests__/developer-connections-domain-commands.test.ts
@@ -106,16 +106,25 @@ describe("developer connection domain commands", () => {
       })
     ).resolves.toEqual([expect.objectContaining({ provider: "sentry" })]);
 
-    expect(serviceMocks.listDeveloperConnectionsForOrg).toHaveBeenCalledWith(
-      expect.objectContaining({
-        auth: expect.objectContaining({
-          identity: expect.objectContaining({
-            orgId: "org_acme",
-            userId: "user_current",
-          }),
-        }),
-      })
-    );
+    expect(serviceMocks.listDeveloperConnectionsForOrg).toHaveBeenCalledWith({
+      db: expect.anything(),
+      organization: { orgId: "org_acme" },
+      viewer: { canManage: false },
+    });
+  });
+
+  it("passes admin manage authority to developer connection catalog listing", async () => {
+    await listDeveloperConnectionsCommand.run({
+      ctx: ctx({ admin: true }),
+      deps: deps(),
+      input: {},
+    });
+
+    expect(serviceMocks.listDeveloperConnectionsForOrg).toHaveBeenCalledWith({
+      db: expect.anything(),
+      organization: { orgId: "org_acme" },
+      viewer: { canManage: true },
+    });
   });
 
   it("requires bound organizations to list developer connections", async () => {

--- a/api/app/src/__tests__/developer-connections-service.test.ts
+++ b/api/app/src/__tests__/developer-connections-service.test.ts
@@ -87,6 +87,14 @@ function ctx(input: { isAdmin?: boolean } = {}) {
   };
 }
 
+function catalogCtx(input: { canManage?: boolean } = {}) {
+  return {
+    db: {} as Database,
+    organization: { orgId: "org_acme" },
+    viewer: { canManage: input.canManage ?? true },
+  };
+}
+
 describe("developer connection services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -154,16 +162,38 @@ describe("developer connection services", () => {
   });
 
   it("lists the four provider catalog rows with admin manage state", async () => {
-    await expect(listDeveloperConnectionsForOrg(ctx())).resolves.toEqual([
-      expect.objectContaining({ provider: "pscale", canManage: true }),
-      expect.objectContaining({ provider: "upstash", canManage: true }),
-      expect.objectContaining({ provider: "sentry", canManage: true }),
-      expect.objectContaining({ provider: "clerk", canManage: true }),
-    ]);
+    await expect(listDeveloperConnectionsForOrg(catalogCtx())).resolves.toEqual(
+      [
+        expect.objectContaining({ provider: "pscale", canManage: true }),
+        expect.objectContaining({ provider: "upstash", canManage: true }),
+        expect.objectContaining({ provider: "sentry", canManage: true }),
+        expect.objectContaining({ provider: "clerk", canManage: true }),
+      ]
+    );
+
+    expect(listCurrentDeveloperConnectionsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { clerkOrgId: "org_acme" }
+    );
+  });
+
+  it("marks developer connections unavailable when the viewer cannot manage them", async () => {
+    await expect(
+      listDeveloperConnectionsForOrg(catalogCtx({ canManage: false }))
+    ).resolves.toContainEqual(
+      expect.objectContaining({
+        canManage: false,
+        connectAvailability: {
+          reason: "permission_required",
+          status: "unavailable",
+        },
+        provider: "sentry",
+      })
+    );
   });
 
   it("keeps the local catalog in sync with the canonical provider list", async () => {
-    const rows = await listDeveloperConnectionsForOrg(ctx());
+    const rows = await listDeveloperConnectionsForOrg(catalogCtx());
     expect(rows.map((row) => row.provider)).toEqual([
       ...DEVELOPER_CONNECTION_PROVIDERS,
     ]);

--- a/api/app/src/domain/developer-connections/commands.ts
+++ b/api/app/src/domain/developer-connections/commands.ts
@@ -34,7 +34,7 @@ type ListDeveloperConnectionsResult = Awaited<
   ReturnType<typeof listDeveloperConnectionsForOrg>
 >;
 
-interface DeveloperConnectionServiceContext {
+interface DeveloperConnectionMutationServiceContext {
   auth: {
     access: Extract<AuthAccess, { kind: "clerk-session" }>;
     identity: Extract<AuthIdentity, { type: "active" }>;
@@ -122,9 +122,11 @@ export const listDeveloperConnectionsCommand = defineCommand<
   run: async ({ ctx, deps }) => {
     const actor = requireBoundClerkOrgActor(ctx);
     try {
-      return await deps.listDeveloperConnectionsForOrg(
-        serviceContextForActor(actor, deps)
-      );
+      return await deps.listDeveloperConnectionsForOrg({
+        db: deps.db,
+        organization: { orgId: actor.orgId },
+        viewer: { canManage: actor.orgRole === "admin" },
+      });
     } catch (error) {
       throw mapDeveloperConnectionServiceError(
         error,
@@ -271,7 +273,7 @@ function serviceContextForActor(
     orgId: string;
   },
   deps: DeveloperConnectionCommandDeps
-): DeveloperConnectionServiceContext {
+): DeveloperConnectionMutationServiceContext {
   return {
     auth: {
       access: accessForActor(actor),

--- a/api/app/src/services/developer-connections/catalog.ts
+++ b/api/app/src/services/developer-connections/catalog.ts
@@ -4,11 +4,15 @@ import type {
   DeveloperConnectionCatalogStatus,
   DeveloperConnectionProvider,
 } from "@repo/api-contract";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
 
 interface DeveloperConnectionServiceContext {
-  auth: AuthContext;
   db: Database;
+  organization: {
+    orgId: string;
+  };
+  viewer: {
+    canManage: boolean;
+  };
 }
 
 type ConnectAvailability =
@@ -77,20 +81,6 @@ export interface DeveloperConnectionCatalogRow {
   provider: DeveloperConnectionProvider;
 }
 
-export function canManageDeveloperConnections(
-  ctx: DeveloperConnectionServiceContext
-) {
-  const identity = ctx.auth.identity;
-  const access = ctx.auth.access;
-  return (
-    identity.type === "active" &&
-    access?.kind === "clerk-session" &&
-    access.userId === identity.userId &&
-    access.orgId === identity.orgId &&
-    access.has({ role: "org:admin" })
-  );
-}
-
 function availabilityFor(canManage: boolean): ConnectAvailability {
   if (!canManage) {
     return { status: "unavailable", reason: "permission_required" };
@@ -116,18 +106,13 @@ function shapeConnection(connection: DeveloperConnection | undefined) {
 export async function listDeveloperConnectionsForOrg(
   ctx: DeveloperConnectionServiceContext
 ): Promise<DeveloperConnectionCatalogRow[]> {
-  const identity = ctx.auth.identity;
-  if (identity.type !== "active") {
-    return [];
-  }
-
   const connections = await listCurrentDeveloperConnections(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
   });
   const byProvider = new Map<DeveloperConnectionProvider, DeveloperConnection>(
     connections.map((connection) => [connection.provider, connection])
   );
-  const canManage = canManageDeveloperConnections(ctx);
+  const canManage = ctx.viewer.canManage;
 
   return DEVELOPER_CONNECTION_CATALOG.map((catalogItem) => ({
     ...catalogItem,


### PR DESCRIPTION
## Summary
- Narrow developer connection catalog listing to explicit `{ db, organization, viewer }` context.
- Keep developer connection mutation services on the existing auth/header context while making list/catalog credential-blind.
- Move the catalog service into the raw-auth-free source ratchet and cover admin/non-admin manage-state behavior.

## Verification
- pnpm --filter @api/app test -- src/__tests__/developer-connections-domain-commands.test.ts src/__tests__/developer-connections-service.test.ts src/__tests__/app-trpc-root-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- pnpm typecheck
- git diff --check
- rg leak scan for auth/header terms in api/app/src/services/developer-connections/catalog.ts

## Review Notes
- Spec reviewer: PASS
- Quality reviewer: PASS
- SKIP_ENV_VALIDATION=true pnpm knip --include files still exits 1 on the known unused-file backlog; no touched files are listed.