### PR TITLE
Refactor developer connection lease context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -46,7 +46,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/connectors/linear-flow.ts",
       "services/connectors/x-flow.ts",
       "services/developer-connections/index.ts",
-      "services/developer-connections/leases.ts",
       "services/developer-sandbox-runs/index.ts",
     ]) {
       const fileSource = source(file);
@@ -60,6 +59,7 @@ describe("api/app app-facing tRPC root", () => {
     for (const file of [
       "services/connectors/catalog.ts",
       "services/developer-connections/catalog.ts",
+      "services/developer-connections/leases.ts",
       "services/user-connectors/catalog.ts",
       "services/user-connectors/granola-flow.ts",
       "services/user-connectors/index.ts",

--- a/api/app/src/__tests__/developer-connections-service.test.ts
+++ b/api/app/src/__tests__/developer-connections-service.test.ts
@@ -95,6 +95,14 @@ function catalogCtx(input: { canManage?: boolean } = {}) {
   };
 }
 
+function leaseCtx() {
+  return {
+    actor: { userId: "user_admin" },
+    db: {} as Database,
+    organization: { orgId: "org_acme" },
+  };
+}
+
 describe("developer connection services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -328,7 +336,7 @@ describe("developer connection services", () => {
     ]);
 
     await expect(
-      issueDeveloperConnectionLeases(ctx(), {
+      issueDeveloperConnectionLeases(leaseCtx(), {
         providers: ["sentry"],
         sandboxRunId: "sandbox_run_1",
         workflowRunId: "workflow_run_1",
@@ -353,7 +361,7 @@ describe("developer connection services", () => {
     listCurrentDeveloperConnectionsMock.mockResolvedValue([]);
 
     await expect(
-      issueDeveloperConnectionLeases(ctx(), {
+      issueDeveloperConnectionLeases(leaseCtx(), {
         providers: ["sentry"],
         sandboxRunId: "sandbox_run_1",
         workflowRunId: "workflow_run_1",
@@ -442,7 +450,7 @@ describe("developer connection services", () => {
     );
 
     await expect(
-      issueAllEnabledDeveloperConnectionLeases(ctx(), {
+      issueAllEnabledDeveloperConnectionLeases(leaseCtx(), {
         sandboxRunId: "developer_sandbox_run_1",
       })
     ).resolves.toEqual({
@@ -514,7 +522,7 @@ describe("developer connection services", () => {
     });
 
     await expect(
-      materializeDeveloperConnectionLeasesForSandboxRun(ctx(), {
+      materializeDeveloperConnectionLeasesForSandboxRun(leaseCtx(), {
         now: new Date("2026-06-03T00:05:00.000Z"),
         sandboxRunId: "developer_sandbox_run_1",
       })

--- a/api/app/src/__tests__/developer-sandbox-runs-service.test.ts
+++ b/api/app/src/__tests__/developer-sandbox-runs-service.test.ts
@@ -356,7 +356,17 @@ describe("developer sandbox run service", () => {
       stdout: "[redacted] ok\n",
     });
 
-    expect(issueAllEnabledDeveloperConnectionLeasesMock).toHaveBeenCalled();
+    expect(issueAllEnabledDeveloperConnectionLeasesMock).toHaveBeenCalledWith(
+      {
+        actor: { userId: "user_admin" },
+        db: expect.anything(),
+        organization: { orgId: "org_acme" },
+      },
+      {
+        sandboxRunId: "developer_sandbox_run_1",
+        workflowRunId: null,
+      }
+    );
     expect(fakeRuntime.calls.writeFiles).toEqual([
       [
         {
@@ -406,9 +416,16 @@ describe("developer sandbox run service", () => {
     expect(issueAllEnabledDeveloperConnectionLeasesMock).not.toHaveBeenCalled();
     expect(
       materializeDeveloperConnectionLeasesForSandboxRunMock
-    ).toHaveBeenCalledWith(expect.anything(), {
-      sandboxRunId: "developer_sandbox_run_1",
-    });
+    ).toHaveBeenCalledWith(
+      {
+        actor: { userId: "user_admin" },
+        db: expect.anything(),
+        organization: { orgId: "org_acme" },
+      },
+      {
+        sandboxRunId: "developer_sandbox_run_1",
+      }
+    );
   });
 
   it("reissues credentials when a loaded run has no active leases left", async () => {
@@ -428,7 +445,11 @@ describe("developer sandbox run service", () => {
     });
 
     expect(issueAllEnabledDeveloperConnectionLeasesMock).toHaveBeenCalledWith(
-      expect.anything(),
+      {
+        actor: { userId: "user_admin" },
+        db: expect.anything(),
+        organization: { orgId: "org_acme" },
+      },
       {
         sandboxRunId: "developer_sandbox_run_1",
         workflowRunId: null,

--- a/api/app/src/services/developer-connections/leases.ts
+++ b/api/app/src/services/developer-connections/leases.ts
@@ -13,17 +13,21 @@ import {
   DEVELOPER_CONNECTION_PROVIDERS,
   type DeveloperConnectionIssueLeaseInput,
 } from "@repo/api-contract";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
-import { AuthzError, ConflictError } from "../../domain/errors";
+import { ConflictError } from "../../domain/errors";
 import {
   type DeveloperConnectionMaterialization,
   materializeDeveloperCredential,
 } from "./adapters";
 import { decryptDeveloperCredential } from "./credentials";
 
-interface DeveloperConnectionServiceContext {
-  auth: AuthContext;
+interface DeveloperConnectionLeaseServiceContext {
+  actor: {
+    userId: string;
+  };
   db: Database;
+  organization: {
+    orgId: string;
+  };
 }
 
 interface SandboxRunLeaseInput {
@@ -34,14 +38,6 @@ interface SandboxRunLeaseInput {
 interface LeaseMaterializationResult {
   leases: DeveloperConnectionLease[];
   materialization: DeveloperConnectionMaterialization[];
-}
-
-function activeIdentity(ctx: DeveloperConnectionServiceContext) {
-  const identity = ctx.auth.identity;
-  if (identity.type !== "active") {
-    throw new AuthzError("AUTH_REQUIRED", "Authentication required.");
-  }
-  return identity;
 }
 
 function assertUsableConnection(connection: DeveloperConnection) {
@@ -89,13 +85,12 @@ function activeLease(lease: DeveloperConnectionLease, now: Date) {
 }
 
 export async function issueDeveloperConnectionLeases(
-  ctx: DeveloperConnectionServiceContext,
+  ctx: DeveloperConnectionLeaseServiceContext,
   input: DeveloperConnectionIssueLeaseInput
 ): Promise<LeaseMaterializationResult> {
-  const identity = activeIdentity(ctx);
   const requested = new Set(input.providers);
   const current = await listCurrentDeveloperConnections(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
   });
   const byProvider = new Map(
     current.map((connection) => [connection.provider, connection])
@@ -122,8 +117,8 @@ export async function issueDeveloperConnectionLeases(
 
     const lease = await issueDeveloperConnectionLease(ctx.db, {
       connectionId: connection.id,
-      clerkOrgId: identity.orgId,
-      actorUserId: identity.userId,
+      clerkOrgId: ctx.organization.orgId,
+      actorUserId: ctx.actor.userId,
       sandboxRunId: input.sandboxRunId,
       workflowRunId: input.workflowRunId,
       provider,
@@ -137,12 +132,11 @@ export async function issueDeveloperConnectionLeases(
 }
 
 export async function issueAllEnabledDeveloperConnectionLeases(
-  ctx: DeveloperConnectionServiceContext,
+  ctx: DeveloperConnectionLeaseServiceContext,
   input: SandboxRunLeaseInput
 ): Promise<LeaseMaterializationResult> {
-  const identity = activeIdentity(ctx);
   const current = await listCurrentDeveloperConnections(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
   });
   const byProvider = new Map(
     current.map((connection) => [connection.provider, connection])
@@ -160,8 +154,8 @@ export async function issueAllEnabledDeveloperConnectionLeases(
     assertUsableConnection(connection);
     const lease = await issueDeveloperConnectionLease(ctx.db, {
       connectionId: connection.id,
-      clerkOrgId: identity.orgId,
-      actorUserId: identity.userId,
+      clerkOrgId: ctx.organization.orgId,
+      actorUserId: ctx.actor.userId,
       sandboxRunId: input.sandboxRunId,
       workflowRunId: input.workflowRunId ?? input.sandboxRunId,
       provider,
@@ -175,14 +169,13 @@ export async function issueAllEnabledDeveloperConnectionLeases(
 }
 
 export async function materializeDeveloperConnectionLeasesForSandboxRun(
-  ctx: DeveloperConnectionServiceContext,
+  ctx: DeveloperConnectionLeaseServiceContext,
   input: { sandboxRunId: string; now?: Date }
 ): Promise<LeaseMaterializationResult> {
-  const identity = activeIdentity(ctx);
   const now = input.now ?? new Date();
   const leases = (
     await listDeveloperConnectionLeasesForSandboxRun(ctx.db, {
-      clerkOrgId: identity.orgId,
+      clerkOrgId: ctx.organization.orgId,
       sandboxRunId: input.sandboxRunId,
     })
   ).filter((lease) => activeLease(lease, now));
@@ -193,7 +186,7 @@ export async function materializeDeveloperConnectionLeasesForSandboxRun(
       ctx.db,
       lease.connectionId
     );
-    if (!connection || connection.clerkOrgId !== identity.orgId) {
+    if (!connection || connection.clerkOrgId !== ctx.organization.orgId) {
       throw new ConflictError(
         "DEVELOPER_CONNECTION_CREDENTIAL_MISSING",
         `${lease.provider} has no credential material`

--- a/api/app/src/services/developer-sandbox-runs/index.ts
+++ b/api/app/src/services/developer-sandbox-runs/index.ts
@@ -41,6 +41,11 @@ interface DeveloperSandboxRunServiceOptions {
   runtime?: SandboxRuntime;
 }
 
+type ActiveDeveloperSandboxIdentity = Extract<
+  AuthContext["identity"],
+  { type: "active" }
+>;
+
 interface DeveloperSandboxCommandInput {
   args?: string[];
   cmd: string;
@@ -126,6 +131,16 @@ export function createDeveloperSandboxRunService(
   const runtime = options.runtime ?? createVercelSandboxRuntime();
   const now = options.now ?? (() => new Date());
 
+  function developerConnectionLeaseContext(
+    identity: ActiveDeveloperSandboxIdentity
+  ) {
+    return {
+      actor: { userId: identity.userId },
+      db: options.db,
+      organization: { orgId: identity.orgId },
+    };
+  }
+
   async function loadRun(
     ctx: DeveloperSandboxRunServiceContext,
     sandboxRunId: string
@@ -145,14 +160,19 @@ export function createDeveloperSandboxRunService(
   }
 
   async function materializeCredentials(
-    ctx: DeveloperSandboxRunServiceContext,
+    identity: ActiveDeveloperSandboxIdentity,
     run: DeveloperSandboxRun
   ): Promise<MaterializedCredentials> {
+    const leaseContext = developerConnectionLeaseContext(identity);
+
     async function issueAndWriteCredentials() {
-      const issued = await issueAllEnabledDeveloperConnectionLeases(ctx, {
-        sandboxRunId: run.publicId,
-        workflowRunId: run.workflowRunId,
-      });
+      const issued = await issueAllEnabledDeveloperConnectionLeases(
+        leaseContext,
+        {
+          sandboxRunId: run.publicId,
+          workflowRunId: run.workflowRunId,
+        }
+      );
       const sandbox = await runtime.get(run.vercelSandboxId);
       const files = issued.materialization.flatMap((entry, index) => {
         const lease = issued.leases[index];
@@ -188,7 +208,7 @@ export function createDeveloperSandboxRunService(
 
     if (run.credentialsLoadedAt) {
       const existing = await materializeDeveloperConnectionLeasesForSandboxRun(
-        ctx,
+        leaseContext,
         { sandboxRunId: run.publicId }
       );
       if (existing.leases.length === 0) {
@@ -281,7 +301,7 @@ export function createDeveloperSandboxRunService(
         };
       }
 
-      const credentials = await materializeCredentials(ctx, run);
+      const credentials = await materializeCredentials(identity, run);
       const sandbox = await runtime.get(run.vercelSandboxId);
       const runtimeCommand = await sandbox.exec({
         cmd: input.command.cmd,


### PR DESCRIPTION
## Summary
- Narrow developer connection lease helpers to explicit `{ db, organization, actor }` context.
- Keep developer sandbox auth resolution local while passing credential-blind lease context to lease materialization helpers.
- Move `services/developer-connections/leases.ts` into the raw-auth-free source ratchet.

## Verification
- pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/developer-connections-service.test.ts src/__tests__/developer-sandbox-runs-service.test.ts src/__tests__/app-trpc-root-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- pnpm typecheck
- git diff --check
- rg leak scan for auth/header/request tokens in api/app/src/services/developer-connections/leases.ts

## Review Notes
- Spec reviewer: PASS
- Quality reviewer: PASS
- SKIP_ENV_VALIDATION=true pnpm knip --include files still exits 1 on the known unused-file backlog; no touched files are listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication context handling for developer connections and sandbox lease operations to enhance code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->