### PR TITLE
Refactor Granola callback auth boundary

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -54,10 +54,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/user-connectors/granola-flow.ts",
       "services/user-connectors/index.ts",
     ];
-    const transportAuthFreeServiceFiles = rawAuthFreeServiceFiles.filter(
-      (file) => file !== "services/user-connectors/granola-flow.ts"
-    );
-
     for (const file of rawAuthFreeServiceFiles) {
       const fileSource = source(file);
 
@@ -74,7 +70,7 @@ describe("api/app app-facing tRPC root", () => {
       "request.headers",
       "headers:",
     ]) {
-      for (const file of transportAuthFreeServiceFiles) {
+      for (const file of rawAuthFreeServiceFiles) {
         expect(source(file), `${file}: ${forbiddenToken}`).not.toContain(
           forbiddenToken
         );

--- a/api/app/src/__tests__/connector-oauth-internal-adapter.test.ts
+++ b/api/app/src/__tests__/connector-oauth-internal-adapter.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const completeGranolaUserConnectorOAuthMock = vi.fn();
+
+vi.mock("@vendor/clerk/server", () => ({
+  auth: authMock,
+}));
+
+vi.mock("../services/connectors", () => ({
+  completeLinearConnectorOAuth: vi.fn(),
+  completeXConnectorOAuth: vi.fn(),
+}));
+
+vi.mock("../services/user-connectors", () => ({
+  completeGranolaUserConnectorOAuth: completeGranolaUserConnectorOAuthMock,
+}));
+
+const { handleGranolaUserConnectorOAuthCallbackRequest } = await import(
+  "../adapters/internal/connector-oauth"
+);
+
+describe("connector OAuth internal adapter", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    authMock.mockResolvedValue({ userId: "user_current" });
+    completeGranolaUserConnectorOAuthMock.mockReset();
+    completeGranolaUserConnectorOAuthMock.mockResolvedValue({
+      redirectUrl: "https://app.lightfast.localhost/account/settings",
+    });
+  });
+
+  it("resolves the Clerk callback user before completing Granola OAuth", async () => {
+    const request = new Request(
+      "https://app.lightfast.localhost/api/connectors/granola/oauth/callback?code=oauth_code&state=provider_state"
+    );
+
+    const response =
+      await handleGranolaUserConnectorOAuthCallbackRequest(request);
+
+    expect(authMock).toHaveBeenCalledWith({ treatPendingAsSignedOut: false });
+    expect(completeGranolaUserConnectorOAuthMock).toHaveBeenCalledWith({
+      callbackUserId: "user_current",
+      code: "oauth_code",
+      requestUrl: request.url,
+      state: "provider_state",
+    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://app.lightfast.localhost/account/settings"
+    );
+  });
+
+  it("does not resolve auth when the callback is missing OAuth parameters", async () => {
+    const response = await handleGranolaUserConnectorOAuthCallbackRequest(
+      new Request(
+        "https://app.lightfast.localhost/api/connectors/granola/oauth/callback?state=provider_state"
+      )
+    );
+
+    expect(authMock).not.toHaveBeenCalled();
+    expect(completeGranolaUserConnectorOAuthMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://app.lightfast.localhost/account/settings?connector=granola&error=missing_oauth_code"
+    );
+  });
+});

--- a/api/app/src/__tests__/user-connectors-flow.test.ts
+++ b/api/app/src/__tests__/user-connectors-flow.test.ts
@@ -1,7 +1,6 @@
 import type { Database, UserConnectorConnection } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const authMock = vi.fn();
 const nanoidMock = vi.fn();
 const redisGetMock = vi.fn();
 const redisGetdelMock = vi.fn();
@@ -119,10 +118,6 @@ vi.mock("@lightfast/connector-granola/node", () => ({
   GranolaOAuthClientProvider: MockGranolaOAuthClientProvider,
   granolaClientMetadata: granolaClientMetadataMock,
   listGranolaMcpTools: listGranolaMcpToolsMock,
-}));
-
-vi.mock("@vendor/clerk/server", () => ({
-  auth: authMock,
 }));
 
 vi.mock("@vendor/lib", () => ({
@@ -271,8 +266,6 @@ describe("user connector catalog services", () => {
 describe("Granola user connector OAuth flow", () => {
   beforeEach(() => {
     vi.useRealTimers();
-    authMock.mockReset();
-    authMock.mockResolvedValue({ userId: "user_current" });
     process.env.VITE_LIGHTFAST_APP_URL = envMock.VITE_LIGHTFAST_APP_URL;
     nanoidMock.mockReset();
     nanoidMock.mockReturnValue("attempt_123456789012345678901234");
@@ -437,6 +430,7 @@ describe("Granola user connector OAuth flow", () => {
 
     await expect(
       completeGranolaUserConnectorOAuth({
+        callbackUserId: "user_current",
         code: "oauth_code",
         requestUrl:
           "https://app.lightfast.localhost/api/connectors/granola/oauth/callback?code=oauth_code&state=provider_state",
@@ -453,7 +447,6 @@ describe("Granola user connector OAuth flow", () => {
     expect(redisGetdelMock).toHaveBeenCalledWith(
       "user-connector-oauth-attempt:provider_state"
     );
-    expect(authMock).toHaveBeenCalledWith({ treatPendingAsSignedOut: false });
     expect(finishAuthMock).toHaveBeenCalledWith("oauth_code");
     expect(streamableHTTPClientTransportMock).toHaveBeenCalledWith(
       new URL("https://granola.test/mcp"),
@@ -506,10 +499,10 @@ describe("Granola user connector OAuth flow", () => {
 
   it("does not consume an OAuth attempt for a different Clerk user", async () => {
     redisGetMock.mockResolvedValue(oauthAttempt());
-    authMock.mockResolvedValue({ userId: "user_other" });
 
     await expect(
       completeGranolaUserConnectorOAuth({
+        callbackUserId: "user_other",
         code: "oauth_code",
         requestUrl:
           "https://app.lightfast.localhost/api/connectors/granola/oauth/callback?code=oauth_code&state=provider_state",
@@ -518,6 +511,26 @@ describe("Granola user connector OAuth flow", () => {
     ).resolves.toEqual({
       redirectUrl:
         "https://app.lightfast.localhost/account/settings?connector=granola&error=permission_required",
+    });
+
+    expect(redisGetdelMock).not.toHaveBeenCalled();
+    expect(finalizeCurrentUserConnectorConnectionMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to sign in without consuming an OAuth attempt when the callback has no Clerk user", async () => {
+    redisGetMock.mockResolvedValue(oauthAttempt());
+
+    await expect(
+      completeGranolaUserConnectorOAuth({
+        callbackUserId: null,
+        code: "oauth_code",
+        requestUrl:
+          "https://app.lightfast.localhost/api/connectors/granola/oauth/callback?code=oauth_code&state=provider_state",
+        state: "provider_state",
+      })
+    ).resolves.toEqual({
+      redirectUrl:
+        "https://app.lightfast.localhost/sign-in?redirect_url=%2Fapi%2Fconnectors%2Fgranola%2Foauth%2Fcallback%3Fcode%3Doauth_code%26state%3Dprovider_state",
     });
 
     expect(redisGetdelMock).not.toHaveBeenCalled();

--- a/api/app/src/adapters/internal/connector-oauth.ts
+++ b/api/app/src/adapters/internal/connector-oauth.ts
@@ -1,3 +1,5 @@
+import { auth } from "@vendor/clerk/server";
+
 import {
   completeLinearConnectorOAuth,
   completeXConnectorOAuth,
@@ -47,7 +49,9 @@ export async function handleGranolaUserConnectorOAuthCallbackRequest(
     return accountSettingsRedirect(request.url, "missing_oauth_code");
   }
 
+  const session = await auth({ treatPendingAsSignedOut: false });
   const result = await completeGranolaUserConnectorOAuth({
+    callbackUserId: session.userId ?? null,
     code,
     requestUrl: request.url,
     state,

--- a/api/app/src/services/user-connectors/granola-flow.ts
+++ b/api/app/src/services/user-connectors/granola-flow.ts
@@ -13,7 +13,6 @@ import {
   listGranolaMcpTools,
 } from "@lightfast/connector-granola/node";
 import { encrypt } from "@repo/app-encryption";
-import { auth } from "@vendor/clerk/server";
 import type { OAuthClientInformationMixed, OAuthTokens } from "@vendor/mcp";
 import { StreamableHTTPClientTransport } from "@vendor/mcp";
 import { log } from "@vendor/observability/log/next";
@@ -345,6 +344,7 @@ async function finalizeGranolaConnection(input: {
 }
 
 export async function completeGranolaUserConnectorOAuth(input: {
+  callbackUserId: string | null;
   code: string;
   requestUrl: string;
   state: string;
@@ -362,11 +362,10 @@ export async function completeGranolaUserConnectorOAuth(input: {
     };
   }
 
-  const session = await auth({ treatPendingAsSignedOut: false });
-  if (!session.userId) {
+  if (!input.callbackUserId) {
     return signInRedirect({ appOrigin, requestUrl: input.requestUrl });
   }
-  if (session.userId !== pendingAttempt.clerkUserId) {
+  if (input.callbackUserId !== pendingAttempt.clerkUserId) {
     return {
       redirectUrl: granolaAccountSettingsUrl({
         appOrigin,

--- a/apps/app/src/__tests__/connectors-routes.test.ts
+++ b/apps/app/src/__tests__/connectors-routes.test.ts
@@ -74,6 +74,11 @@ describe("app connector API routes", () => {
     expect(connectorOAuthAdapterSource).toContain(
       "completeGranolaUserConnectorOAuth"
     );
+    expect(connectorOAuthAdapterSource).toContain("@vendor/clerk/server");
+    expect(connectorOAuthAdapterSource).toContain(
+      "auth({ treatPendingAsSignedOut: false })"
+    );
+    expect(connectorOAuthAdapterSource).toContain("callbackUserId");
     expect(connectorOAuthAdapterSource).toContain("missing_oauth_code");
     expect(connectorOAuthAdapterSource).toContain("Response.redirect");
 


### PR DESCRIPTION
## Summary
- move Granola user-connector callback Clerk auth lookup into the internal connector OAuth adapter
- pass an explicit callback user id into Granola OAuth completion
- remove the Granola service from the transport-auth source-test carve-out

## Test Plan
- [x] pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/user-connectors-flow.test.ts src/__tests__/connector-oauth-internal-adapter.test.ts src/__tests__/app-trpc-root-source.test.ts
- [x] pnpm --filter @lightfast/app exec vitest run --passWithNoTests src/__tests__/connectors-routes.test.ts
- [x] pnpm --filter @api/app typecheck
- [x] pnpm --filter @lightfast/app typecheck
- [x] pnpm --filter @api/app test
- [x] pnpm check
- [x] pnpm typecheck
- [x] pnpm turbo boundaries
- [x] git diff --check
- [x] SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog; touched files not listed)

## Reviews
- [x] spec compliance subagent review
- [x] code quality subagent review