### PR TITLE
Refactor developer connection context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -45,7 +45,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/connectors/index.ts",
       "services/connectors/linear-flow.ts",
       "services/connectors/x-flow.ts",
-      "services/developer-connections/index.ts",
     ]) {
       const fileSource = source(file);
 
@@ -58,6 +57,7 @@ describe("api/app app-facing tRPC root", () => {
     const rawAuthFreeServiceFiles = [
       "services/connectors/catalog.ts",
       "services/developer-connections/catalog.ts",
+      "services/developer-connections/index.ts",
       "services/developer-connections/leases.ts",
       "services/developer-sandbox-runs/index.ts",
       "services/user-connectors/catalog.ts",

--- a/api/app/src/__tests__/developer-connections-domain-commands.test.ts
+++ b/api/app/src/__tests__/developer-connections-domain-commands.test.ts
@@ -60,7 +60,6 @@ function deps() {
     connectDeveloperConnection: serviceMocks.connectDeveloperConnection,
     db: {} as Database,
     disconnectDeveloperConnection: serviceMocks.disconnectDeveloperConnection,
-    headers: new Headers(),
     listDeveloperConnectionsForOrg: serviceMocks.listDeveloperConnectionsForOrg,
     setDeveloperConnectionSandboxEnabled:
       serviceMocks.setDeveloperConnectionSandboxEnabled,
@@ -212,6 +211,15 @@ describe("developer connection domain commands", () => {
         },
       })
     ).resolves.toEqual({ provider: "sentry", status: "connected" });
+    const connectContext =
+      serviceMocks.connectDeveloperConnection.mock.calls[0]?.[0];
+    expect(connectContext).toEqual({
+      actor: { userId: "user_current" },
+      db: expect.anything(),
+      organization: { orgId: "org_acme" },
+    });
+    expect(connectContext).not.toHaveProperty("auth");
+    expect(connectContext).not.toHaveProperty("headers");
 
     await expect(
       setDeveloperConnectionSandboxEnabledCommand.run({

--- a/api/app/src/__tests__/developer-connections-service.test.ts
+++ b/api/app/src/__tests__/developer-connections-service.test.ts
@@ -64,26 +64,9 @@ const {
 
 function ctx(input: { isAdmin?: boolean } = {}) {
   return {
-    auth: {
-      access: {
-        kind: "clerk-session" as const,
-        userId: "user_admin",
-        orgId: "org_acme",
-        has: ({ role }: { role?: string }) =>
-          (input.isAdmin ?? true) ? role === "org:admin" : false,
-      },
-      identity: {
-        type: "active" as const,
-        userId: "user_admin",
-        orgId: "org_acme",
-        orgGate: {
-          bindingStatus: "bound" as const,
-          nextSetupRequirement: null,
-        },
-      },
-    },
+    actor: { userId: input.isAdmin === false ? "user_member" : "user_admin" },
     db: {} as Database,
-    headers: new Headers(),
+    organization: { orgId: "org_acme" },
   };
 }
 
@@ -230,22 +213,6 @@ describe("developer connection services", () => {
         providerAccountName: "lightfast/main",
         credentialKind: "pscale_service_token",
         actorUserId: "user_admin",
-      })
-    );
-  });
-
-  it("throws a domain authz error when non-admin users manage developer connections", async () => {
-    await expect(
-      connectDeveloperConnection(ctx({ isAdmin: false }), {
-        provider: "pscale",
-        providerAccountName: "lightfast/main",
-        serviceTokenId: "token-id",
-        serviceToken: "token-secret",
-      })
-    ).rejects.toThrowError(
-      expect.objectContaining({
-        code: "PERMISSION_REQUIRED",
-        kind: "authz",
       })
     );
   });

--- a/api/app/src/__tests__/developer-connections-tanstack-adapter-source.test.ts
+++ b/api/app/src/__tests__/developer-connections-tanstack-adapter-source.test.ts
@@ -35,4 +35,17 @@ describe("developer-connections TanStack adapter boundary", () => {
     expect(source).not.toContain("TRPCError");
     expect(source).not.toContain("ORPCError");
   });
+
+  it("does not rebuild auth-shaped service contexts in developer-connection commands", () => {
+    const source = readFileSync(
+      resolve(repoRoot, "api/app/src/domain/developer-connections/commands.ts"),
+      "utf8"
+    );
+
+    expect(source).not.toContain("../../auth/identity");
+    expect(source).not.toContain("AuthAccess");
+    expect(source).not.toContain("AuthIdentity");
+    expect(source).not.toContain("headers: Headers");
+    expect(source).not.toContain("accessForActor");
+  });
 });

--- a/api/app/src/__tests__/developer-services-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/developer-services-domain-errors-source.test.ts
@@ -12,7 +12,6 @@ describe("developer service domain errors", () => {
   it("keeps developer service errors framework-neutral", () => {
     for (const file of [
       "services/developer-connections/auth-box.ts",
-      "services/developer-connections/index.ts",
       "services/developer-connections/leases.ts",
       "services/developer-sandbox-runs/index.ts",
     ]) {
@@ -22,5 +21,13 @@ describe("developer service domain errors", () => {
       expect(fileSource, file).not.toContain("@trpc/server");
       expect(fileSource, file).not.toContain("TRPCError");
     }
+
+    const developerConnectionSource = source(
+      "services/developer-connections/index.ts"
+    );
+    expect(developerConnectionSource).not.toContain("@trpc/server");
+    expect(developerConnectionSource).not.toContain("TRPCError");
+    expect(developerConnectionSource).not.toContain("../../trpc");
+    expect(developerConnectionSource).not.toContain("../../domain/errors");
   });
 });

--- a/api/app/src/adapters/tanstack/developer-connections.ts
+++ b/api/app/src/adapters/tanstack/developer-connections.ts
@@ -65,7 +65,6 @@ async function createTanStackDeveloperConnectionRequest() {
       actor: maybeMarkOrgAdmin({ actor, auth }),
       request: { id: requestId(), source: "tanstack" as const },
     },
-    headers,
   };
 }
 
@@ -91,7 +90,6 @@ export const listDeveloperConnections = createServerFn({
       ctx: request.ctx,
       deps: createDefaultDeveloperConnectionCommandDeps({
         db,
-        headers: request.headers,
       }),
       input: {},
     });
@@ -110,7 +108,6 @@ export const connectDeveloperConnection = createServerFn({ method: "POST" })
         ctx: request.ctx,
         deps: createDefaultDeveloperConnectionCommandDeps({
           db,
-          headers: request.headers,
         }),
         input: data,
       });
