### PR TITLE
refactor(api): isolate connector mcp http adapter

### DIFF
--- a/api/app/src/__tests__/connector-mcp-internal-adapter.test.ts
+++ b/api/app/src/__tests__/connector-mcp-internal-adapter.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const serviceMocks = vi.hoisted(() => ({
+  handleXConnectorMcpRequest: vi.fn(),
+}));
+
+vi.mock("../services/connectors/x-mcp-bridge", () => ({
+  handleXConnectorMcpRequest: serviceMocks.handleXConnectorMcpRequest,
+}));
+
+const { handleXConnectorMcpRequest } = await import(
+  "../adapters/internal/connector-mcp"
+);
+
+function mcpRequest(input: { body?: string; token?: string; url?: string }) {
+  return new Request(
+    input.url ?? "https://app.lightfast.localhost/api/connectors/x/mcp",
+    {
+      body: input.body,
+      headers: {
+        accept: "application/json, text/event-stream",
+        ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
+        "content-type": "application/json",
+      },
+      method: "POST",
+    }
+  );
+}
+
+describe("connector MCP internal adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceMocks.handleXConnectorMcpRequest.mockResolvedValue(
+      new Response("ok", { status: 200 })
+    );
+  });
+
+  it("parses JSON body, extracts the bearer token, and forwards explicit request context", async () => {
+    const body = { id: 1, jsonrpc: "2.0", method: "tools/list" };
+    const request = mcpRequest({
+      body: JSON.stringify(body),
+      token: "lfmcp_v1.test",
+      url: "https://custom.lightfast.localhost/api/connectors/x/mcp?cursor=1",
+    });
+
+    const response = await handleXConnectorMcpRequest(request);
+
+    expect(response.status).toBe(200);
+    expect(serviceMocks.handleXConnectorMcpRequest).toHaveBeenCalledWith({
+      appOrigin: "https://custom.lightfast.localhost",
+      parsedBody: body,
+      request,
+      token: "lfmcp_v1.test",
+    });
+  });
+
+  it("rejects malformed JSON before calling the service", async () => {
+    const response = await handleXConnectorMcpRequest(
+      mcpRequest({ body: "{bad json", token: "lfmcp_v1.test" })
+    );
+
+    await expect(response.text()).resolves.toBe("Invalid request body");
+    expect(response.status).toBe(400);
+    expect(serviceMocks.handleXConnectorMcpRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing bearer tokens before reading malformed request bodies", async () => {
+    const response = await handleXConnectorMcpRequest(
+      mcpRequest({ body: "{bad json" })
+    );
+
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(response.status).toBe(401);
+    expect(serviceMocks.handleXConnectorMcpRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing bearer tokens before calling the service", async () => {
+    const response = await handleXConnectorMcpRequest(
+      mcpRequest({
+        body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "tools/list" }),
+      })
+    );
+
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(response.status).toBe(401);
+    expect(serviceMocks.handleXConnectorMcpRequest).not.toHaveBeenCalled();
+  });
+});

--- a/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
@@ -62,6 +62,8 @@ describe("connector service domain errors", () => {
     expect(adapterSource).toContain("appOrigin");
     expect(adapterSource).toContain("token");
     expect(adapterSource).toContain("../../services/connectors/x-mcp-bridge");
-    expect(adapterSource).not.toContain('from "../../services/connectors"');
+    expect(adapterSource).not.toMatch(
+      /\bfrom\s*["']\.\.\/\.\.\/services\/connectors["']/
+    );
   });
 });

--- a/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
@@ -42,4 +42,26 @@ describe("connector service domain errors", () => {
       expect(fileSource, file).not.toContain("TRPCError");
     }
   });
