### PR TITLE
refactor(api): narrow github webhook service import

### DIFF
--- a/api/app/src/__tests__/github-webhook-boundary-source.test.ts
+++ b/api/app/src/__tests__/github-webhook-boundary-source.test.ts
@@ -14,12 +14,18 @@ describe("GitHub webhook request boundary", () => {
       resolve(apiRoot, "services/github/webhook/handler.ts"),
       "utf8"
     );
+    const serviceIndexSource = readFileSync(
+      resolve(apiRoot, "services/github/index.ts"),
+      "utf8"
+    );
 
     expect(adapterSource).toContain("GITHUB_APP_WEBHOOK_SECRET");
     expect(adapterSource).toContain("verifyGitHubWebhookSignature");
     expect(adapterSource).toContain("githubWebhookHeadersSchema");
     expect(adapterSource).toContain("request.text()");
     expect(adapterSource).toContain("handleVerifiedGitHubWebhook");
+    expect(adapterSource).toContain('../../services/github/webhook/handler"');
+    expect(adapterSource).not.toContain('../../services/github"');
 
     expect(serviceSource).toContain("handleVerifiedGitHubWebhook");
     expect(serviceSource).not.toContain("request: Request");
@@ -30,5 +36,7 @@ describe("GitHub webhook request boundary", () => {
     expect(serviceSource).not.toContain("verifyGitHubWebhookSignature");
     expect(serviceSource).not.toContain("x-hub-signature-256");
     expect(serviceSource).not.toContain("input.request");
+
+    expect(serviceIndexSource).not.toContain("handleVerifiedGitHubWebhook");
   });
 });

--- a/api/app/src/adapters/internal/github-webhook.ts
+++ b/api/app/src/adapters/internal/github-webhook.ts
@@ -3,7 +3,7 @@ import { verifyGitHubWebhookSignature } from "@lightfast/connector-github/node";
 import { log } from "@vendor/observability/log/next";
 
 import { env } from "../../env";
-import { handleVerifiedGitHubWebhook } from "../../services/github";
+import { handleVerifiedGitHubWebhook } from "../../services/github/webhook/handler";
 
 function response(status: number, body: Record<string, unknown>) {
   return Response.json(body, { status });

--- a/api/app/src/services/github/index.ts
+++ b/api/app/src/services/github/index.ts
@@ -23,4 +23,3 @@ export {
 } from "./user-account/flow";
 export { requireGitHubUserAccount } from "./user-account/gate";
 export { getFreshGitHubUserAccessToken } from "./user-account/refresh";
-export { handleVerifiedGitHubWebhook } from "./webhook";

--- a/api/app/src/services/github/webhook/index.ts
+++ b/api/app/src/services/github/webhook/index.ts
@@ -1,1 +1,0 @@
-export { handleVerifiedGitHubWebhook } from "./handler";


### PR DESCRIPTION
## Summary
- Import the GitHub webhook service from its concrete handler instead of the broad GitHub service barrel.
- Remove the now-unused webhook service barrel export.
- Add a source-boundary ratchet so the adapter stays pinned to the concrete webhook handler.

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/github-webhook-boundary-source.test.ts src/__tests__/github-webhook.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/github-routes.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm knip --include files (fails only on known unused-file backlog; touched/deleted webhook files are not reported)