### PR TITLE
Refactor connector service context

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -41,21 +41,11 @@ describe("api/app app-facing tRPC root", () => {
     expect(identitySource).not.toContain("tRPC");
     expect(identitySource).not.toContain("trpc");
 
-    for (const file of [
+    const rawAuthFreeServiceFiles = [
+      "services/connectors/catalog.ts",
       "services/connectors/index.ts",
       "services/connectors/linear-flow.ts",
       "services/connectors/x-flow.ts",
-    ]) {
-      const fileSource = source(file);
-
-      expect(fileSource, file).not.toContain("../../trpc");
-      expect(fileSource, file).not.toContain("../trpc");
-      expect(fileSource, file).toContain("../../auth/identity");
-      expect(fileSource, file).toContain("ResolvedAuthContext");
-    }
-
-    const rawAuthFreeServiceFiles = [
-      "services/connectors/catalog.ts",
       "services/developer-connections/catalog.ts",
       "services/developer-connections/index.ts",
       "services/developer-connections/leases.ts",

--- a/api/app/src/__tests__/connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/connectors-domain-commands.test.ts
@@ -65,7 +65,6 @@ function deps() {
   return createDefaultConnectorCommandDeps({
     db: {} as Database,
     disconnectConnector: serviceMocks.disconnectConnector,
-    headers: new Headers(),
     listConnectorsForOrg: serviceMocks.listConnectorsForOrg,
     listUserConnectorsForViewer: serviceMocks.listUserConnectorsForViewer,
     refreshConnectorTools: serviceMocks.refreshConnectorTools,
@@ -166,9 +165,16 @@ describe("connector domain commands", () => {
     });
 
     expect(serviceMocks.startConnectorOAuth).toHaveBeenCalledWith(
-      expect.anything(),
+      {
+        actor: { userId: "user_current" },
+        db: expect.anything(),
+        organization: { orgId: "org_acme" },
+      },
       { provider: "x" }
     );
+    const serviceContext = serviceMocks.startConnectorOAuth.mock.calls[0]?.[0];
+    expect(serviceContext).not.toHaveProperty("auth");
+    expect(serviceContext).not.toHaveProperty("headers");
   });
 
   it("preserves domain errors raised by connector services", async () => {

--- a/api/app/src/__tests__/connectors-flow.test.ts
+++ b/api/app/src/__tests__/connectors-flow.test.ts
@@ -219,28 +219,11 @@ const {
 } = await import("../services/connectors");
 const { listConnectorsForOrg } = await import("../services/connectors/catalog");
 
-function ctx(input: { isAdmin?: boolean } = {}) {
+function ctx() {
   return {
-    auth: {
-      access: {
-        has: ({ role }: { role?: string }) =>
-          (input.isAdmin ?? true) ? role === "org:admin" : false,
-        kind: "clerk-session" as const,
-        orgId: "org_acme",
-        userId: "user_current",
-      },
-      identity: {
-        orgGate: {
-          bindingStatus: "bound" as const,
-          nextSetupRequirement: null,
-        },
-        orgId: "org_acme",
-        type: "active" as const,
-        userId: "user_current",
-      },
-    },
+    actor: { userId: "user_current" },
     db: {} as Database,
-    headers: new Headers(),
+    organization: { orgId: "org_acme" },
   };
 }
 
@@ -849,25 +832,6 @@ describe("Linear connector flow", () => {
 
     await expect(startLinearConnectorOAuth(ctx())).rejects.toThrow(
       "Linear connector environment is incomplete."
-    );
-  });
-
-  it("throws a domain authz error when Linear starts without an active organization", async () => {
-    const context = ctx();
-
-    await expect(
-      startLinearConnectorOAuth({
-        ...context,
-        auth: {
-          ...context.auth,
-          identity: { type: "pending" as const, userId: "user_current" },
-        },
-      })
-    ).rejects.toThrowError(
-      expect.objectContaining({
-        code: "ORG_REQUIRED",
-        kind: "authz",
-      })
     );
   });
 
@@ -1497,25 +1461,6 @@ describe("X connector flow", () => {
       "connector-oauth-attempt:x:attempt_123456789012345678901234",
       expect.objectContaining({ mode: "reconnect", provider: "x" }),
       { ex: 900 }
-    );
-  });
-
-  it("throws a domain authz error when X starts without an active organization", async () => {
-    const context = ctx();
-
-    await expect(
-      startXConnectorOAuth({
-        ...context,
-        auth: {
-          ...context.auth,
-          identity: { type: "pending" as const, userId: "user_current" },
-        },
-      })
-    ).rejects.toThrowError(
-      expect.objectContaining({
-        code: "ORG_REQUIRED",
-        kind: "authz",
-      })
     );
   });
 

--- a/api/app/src/__tests__/connectors-tanstack-adapter-source.test.ts
+++ b/api/app/src/__tests__/connectors-tanstack-adapter-source.test.ts
@@ -31,4 +31,25 @@ describe("connectors TanStack adapter boundary", () => {
     expect(source).not.toContain("TRPCError");
     expect(source).not.toContain("ORPCError");
   });
+
+  it("does not rebuild auth-shaped service contexts in connector commands", () => {
+    const source = readFileSync(
+      resolve(repoRoot, "api/app/src/domain/connectors/commands.ts"),
+      "utf8"
+    );
+
+    expect(source).not.toContain("../../auth/identity");
+    expect(source).not.toContain("AuthAccess");
+    expect(source).not.toContain("AuthIdentity");
+    expect(source).not.toContain("accessForActor");
+    for (const forbiddenToken of [
+      "@vendor/clerk/server",
+      "Headers",
+      "getRequest",
+      "headers",
+      "request.headers",
+    ]) {
+      expect(source, forbiddenToken).not.toContain(forbiddenToken);
+    }
+  });
 });

--- a/api/app/src/adapters/tanstack/connectors.ts
+++ b/api/app/src/adapters/tanstack/connectors.ts
@@ -66,7 +66,6 @@ async function createTanStackConnectorRequest() {
       actor: maybeMarkOrgAdmin({ actor, auth }),
       request: { id: requestId(), source: "tanstack" as const },
     },
-    headers,
   };
 }
 
@@ -82,10 +81,9 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
-function deps(input: { headers: Headers }) {
+function deps() {
   return createDefaultConnectorCommandDeps({
     db,
-    headers: input.headers,
   });
 }
 
@@ -96,7 +94,7 @@ export const listConnectors = createServerFn({ method: "GET" }).handler(
       const request = await createTanStackConnectorRequest();
       return await listConnectorsCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: {},
       });
     } catch (error) {
@@ -112,7 +110,7 @@ export const listConnectorSections = createServerFn({ method: "GET" }).handler(
       const request = await createTanStackConnectorRequest();
       return await listConnectorSectionsCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: {},
       });
     } catch (error) {
@@ -129,7 +127,7 @@ export const startConnector = createServerFn({ method: "POST" })
       const request = await createTanStackConnectorRequest();
       return await startConnectorOAuthCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -145,7 +143,7 @@ export const refreshConnectorTools = createServerFn({ method: "POST" })
       const request = await createTanStackConnectorRequest();
       const result = await refreshConnectorToolsCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: data,
       });
       return {
@@ -165,7 +163,7 @@ export const setConnectorAutomationEnabled = createServerFn({ method: "POST" })
       const request = await createTanStackConnectorRequest();
       return await setConnectorAutomationEnabledCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -181,7 +179,7 @@ export const setConnectorAgentEnabled = createServerFn({ method: "POST" })
       const request = await createTanStackConnectorRequest();
       return await setConnectorAgentEnabledCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -197,7 +195,7 @@ export const disconnectConnector = createServerFn({ method: "POST" })
       const request = await createTanStackConnectorRequest();
       return await disconnectConnectorCommand.run({
         ctx: request.ctx,
-        deps: deps({ headers: request.headers }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/domain/connectors/commands.ts
+++ b/api/app/src/domain/connectors/commands.ts
@@ -2,7 +2,6 @@ import type { Database } from "@db/app";
 import { connectableConnectorProviderSchema } from "@repo/api-contract";
 import { z } from "zod";
 
-import type { AuthAccess, AuthIdentity } from "../../auth/identity";
 import {
   disconnectConnector,
   listConnectorsForOrg,
@@ -12,7 +11,7 @@ import {
   startConnectorOAuth,
 } from "../../services/connectors";
 import { listUserConnectorsForViewer } from "../../services/user-connectors";
-import type { Actor, ExecutionContext } from "../actor";
+import type { ExecutionContext } from "../actor";
 import { defineCommand } from "../command";
 import {
   AuthzError,
@@ -23,6 +22,7 @@ import {
   ValidationError,
 } from "../errors";
 import {
+  type ClerkOrgAdminActor,
   requireActiveClerkOrgActor,
   requireBoundClerkOrgActor,
   requireClerkOrgAdminActor,
@@ -40,18 +40,18 @@ type RefreshConnectorToolsResult = Awaited<
 >;
 
 interface ConnectorMutationServiceContext {
-  auth: {
-    access: Extract<AuthAccess, { kind: "clerk-session" }>;
-    identity: Extract<AuthIdentity, { type: "active" }>;
+  actor: {
+    userId: string;
   };
   db: Database;
-  headers: Headers;
+  organization: {
+    orgId: string;
+  };
 }
 
 interface ConnectorCommandDeps {
   db: Database;
   disconnectConnector: typeof disconnectConnector;
-  headers: Headers;
   listConnectorsForOrg: typeof listConnectorsForOrg;
   listUserConnectorsForViewer: typeof listUserConnectorsForViewer;
   refreshConnectorTools: typeof refreshConnectorTools;
@@ -63,7 +63,6 @@ interface ConnectorCommandDeps {
 export function createDefaultConnectorCommandDeps(input: {
   db: Database;
   disconnectConnector?: typeof disconnectConnector;
-  headers: Headers;
   listConnectorsForOrg?: typeof listConnectorsForOrg;
   listUserConnectorsForViewer?: typeof listUserConnectorsForViewer;
   refreshConnectorTools?: typeof refreshConnectorTools;
@@ -74,7 +73,6 @@ export function createDefaultConnectorCommandDeps(input: {
   return {
     db: input.db,
     disconnectConnector: input.disconnectConnector ?? disconnectConnector,
-    headers: input.headers,
     listConnectorsForOrg: input.listConnectorsForOrg ?? listConnectorsForOrg,
     listUserConnectorsForViewer:
       input.listUserConnectorsForViewer ?? listUserConnectorsForViewer,
@@ -310,47 +308,19 @@ export const disconnectConnectorCommand = defineCommand<
 });
 
 function serviceContextForActor(
-  actor: Extract<Actor, { kind: "clerkUser" }> & {
-    orgGate: NonNullable<Extract<Actor, { kind: "clerkUser" }>["orgGate"]>;
-    orgId: string;
-  },
+  actor: ClerkOrgAdminActor,
   deps: ConnectorCommandDeps
 ): ConnectorMutationServiceContext {
   return {
-    auth: {
-      access: accessForActor(actor),
-      identity: {
-        type: "active",
-        userId: actor.userId,
-        orgId: actor.orgId,
-        orgGate: actor.orgGate,
-      },
-    },
+    actor: { userId: actor.userId },
     db: deps.db,
-    headers: deps.headers,
+    organization: { orgId: actor.orgId },
   };
 }
 
 function requireBoundClerkOrgAdminActor(ctx: ExecutionContext) {
   requireBoundClerkOrgActor(ctx);
   return requireClerkOrgAdminActor(ctx);
-}
-
-function accessForActor(
-  actor: Extract<Actor, { kind: "clerkUser" }> & { orgId: string }
-): Extract<AuthAccess, { kind: "clerk-session" }> {
-  const has = ((params: { role?: string }) =>
-    actor.orgRole === "admin" && params.role === "org:admin") as Extract<
-    AuthAccess,
-    { kind: "clerk-session" }
-  >["has"];
-
-  return {
-    kind: "clerk-session",
-    userId: actor.userId,
-    orgId: actor.orgId,
-    has,
-  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/api/app/src/services/connectors/index.ts
+++ b/api/app/src/services/connectors/index.ts
@@ -1,6 +1,5 @@
 import type { Database } from "@db/app";
 import type { ConnectableConnectorProvider } from "@repo/api-contract";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
 import { ValidationError } from "../../domain/errors";
 import { listConnectorsForOrg } from "./catalog";
 import {
@@ -19,9 +18,13 @@ import {
 } from "./x-flow";
 
 interface ConnectorServiceContext {
-  auth: AuthContext;
+  actor: {
+    userId: string;
+  };
   db: Database;
-  headers: Headers;
+  organization: {
+    orgId: string;
+  };
 }
 
 interface ConnectorProviderInput {

--- a/api/app/src/services/connectors/linear-flow.ts
+++ b/api/app/src/services/connectors/linear-flow.ts
@@ -27,7 +27,6 @@ import {
 import { decrypt, encrypt } from "@repo/app-encryption";
 import { log } from "@vendor/observability/log/next";
 import { findUserOrganizationMembership } from "../../auth/clerk-org-membership";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
 import { AuthzError, NotFoundError } from "../../domain/errors";
 import { env } from "../../env";
 import {
@@ -44,8 +43,13 @@ import {
 } from "./config";
 
 interface ConnectorServiceContext {
-  auth: AuthContext;
+  actor: {
+    userId: string;
+  };
   db: Database;
+  organization: {
+    orgId: string;
+  };
 }
 
 export interface LinearRedirectResult {
@@ -53,10 +57,10 @@ export interface LinearRedirectResult {
 }
 
 function activeIdentity(ctx: ConnectorServiceContext) {
-  if (ctx.auth.identity.type !== "active") {
-    throw new AuthzError("ORG_REQUIRED", "An active organization is required.");
-  }
-  return ctx.auth.identity;
+  return {
+    orgId: ctx.organization.orgId,
+    userId: ctx.actor.userId,
+  };
 }
 
 async function getOrgSlug(input: {

--- a/api/app/src/services/connectors/x-flow.ts
+++ b/api/app/src/services/connectors/x-flow.ts
@@ -28,7 +28,6 @@ import {
 import { decrypt, encrypt } from "@repo/app-encryption";
 import { log } from "@vendor/observability/log/next";
 import { findUserOrganizationMembership } from "../../auth/clerk-org-membership";
-import type { ResolvedAuthContext as AuthContext } from "../../auth/identity";
 import { AuthzError, NotFoundError } from "../../domain/errors";
 import { env } from "../../env";
 import {
@@ -46,8 +45,13 @@ import {
 import { issueConnectorMcpToken } from "./mcp-auth";
 
 interface ConnectorServiceContext {
-  auth: AuthContext;
+  actor: {
+    userId: string;
+  };
   db: Database;
+  organization: {
+    orgId: string;
+  };
 }
 
 export interface XRedirectResult {
@@ -62,10 +66,10 @@ export interface XConnectorOAuthRedirectPaths {
 }
 
 function activeIdentity(ctx: ConnectorServiceContext) {
-  if (ctx.auth.identity.type !== "active") {
-    throw new AuthzError("ORG_REQUIRED", "An active organization is required.");
-  }
-  return ctx.auth.identity;
+  return {
+    orgId: ctx.organization.orgId,
+    userId: ctx.actor.userId,
+  };
 }
 
 async function getOrgSlug(input: {


### PR DESCRIPTION
## Summary
- narrow org connector interactive services to explicit actor + organization context
- stop connector command deps from carrying request headers or rebuilding auth-shaped service contexts
- add source ratchets that keep connector services/commands free of raw auth transport concerns

## Test Plan
- [x] pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/connectors-flow.test.ts src/__tests__/connectors-domain-commands.test.ts src/__tests__/connectors-tanstack-adapter-source.test.ts src/__tests__/app-trpc-root-source.test.ts
- [x] pnpm --filter @api/app typecheck
- [x] pnpm typecheck
- [x] pnpm --filter @api/app test
- [x] pnpm check
- [x] pnpm turbo boundaries
- [x] git diff --check
- [x] SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog; touched files not listed)