+
+  it("keeps X connector MCP HTTP parsing in the internal adapter", () => {
+    const serviceSource = source("services/connectors/x-mcp-bridge.ts");
+    const adapterSource = source("adapters/internal/connector-mcp.ts");
+
+    expect(serviceSource).not.toContain("parseRequestBody");
+    expect(serviceSource).not.toContain("bearerToken");
+    expect(serviceSource).not.toContain('headers.get("authorization")');
+    expect(serviceSource).not.toContain("MALFORMED_JSON_REQUEST");
+    expect(serviceSource).not.toContain("Invalid request body");
+
+    expect(adapterSource).toContain("parseRequestBody");
+    expect(adapterSource).toContain("bearerToken");
+    expect(adapterSource).toContain('headers.get("authorization")');
+    expect(adapterSource).toContain("MALFORMED_JSON_REQUEST");
+    expect(adapterSource).toContain("Invalid request body");
+    expect(adapterSource).toContain("parsedBody");
+    expect(adapterSource).toContain("appOrigin");
+    expect(adapterSource).toContain("token");
+    expect(adapterSource).toContain("../../services/connectors/x-mcp-bridge");
+    expect(adapterSource).not.toContain('from "../../services/connectors"');
+  });
 });

--- a/api/app/src/__tests__/connectors-x-mcp-bridge.test.ts
+++ b/api/app/src/__tests__/connectors-x-mcp-bridge.test.ts
@@ -59,9 +59,16 @@ vi.mock("../env", () => ({ env: envMock }));
 const { issueConnectorMcpToken } = await import(
   "../services/connectors/mcp-auth"
 );
-const { getFreshXConnectorAccessToken, handleXConnectorMcpRequest } =
-  await import("../services/connectors/x-mcp-bridge");
+const {
+  getFreshXConnectorAccessToken,
+  handleXConnectorMcpRequest: handleXConnectorMcpServiceRequest,
+} = await import("../services/connectors/x-mcp-bridge");
 const { X_OAUTH_SCOPES } = await import("@lightfast/connector-x/oauth");
