### PR TITLE
Refactor developer sandbox run context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -46,7 +46,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/connectors/linear-flow.ts",
       "services/connectors/x-flow.ts",
       "services/developer-connections/index.ts",
-      "services/developer-sandbox-runs/index.ts",
     ]) {
       const fileSource = source(file);
 
@@ -56,14 +55,20 @@ describe("api/app app-facing tRPC root", () => {
       expect(fileSource, file).toContain("ResolvedAuthContext");
     }
 
-    for (const file of [
+    const rawAuthFreeServiceFiles = [
       "services/connectors/catalog.ts",
       "services/developer-connections/catalog.ts",
       "services/developer-connections/leases.ts",
+      "services/developer-sandbox-runs/index.ts",
       "services/user-connectors/catalog.ts",
       "services/user-connectors/granola-flow.ts",
       "services/user-connectors/index.ts",
-    ]) {
+    ];
+    const transportAuthFreeServiceFiles = rawAuthFreeServiceFiles.filter(
+      (file) => file !== "services/user-connectors/granola-flow.ts"
+    );
+
+    for (const file of rawAuthFreeServiceFiles) {
       const fileSource = source(file);
 
       expect(fileSource, file).not.toContain("../../trpc");
@@ -72,7 +77,6 @@ describe("api/app app-facing tRPC root", () => {
       expect(fileSource, file).not.toContain("ResolvedAuthContext");
     }
 
-    const connectorCatalogSource = source("services/connectors/catalog.ts");
     for (const forbiddenToken of [
       "@vendor/clerk/server",
       "Headers",
@@ -80,9 +84,11 @@ describe("api/app app-facing tRPC root", () => {
       "request.headers",
       "headers:",
     ]) {
-      expect(connectorCatalogSource, forbiddenToken).not.toContain(
-        forbiddenToken
-      );
+      for (const file of transportAuthFreeServiceFiles) {
+        expect(source(file), `${file}: ${forbiddenToken}`).not.toContain(
+          forbiddenToken
+        );
+      }
     }
   });
 });

--- a/api/app/src/__tests__/developer-sandbox-runs-service.test.ts
+++ b/api/app/src/__tests__/developer-sandbox-runs-service.test.ts
@@ -46,27 +46,8 @@ const { createDeveloperSandboxRunService } = await import(
 
 function ctx() {
   return {
-    auth: {
-      identity: {
-        type: "active" as const,
-        userId: "user_admin",
-        orgId: "org_acme",
-        orgGate: {
-          bindingStatus: "bound" as const,
-          nextSetupRequirement: null,
-        },
-      },
-    },
-    db: {} as Database,
-  };
-}
-
-function unauthenticatedCtx() {
-  return {
-    auth: {
-      identity: { type: "unauthenticated" as const },
-    },
-    db: {} as Database,
+    actor: { userId: "user_admin" },
+    organization: { orgId: "org_acme" },
   };
 }
 
@@ -275,20 +256,6 @@ describe("developer sandbox run service", () => {
       })
     );
     expect(issueAllEnabledDeveloperConnectionLeasesMock).not.toHaveBeenCalled();
-  });
-
-  it("throws a domain authz error when creating without an active identity", async () => {
-    const fakeRuntime = runtime();
-    const service = createService(fakeRuntime);
-
-    await expect(
-      service.createDeveloperSandboxRun(unauthenticatedCtx())
-    ).rejects.toThrowError(
-      expect.objectContaining({
-        code: "AUTH_REQUIRED",
-        kind: "authz",
-      })
-    );
   });
 
   it("throws a domain not-found error when a sandbox run cannot be loaded", async () => {

--- a/api/app/src/services/developer-sandbox-runs/index.ts
+++ b/api/app/src/services/developer-sandbox-runs/index.ts
@@ -17,8 +17,7 @@ import {
   createVercelSandboxRuntime,
   type SandboxRuntime,
 } from "@repo/sandbox-runtime";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
-import { AuthzError, ConflictError, NotFoundError } from "../../domain/errors";
+import { ConflictError, NotFoundError } from "../../domain/errors";
 import {
   issueAllEnabledDeveloperConnectionLeases,
   materializeDeveloperConnectionLeasesForSandboxRun,
@@ -31,8 +30,12 @@ const DEFAULT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000;
 const CREDENTIAL_BASE_DIR = "/vercel/sandbox/.lightfast/provider-auth";
 
 interface DeveloperSandboxRunServiceContext {
-  auth: AuthContext;
-  db: Database;
+  actor: {
+    userId: string;
+  };
+  organization: {
+    orgId: string;
+  };
 }
 
 interface DeveloperSandboxRunServiceOptions {
@@ -40,11 +43,6 @@ interface DeveloperSandboxRunServiceOptions {
   now?: () => Date;
   runtime?: SandboxRuntime;
 }
-
-type ActiveDeveloperSandboxIdentity = Extract<
-  AuthContext["identity"],
-  { type: "active" }
->;
 
 interface DeveloperSandboxCommandInput {
   args?: string[];
@@ -57,20 +55,6 @@ interface DeveloperSandboxCommandInput {
 interface MaterializedCredentials {
   env: Record<string, string>;
   secrets: string[];
-}
-
-export function canUseDeveloperSandboxes(
-  ctx: DeveloperSandboxRunServiceContext
-) {
-  return ctx.auth.identity.type === "active";
-}
-
-function activeIdentity(ctx: DeveloperSandboxRunServiceContext) {
-  const identity = ctx.auth.identity;
-  if (!canUseDeveloperSandboxes(ctx) || identity.type !== "active") {
-    throw new AuthzError("AUTH_REQUIRED", "Authentication required.");
-  }
-  return identity;
 }
 
 function ensureRunnableRun(run: DeveloperSandboxRun, now: Date) {
@@ -132,12 +116,12 @@ export function createDeveloperSandboxRunService(
   const now = options.now ?? (() => new Date());
 
   function developerConnectionLeaseContext(
-    identity: ActiveDeveloperSandboxIdentity
+    ctx: DeveloperSandboxRunServiceContext
   ) {
     return {
-      actor: { userId: identity.userId },
+      actor: { userId: ctx.actor.userId },
       db: options.db,
-      organization: { orgId: identity.orgId },
+      organization: { orgId: ctx.organization.orgId },
     };
   }
 
@@ -145,9 +129,8 @@ export function createDeveloperSandboxRunService(
     ctx: DeveloperSandboxRunServiceContext,
     sandboxRunId: string
   ) {
-    const identity = activeIdentity(ctx);
     const run = await getDeveloperSandboxRunByPublicId(options.db, {
-      clerkOrgId: identity.orgId,
+      clerkOrgId: ctx.organization.orgId,
       publicId: sandboxRunId,
     });
     if (!run) {
@@ -156,14 +139,14 @@ export function createDeveloperSandboxRunService(
         "Developer sandbox run was not found."
       );
     }
-    return { identity, run };
+    return { run };
   }
 
   async function materializeCredentials(
-    identity: ActiveDeveloperSandboxIdentity,
+    ctx: DeveloperSandboxRunServiceContext,
     run: DeveloperSandboxRun
   ): Promise<MaterializedCredentials> {
-    const leaseContext = developerConnectionLeaseContext(identity);
+    const leaseContext = developerConnectionLeaseContext(ctx);
 
     async function issueAndWriteCredentials() {
       const issued = await issueAllEnabledDeveloperConnectionLeases(
@@ -234,7 +217,6 @@ export function createDeveloperSandboxRunService(
       ctx: DeveloperSandboxRunServiceContext,
       input: { requestedTtlMs?: number; workflowRunId?: string | null } = {}
     ) {
-      const identity = activeIdentity(ctx);
       const sandbox = await runtime.create({
         name: `developer-sandbox-${randomUUID()}`,
         runtime: "node24",
@@ -243,8 +225,8 @@ export function createDeveloperSandboxRunService(
 
       try {
         return await createDeveloperSandboxRun(options.db, {
-          clerkOrgId: identity.orgId,
-          actorUserId: identity.userId,
+          clerkOrgId: ctx.organization.orgId,
+          actorUserId: ctx.actor.userId,
           workflowRunId: input.workflowRunId ?? null,
           vercelSandboxId: sandbox.id,
           requestedTtlMs: input.requestedTtlMs,
@@ -262,14 +244,14 @@ export function createDeveloperSandboxRunService(
         command: DeveloperSandboxCommandInput;
       }
     ) {
-      const { identity, run } = await loadRun(ctx, input.sandboxRunId);
+      const { run } = await loadRun(ctx, input.sandboxRunId);
       const startedAt = now();
       ensureRunnableRun(run, startedAt);
       const policy = evaluateDeveloperSandboxCommandPolicy(input.command);
       const command = await createDeveloperSandboxCommand(options.db, {
         sandboxRunId: run.id,
-        clerkOrgId: identity.orgId,
-        actorUserId: identity.userId,
+        clerkOrgId: ctx.organization.orgId,
+        actorUserId: ctx.actor.userId,
         cmd: input.command.cmd,
         args: input.command.args ?? [],
         cwd: input.command.cwd ?? null,
@@ -301,7 +283,7 @@ export function createDeveloperSandboxRunService(
         };
       }
 
-      const credentials = await materializeCredentials(identity, run);
+      const credentials = await materializeCredentials(ctx, run);
       const sandbox = await runtime.get(run.vercelSandboxId);
       const runtimeCommand = await sandbox.exec({
         cmd: input.command.cmd,
@@ -347,10 +329,10 @@ export function createDeveloperSandboxRunService(
       ctx: DeveloperSandboxRunServiceContext,
       input: { sandboxRunId: string }
     ) {
-      const { identity, run } = await loadRun(ctx, input.sandboxRunId);
+      const { run } = await loadRun(ctx, input.sandboxRunId);
       const stoppedAt = now();
       await revokeDeveloperConnectionLeasesForSandboxRun(options.db, {
-        clerkOrgId: identity.orgId,
+        clerkOrgId: ctx.organization.orgId,
         sandboxRunId: run.publicId,
         revokedAt: stoppedAt,
       });


### PR DESCRIPTION
## Summary
- Narrow developer sandbox run service context to explicit actor and organization inputs.
- Keep the service factory as the db owner while deriving developer connection lease context internally.
- Ratchet the sandbox run service into the raw-auth-free service boundary.

## Test Plan
- pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/developer-sandbox-runs-service.test.ts src/__tests__/app-trpc-root-source.test.ts
- pnpm typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm knip --include files (expected known unused-file backlog; touched files not listed)

## Reviews
- Spec review: approved
- Code quality review: approved
