### PR TITLE
refactor(api): keep github webhook service response-neutral

### DIFF
--- a/api/app/src/__tests__/github-webhook-boundary-source.test.ts
+++ b/api/app/src/__tests__/github-webhook-boundary-source.test.ts
@@ -23,6 +23,9 @@ describe("GitHub webhook request boundary", () => {
 
     expect(serviceSource).toContain("handleVerifiedGitHubWebhook");
     expect(serviceSource).not.toContain("request: Request");
+    expect(serviceSource).not.toContain("Promise<Response>");
+    expect(serviceSource).not.toContain("Response.json");
+    expect(serviceSource).not.toContain("new Response");
     expect(serviceSource).not.toContain("env");
     expect(serviceSource).not.toContain("verifyGitHubWebhookSignature");
     expect(serviceSource).not.toContain("x-hub-signature-256");

--- a/api/app/src/adapters/internal/github-webhook.ts
+++ b/api/app/src/adapters/internal/github-webhook.ts
@@ -101,9 +101,10 @@ export async function handleGitHubWebhookRequest(
     return response(401, { ok: false });
   }
 
-  return handleVerifiedGitHubWebhook({
+  const result = await handleVerifiedGitHubWebhook({
     body,
     deliveryId: headers.deliveryId,
     event: headers.event,
   });
+  return response(result.status, result.body);
 }

--- a/api/app/src/services/github/webhook/handler.ts
+++ b/api/app/src/services/github/webhook/handler.ts
@@ -25,8 +25,16 @@ import { inngest } from "../../../inngest/client";
 
 const ZERO_SHA = "0".repeat(40);
 
-function response(status: number, body: Record<string, unknown>) {
-  return Response.json(body, { status });
+export interface GitHubWebhookResult {
+  body: Record<string, unknown>;
+  status: number;
+}
+
+function webhookResult(
+  status: number,
+  body: Record<string, unknown>
+): GitHubWebhookResult {
+  return { body, status };
 }
 
 function webhookRejectionMeta(input: {
@@ -61,10 +69,10 @@ async function handleGitHubPrWebhook(input: {
   deliveryId: string;
   event: string;
   json: unknown;
-}): Promise<Response> {
+}): Promise<GitHubWebhookResult> {
   const parsedEvent = githubPrWebhookEventSchema.safeParse(input.event);
   if (!parsedEvent.success) {
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const parsedPayload = githubPrWebhookPayloadSchema.safeParse(input.json);
@@ -75,7 +83,7 @@ async function handleGitHubPrWebhook(input: {
       reason: "invalid_pr_payload",
       status: 400,
     });
-    return response(400, { ok: false });
+    return webhookResult(400, { ok: false });
   }
   const rawPayload = input.json as Record<string, unknown>;
 
@@ -92,11 +100,11 @@ async function handleGitHubPrWebhook(input: {
       reason: "invalid_pr_payload_normalization",
       status: 400,
     });
-    return response(400, { ok: false });
+    return webhookResult(400, { ok: false });
   }
 
   if (!normalized) {
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const binding = await getOrgBindingByProviderInstallation(db, {
@@ -104,7 +112,7 @@ async function handleGitHubPrWebhook(input: {
     providerInstallationId: normalized.providerInstallationId,
   });
   if (!binding || binding.status !== "active") {
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const watch = await getWatchedSourceControlRepository(db, {
@@ -112,11 +120,11 @@ async function handleGitHubPrWebhook(input: {
     providerRepositoryId: normalized.providerRepositoryId,
   });
   if (!watch) {
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   if (!watchesWebhookEvent(watch.watchedWebhookEvents, normalized.event)) {
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   await recordSourceControlPrWebhookDelivery(db, {
@@ -133,19 +141,19 @@ async function handleGitHubPrWebhook(input: {
     sourceControlRepositoryId: watch.id,
   });
 
-  return response(202, { ok: true });
+  return webhookResult(202, { ok: true });
 }
 
 export async function handleVerifiedGitHubWebhook(input: {
   body: string;
   deliveryId: string;
   event: string;
-}): Promise<Response> {
+}): Promise<GitHubWebhookResult> {
   const isPrWebhookEvent = githubPrWebhookEventSchema.safeParse(
     input.event
   ).success;
   if (input.event !== "ping" && input.event !== "push" && !isPrWebhookEvent) {
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   let json: unknown;
@@ -158,7 +166,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       reason: "malformed_json",
       status: 400,
     });
-    return response(400, { ok: false });
+    return webhookResult(400, { ok: false });
   }
 
   if (input.event === "ping") {
@@ -170,9 +178,9 @@ export async function handleVerifiedGitHubWebhook(input: {
         reason: "invalid_ping_payload",
         status: 400,
       });
-      return response(400, { ok: false });
+      return webhookResult(400, { ok: false });
     }
-    return response(202, { ok: true });
+    return webhookResult(202, { ok: true });
   }
 
   if (isPrWebhookEvent) {
@@ -191,7 +199,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       reason: "invalid_push_payload",
       status: 400,
     });
-    return response(400, { ok: false });
+    return webhookResult(400, { ok: false });
   }
 
   const push = normalizeGitHubPushWebhookPayload(parsedPush.data);
@@ -204,7 +212,7 @@ export async function handleVerifiedGitHubWebhook(input: {
   const delivery = deliveryRecord.delivery;
 
   if (delivery.status !== "received") {
-    return response(202, { ok: true, duplicate: true });
+    return webhookResult(202, { ok: true, duplicate: true });
   }
 
   if (push.afterSha === ZERO_SHA) {
@@ -212,7 +220,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       deliveryId: input.deliveryId,
       status: "ignored",
     });
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const binding = await getOrgBindingByProviderInstallation(db, {
@@ -224,7 +232,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       deliveryId: input.deliveryId,
       status: "ignored",
     });
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const watch = await getWatchedSourceControlRepository(db, {
@@ -236,7 +244,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       deliveryId: input.deliveryId,
       status: "ignored",
     });
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   if (watch.syncStatus !== "enabled") {
@@ -244,7 +252,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       deliveryId: input.deliveryId,
       status: "ignored",
     });
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   if (watch.watchedPathGlobs === null) {
@@ -252,7 +260,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       deliveryId: input.deliveryId,
       status: "ignored",
     });
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const changedPathsMatch = matchesAnyWatchedPath(
@@ -267,7 +275,7 @@ export async function handleVerifiedGitHubWebhook(input: {
       deliveryId: input.deliveryId,
       status: "ignored",
     });
-    return response(202, { ok: true, ignored: true });
+    return webhookResult(202, { ok: true, ignored: true });
   }
 
   const event = sourceControlRepositoryPushEventSchema.parse({
@@ -285,5 +293,5 @@ export async function handleVerifiedGitHubWebhook(input: {
     status: "queued",
   });
 
-  return response(202, { ok: true });
+  return webhookResult(202, { ok: true });
 }


### PR DESCRIPTION
## Summary
- make the verified GitHub webhook service return a transport-neutral result instead of constructing Response objects
- keep HTTP response mapping in the internal GitHub webhook adapter
- extend the webhook boundary source ratchet to prevent Response construction from returning to the service

## Verification
- pnpm --filter @api/app test -- src/__tests__/github-webhook-boundary-source.test.ts src/__tests__/github-webhook.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/github-routes.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- git diff --check
- pnpm turbo boundaries
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog; touched files not listed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests to strengthen GitHub webhook boundary checks.

* **Refactor**
  * Standardized webhook response handling across all GitHub event types.
  * Improved webhook error reporting with consistent result validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->