### PR TITLE
Refactor skill event auth boundary

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -81,4 +81,20 @@ describe("api/app app-facing tRPC root", () => {
       }
     }
   });
+
+  it("keeps skill events service independent of request auth and HTTP mapping", () => {
+    const serviceSource = source("services/skills/events.ts");
+
+    for (const forbiddenToken of [
+      "Request",
+      "Response",
+      "resolveAuthContextFromClerk",
+      "getRequest",
+      "request.headers",
+      "@vendor/clerk/server",
+      "@db/app/client",
+    ]) {
+      expect(serviceSource, forbiddenToken).not.toContain(forbiddenToken);
+    }
+  });
 });

--- a/api/app/src/__tests__/skills-events-internal-adapter.test.ts
+++ b/api/app/src/__tests__/skills-events-internal-adapter.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createSkillIndexEventStream: vi.fn(),
+  db: { kind: "mock-db" },
+  resolveAuthContextFromClerk: vi.fn(),
+}));
+
+vi.mock("@db/app/client", () => ({
+  db: mocks.db,
+}));
+
+vi.mock("../auth/identity", () => ({
+  resolveAuthContextFromClerk: mocks.resolveAuthContextFromClerk,
+}));
+
+vi.mock("../services/skills/events", () => ({
+  createSkillIndexEventStream: mocks.createSkillIndexEventStream,
+}));
+
+const { handleSkillIndexEventsRequest } = await import(
+  "../adapters/internal/skills-events"
+);
+
+describe("skills events internal adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createSkillIndexEventStream.mockReturnValue(new ReadableStream());
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValueOnce({
+      identity: { type: "unauthenticated" },
+    });
+
+    const response = await handleSkillIndexEventsRequest(createRequest());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mocks.createSkillIndexEventStream).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when a signed-in user has no active organization", async () => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValueOnce({
+      identity: { type: "pending", userId: "user_123" },
+    });
+
+    const response = await handleSkillIndexEventsRequest(createRequest());
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Organization required",
+    });
+    expect(mocks.createSkillIndexEventStream).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the active organization is not bound", async () => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValueOnce({
+      identity: {
+        orgGate: { bindingStatus: "unbound", nextSetupRequirement: "github" },
+        orgId: "org_unbound",
+        type: "active",
+        userId: "user_123",
+      },
+    });
+
+    const response = await handleSkillIndexEventsRequest(createRequest());
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Organization setup required",
+    });
+    expect(mocks.createSkillIndexEventStream).not.toHaveBeenCalled();
+  });
+
+  it("opens an SSE stream for a bound active organization", async () => {
+    const request = createRequest();
+    const stream = new ReadableStream();
+    mocks.createSkillIndexEventStream.mockReturnValueOnce(stream);
+    mocks.resolveAuthContextFromClerk.mockResolvedValueOnce({
+      identity: {
+        orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+        orgId: "org_bound",
+        type: "active",
+        userId: "user_123",
+      },
+    });
+
+    const response = await handleSkillIndexEventsRequest(request);
+
+    expect(mocks.resolveAuthContextFromClerk).toHaveBeenCalledWith({
+      db: mocks.db,
+      headers: request.headers,
+    });
+    expect(mocks.createSkillIndexEventStream).toHaveBeenCalledWith({
+      clerkOrgId: "org_bound",
+      signal: request.signal,
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toBe(stream);
+    expect(response.headers.get("cache-control")).toBe(
+      "no-store, no-cache, no-transform"
+    );
+    expect(response.headers.get("connection")).toBe("keep-alive");
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+  });
+});
+
+function createRequest() {
+  return new Request("https://app.lightfast.localhost/api/skills/events", {
+    headers: { authorization: "Bearer token_test" },
+  });
+}

