### PR TITLE
refactor(api): split github webhook request boundary

### DIFF
--- a/api/app/src/__tests__/github-webhook-boundary-source.test.ts
+++ b/api/app/src/__tests__/github-webhook-boundary-source.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+describe("GitHub webhook request boundary", () => {
+  it("keeps request parsing and signature verification in the internal adapter", () => {
+    const adapterSource = readFileSync(
+      resolve(apiRoot, "adapters/internal/github-webhook.ts"),
+      "utf8"
+    );
+    const serviceSource = readFileSync(
+      resolve(apiRoot, "services/github/webhook/handler.ts"),
+      "utf8"
+    );
+
+    expect(adapterSource).toContain("GITHUB_APP_WEBHOOK_SECRET");
+    expect(adapterSource).toContain("verifyGitHubWebhookSignature");
+    expect(adapterSource).toContain("githubWebhookHeadersSchema");
+    expect(adapterSource).toContain("request.text()");
+    expect(adapterSource).toContain("handleVerifiedGitHubWebhook");
+
+    expect(serviceSource).toContain("handleVerifiedGitHubWebhook");
+    expect(serviceSource).not.toContain("request: Request");
+    expect(serviceSource).not.toContain("env");
+    expect(serviceSource).not.toContain("verifyGitHubWebhookSignature");
+    expect(serviceSource).not.toContain("x-hub-signature-256");
+    expect(serviceSource).not.toContain("input.request");
+  });
+});

--- a/api/app/src/__tests__/github-webhook.test.ts
+++ b/api/app/src/__tests__/github-webhook.test.ts
@@ -60,6 +60,15 @@ function signedRequest(
   });
 }
 