@@ -131,7 +128,6 @@ export const startSentryDeveloperConnectionAuth = createServerFn({
         ctx: request.ctx,
         deps: createDefaultDeveloperConnectionCommandDeps({
           db,
-          headers: request.headers,
         }),
         input: data,
       });
@@ -152,7 +148,6 @@ export const completeSentryDeveloperConnectionAuth = createServerFn({
         ctx: request.ctx,
         deps: createDefaultDeveloperConnectionCommandDeps({
           db,
-          headers: request.headers,
         }),
         input: data,
       });
@@ -173,7 +168,6 @@ export const setDeveloperConnectionSandboxEnabled = createServerFn({
         ctx: request.ctx,
         deps: createDefaultDeveloperConnectionCommandDeps({
           db,
-          headers: request.headers,
         }),
         input: data,
       });
@@ -192,7 +186,6 @@ export const disconnectDeveloperConnection = createServerFn({ method: "POST" })
         ctx: request.ctx,
         deps: createDefaultDeveloperConnectionCommandDeps({
           db,
-          headers: request.headers,
         }),
         input: data,
       });

--- a/api/app/src/domain/developer-connections/commands.ts
+++ b/api/app/src/domain/developer-connections/commands.ts
@@ -10,7 +10,6 @@ import {
 } from "@repo/api-contract";
 import { z } from "zod";
 