--- a/api/app/src/__tests__/skills-events-service.test.ts
+++ b/api/app/src/__tests__/skills-events-service.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MessageHandler = (payload: { message: unknown }) => void;
+
+interface FakeSubscription {
+  channel: string;
+  emitMessage: (message: unknown) => void;
+  handlers: Map<string, MessageHandler[]>;
+  on: ReturnType<typeof vi.fn>;
+  removeAllListeners: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+const mocks = vi.hoisted(() => ({
+  publish: vi.fn(),
+  subscribe: vi.fn(),
+  subscriptions: [] as FakeSubscription[],
+}));
+
+vi.mock("@vendor/upstash", () => ({
+  redis: {
+    publish: mocks.publish,
+    subscribe: mocks.subscribe,
+  },
+}));
+
+describe("skills events service stream", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.subscriptions.length = 0;
+    mocks.subscribe.mockImplementation((channel: string) => {
+      let subscription: FakeSubscription;
+      subscription = {
+        channel,
+        emitMessage(message: unknown) {
+          const handlers =
+            subscription.handlers.get(`message:${channel}`) ?? [];
+          for (const handler of handlers) {
+            handler({ message });
+          }
+        },
+        handlers: new Map<string, MessageHandler[]>(),
+        on: vi.fn((event: string, handler: MessageHandler) => {
+          const handlers = subscription.handlers.get(event) ?? [];
+          handlers.push(handler);
+          subscription.handlers.set(event, handlers);
+          return subscription;
+        }),
+        removeAllListeners: vi.fn(() => {
+          subscription.handlers.clear();
+        }),
+        unsubscribe: vi.fn(async () => undefined),
+      };
+      mocks.subscriptions.push(subscription);
+      return subscription;
+    });
+  });
+
+  it("streams skill-index Redis messages for the requested Clerk organization", async () => {
+    const createSkillIndexEventStream = await loadCreateSkillIndexEventStream();
+    const stream = createSkillIndexEventStream({ clerkOrgId: "org_123" });
+    const reader = stream.getReader();
+
+    mocks.subscriptions[0]?.emitMessage({ snapshotVersion: 7 });
+    const chunk = await reader.read();
+
+    expect(chunk.done).toBe(false);
+    if (chunk.done) {
+      throw new Error("Expected a skill-index event chunk");
+    }
+    expect(mocks.subscribe).toHaveBeenCalledWith(
+      "lightfast:org:org_123:skills:index"
+    );
+    expect(new TextDecoder().decode(chunk.value)).toBe(
+      'event: skill-index\ndata: {"snapshotVersion":7}\n\n'
+    );
+
+    await reader.cancel();
+  });
+
+  it("unsubscribes and removes listeners when the stream is canceled", async () => {
+    const createSkillIndexEventStream = await loadCreateSkillIndexEventStream();
+    const stream = createSkillIndexEventStream({ clerkOrgId: "org_123" });
+    const reader = stream.getReader();
+    const subscription = mocks.subscriptions[0];
+
+    await reader.cancel();
+
+    expect(subscription?.unsubscribe).toHaveBeenCalledWith([
+      "lightfast:org:org_123:skills:index",
+    ]);
+    expect(subscription?.removeAllListeners).toHaveBeenCalled();
+  });
+
+  it("unsubscribes and closes the stream when the request signal aborts", async () => {
+    const createSkillIndexEventStream = await loadCreateSkillIndexEventStream();
+    const abortController = new AbortController();
+    const stream = createSkillIndexEventStream({
+      clerkOrgId: "org_123",
+      signal: abortController.signal,
+    });
+    const reader = stream.getReader();
+    const subscription = mocks.subscriptions[0];
+
+    abortController.abort();
+
+    await expect(reader.read()).resolves.toMatchObject({ done: true });
+    await vi.waitFor(() => {
+      expect(subscription?.unsubscribe).toHaveBeenCalledWith([
+        "lightfast:org:org_123:skills:index",
+      ]);
+    });
+    expect(subscription?.removeAllListeners).toHaveBeenCalled();
+  });
+});
+
+async function loadCreateSkillIndexEventStream() {
+  const service = (await import("../services/skills/events")) as {
+    createSkillIndexEventStream?: (input: {
+      clerkOrgId: string;
+      signal?: AbortSignal;
+    }) => ReadableStream<Uint8Array>;
+  };
+
+  expect(service.createSkillIndexEventStream).toEqual(expect.any(Function));
+  return service.createSkillIndexEventStream!;
+}

