### PR TITLE
refactor(api): split native auth request boundaries

### DIFF
--- a/api/app/src/__tests__/native-auth-boundary-source.test.ts
+++ b/api/app/src/__tests__/native-auth-boundary-source.test.ts
@@ -39,4 +39,15 @@ describe("native auth boundary exports", () => {
     expect(rootSource).not.toContain("nativeAuthRouter");
     expect(rootSource).not.toContain("native:");
   });
+
+  it("keeps native auth core free of request and auth-context adapters", () => {
+    const nativeAuthSource = source("src/native-auth/index.ts");
+
+    expect(nativeAuthSource).not.toContain("ResolvedAuthContext");
+    expect(nativeAuthSource).not.toContain("headers: Headers");
+    expect(nativeAuthSource).not.toContain("NATIVE_AUTH_HEADERS");
+    expect(nativeAuthSource).not.toContain("resolveAuthContextFromClerk");
+    expect(nativeAuthSource).not.toContain("ForAuthContext");
+    expect(nativeAuthSource).not.toContain("ForRequest");
+  });
 });

--- a/api/app/src/__tests__/native-auth-server-routes.test.ts
+++ b/api/app/src/__tests__/native-auth-server-routes.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class NativeAuthError extends Error {
+    readonly code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED";
+    readonly status: number;
+
+    constructor(
+      code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED",
+      message: string
+    ) {
+      super(message);
+      this.name = "NativeAuthError";
+      this.code = code;
+      this.status =
+        code === "UNAUTHORIZED" ? 401 : code === "FORBIDDEN" ? 403 : 500;
+    }
+  }
+
+  return {
+    db: {},
+    finalizeNativeAuthAttemptForNativeOAuth: vi.fn(),
+    getNativeAuthSessionForNativeOAuth: vi.fn(),
+    getNativeOAuthClientConfig: vi.fn(),
+    NativeAuthError,
+    resolveAuthContextFromClerk: vi.fn(),
+  };
+});
+
+vi.mock("@db/app/client", () => ({ db: mocks.db }));
+
+vi.mock("../auth/identity", () => ({
+  resolveAuthContextFromClerk: mocks.resolveAuthContextFromClerk,
+}));
+
+vi.mock("../native-auth", () => ({
+  finalizeNativeAuthAttemptForNativeOAuth:
+    mocks.finalizeNativeAuthAttemptForNativeOAuth,
+  getNativeAuthSessionForNativeOAuth: mocks.getNativeAuthSessionForNativeOAuth,
+  getNativeOAuthClientConfig: mocks.getNativeOAuthClientConfig,
+  isNativeAuthError: (error: unknown) => error instanceof mocks.NativeAuthError,
+  NativeAuthError: mocks.NativeAuthError,
+}));
+
+const {
+  handleNativeOAuthDesktopSessionRequest,
+  handleNativeOAuthFinalizeRequest,
+} = await import("../native-auth/server-routes");
+
+const session = {
+  client: "desktop" as const,
+  organization: { id: "org_1", name: "Acme", slug: "acme" },
+  user: {
+    email: "dev@example.com",
+    id: "user_1",
+    imageUrl: "https://img.example.com/user_1.png",
+    initials: "JP",
+    username: "jeevanpillay",
+  },
+};
+
+function activeNativeAuth(client: "cli" | "desktop" = "desktop") {
+  return {
+    access: {
+      client,
+      clientId: `${client}_client_test`,
+      kind: "clerk-oauth" as const,
+      scopes: ["openid"],
+      userId: "user_1",
+    },
+    identity: {
+      orgGate: { bindingStatus: "bound" as const, nextSetupRequirement: null },
+      orgId: "org_1",
+      type: "active" as const,
+      userId: "user_1",
+    },
+  };
+}
+
+function finalizeRequest(body: unknown) {
+  return new Request("https://app.lightfast.test/api/oauth/finalize", {
+    body: JSON.stringify(body),
+    headers: {
+      authorization: "Bearer access_test",
+      "content-type": "application/json",
+      "x-lightfast-organization-id": "org_1",
+    },
+    method: "POST",
+  });
+}
+
+function desktopSessionRequest() {
+  return new Request("https://app.lightfast.test/api/oauth/desktop/session", {
+    headers: {
+      authorization: "Bearer access_test",
+      "x-lightfast-organization-id": "org_1",
+    },
+    method: "GET",
+  });
+}
+
+describe("native OAuth server routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.finalizeNativeAuthAttemptForNativeOAuth.mockResolvedValue(session);
+    mocks.getNativeAuthSessionForNativeOAuth.mockResolvedValue(session);
+    mocks.resolveAuthContextFromClerk.mockResolvedValue(activeNativeAuth());
+  });
+
+  it("finalizes native OAuth by stamping the body client and passing the OAuth user", async () => {
+    const body = {
+      attemptId: "attempt_123456789",
+      client: "cli" as const,
+      state: "state_1234567890",
+    };
+    mocks.resolveAuthContextFromClerk.mockResolvedValue(
+      activeNativeAuth("cli")
+    );
+
+    const response = await handleNativeOAuthFinalizeRequest(
+      finalizeRequest(body)
+    );
+
+    await expect(response.json()).resolves.toEqual(session);
+    expect(response.status).toBe(200);
+    expect(mocks.resolveAuthContextFromClerk).toHaveBeenCalledWith({
+      db: mocks.db,
+      headers: expect.any(Headers),
+    });
+    const [firstCall] = mocks.resolveAuthContextFromClerk.mock.calls;
+    expect(firstCall).toBeDefined();
+    expect(firstCall![0].headers.get("authorization")).toBe(
+      "Bearer access_test"
+    );
+    expect(firstCall![0].headers.get("x-lightfast-native-client")).toBe("cli");
+    expect(mocks.finalizeNativeAuthAttemptForNativeOAuth).toHaveBeenCalledWith({
+      data: body,
+      db: mocks.db,
+      userId: "user_1",
+    });
+  });
+
+  it("allows pending native OAuth identity when finalizing an attempt", async () => {
+    const body = {
+      attemptId: "attempt_123456789",
+      client: "desktop" as const,
+      state: "state_1234567890",
+    };
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      access: {
+        client: "desktop",
+        clientId: "desktop_client_test",
+        kind: "clerk-oauth",
+        scopes: ["openid"],
+        userId: "user_1",
+      },
+      identity: { type: "pending", userId: "user_1" },
+    });
+
+    const response = await handleNativeOAuthFinalizeRequest(
+      finalizeRequest(body)
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.finalizeNativeAuthAttemptForNativeOAuth).toHaveBeenCalledWith({
+      data: body,
+      db: mocks.db,
+      userId: "user_1",
+    });
+  });
+
+  it.each([
+    {
+      auth: { identity: { type: "unauthenticated" as const } },
+      label: "unauthenticated",
+    },
+    {
+      auth: {
+        access: {
+          has: vi.fn(),
+          kind: "clerk-session" as const,
+          orgId: "org_1",
+          userId: "user_1",
+        },
+        identity: {
+          orgGate: {
+            bindingStatus: "bound" as const,
+            nextSetupRequirement: null,
+          },
+          orgId: "org_1",
+          type: "active" as const,
+          userId: "user_1",
+        },
+      },
+      label: "cookie session",
+    },
+  ])("maps $label desktop session auth to 401", async ({ auth }) => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValue(auth);
+
+    const response = await handleNativeOAuthDesktopSessionRequest(
+      desktopSessionRequest()
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Lightfast native OAuth authentication required.",
+      },
+    });
+    expect(response.status).toBe(401);
+    expect(mocks.getNativeAuthSessionForNativeOAuth).not.toHaveBeenCalled();
+  });
+
+  it("maps pending desktop session identity to 403", async () => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      access: {
+        client: "desktop",
+        clientId: "desktop_client_test",
+        kind: "clerk-oauth",
+        scopes: ["openid"],
+        userId: "user_1",
+      },
+      identity: { type: "pending", userId: "user_1" },
+    });
+
+    const response = await handleNativeOAuthDesktopSessionRequest(
+      desktopSessionRequest()
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "FORBIDDEN",
+        message: "Native session organization required",
+      },
+    });
+    expect(response.status).toBe(403);
+    expect(mocks.getNativeAuthSessionForNativeOAuth).not.toHaveBeenCalled();
+  });
+
+  it("loads desktop session metadata with explicit native OAuth values", async () => {
+    const response = await handleNativeOAuthDesktopSessionRequest(
+      desktopSessionRequest()
+    );
+
+    await expect(response.json()).resolves.toEqual(session);
+    expect(response.status).toBe(200);
+    expect(mocks.getNativeAuthSessionForNativeOAuth).toHaveBeenCalledWith({
+      client: "desktop",
+      db: mocks.db,
+      organizationId: "org_1",
+      userId: "user_1",
+    });
+  });
+});