+
+const requestFixtureInput = new WeakMap<
+  Request,
+  { body: unknown; token: string | null }
+>();
 
 function connection(
   overrides: Partial<OrgConnectorConnection> = {}
@@ -98,25 +105,40 @@ function connection(
 }
 
 function mcpRequest(input: { body: unknown; token?: string }) {
-  return new Request("https://app.lightfast.localhost/api/connectors/x/mcp", {
-    body: JSON.stringify(input.body),
-    headers: {
-      accept: "application/json, text/event-stream",
-      ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
-      "content-type": "application/json",
-    },
-    method: "POST",
+  const request = new Request(
+    "https://app.lightfast.localhost/api/connectors/x/mcp",
+    {
+      body: JSON.stringify(input.body),
+      headers: {
+        accept: "application/json, text/event-stream",
+        ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
+        "content-type": "application/json",
+      },
+      method: "POST",
+    }
+  );
+
+  requestFixtureInput.set(request, {
+    body: input.body,
+    token: input.token ?? null,
   });
+
+  return request;
 }
 
-function malformedRequest() {
-  return new Request("https://app.lightfast.localhost/api/connectors/x/mcp", {
-    body: "{bad json",
-    headers: {
-      accept: "application/json, text/event-stream",
-      "content-type": "application/json",
-    },
-    method: "POST",
+async function handleXConnectorMcpRequest(input: {
+  request: Request;
+}): Promise<Response> {
+  const fixtureInput = requestFixtureInput.get(input.request);
+  if (!fixtureInput) {
+    throw new Error("MCP bridge test request fixture input missing.");
+  }
+
+  return await handleXConnectorMcpServiceRequest({
+    appOrigin: new URL(input.request.url).origin,
+    parsedBody: fixtureInput.body,
+    request: input.request,
+    token: fixtureInput.token,
   });
 }
 
@@ -443,15 +465,6 @@ describe("X MCP bridge service", () => {
     });
 
     expect(response.status).toBe(401);
-    expect(executeXApiToolMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects requests when the request body is not valid JSON", async () => {
-    const response = await handleXConnectorMcpRequest({
-      request: malformedRequest(),
-    });
-
-    expect(response.status).toBe(400);
     expect(executeXApiToolMock).not.toHaveBeenCalled();
   });
 

--- a/api/app/src/adapters/internal/connector-mcp.ts
+++ b/api/app/src/adapters/internal/connector-mcp.ts
@@ -1,7 +1,55 @@
-import { handleXConnectorMcpRequest as handleXConnectorMcpServiceRequest } from "../../services/connectors";
+import { handleXConnectorMcpRequest as handleXConnectorMcpServiceRequest } from "../../services/connectors/x-mcp-bridge";
+
+const MALFORMED_JSON_REQUEST = Symbol("malformed-json");
 
 export async function handleXConnectorMcpRequest(
   request: Request
 ): Promise<Response> {
-  return handleXConnectorMcpServiceRequest({ request });
+  const token = bearerToken(request.headers);
+  if (!token) {
+    return unauthorizedResponse();
+  }
+
+  const parsedBody = await parseRequestBody(request);
+  if (parsedBody === MALFORMED_JSON_REQUEST) {
+    return invalidRequestResponse();
+  }
+
+  return handleXConnectorMcpServiceRequest({
+    appOrigin: new URL(request.url).origin,
+    parsedBody,
+    request,
+    token,
+  });
+}
+
+async function parseRequestBody(request: Request): Promise<unknown> {
+  if (request.method !== "POST") {
+    return;
+  }
+
+  const text = await request.clone().text();
+  if (!text) {
+    return;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return MALFORMED_JSON_REQUEST;
+  }
+}
+
+function bearerToken(headers: Headers): string | null {
+  const authorization = headers.get("authorization");
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] ?? null;
+}
+
+function unauthorizedResponse() {
+  return new Response("Unauthorized", { status: 401 });
+}
+
+function invalidRequestResponse() {
+  return new Response("Invalid request body", { status: 400 });
 }

--- a/api/app/src/services/connectors/index.ts
+++ b/api/app/src/services/connectors/index.ts
@@ -61,7 +61,6 @@ export {
   startXConnectorOAuth,
   type XConnectorOAuthRedirectPaths,
 } from "./x-flow";
-export { handleXConnectorMcpRequest } from "./x-mcp-bridge";
 export { listConnectorsForOrg };
 
 function unsupportedProvider(provider: string): never {

--- a/api/app/src/services/connectors/x-mcp-bridge.ts
+++ b/api/app/src/services/connectors/x-mcp-bridge.ts
@@ -31,25 +31,24 @@ type XBridgeRequestKind =
   | { purpose: null };
 
 const permissiveToolInputSchema = z.object({}).passthrough();
-const MALFORMED_JSON_REQUEST = Symbol("malformed-json");
 
 type XToolArgs = Record<string, unknown>;
 
 export async function handleXConnectorMcpRequest(input: {
+  appOrigin: string;
+  parsedBody: unknown;
   request: Request;
+  token: string | null;
 }): Promise<Response> {
-  const parsedBody = await parseRequestBody(input.request);
-  if (parsedBody === MALFORMED_JSON_REQUEST) {
-    return invalidRequestResponse();
-  }
-
-  const token = bearerToken(input.request.headers);
-  if (!token) {
+  if (!input.token) {
     return unauthorizedResponse();
   }
 
-  const requestKind = deriveRequestKind(parsedBody);
-  const claims = await verifyXBridgeToken({ requestKind, token });
+  const requestKind = deriveRequestKind(input.parsedBody);
+  const claims = await verifyXBridgeToken({
+    requestKind,
+    token: input.token,
+  });
   if (!claims) {
     return unauthorizedResponse();
   }
@@ -67,7 +66,7 @@ export async function handleXConnectorMcpRequest(input: {
     version: "0.1.0",
   });
   registerXTools(server, {
-    appOrigin: new URL(input.request.url).origin,
+    appOrigin: input.appOrigin,
     claims,
     connection,
   });
@@ -79,7 +78,9 @@ export async function handleXConnectorMcpRequest(input: {
 
   try {
     await server.connect(transport);
-    return await transport.handleRequest(input.request, { parsedBody });
+    return await transport.handleRequest(input.request, {
+      parsedBody: input.parsedBody,
+    });
   } finally {
     await server.close();
   }
@@ -310,23 +311,6 @@ async function getAuthorizedXConnection(input: {
   return connection;
 }
 
-async function parseRequestBody(request: Request): Promise<unknown> {
-  if (request.method !== "POST") {
-    return;
-  }
-
-  const text = await request.clone().text();
-  if (!text) {
-    return;
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return MALFORMED_JSON_REQUEST;
-  }
-}
-
 function deriveRequestKind(parsedBody: unknown): XBridgeRequestKind {
   const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
   const methods = messages.flatMap((message) =>
@@ -358,18 +342,8 @@ function toolNameFromParams(params: unknown): string | undefined {
   return typeof name === "string" ? name : undefined;
 }
 
-function bearerToken(headers: Headers): string | null {
-  const authorization = headers.get("authorization");
-  const match = authorization?.match(/^Bearer\s+(.+)$/i);
-  return match?.[1] ?? null;
-}
-
 function unauthorizedResponse() {
   return new Response("Unauthorized", { status: 401 });
-}
-
-function invalidRequestResponse() {
-  return new Response("Invalid request body", { status: 400 });
 }
 
 function shouldRefreshAccessToken(connection: OrgConnectorConnection) {

--- a/apps/app/src/__tests__/connectors-routes.test.ts
+++ b/apps/app/src/__tests__/connectors-routes.test.ts
@@ -116,8 +116,8 @@ describe("app connector API routes", () => {
       "../../services/connectors/x-mcp-bridge"
     );
     expect(connectorMcpAdapterSource).toContain("handleXConnectorMcpRequest");
-    expect(connectorMcpAdapterSource).not.toContain(
-      '../../services/connectors"'
+    expect(connectorMcpAdapterSource).not.toMatch(
+      /\bfrom\s*["']\.\.\/\.\.\/services\/connectors["']/
     );
 
     for (const routeSource of [xMcpSource, connectorMcpAdapterSource]) {

--- a/apps/app/src/__tests__/connectors-routes.test.ts
+++ b/apps/app/src/__tests__/connectors-routes.test.ts
@@ -112,8 +112,13 @@ describe("app connector API routes", () => {
       default: "./src/adapters/internal/connector-mcp.ts",
       types: "./src/adapters/internal/connector-mcp.ts",
     });
-    expect(connectorMcpAdapterSource).toContain("../../services/connectors");
+    expect(connectorMcpAdapterSource).toContain(
+      "../../services/connectors/x-mcp-bridge"
+    );
     expect(connectorMcpAdapterSource).toContain("handleXConnectorMcpRequest");
+    expect(connectorMcpAdapterSource).not.toContain(
+      '../../services/connectors"'
+    );
 
     for (const routeSource of [xMcpSource, connectorMcpAdapterSource]) {
       expect(routeSource).not.toContain("next/");


### PR DESCRIPTION
## Summary
- move X connector MCP request body parsing, malformed JSON handling, bearer extraction, and app-origin derivation into the internal connector MCP adapter
- make the X connector MCP bridge service accept explicit appOrigin, parsedBody, request, and token values
- remove the X MCP handler from the connector service barrel and add adapter/source-boundary tests

## Verification
- pnpm --filter @api/app test -- src/__tests__/connector-mcp-internal-adapter.test.ts src/__tests__/connector-service-domain-errors-source.test.ts src/__tests__/connectors-x-mcp-bridge.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- git diff --check
- pnpm turbo boundaries
- pnpm typecheck
- SKIP_ENV_VALIDATION=true pnpm knip --include files (fails on known unused-file backlog; no touched/new files listed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request validation architecture with clearer error responses for missing authentication (401) and invalid request bodies (400).
  * Enhanced separation of concerns between HTTP request handling and service logic processing.

* **Tests**
  * Added comprehensive test coverage for request validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->