-import type { AuthAccess, AuthIdentity } from "../../auth/identity";
 import {
   completeSentryDeveloperConnectionAuth,
   connectDeveloperConnection,
@@ -19,7 +18,7 @@ import {
   setDeveloperConnectionSandboxEnabled,
   startSentryDeveloperConnectionAuth,
 } from "../../services/developer-connections";
-import type { Actor, ExecutionContext } from "../actor";
+import type { ExecutionContext } from "../actor";
 import { defineCommand } from "../command";
 import {
   AuthzError,
@@ -28,19 +27,24 @@ import {
   isDomainError,
   ValidationError,
 } from "../errors";
-import { requireBoundClerkOrgActor, requireClerkOrgAdminActor } from "../gates";
+import {
+  type ClerkOrgAdminActor,
+  requireBoundClerkOrgActor,
+  requireClerkOrgAdminActor,
+} from "../gates";
 
 type ListDeveloperConnectionsResult = Awaited<
   ReturnType<typeof listDeveloperConnectionsForOrg>
 >;
 
 interface DeveloperConnectionMutationServiceContext {
-  auth: {
-    access: Extract<AuthAccess, { kind: "clerk-session" }>;
-    identity: Extract<AuthIdentity, { type: "active" }>;
+  actor: {
+    userId: string;
   };
   db: Database;
-  headers: Headers;
+  organization: {
+    orgId: string;
+  };
 }
 
 interface DeveloperConnectionCommandDeps {
@@ -48,7 +52,6 @@ interface DeveloperConnectionCommandDeps {
   connectDeveloperConnection: typeof connectDeveloperConnection;
   db: Database;
   disconnectDeveloperConnection: typeof disconnectDeveloperConnection;
-  headers: Headers;
   listDeveloperConnectionsForOrg: typeof listDeveloperConnectionsForOrg;
   setDeveloperConnectionSandboxEnabled: typeof setDeveloperConnectionSandboxEnabled;
   startSentryDeveloperConnectionAuth: typeof startSentryDeveloperConnectionAuth;
@@ -59,7 +62,6 @@ export function createDefaultDeveloperConnectionCommandDeps(input: {
   connectDeveloperConnection?: typeof connectDeveloperConnection;
   db: Database;
   disconnectDeveloperConnection?: typeof disconnectDeveloperConnection;
-  headers: Headers;
   listDeveloperConnectionsForOrg?: typeof listDeveloperConnectionsForOrg;
   setDeveloperConnectionSandboxEnabled?: typeof setDeveloperConnectionSandboxEnabled;
   startSentryDeveloperConnectionAuth?: typeof startSentryDeveloperConnectionAuth;
@@ -73,7 +75,6 @@ export function createDefaultDeveloperConnectionCommandDeps(input: {
     db: input.db,
     disconnectDeveloperConnection:
       input.disconnectDeveloperConnection ?? disconnectDeveloperConnection,
-    headers: input.headers,
     listDeveloperConnectionsForOrg:
       input.listDeveloperConnectionsForOrg ?? listDeveloperConnectionsForOrg,
     setDeveloperConnectionSandboxEnabled:
@@ -268,47 +269,19 @@ export const disconnectDeveloperConnectionCommand = defineCommand<
 });
 
 function serviceContextForActor(
-  actor: Extract<Actor, { kind: "clerkUser" }> & {
-    orgGate: NonNullable<Extract<Actor, { kind: "clerkUser" }>["orgGate"]>;
-    orgId: string;
-  },
+  actor: ClerkOrgAdminActor,
   deps: DeveloperConnectionCommandDeps
 ): DeveloperConnectionMutationServiceContext {
   return {
-    auth: {
-      access: accessForActor(actor),
-      identity: {
-        type: "active",
-        userId: actor.userId,
-        orgId: actor.orgId,
-        orgGate: actor.orgGate,
-      },
-    },
+    actor: { userId: actor.userId },
     db: deps.db,
-    headers: deps.headers,
+    organization: { orgId: actor.orgId },
   };
 }
 
 function requireBoundClerkOrgAdminActor(ctx: ExecutionContext) {
   requireBoundClerkOrgActor(ctx);
   return requireClerkOrgAdminActor(ctx);
-}
-
-function accessForActor(
-  actor: Extract<Actor, { kind: "clerkUser" }> & { orgId: string }
-): Extract<AuthAccess, { kind: "clerk-session" }> {
-  const has = ((params: { role?: string }) =>
-    actor.orgRole === "admin" && params.role === "org:admin") as Extract<
-    AuthAccess,
-    { kind: "clerk-session" }
-  >["has"];
-
-  return {
-    kind: "clerk-session",
-    userId: actor.userId,
-    orgId: actor.orgId,
-    has,
-  };
 }
 
 function mapDeveloperConnectionServiceError(

--- a/api/app/src/services/developer-connections/index.ts
+++ b/api/app/src/services/developer-connections/index.ts
@@ -11,8 +11,6 @@ import type {
   DeveloperConnectionSetSandboxEnabledInput,
   DeveloperConnectionStartAuthInput,
 } from "@repo/api-contract";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
-import { AuthzError } from "../../domain/errors";
 import { verifyDeveloperConnectionInput } from "./adapters";
 import { sentryAuthBoxClient } from "./auth-box";
 import { listDeveloperConnectionsForOrg } from "./catalog";
@@ -24,9 +22,13 @@ import {
 } from "./leases";
 
 interface DeveloperConnectionServiceContext {
-  auth: AuthContext;
+  actor: {
+    userId: string;
+  };
   db: Database;
-  headers: Headers;
+  organization: {
+    orgId: string;
+  };
 }
 
 export {
@@ -36,35 +38,16 @@ export {
   materializeDeveloperConnectionLeasesForSandboxRun,
 };
 
-function activeAdmin(ctx: DeveloperConnectionServiceContext) {
-  const identity = ctx.auth.identity;
-  const access = ctx.auth.access;
-  if (
-    identity.type !== "active" ||
-    access?.kind !== "clerk-session" ||
-    access.userId !== identity.userId ||
-    access.orgId !== identity.orgId ||
-    !access.has({ role: "org:admin" })
-  ) {
-    throw new AuthzError(
-      "PERMISSION_REQUIRED",
-      "Only organization administrators can perform this action."
-    );
-  }
-  return identity;
-}
-
 export async function connectDeveloperConnection(
   ctx: DeveloperConnectionServiceContext,
   input: DeveloperConnectionConnectInput
 ) {
-  const identity = activeAdmin(ctx);
   const verified = await verifyDeveloperConnectionInput(input);
   const encryptedCredential = await encryptDeveloperCredential(
     verified.credentialPayload
   );
   const connection = await replaceCurrentDeveloperConnection(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
     provider: input.provider,
     providerAccountId: verified.providerAccountId,
     providerAccountName: verified.providerAccountName,
@@ -74,7 +57,7 @@ export async function connectDeveloperConnection(
     scopes: verified.scopes,
     metadata: verified.metadata,
     expiresAt: verified.expiresAt,
-    actorUserId: identity.userId,
+    actorUserId: ctx.actor.userId,
     verifiedAt: new Date(),
   });
   return { provider: connection.provider, status: connection.status };
@@ -84,10 +67,9 @@ export async function startSentryDeveloperConnectionAuth(
   ctx: DeveloperConnectionServiceContext,
   input: DeveloperConnectionStartAuthInput
 ) {
-  const identity = activeAdmin(ctx);
   return await sentryAuthBoxClient.start({
-    actorUserId: identity.userId,
-    clerkOrgId: identity.orgId,
+    actorUserId: ctx.actor.userId,
+    clerkOrgId: ctx.organization.orgId,
     providerAccountName: input.providerAccountName,
   });
 }
@@ -96,17 +78,16 @@ export async function completeSentryDeveloperConnectionAuth(
   ctx: DeveloperConnectionServiceContext,
   input: DeveloperConnectionCompleteAuthInput
 ) {
-  const identity = activeAdmin(ctx);
   const verified = await sentryAuthBoxClient.complete({
-    actorUserId: identity.userId,
+    actorUserId: ctx.actor.userId,
     attemptId: input.attemptId,
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
   });
   const encryptedCredential = await encryptDeveloperCredential({
     token: verified.token,
   });
   const connection = await replaceCurrentDeveloperConnection(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
     provider: "sentry",
     providerAccountId: verified.providerAccountId,
     providerAccountName: verified.providerAccountName,
@@ -116,7 +97,7 @@ export async function completeSentryDeveloperConnectionAuth(
     scopes: verified.scopes,
     metadata: { authType: "device_code" },
     expiresAt: verified.expiresAt,
-    actorUserId: identity.userId,
+    actorUserId: ctx.actor.userId,
     verifiedAt: new Date(),
   });
   return { provider: connection.provider, status: connection.status };
@@ -126,12 +107,11 @@ export async function setDeveloperConnectionSandboxEnabled(
   ctx: DeveloperConnectionServiceContext,
   input: DeveloperConnectionSetSandboxEnabledInput
 ) {
-  const identity = activeAdmin(ctx);
   await setCurrentDeveloperConnectionSandboxEnabled(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
     provider: input.provider,
     enabled: input.enabled,
-    actorUserId: identity.userId,
+    actorUserId: ctx.actor.userId,
   });
   return { enabled: input.enabled };
 }
@@ -140,11 +120,10 @@ export async function disconnectDeveloperConnection(
   ctx: DeveloperConnectionServiceContext,
   input: { provider: DeveloperConnectionProvider }
 ) {
-  const identity = activeAdmin(ctx);
   await revokeCurrentDeveloperConnection(ctx.db, {
-    clerkOrgId: identity.orgId,
+    clerkOrgId: ctx.organization.orgId,
     provider: input.provider,
-    actorUserId: identity.userId,
+    actorUserId: ctx.actor.userId,
   });
   return { disconnected: true };
 }


### PR DESCRIPTION
## Summary
- Narrow developer connection mutation services to explicit actor and organization context.
- Keep admin authorization in developer-connection domain commands instead of rebuilding auth-shaped service contexts.
- Stop passing request headers through developer-connection command deps and ratchet the service into the raw-auth-free boundary.

## Test Plan
- pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/developer-connections-service.test.ts src/__tests__/developer-connections-domain-commands.test.ts src/__tests__/developer-connections-tanstack-adapter-source.test.ts src/__tests__/app-trpc-root-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm knip --include files (expected known unused-file backlog; touched files not listed)

## Reviews
- Spec review: approved
- Code quality review: approved