--- a/api/app/src/__tests__/native-auth-tanstack-adapter.test.ts
+++ b/api/app/src/__tests__/native-auth-tanstack-adapter.test.ts
@@ -5,22 +5,19 @@ const mocks = vi.hoisted(() => {
     readonly code: "FORBIDDEN" | "UNAUTHORIZED";
     readonly status: number;
 
-    constructor(input: {
-      code: "FORBIDDEN" | "UNAUTHORIZED";
-      message: string;
-      status: number;
-    }) {
-      super(input.message);
+    constructor(code: "FORBIDDEN" | "UNAUTHORIZED", message: string) {
+      super(message);
       this.name = "NativeAuthError";
-      this.code = input.code;
-      this.status = input.status;
+      this.code = code;
+      this.status = code === "UNAUTHORIZED" ? 401 : 403;
     }
   }
 
   return {
-    createNativeAuthAttemptForAuthContext: vi.fn(),
+    createNativeAuthAttemptForUser: vi.fn(),
+    db: {},
     getRequest: vi.fn(),
-    listNativeOrganizationsForAuthContext: vi.fn(),
+    listNativeOrganizationsForUser: vi.fn(),
     NativeAuthError,
     redirect: vi.fn((input) => input),
     resolveAuthContextFromClerk: vi.fn(),
@@ -29,7 +26,7 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@db/app/client", () => ({ db: {} }));
+vi.mock("@db/app/client", () => ({ db: mocks.db }));
 
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => ({
@@ -59,15 +56,17 @@ vi.mock("../auth/identity", () => ({
 }));
 
 vi.mock("../native-auth", () => ({
-  createNativeAuthAttemptForAuthContext:
-    mocks.createNativeAuthAttemptForAuthContext,
+  createNativeAuthAttemptForUser: mocks.createNativeAuthAttemptForUser,
   isNativeAuthError: (error: unknown) => error instanceof mocks.NativeAuthError,
-  listNativeOrganizationsForAuthContext:
-    mocks.listNativeOrganizationsForAuthContext,
+  listNativeOrganizationsForUser: mocks.listNativeOrganizationsForUser,
+  NativeAuthError: mocks.NativeAuthError,
 }));
 
-const { listNativeAuthOrganizations, loadNativeAuthOrganizations } =
-  await import("../adapters/tanstack/native-auth");
+const {
+  createNativeAuthAttempt,
+  listNativeAuthOrganizations,
+  loadNativeAuthOrganizations,
+} = await import("../adapters/tanstack/native-auth");
 
 describe("native auth TanStack adapter", () => {
   beforeEach(() => {
@@ -77,6 +76,46 @@ describe("native auth TanStack adapter", () => {
     );
     mocks.resolveAuthContextFromClerk.mockResolvedValue({
       identity: { type: "pending", userId: "user_1" },
+    });
+    mocks.createNativeAuthAttemptForUser.mockResolvedValue({
+      attemptId: "native_attempt_test",
+      authorizationUrl: "https://clerk.example.com/oauth/authorize",
+    });
+    mocks.listNativeOrganizationsForUser.mockResolvedValue([]);
+  });
+
+  it("lists native auth organizations for the resolved signed-in user", async () => {
+    await expect(listNativeAuthOrganizations()).resolves.toEqual([]);
+
+    expect(mocks.resolveAuthContextFromClerk).toHaveBeenCalledWith({
+      db: mocks.db,
+      headers: expect.any(Headers),
+    });
+    expect(mocks.listNativeOrganizationsForUser).toHaveBeenCalledWith({
+      db: mocks.db,
+      userId: "user_1",
+    });
+  });
+
+  it("creates native auth attempts for the resolved signed-in user", async () => {
+    const data = {
+      client: "cli",
+      codeChallenge: "a".repeat(43),
+      codeChallengeMethod: "S256",
+      organizationId: "org_1",
+      redirectUri: "http://127.0.0.1:54321/callback",
+      stateNonce: "state_nonce_test1",
+    } as const;
+
+    await expect(createNativeAuthAttempt({ data })).resolves.toEqual({
+      attemptId: "native_attempt_test",
+      authorizationUrl: "https://clerk.example.com/oauth/authorize",
+    });
+
+    expect(mocks.createNativeAuthAttemptForUser).toHaveBeenCalledWith({
+      data,
+      db: mocks.db,
+      userId: "user_1",
     });
   });
 
@@ -110,8 +149,8 @@ describe("native auth TanStack adapter", () => {
     message,
     status,
   }) => {
-    mocks.listNativeOrganizationsForAuthContext.mockRejectedValue(
-      new mocks.NativeAuthError({ code, message, status })
+    mocks.listNativeOrganizationsForUser.mockRejectedValue(
+      new mocks.NativeAuthError(code, message)
     );
 
     await expect(listNativeAuthOrganizations()).rejects.toThrow(message);
@@ -123,13 +162,9 @@ describe("native auth TanStack adapter", () => {
     mocks.getRequest.mockReturnValue(
       new Request("https://lightfast.localhost/oauth/cli/start?state=abc")
     );
-    mocks.listNativeOrganizationsForAuthContext.mockRejectedValue(
-      new mocks.NativeAuthError({
-        code: "UNAUTHORIZED",
-        message: "Authentication required. Please sign in.",
-        status: 401,
-      })
-    );
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      identity: { type: "unauthenticated" },
+    });
 
     await expect(loadNativeAuthOrganizations()).rejects.toMatchObject({
       search: { redirect_url: "/oauth/cli/start?state=abc" },
@@ -143,5 +178,6 @@ describe("native auth TanStack adapter", () => {
       to: "/sign-in",
     });
     expect(mocks.setResponseStatus).not.toHaveBeenCalled();
+    expect(mocks.listNativeOrganizationsForUser).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/native-rpc-adapter.test.ts
+++ b/api/app/src/__tests__/native-rpc-adapter.test.ts
@@ -5,27 +5,36 @@ const mocks = vi.hoisted(() => {
     readonly code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED";
     readonly status: number;
 
-    constructor(input: {
-      code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED";
-      message: string;
-      status: number;
-    }) {
-      super(input.message);
+    constructor(
+      code: "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | "UNAUTHORIZED",
+      message: string
+    ) {
+      super(message);
       this.name = "NativeAuthError";
-      this.code = input.code;
-      this.status = input.status;
+      this.code = code;
+      this.status =
+        code === "UNAUTHORIZED" ? 401 : code === "FORBIDDEN" ? 403 : 500;
     }
   }
 
   return {
-    getNativeAuthSessionForRequest: vi.fn(),
+    db: {},
+    getNativeAuthSessionForNativeOAuth: vi.fn(),
     NativeAuthError,
+    resolveAuthContextFromClerk: vi.fn(),
   };
 });
 
+vi.mock("@db/app/client", () => ({ db: mocks.db }));
+
+vi.mock("../auth/identity", () => ({
+  resolveAuthContextFromClerk: mocks.resolveAuthContextFromClerk,
+}));
+
 vi.mock("../native-auth", () => ({
-  getNativeAuthSessionForRequest: mocks.getNativeAuthSessionForRequest,
+  getNativeAuthSessionForNativeOAuth: mocks.getNativeAuthSessionForNativeOAuth,
   isNativeAuthError: (error: unknown) => error instanceof mocks.NativeAuthError,
+  NativeAuthError: mocks.NativeAuthError,
 }));
 
 const { handleCliNativeRpcRequest } = await import("../adapters/cli-api");
@@ -61,7 +70,22 @@ const session = {
 describe("native RPC adapters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getNativeAuthSessionForRequest.mockResolvedValue(session);
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      access: {
+        client: "desktop",
+        clientId: "desktop_client_test",
+        kind: "clerk-oauth",
+        scopes: ["openid"],
+        userId: "user_1",
+      },
+      identity: {
+        orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+        orgId: "org_1",
+        type: "active",
+        userId: "user_1",
+      },
+    });
+    mocks.getNativeAuthSessionForNativeOAuth.mockResolvedValue(session);
   });
 
   it("handles desktop auth.session through the desktop native OAuth source", async () => {
@@ -76,18 +100,40 @@ describe("native RPC adapters", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-type")).toContain("application/json");
-    expect(mocks.getNativeAuthSessionForRequest).toHaveBeenCalledWith({
+    expect(mocks.resolveAuthContextFromClerk).toHaveBeenCalledWith({
+      db: mocks.db,
       headers: expect.any(Headers),
-      source: "desktop",
     });
-    const [firstCall] = mocks.getNativeAuthSessionForRequest.mock.calls;
+    const [firstCall] = mocks.resolveAuthContextFromClerk.mock.calls;
     expect(firstCall).toBeDefined();
     const { headers } = firstCall![0];
     expect(headers.get("authorization")).toBe("Bearer access_test");
+    expect(headers.get("x-lightfast-native-client")).toBe("desktop");
+    expect(mocks.getNativeAuthSessionForNativeOAuth).toHaveBeenCalledWith({
+      client: "desktop",
+      db: mocks.db,
+      organizationId: "org_1",
+      userId: "user_1",
+    });
   });
 
   it("handles CLI auth.session through the CLI native OAuth source", async () => {
-    mocks.getNativeAuthSessionForRequest.mockResolvedValue({
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      access: {
+        client: "cli",
+        clientId: "cli_client_test",
+        kind: "clerk-oauth",
+        scopes: ["openid"],
+        userId: "user_1",
+      },
+      identity: {
+        orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+        orgId: "org_1",
+        type: "active",
+        userId: "user_1",
+      },
+    });
+    mocks.getNativeAuthSessionForNativeOAuth.mockResolvedValue({
       ...session,
       client: "cli",
     });
@@ -100,9 +146,14 @@ describe("native RPC adapters", () => {
       ok: true,
       result: { client: "cli", organization: { id: "org_1" } },
     });
-    expect(mocks.getNativeAuthSessionForRequest).toHaveBeenCalledWith({
-      headers: expect.any(Headers),
-      source: "cli",
+    const [firstCall] = mocks.resolveAuthContextFromClerk.mock.calls;
+    expect(firstCall).toBeDefined();
+    expect(firstCall![0].headers.get("x-lightfast-native-client")).toBe("cli");
+    expect(mocks.getNativeAuthSessionForNativeOAuth).toHaveBeenCalledWith({
+      client: "cli",
+      db: mocks.db,
+      organizationId: "org_1",
+      userId: "user_1",
     });
   });
 
@@ -122,7 +173,7 @@ describe("native RPC adapters", () => {
       },
     });
     expect(response.status).toBe(400);
-    expect(mocks.getNativeAuthSessionForRequest).not.toHaveBeenCalled();
+    expect(mocks.getNativeAuthSessionForNativeOAuth).not.toHaveBeenCalled();
   });
 
   it("rejects explicit null command input", async () => {
@@ -138,7 +189,7 @@ describe("native RPC adapters", () => {
       },
     });
     expect(response.status).toBe(400);
-    expect(mocks.getNativeAuthSessionForRequest).not.toHaveBeenCalled();
+    expect(mocks.getNativeAuthSessionForNativeOAuth).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -165,8 +216,8 @@ describe("native RPC adapters", () => {
     message,
     status,
   }) => {
-    mocks.getNativeAuthSessionForRequest.mockRejectedValue(
-      new mocks.NativeAuthError({ code, message, status })
+    mocks.getNativeAuthSessionForNativeOAuth.mockRejectedValue(
+      new mocks.NativeAuthError(code, message)
     );
 
     const response = await handleDesktopNativeRpcRequest(
@@ -183,8 +234,99 @@ describe("native RPC adapters", () => {
     expect(response.status).toBe(status);
   });
 
+  it.each([
+    {
+      auth: { identity: { type: "unauthenticated" as const } },
+      label: "unauthenticated",
+    },
+    {
+      auth: {
+        access: {
+          has: vi.fn(),
+          kind: "clerk-session" as const,
+          orgId: "org_1",
+          userId: "user_1",
+        },
+        identity: {
+          orgGate: {
+            bindingStatus: "bound" as const,
+            nextSetupRequirement: null,
+          },
+          orgId: "org_1",
+          type: "active" as const,
+          userId: "user_1",
+        },
+      },
+      label: "cookie session",
+    },
+    {
+      auth: {
+        access: {
+          client: "cli" as const,
+          clientId: "cli_client_test",
+          kind: "clerk-oauth" as const,
+          scopes: ["openid"],
+          userId: "user_1",
+        },
+        identity: {
+          orgGate: {
+            bindingStatus: "bound" as const,
+            nextSetupRequirement: null,
+          },
+          orgId: "org_1",
+          type: "active" as const,
+          userId: "user_1",
+        },
+      },
+      label: "wrong native client",
+    },
+  ])("maps resolver-derived $label auth to unauthorized", async ({ auth }) => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValue(auth);
+
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({ command: "auth.session" })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Lightfast native OAuth authentication required.",
+      },
+    });
+    expect(response.status).toBe(401);
+    expect(mocks.getNativeAuthSessionForNativeOAuth).not.toHaveBeenCalled();
+  });
+
+  it("maps resolver-derived pending native OAuth identity to forbidden", async () => {
+    mocks.resolveAuthContextFromClerk.mockResolvedValue({
+      access: {
+        client: "desktop",
+        clientId: "desktop_client_test",
+        kind: "clerk-oauth",
+        scopes: ["openid"],
+        userId: "user_1",
+      },
+      identity: { type: "pending", userId: "user_1" },
+    });
+
+    const response = await handleDesktopNativeRpcRequest(
+      rpcRequest({ command: "auth.session" })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "Native session organization required",
+      },
+    });
+    expect(response.status).toBe(403);
+    expect(mocks.getNativeAuthSessionForNativeOAuth).not.toHaveBeenCalled();
+  });
+
   it("treats invalid backend output as an internal native RPC error", async () => {
-    mocks.getNativeAuthSessionForRequest.mockResolvedValue({
+    mocks.getNativeAuthSessionForNativeOAuth.mockResolvedValue({
       organization: { id: "org_1", name: "Acme", slug: "acme" },
       user: { email: "dev@example.com", id: "user_1" },
     });

--- a/api/app/src/adapters/native-rpc.ts
+++ b/api/app/src/adapters/native-rpc.ts
@@ -1,4 +1,6 @@
+import { db } from "@db/app/client";
 import {
+  NATIVE_AUTH_HEADERS,
   type NativeClient,
   type NativeRpcCommand,
   type NativeRpcErrorCode,
@@ -8,9 +10,11 @@ import {
   nativeRpcRequestSchema,
 } from "@repo/native-auth-contract";
 
+import { resolveAuthContextFromClerk } from "../auth/identity";
 import {
-  getNativeAuthSessionForRequest,
+  getNativeAuthSessionForNativeOAuth,
   isNativeAuthError,
+  NativeAuthError,
 } from "../native-auth";
 
 type NativeRpcStatus = 400 | 401 | 403 | 404 | 500;
@@ -45,6 +49,50 @@ function errorResponse(
 
 function invalidRequestResponse() {
   return errorResponse("BAD_REQUEST", "Native RPC request is invalid.", 400);
+}
+
+async function resolveNativeRpcAuth(input: {
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const headers = new Headers(input.headers);
+  headers.set(NATIVE_AUTH_HEADERS.client, input.source);
+
+  return resolveAuthContextFromClerk({
+    db,
+    headers,
+  });
+}
+
+async function loadNativeRpcAuthSession(input: {
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const auth = await resolveNativeRpcAuth(input);
+  if (
+    auth.identity.type === "unauthenticated" ||
+    auth.access?.kind !== "clerk-oauth" ||
+    auth.access.client !== input.source
+  ) {
+    throw new NativeAuthError(
+      "UNAUTHORIZED",
+      "Lightfast native OAuth authentication required."
+    );
+  }
+
+  if (auth.identity.type !== "active") {
+    throw new NativeAuthError(
+      "FORBIDDEN",
+      "Native session organization required"
+    );
+  }
+
+  return getNativeAuthSessionForNativeOAuth({
+    client: auth.access.client,
+    db,
+    organizationId: auth.identity.orgId,
+    userId: auth.identity.userId,
+  });
 }
 
 function normalizeErrorResponse(error: unknown) {
@@ -93,7 +141,7 @@ export async function handleNativeRpcRequest(
           return invalidRequestResponse();
         }
 
-        const result = await getNativeAuthSessionForRequest({
+        const result = await loadNativeRpcAuthSession({
           headers: request.headers,
           source: surface.source,
         });

--- a/api/app/src/adapters/tanstack/native-auth.ts
+++ b/api/app/src/adapters/tanstack/native-auth.ts
@@ -10,9 +10,10 @@ import {
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import {
-  createNativeAuthAttemptForAuthContext,
+  createNativeAuthAttemptForUser,
   isNativeAuthError,
-  listNativeOrganizationsForAuthContext,
+  listNativeOrganizationsForUser,
+  NativeAuthError,
 } from "../../native-auth";
 
 async function createTanStackNativeAuthContext() {
@@ -21,6 +22,19 @@ async function createTanStackNativeAuthContext() {
     db,
     headers: new Headers(request.headers),
   });
+}
+
+function requireSignedInNativeAuthIdentity(
+  auth: Awaited<ReturnType<typeof createTanStackNativeAuthContext>>
+) {
+  if (auth.identity.type === "unauthenticated") {
+    throw new NativeAuthError(
+      "UNAUTHORIZED",
+      "Authentication required. Please sign in."
+    );
+  }
+
+  return auth.identity;
 }
 
 function oauthRequestRedirectTarget(requestUrl: string): string {
@@ -70,9 +84,12 @@ async function listNativeAuthOrganizationsForCurrentRequest(
   const request = getRequest();
   noStore();
   try {
-    return await listNativeOrganizationsForAuthContext({
-      auth: await createTanStackNativeAuthContext(),
+    const identity = requireSignedInNativeAuthIdentity(
+      await createTanStackNativeAuthContext()
+    );
+    return await listNativeOrganizationsForUser({
       db,
+      userId: identity.userId,
     });
   } catch (error) {
     mapTanStackNativeAuthError(error, {
@@ -99,10 +116,13 @@ export const createNativeAuthAttempt = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     noStore();
     try {
-      return await createNativeAuthAttemptForAuthContext({
-        auth: await createTanStackNativeAuthContext(),
+      const identity = requireSignedInNativeAuthIdentity(
+        await createTanStackNativeAuthContext()
+      );
+      return await createNativeAuthAttemptForUser({
         data,
         db,
+        userId: identity.userId,
       });
     } catch (error) {
       mapTanStackNativeAuthError(error);

--- a/api/app/src/native-auth/index.ts
+++ b/api/app/src/native-auth/index.ts
@@ -1,7 +1,5 @@
 import type { Database } from "@db/app";
-import { db as defaultDb } from "@db/app/client";
 import {
-  NATIVE_AUTH_HEADERS,
   type NativeClient,
   type NativeCreateAttemptInput,
   type NativeOAuthConfig,
@@ -17,8 +15,6 @@ import {
   findUserOrganizationMembership,
   listUserOrganizationMemberships,
 } from "../auth/clerk-org-membership";
-import type { AuthIdentity, ResolvedAuthContext } from "../auth/identity";
-import { resolveAuthContextFromClerk } from "../auth/identity";
 import {
   consumeNativeAuthAttempt,
   issueNativeAuthAttempt,
@@ -98,35 +94,6 @@ export async function listNativeOrganizationsForUser(input: {
   );
 }
 
-function requireSignedInIdentity(
-  auth: ResolvedAuthContext
-): Extract<AuthIdentity, { type: "active" | "pending" }> {
-  if (auth.identity.type === "unauthenticated") {
-    throw new NativeAuthError(
-      "UNAUTHORIZED",
-      "Authentication required. Please sign in."
-    );
-  }
-  return auth.identity;
-}
-
-function requireNativeOAuthContext(auth: ResolvedAuthContext) {
-  if (
-    auth.identity.type === "unauthenticated" ||
-    auth.access?.kind !== "clerk-oauth"
-  ) {
-    throw new NativeAuthError(
-      "UNAUTHORIZED",
-      "Lightfast native OAuth authentication required."
-    );
-  }
-
-  return {
-    access: auth.access,
-    identity: auth.identity,
-  };
-}
-
 async function assertNativeOrgMembership(input: {
   organizationId: string;
   userId: string;
@@ -185,17 +152,6 @@ async function createNativeSessionMetadata(input: {
   });
 }
 
-export async function listNativeOrganizationsForAuthContext(input: {
-  auth: ResolvedAuthContext;
-  db: Database;
-}): Promise<NativeOrganization[]> {
-  const identity = requireSignedInIdentity(input.auth);
-  return listNativeOrganizationsForUser({
-    db: input.db,
-    userId: identity.userId,
-  });
-}
-
 export async function createNativeAuthAttemptForUser(input: {
   db: Database;
   data: NativeCreateAttemptInput;
@@ -221,45 +177,25 @@ export async function createNativeAuthAttemptForUser(input: {
   };
 }
 
-export async function createNativeAuthAttemptForAuthContext(input: {
-  auth: ResolvedAuthContext;
-  data: NativeCreateAttemptInput;
+export async function getNativeAuthSessionForNativeOAuth(input: {
+  client: NativeClient;
   db: Database;
+  organizationId: string;
+  userId: string;
 }) {
-  const identity = requireSignedInIdentity(input.auth);
-  return createNativeAuthAttemptForUser({
-    data: input.data,
-    db: input.db,
-    userId: identity.userId,
-  });
-}
-
-export async function getNativeAuthSessionForAuthContext(input: {
-  auth: ResolvedAuthContext;
-  db: Database;
-}) {
-  const { access, identity } = requireNativeOAuthContext(input.auth);
-  if (identity.type !== "active") {
-    throw new NativeAuthError(
-      "FORBIDDEN",
-      "Native session organization required"
-    );
-  }
-
   return createNativeSessionMetadata({
     db: input.db,
-    client: access.client,
-    organizationId: identity.orgId,
-    userId: identity.userId,
+    client: input.client,
+    organizationId: input.organizationId,
+    userId: input.userId,
   });
 }
 
-export async function finalizeNativeAuthAttemptForAuthContext(input: {
-  auth: ResolvedAuthContext;
+export async function finalizeNativeAuthAttemptForNativeOAuth(input: {
   data: NativeFinalizeRequest;
   db: Database;
+  userId: string;
 }) {
-  const { access } = requireNativeOAuthContext(input.auth);
   const attempt = await consumeNativeAuthAttempt({
     attemptId: input.data.attemptId,
     state: input.data.state,
@@ -267,7 +203,7 @@ export async function finalizeNativeAuthAttemptForAuthContext(input: {
   if (!attempt || attempt.client !== input.data.client) {
     throw new NativeAuthError("UNAUTHORIZED", "Invalid native auth attempt");
   }
-  if (access.userId !== attempt.userId) {
+  if (input.userId !== attempt.userId) {
     throw new NativeAuthError("FORBIDDEN", "Native auth user mismatch");
   }
   return createNativeSessionMetadata({
@@ -275,45 +211,5 @@ export async function finalizeNativeAuthAttemptForAuthContext(input: {
     client: input.data.client,
     organizationId: attempt.organizationId,
     userId: attempt.userId,
-  });
-}
-
-async function resolveNativeOAuthRequestAuth(input: {
-  db?: Database;
-  headers: Headers;
-  source: NativeClient;
-}) {
-  const headers = new Headers(input.headers);
-  headers.set(NATIVE_AUTH_HEADERS.client, input.source);
-
-  return resolveAuthContextFromClerk({
-    db: input.db ?? defaultDb,
-    headers,
-  });
-}
-
-export async function getNativeAuthSessionForRequest(input: {
-  db?: Database;
-  headers: Headers;
-  source: NativeClient;
-}) {
-  const auth = await resolveNativeOAuthRequestAuth(input);
-  return getNativeAuthSessionForAuthContext({
-    auth,
-    db: input.db ?? defaultDb,
-  });
-}
-
-export async function finalizeNativeAuthAttemptForRequest(input: {
-  data: NativeFinalizeRequest;
-  db?: Database;
-  headers: Headers;
-  source: NativeClient;
-}) {
-  const auth = await resolveNativeOAuthRequestAuth(input);
-  return finalizeNativeAuthAttemptForAuthContext({
-    auth,
-    data: input.data,
-    db: input.db ?? defaultDb,
   });
 }

--- a/api/app/src/native-auth/server-routes.ts
+++ b/api/app/src/native-auth/server-routes.ts
@@ -1,16 +1,55 @@
+import { db } from "@db/app/client";
 import {
+  NATIVE_AUTH_HEADERS,
+  type NativeClient,
   nativeClientSchema,
   nativeFinalizeRequestSchema,
   nativeOAuthConfigSchema,
   nativeSessionMetadataSchema,
 } from "@repo/native-auth-contract";
 
+import { resolveAuthContextFromClerk } from "../auth/identity";
 import {
-  finalizeNativeAuthAttemptForRequest,
-  getNativeAuthSessionForRequest,
+  finalizeNativeAuthAttemptForNativeOAuth,
+  getNativeAuthSessionForNativeOAuth,
   getNativeOAuthClientConfig,
   isNativeAuthError,
+  NativeAuthError,
 } from ".";
+
+async function resolveNativeOAuthRequestAuth(input: {
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const headers = new Headers(input.headers);
+  headers.set(NATIVE_AUTH_HEADERS.client, input.source);
+
+  return resolveAuthContextFromClerk({
+    db,
+    headers,
+  });
+}
+
+async function requireNativeOAuthRequestAccess(input: {
+  headers: Headers;
+  source: NativeClient;
+}) {
+  const auth = await resolveNativeOAuthRequestAuth(input);
+  if (
+    auth.identity.type === "unauthenticated" ||
+    auth.access?.kind !== "clerk-oauth"
+  ) {
+    throw new NativeAuthError(
+      "UNAUTHORIZED",
+      "Lightfast native OAuth authentication required."
+    );
+  }
+
+  return {
+    access: auth.access,
+    identity: auth.identity,
+  };
+}
 
 export function handleNativeOAuthClientConfigRequest(client: string): Response {
   try {
@@ -31,10 +70,14 @@ export async function handleNativeOAuthFinalizeRequest(
     const body = nativeFinalizeRequestSchema.parse(
       await request.json().catch(() => null)
     );
-    const session = await finalizeNativeAuthAttemptForRequest({
-      data: body,
+    const { access } = await requireNativeOAuthRequestAccess({
       headers: request.headers,
       source: body.client,
+    });
+    const session = await finalizeNativeAuthAttemptForNativeOAuth({
+      data: body,
+      db,
+      userId: access.userId,
     });
     return nativeOAuthJson(nativeSessionMetadataSchema.parse(session));
   } catch (error) {
@@ -46,9 +89,21 @@ export async function handleNativeOAuthDesktopSessionRequest(
   request: Request
 ): Promise<Response> {
   try {
-    const session = await getNativeAuthSessionForRequest({
+    const { access, identity } = await requireNativeOAuthRequestAccess({
       headers: request.headers,
       source: "desktop",
+    });
+    if (identity.type !== "active") {
+      throw new NativeAuthError(
+        "FORBIDDEN",
+        "Native session organization required"
+      );
+    }
+    const session = await getNativeAuthSessionForNativeOAuth({
+      client: access.client,
+      db,
+      organizationId: identity.orgId,
+      userId: identity.userId,
     });
     return nativeOAuthJson(nativeSessionMetadataSchema.parse(session));
   } catch (error) {

--- a/apps/app/src/__tests__/native-rpc-routes-source.test.ts
+++ b/apps/app/src/__tests__/native-rpc-routes-source.test.ts
@@ -63,7 +63,10 @@ describe("native RPC route boundaries", () => {
     expect(cliAdapter).toContain("cliNativeRpcCommands");
     expect(cliAdapter).toContain('"auth.session"');
     expect(cliAdapter).toContain('source: "cli"');
-    expect(sharedAdapter).toContain("getNativeAuthSessionForRequest");
+    expect(sharedAdapter).toContain("resolveAuthContextFromClerk");
+    expect(sharedAdapter).toContain("NATIVE_AUTH_HEADERS");
+    expect(sharedAdapter).toContain("getNativeAuthSessionForNativeOAuth");
+    expect(sharedAdapter).not.toContain("getNativeAuthSessionForRequest");
     expect(sharedAdapter).toContain("nativeRpcRequestSchema");
     expect(sharedAdapter).toContain("nativeRpcAuthSessionInputSchema");
     expect(sharedAdapter).not.toContain("/api/v1/rpc");

--- a/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
+++ b/apps/app/src/__tests__/oauth-protocol-routes-source.test.ts
@@ -226,10 +226,18 @@ describe("app OAuth protocol route migration", () => {
     expect(nativeServerRoutesSource).toContain("getNativeOAuthClientConfig");
     expect(nativeServerRoutesSource).toContain("nativeFinalizeRequestSchema");
     expect(nativeServerRoutesSource).toContain("nativeSessionMetadataSchema");
+    expect(nativeServerRoutesSource).toContain("resolveAuthContextFromClerk");
+    expect(nativeServerRoutesSource).toContain("NATIVE_AUTH_HEADERS");
     expect(nativeServerRoutesSource).toContain(
-      "finalizeNativeAuthAttemptForRequest"
+      "finalizeNativeAuthAttemptForNativeOAuth"
     );
     expect(nativeServerRoutesSource).toContain(
+      "getNativeAuthSessionForNativeOAuth"
+    );
+    expect(nativeServerRoutesSource).not.toContain(
+      "finalizeNativeAuthAttemptForRequest"
+    );
+    expect(nativeServerRoutesSource).not.toContain(
       "getNativeAuthSessionForRequest"
     );
     expect(nativeServerRoutesSource).toContain('source: "desktop"');


### PR DESCRIPTION
## Summary
- Remove request/header/auth-context helper exports from native auth core.
- Move native OAuth route and native RPC auth resolution into their explicit adapter boundaries.
- Add behavior/source tests for native OAuth server routes, native RPC auth failures, TanStack native auth adapters, and app route ratchets.

## Test Plan
- [x] pnpm --filter @api/app test -- src/__tests__/native-auth-server-routes.test.ts src/__tests__/native-rpc-adapter.test.ts src/__tests__/native-auth-tanstack-adapter.test.ts src/__tests__/native-auth-boundary-source.test.ts
- [x] pnpm --filter @lightfast/app test -- src/__tests__/native-rpc-routes-source.test.ts src/__tests__/oauth-protocol-routes-source.test.ts
- [x] pnpm --filter @api/app typecheck
- [x] pnpm check
- [x] pnpm turbo boundaries
- [x] pnpm typecheck
- [x] git diff --check
- [x] SKIP_ENV_VALIDATION=true pnpm knip --include files (expected known unused-file backlog; touched files not listed)

## Reviews
- Spec compliance subagent: approved.
- Code-quality subagent: requested direct native OAuth route/native RPC auth behavior tests; re-review approved after added coverage.