+async function handleGitHubWebhook(input: {
+  request: Request;
+}): Promise<Response> {
+  const { handleGitHubWebhookRequest } = await import(
+    "../adapters/internal/github-webhook"
+  );
+  return handleGitHubWebhookRequest(input.request);
+}
+
 const pushPayload = {
   after: "a".repeat(40),
   before: "b".repeat(40),
@@ -138,9 +147,6 @@ describe("handleGitHubWebhook", () => {
     ).GITHUB_APP_WEBHOOK_SECRET = "";
 
     try {
-      const { handleGitHubWebhook } = await import(
-        "../services/github/webhook"
-      );
       const res = await handleGitHubWebhook({
         request: signedRequest(pushPayload),
       });
@@ -163,7 +169,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("rejects invalid signatures before durable work", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     const res = await handleGitHubWebhook({
       request: new Request(
         "https://app.lightfast.localhost/api/github/webhook",
@@ -190,7 +195,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("rejects missing signatures as unauthorized before durable work", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     const res = await handleGitHubWebhook({
       request: new Request(
         "https://app.lightfast.localhost/api/github/webhook",
@@ -220,7 +224,6 @@ describe("handleGitHubWebhook", () => {
     const signature = `sha256=${createHmac("sha256", "secret")
       .update(body)
       .digest("hex")}`;
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
 
     const res = await handleGitHubWebhook({
       request: new Request(
@@ -248,8 +251,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("rejects signed push payloads with malformed routing fields before durable work", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
-
     const res = await handleGitHubWebhook({
       request: signedRequest({
         ...pushPayload,
@@ -263,8 +264,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("ignores signed unsupported events without durable work", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
-
     const res = await handleGitHubWebhook({
       request: signedRequest({ action: "opened" }, "delivery-issues", "issues"),
     });
@@ -275,7 +274,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("does not enqueue a duplicate queued delivery", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: false,
       delivery: { status: "queued" },
@@ -295,7 +293,6 @@ describe("handleGitHubWebhook", () => {
     "failed",
     "processed",
   ] as const)("does not enqueue a duplicate terminal %s delivery", async (status) => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: false,
       delivery: { status },
@@ -312,7 +309,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("continues processing a duplicate received delivery retry", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: false,
       delivery: { status: "received" },
@@ -361,7 +357,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("marks unbound installation deliveries ignored", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -384,7 +379,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("marks unwatched repository deliveries ignored", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -412,7 +406,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("queues watched repository pushes once", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -454,7 +447,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("ignores watched repository pushes that do not touch watched paths", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -497,7 +489,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("queues watched main pushes when GitHub omits part of the commit list", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -542,7 +533,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("ignores disabled registered repository pushes without enqueueing", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -576,7 +566,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("ignores PR events when the repository does not watch the event family", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     getBindingMock.mockResolvedValue({
       clerkOrgId: "org_123",
       id: 7,
@@ -607,7 +596,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("stores watched PR event raw payloads without checking sync status or path globs", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     getBindingMock.mockResolvedValue({
       clerkOrgId: "org_123",
       id: 7,
@@ -657,7 +645,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("stores watched PR-attached issue comments with nullable PR id", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     getBindingMock.mockResolvedValue({
       clerkOrgId: "org_123",
       id: 7,
@@ -697,7 +684,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("ignores issue comments that are not attached to PRs", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     const res = await handleGitHubWebhook({
       request: signedRequest(
         {
@@ -715,7 +701,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("returns 400 for malformed signed PR payloads before persistence", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     const res = await handleGitHubWebhook({
       request: signedRequest(
         {
@@ -733,7 +718,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("does not mark queued when enqueue fails", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },
@@ -768,7 +752,6 @@ describe("handleGitHubWebhook", () => {
   });
 
   it("ignores deleted branch pushes without enqueueing", async () => {
-    const { handleGitHubWebhook } = await import("../services/github/webhook");
     recordDeliveryMock.mockResolvedValue({
       created: true,
       delivery: { status: "received" },

--- a/api/app/src/adapters/internal/github-webhook.ts
+++ b/api/app/src/adapters/internal/github-webhook.ts
@@ -1,7 +1,109 @@
-import { handleGitHubWebhook as handleGitHubWebhookServiceRequest } from "../../services/github";
+import { githubWebhookHeadersSchema } from "@lightfast/connector-github/contract";
+import { verifyGitHubWebhookSignature } from "@lightfast/connector-github/node";
+import { log } from "@vendor/observability/log/next";
+
+import { env } from "../../env";
+import { handleVerifiedGitHubWebhook } from "../../services/github";
+
+function response(status: number, body: Record<string, unknown>) {
+  return Response.json(body, { status });
+}
+
+function readWebhookLogHeaders(request: Request) {
+  return {
+    deliveryId: request.headers.get("x-github-delivery"),
+    event: request.headers.get("x-github-event"),
+  };
+}
+
+function webhookRejectionMeta(input: {
+  deliveryId?: string | null;
+  event?: string | null;
+  reason: string;
+  status: number;
+}) {
+  const meta: Record<string, unknown> = {
+    reason: input.reason,
+    status: input.status,
+  };
+  if (input.deliveryId) {
+    meta.deliveryId = input.deliveryId;
+  }
+  if (input.event) {
+    meta.event = input.event;
+  }
+  return meta;
+}
+
+function logWebhookRejection(input: {
+  deliveryId?: string | null;
+  event?: string | null;
+  reason: string;
+  status: number;
+}) {
+  log.warn("[github-webhook] rejected", webhookRejectionMeta(input));
+}
 
 export async function handleGitHubWebhookRequest(
   request: Request
 ): Promise<Response> {
-  return handleGitHubWebhookServiceRequest({ request });
+  const secret = env.GITHUB_APP_WEBHOOK_SECRET;
+  if (!secret) {
+    log.error(
+      "[github-webhook] rejected",
+      webhookRejectionMeta({
+        ...readWebhookLogHeaders(request),
+        reason: "missing_webhook_secret",
+        status: 500,
+      })
+    );
+    return response(500, { ok: false });
+  }
+
+  const body = await request.text();
+  const signature256 = request.headers.get("x-hub-signature-256");
+  if (!signature256) {
+    logWebhookRejection({
+      ...readWebhookLogHeaders(request),
+      reason: "missing_signature",
+      status: 401,
+    });
+    return response(401, { ok: false });
+  }
+
+  const parsedHeaders = githubWebhookHeadersSchema.safeParse({
+    deliveryId: request.headers.get("x-github-delivery"),
+    event: request.headers.get("x-github-event"),
+    signature256,
+  });
+  if (!parsedHeaders.success) {
+    logWebhookRejection({
+      ...readWebhookLogHeaders(request),
+      reason: "invalid_headers",
+      status: 400,
+    });
+    return response(400, { ok: false });
+  }
+
+  const headers = parsedHeaders.data;
+  const signatureOk = verifyGitHubWebhookSignature({
+    body,
+    secret,
+    signature256: headers.signature256,
+  });
+  if (!signatureOk) {
+    logWebhookRejection({
+      deliveryId: headers.deliveryId,
+      event: headers.event,
+      reason: "invalid_signature",
+      status: 401,
+    });
+    return response(401, { ok: false });
+  }
+
+  return handleVerifiedGitHubWebhook({
+    body,
+    deliveryId: headers.deliveryId,
+    event: headers.event,
+  });
 }

--- a/api/app/src/services/github/index.ts
+++ b/api/app/src/services/github/index.ts
@@ -23,4 +23,4 @@ export {
 } from "./user-account/flow";
 export { requireGitHubUserAccount } from "./user-account/gate";
 export { getFreshGitHubUserAccessToken } from "./user-account/refresh";
-export { handleGitHubWebhook } from "./webhook";
+export { handleVerifiedGitHubWebhook } from "./webhook";

--- a/api/app/src/services/github/webhook/handler.ts
+++ b/api/app/src/services/github/webhook/handler.ts
@@ -11,11 +11,9 @@ import {
   githubPrWebhookEventSchema,
   githubPrWebhookPayloadSchema,
   githubPushWebhookPayloadSchema,
-  githubWebhookHeadersSchema,
   normalizeGitHubPrWebhookPayload,
   normalizeGitHubPushWebhookPayload,
 } from "@lightfast/connector-github/contract";
-import { verifyGitHubWebhookSignature } from "@lightfast/connector-github/node";
 import {
   matchesAnyWatchedPath,
   sourceControlRepositoryPushEventSchema,
@@ -23,28 +21,12 @@ import {
 } from "@repo/source-control-contract";
 import { log } from "@vendor/observability/log/next";
 
-import { env } from "../../../env";
 import { inngest } from "../../../inngest/client";
 
 const ZERO_SHA = "0".repeat(40);
 
 function response(status: number, body: Record<string, unknown>) {
   return Response.json(body, { status });
-}
-
-function readHeaders(request: Request) {
-  return githubWebhookHeadersSchema.safeParse({
-    deliveryId: request.headers.get("x-github-delivery"),
-    event: request.headers.get("x-github-event"),
-    signature256: request.headers.get("x-hub-signature-256"),
-  });
-}
-
-function readWebhookLogHeaders(request: Request) {
-  return {
-    deliveryId: request.headers.get("x-github-delivery"),
-    event: request.headers.get("x-github-event"),
-  };
 }
 
 function webhookRejectionMeta(input: {
@@ -154,89 +136,37 @@ async function handleGitHubPrWebhook(input: {
   return response(202, { ok: true });
 }
 
-export async function handleGitHubWebhook(input: {
-  request: Request;
+export async function handleVerifiedGitHubWebhook(input: {
+  body: string;
+  deliveryId: string;
+  event: string;
 }): Promise<Response> {
-  const secret = env.GITHUB_APP_WEBHOOK_SECRET;
-  if (!secret) {
-    log.error(
-      "[github-webhook] rejected",
-      webhookRejectionMeta({
-        ...readWebhookLogHeaders(input.request),
-        reason: "missing_webhook_secret",
-        status: 500,
-      })
-    );
-    return response(500, { ok: false });
-  }
-
-  const body = await input.request.text();
-  const signature256 = input.request.headers.get("x-hub-signature-256");
-  if (!signature256) {
-    logWebhookRejection({
-      ...readWebhookLogHeaders(input.request),
-      reason: "missing_signature",
-      status: 401,
-    });
-    return response(401, { ok: false });
-  }
-
-  const parsedHeaders = readHeaders(input.request);
-  if (!parsedHeaders.success) {
-    logWebhookRejection({
-      ...readWebhookLogHeaders(input.request),
-      reason: "invalid_headers",
-      status: 400,
-    });
-    return response(400, { ok: false });
-  }
-
-  const headers = parsedHeaders.data;
-  const signatureOk = verifyGitHubWebhookSignature({
-    body,
-    secret,
-    signature256: headers.signature256,
-  });
-  if (!signatureOk) {
-    logWebhookRejection({
-      deliveryId: headers.deliveryId,
-      event: headers.event,
-      reason: "invalid_signature",
-      status: 401,
-    });
-    return response(401, { ok: false });
-  }
-
   const isPrWebhookEvent = githubPrWebhookEventSchema.safeParse(
-    headers.event
+    input.event
   ).success;
-  if (
-    headers.event !== "ping" &&
-    headers.event !== "push" &&
-    !isPrWebhookEvent
-  ) {
+  if (input.event !== "ping" && input.event !== "push" && !isPrWebhookEvent) {
     return response(202, { ok: true, ignored: true });
   }
 
   let json: unknown;
   try {
-    json = JSON.parse(body);
+    json = JSON.parse(input.body);
   } catch {
     logWebhookRejection({
-      deliveryId: headers.deliveryId,
-      event: headers.event,
+      deliveryId: input.deliveryId,
+      event: input.event,
       reason: "malformed_json",
       status: 400,
     });
     return response(400, { ok: false });
   }
 
-  if (headers.event === "ping") {
+  if (input.event === "ping") {
     const parsedPing = githubPingWebhookPayloadSchema.safeParse(json);
     if (!parsedPing.success) {
       logWebhookRejection({
-        deliveryId: headers.deliveryId,
-        event: headers.event,
+        deliveryId: input.deliveryId,
+        event: input.event,
         reason: "invalid_ping_payload",
         status: 400,
       });
@@ -247,8 +177,8 @@ export async function handleGitHubWebhook(input: {
 
   if (isPrWebhookEvent) {
     return await handleGitHubPrWebhook({
-      deliveryId: headers.deliveryId,
-      event: headers.event,
+      deliveryId: input.deliveryId,
+      event: input.event,
       json,
     });
   }
@@ -256,8 +186,8 @@ export async function handleGitHubWebhook(input: {
   const parsedPush = githubPushWebhookPayloadSchema.safeParse(json);
   if (!parsedPush.success) {
     logWebhookRejection({
-      deliveryId: headers.deliveryId,
-      event: headers.event,
+      deliveryId: input.deliveryId,
+      event: input.event,
       reason: "invalid_push_payload",
       status: 400,
     });
@@ -266,8 +196,8 @@ export async function handleGitHubWebhook(input: {
 
   const push = normalizeGitHubPushWebhookPayload(parsedPush.data);
   const deliveryRecord = await recordSourceControlWebhookDeliveryReceived(db, {
-    deliveryId: headers.deliveryId,
-    event: headers.event,
+    deliveryId: input.deliveryId,
+    event: input.event,
     providerInstallationId: push.providerInstallationId,
     providerRepositoryId: push.providerRepositoryId,
   });
@@ -279,7 +209,7 @@ export async function handleGitHubWebhook(input: {
 
   if (push.afterSha === ZERO_SHA) {
     await markSourceControlWebhookDeliveryStatus(db, {
-      deliveryId: headers.deliveryId,
+      deliveryId: input.deliveryId,
       status: "ignored",
     });
     return response(202, { ok: true, ignored: true });
@@ -291,7 +221,7 @@ export async function handleGitHubWebhook(input: {
   });
   if (!binding || binding.status !== "active") {
     await markSourceControlWebhookDeliveryStatus(db, {
-      deliveryId: headers.deliveryId,
+      deliveryId: input.deliveryId,
       status: "ignored",
     });
     return response(202, { ok: true, ignored: true });
@@ -303,7 +233,7 @@ export async function handleGitHubWebhook(input: {
   });
   if (!watch) {
     await markSourceControlWebhookDeliveryStatus(db, {
-      deliveryId: headers.deliveryId,
+      deliveryId: input.deliveryId,
       status: "ignored",
     });
     return response(202, { ok: true, ignored: true });
@@ -311,7 +241,7 @@ export async function handleGitHubWebhook(input: {
 
   if (watch.syncStatus !== "enabled") {
     await markSourceControlWebhookDeliveryStatus(db, {
-      deliveryId: headers.deliveryId,
+      deliveryId: input.deliveryId,
       status: "ignored",
     });
     return response(202, { ok: true, ignored: true });
@@ -319,7 +249,7 @@ export async function handleGitHubWebhook(input: {
 
   if (watch.watchedPathGlobs === null) {
     await markSourceControlWebhookDeliveryStatus(db, {
-      deliveryId: headers.deliveryId,
+      deliveryId: input.deliveryId,
       status: "ignored",
     });
     return response(202, { ok: true, ignored: true });
@@ -334,7 +264,7 @@ export async function handleGitHubWebhook(input: {
 
   if (!(changedPathsMatch || shouldConservativelyQueue)) {
     await markSourceControlWebhookDeliveryStatus(db, {
-      deliveryId: headers.deliveryId,
+      deliveryId: input.deliveryId,
       status: "ignored",
     });
     return response(202, { ok: true, ignored: true });
@@ -342,7 +272,7 @@ export async function handleGitHubWebhook(input: {
 
   const event = sourceControlRepositoryPushEventSchema.parse({
     ...push,
-    deliveryId: headers.deliveryId,
+    deliveryId: input.deliveryId,
     orgSourceControlBindingId: binding.id,
     repositoryWatchId: watch.id,
   });
@@ -351,7 +281,7 @@ export async function handleGitHubWebhook(input: {
     data: event,
   });
   await markSourceControlWebhookDeliveryStatus(db, {
-    deliveryId: headers.deliveryId,
+    deliveryId: input.deliveryId,
     status: "queued",
   });
 

--- a/api/app/src/services/github/webhook/index.ts
+++ b/api/app/src/services/github/webhook/index.ts
@@ -1,1 +1,1 @@
-export { handleGitHubWebhook } from "./handler";
+export { handleVerifiedGitHubWebhook } from "./handler";


### PR DESCRIPTION
## Summary
- move GitHub webhook request parsing, env lookup, header validation, and signature verification into the internal adapter
- keep the webhook service on verified `{ body, deliveryId, event }` input via `handleVerifiedGitHubWebhook`
- add a source ratchet for the adapter/service boundary

## Verification
- `pnpm --filter @api/app exec vitest run --passWithNoTests src/__tests__/github-webhook-boundary-source.test.ts src/__tests__/github-webhook.test.ts`
- `pnpm --filter @lightfast/app exec vitest run --passWithNoTests src/__tests__/github-routes.test.ts src/__tests__/authenticated-routes-source.test.ts`
- `pnpm --filter @api/app typecheck`
- `pnpm check`
- `pnpm turbo boundaries`
- `pnpm typecheck`
- `pnpm --filter @api/app test`
- `git diff --cached --check`
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` (known unused-file backlog only; touched files not listed)

## Reviews
- Spec compliance subagent: pass
- Code quality subagent: pass