--- a/api/app/src/adapters/internal/skills-events.ts
+++ b/api/app/src/adapters/internal/skills-events.ts
@@ -1,7 +1,42 @@
-import { handleSkillIndexEventsRequest as handleSkillIndexEventsServiceRequest } from "../../services/skills/events";
+import { db } from "@db/app/client";
+
+import { resolveAuthContextFromClerk } from "../../auth/identity";
+import { createSkillIndexEventStream } from "../../services/skills/events";
 
 export async function handleSkillIndexEventsRequest(
   request: Request
 ): Promise<Response> {
-  return handleSkillIndexEventsServiceRequest(request);
+  const authContext = await resolveAuthContextFromClerk({
+    db,
+    headers: request.headers,
+  });
+  const identity = authContext.identity;
+
+  if (identity.type === "unauthenticated") {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (identity.type !== "active") {
+    return Response.json({ error: "Organization required" }, { status: 403 });
+  }
+  if (identity.orgGate.bindingStatus !== "bound") {
+    return Response.json(
+      { error: "Organization setup required" },
+      { status: 403 }
+    );
+  }
+
+  return new Response(
+    createSkillIndexEventStream({
+      clerkOrgId: identity.orgId,
+      signal: request.signal,
+    }),
+    {
+      headers: {
+        "cache-control": "no-store, no-cache, no-transform",
+        connection: "keep-alive",
+        "content-type": "text/event-stream",
+        "x-accel-buffering": "no",
+      },
+    }
+  );
 }

--- a/api/app/src/services/skills/events.ts
+++ b/api/app/src/services/skills/events.ts
@@ -1,7 +1,4 @@
-import { db } from "@db/app/client";
 import { redis } from "@vendor/upstash";
-
-import { resolveAuthContextFromClerk } from "../../auth/identity";
 
 type UpstashSubscription = ReturnType<typeof redis.subscribe<string>>;
 
@@ -12,45 +9,7 @@ interface SubscriberRecord {
 
 const subscribers = new Map<string, SubscriberRecord>();
 
-export async function handleSkillIndexEventsRequest(
-  request: Request
-): Promise<Response> {
-  const authContext = await resolveAuthContextFromClerk({
-    db,
-    headers: request.headers,
-  });
-  const identity = authContext.identity;
-
-  if (identity.type === "unauthenticated") {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (identity.type !== "active") {
-    return Response.json({ error: "Organization required" }, { status: 403 });
-  }
-  if (identity.orgGate.bindingStatus !== "bound") {
-    return Response.json(
-      { error: "Organization setup required" },
-      { status: 403 }
-    );
-  }
-
-  return new Response(
-    createSkillIndexEventStream({
-      clerkOrgId: identity.orgId,
-      signal: request.signal,
-    }),
-    {
-      headers: {
-        "cache-control": "no-store, no-cache, no-transform",
-        connection: "keep-alive",
-        "content-type": "text/event-stream",
-        "x-accel-buffering": "no",
-      },
-    }
-  );
-}
-
-function createSkillIndexEventStream(input: {
+export function createSkillIndexEventStream(input: {
   clerkOrgId: string;
   signal?: AbortSignal;
 }) {

--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -1696,8 +1696,16 @@ describe("app authenticated route migration", () => {
       "handleSkillIndexEventsRequest"
     );
     expect(skillsEventsAdapterSource).toContain("../../services/skills/events");
-    expect(skillsEventsServiceSource).toContain("resolveAuthContextFromClerk");
-    expect(skillsEventsServiceSource).toContain("@db/app/client");
+    expect(skillsEventsAdapterSource).toContain("resolveAuthContextFromClerk");
+    expect(skillsEventsAdapterSource).toContain("@db/app/client");
+    expect(skillsEventsAdapterSource).toContain("Request");
+    expect(skillsEventsAdapterSource).toContain("Response");
+    expect(skillsEventsServiceSource).not.toContain(
+      "resolveAuthContextFromClerk"
+    );
+    expect(skillsEventsServiceSource).not.toContain("@db/app/client");
+    expect(skillsEventsServiceSource).not.toContain("Request");
+    expect(skillsEventsServiceSource).not.toContain("Response");
     expect(skillsEventsServiceSource).toContain("createSkillIndexEventStream");
     expect(skillsEventsServiceSource).toContain("redis.subscribe");
     expect(existsSync(nativeProxyServerPath)).toBe(false);


### PR DESCRIPTION
## Summary
- move skill-index SSE auth and HTTP error mapping from the service into the internal adapter
- leave the skill events service focused on the Redis-backed event stream for an explicit Clerk org id
- add adapter/service tests and source ratchets for the new boundary

## Test Plan
- [x] pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/skills-events-internal-adapter.test.ts src/__tests__/skills-events-service.test.ts src/__tests__/app-trpc-root-source.test.ts
- [x] pnpm --filter @lightfast/app exec vitest run --passWithNoTests src/__tests__/authenticated-routes-source.test.ts
- [x] pnpm --filter @api/app typecheck
- [x] pnpm --filter @lightfast/app typecheck
- [x] pnpm --filter @api/app test
- [x] pnpm check
- [x] pnpm typecheck
- [x] pnpm turbo boundaries
- [x] git diff --check
- [x] SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog; touched files not listed)

## Reviews
- [x] spec compliance subagent review
- [x] code quality subagent review