### PR TITLE
Refactor connector catalog context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -42,7 +42,6 @@ describe("api/app app-facing tRPC root", () => {
     expect(identitySource).not.toContain("trpc");
 
     for (const file of [
-      "services/connectors/catalog.ts",
       "services/connectors/index.ts",
       "services/connectors/linear-flow.ts",
       "services/connectors/x-flow.ts",
@@ -59,6 +58,7 @@ describe("api/app app-facing tRPC root", () => {
     }
 
     for (const file of [
+      "services/connectors/catalog.ts",
       "services/developer-connections/catalog.ts",
       "services/user-connectors/catalog.ts",
       "services/user-connectors/granola-flow.ts",
@@ -70,6 +70,19 @@ describe("api/app app-facing tRPC root", () => {
       expect(fileSource, file).not.toContain("../trpc");
       expect(fileSource, file).not.toContain("../../auth/identity");
       expect(fileSource, file).not.toContain("ResolvedAuthContext");
+    }
+
+    const connectorCatalogSource = source("services/connectors/catalog.ts");
+    for (const forbiddenToken of [
+      "@vendor/clerk/server",
+      "Headers",
+      "getRequest",
+      "request.headers",
+      "headers:",
+    ]) {
+      expect(connectorCatalogSource, forbiddenToken).not.toContain(
+        forbiddenToken
+      );
     }
   });
 });

--- a/api/app/src/__tests__/connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/connectors-domain-commands.test.ts
@@ -128,33 +128,29 @@ describe("connector domain commands", () => {
       ],
     });
 
-    expect(serviceMocks.listConnectorsForOrg).toHaveBeenCalledWith(
-      expect.objectContaining({
-        auth: expect.objectContaining({
-          access: expect.objectContaining({ kind: "clerk-session" }),
-          identity: expect.objectContaining({
-            orgGate: expect.objectContaining({ bindingStatus: "unbound" }),
-            orgId: "org_acme",
-            userId: "user_current",
-          }),
-        }),
-      })
-    );
+    expect(serviceMocks.listConnectorsForOrg).toHaveBeenCalledWith({
+      db: expect.anything(),
+      organization: { orgId: "org_acme" },
+      viewer: { canManage: false },
+    });
     expect(serviceMocks.listUserConnectorsForViewer).toHaveBeenCalledWith({
       db: expect.anything(),
       viewer: { userId: "user_current" },
     });
   });
 
-  it("marks admin actors as matching Clerk-session admins for catalog canManage checks", async () => {
+  it("passes admin manage authority to connector catalog listing", async () => {
     await listConnectorsCommand.run({
       ctx: ctx({ admin: true }),
       deps: deps(),
       input: {},
     });
 
-    const serviceContext = serviceMocks.listConnectorsForOrg.mock.calls[0]?.[0];
-    expect(serviceContext.auth.access.has({ role: "org:admin" })).toBe(true);
+    expect(serviceMocks.listConnectorsForOrg).toHaveBeenCalledWith({
+      db: expect.anything(),
+      organization: { orgId: "org_acme" },
+      viewer: { canManage: true },
+    });
   });
 
   it("allows org admins to start connector OAuth before binding", async () => {

--- a/api/app/src/__tests__/connectors-flow.test.ts
+++ b/api/app/src/__tests__/connectors-flow.test.ts
@@ -244,6 +244,14 @@ function ctx(input: { isAdmin?: boolean } = {}) {
   };
 }
 
+function catalogCtx(input: { canManage?: boolean } = {}) {
+  return {
+    db: {} as Database,
+    organization: { orgId: "org_acme" },
+    viewer: { canManage: input.canManage ?? true },
+  };
+}
+
 function connection(
   overrides: Partial<OrgConnectorConnection> = {}
 ): OrgConnectorConnection {
@@ -326,7 +334,7 @@ describe("connector catalog services", () => {
       connection({ enabledForAutomations: true }),
     ]);
 
-    const rows = await listConnectorsForOrg(ctx());
+    const rows = await listConnectorsForOrg(catalogCtx());
 
     expect(rows).toEqual(
       expect.arrayContaining([
@@ -362,9 +370,13 @@ describe("connector catalog services", () => {
       connectAvailability: { status: "available" },
       provider: "x",
     });
+    expect(listCurrentOrgConnectorConnectionsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { clerkOrgId: "org_acme" }
+    );
 
     envMock.X_CLIENT_SECRET = undefined as unknown as string;
-    const missingXConfigRows = await listConnectorsForOrg(ctx());
+    const missingXConfigRows = await listConnectorsForOrg(catalogCtx());
     expect(
       missingXConfigRows.find((row) => row.provider === "x")
     ).toMatchObject({
@@ -374,6 +386,21 @@ describe("connector catalog services", () => {
         status: "unavailable",
       },
     });
+  });
+
+  it("marks connectors unavailable when the viewer cannot manage them", async () => {
+    const rows = await listConnectorsForOrg(catalogCtx({ canManage: false }));
+
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        canManage: false,
+        connectAvailability: {
+          reason: "permission_required",
+          status: "unavailable",
+        },
+        provider: "linear",
+      })
+    );
   });
 
   it("marks X connections with missing requested scopes for reconnect", async () => {
@@ -388,7 +415,7 @@ describe("connector catalog services", () => {
       }),
     ]);
 
-    const rows = await listConnectorsForOrg(ctx());
+    const rows = await listConnectorsForOrg(catalogCtx());
     const xRow = rows.find((row) => row.provider === "x");
 
     expect(xRow?.connection).toMatchObject({

--- a/api/app/src/domain/connectors/commands.ts
+++ b/api/app/src/domain/connectors/commands.ts
@@ -39,7 +39,7 @@ type RefreshConnectorToolsResult = Awaited<
   ReturnType<typeof refreshConnectorTools>
 >;
 
-interface ConnectorServiceContext {
+interface ConnectorMutationServiceContext {
   auth: {
     access: Extract<AuthAccess, { kind: "clerk-session" }>;
     identity: Extract<AuthIdentity, { type: "active" }>;
@@ -131,9 +131,11 @@ export const listConnectorsCommand = defineCommand<
   run: async ({ ctx, deps }) => {
     const actor = requireActiveClerkOrgActor(ctx);
     try {
-      return await deps.listConnectorsForOrg(
-        serviceContextForActor(actor, deps)
-      );
+      return await deps.listConnectorsForOrg({
+        db: deps.db,
+        organization: { orgId: actor.orgId },
+        viewer: { canManage: actor.orgRole === "admin" },
+      });
     } catch (error) {
       throw mapConnectorServiceError(
         error,
@@ -155,10 +157,13 @@ export const listConnectorSectionsCommand = defineCommand<
   output: listConnectorSectionsOutput,
   run: async ({ ctx, deps }) => {
     const actor = requireActiveClerkOrgActor(ctx);
-    const serviceContext = serviceContextForActor(actor, deps);
     try {
       return {
-        teamConnectors: await deps.listConnectorsForOrg(serviceContext),
+        teamConnectors: await deps.listConnectorsForOrg({
+          db: deps.db,
+          organization: { orgId: actor.orgId },
+          viewer: { canManage: actor.orgRole === "admin" },
+        }),
         yourConnectors: await deps.listUserConnectorsForViewer({
           db: deps.db,
           viewer: { userId: actor.userId },
@@ -310,7 +315,7 @@ function serviceContextForActor(
     orgId: string;
   },
   deps: ConnectorCommandDeps
-): ConnectorServiceContext {
+): ConnectorMutationServiceContext {
   return {
     auth: {
       access: accessForActor(actor),

--- a/api/app/src/services/connectors/catalog.ts
+++ b/api/app/src/services/connectors/catalog.ts
@@ -10,12 +10,16 @@ import {
   type ConnectableConnectorProvider,
   type ConnectorProvider,
 } from "@repo/api-contract";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
 import { getXConnectorConfig } from "./config";
 
-interface ConnectorServiceContext {
-  auth: AuthContext;
+interface ConnectorCatalogServiceContext {
   db: Database;
+  organization: {
+    orgId: string;
+  };
+  viewer: {
+    canManage: boolean;
+  };
 }
 
 type ConnectAvailability =
@@ -88,18 +92,6 @@ const CONNECTOR_CATALOG = [
   | "displayName"
   | "provider"
 >[];
-
-function canManageConnectors(ctx: ConnectorServiceContext): boolean {
-  const identity = ctx.auth.identity;
-  const access = ctx.auth.access;
-  return (
-    identity.type === "active" &&
-    access?.kind === "clerk-session" &&
-    access.userId === identity.userId &&
-    access.orgId === identity.orgId &&
-    access.has({ role: "org:admin" })
-  );
-}
 
 function isConnectableProvider(
   provider: ConnectorProvider
@@ -232,20 +224,15 @@ function missingRequestedScopes(connection: OrgConnectorConnection): string[] {
 }
 
 export async function listConnectorsForOrg(
-  ctx: ConnectorServiceContext
+  ctx: ConnectorCatalogServiceContext
 ): Promise<ConnectorCatalogRow[]> {
-  const identity = ctx.auth.identity;
-  if (identity.type !== "active") {
-    return [];
-  }
-
   const connections = await listCurrentOrgConnectorConnections(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
   });
   const byProvider = new Map<ConnectorProvider, OrgConnectorConnection>(
     connections.map((connection) => [connection.provider, connection])
   );
-  const canManage = canManageConnectors(ctx);
+  const canManage = ctx.viewer.canManage;
 
   return CONNECTOR_CATALOG.map((catalogItem) => {
     const connection = byProvider.get(catalogItem.provider);


### PR DESCRIPTION
## Summary
- Narrow org connector catalog listing to explicit `{ db, organization, viewer }` context.
- Keep connector mutations/OAuth/refresh/disconnect on the existing auth+headers mutation context.
- Move the org connector catalog service into the raw-auth-free source ratchet and add catalog-only raw credential token checks.

## Verification
- pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/connectors-domain-commands.test.ts src/__tests__/connectors-flow.test.ts src/__tests__/app-trpc-root-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- pnpm typecheck
- git diff --check
- rg leak scan for auth/header/request tokens in api/app/src/services/connectors/catalog.ts

## Review Notes
- Spec reviewer: PASS
- Quality reviewer: PASS
- SKIP_ENV_VALIDATION=true pnpm knip --include files still exits 1 on the known unused-file backlog; no touched files are listed.