### PR TITLE
refactor(api): narrow connector oauth service imports

### DIFF
--- a/api/app/src/__tests__/connector-oauth-boundary-source.test.ts
+++ b/api/app/src/__tests__/connector-oauth-boundary-source.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("connector OAuth request boundary", () => {
+  it("imports concrete connector OAuth services instead of broad service barrels", () => {
+    const adapterSource = source("adapters/internal/connector-oauth.ts");
+
+    expect(adapterSource).toContain("../../services/connectors/linear-flow");
+    expect(adapterSource).toContain("../../services/connectors/x-flow");
+    expect(adapterSource).toContain(
+      "../../services/user-connectors/granola-flow"
+    );
+    expect(adapterSource).not.toMatch(
+      /\bfrom\s*["']\.\.\/\.\.\/services\/connectors["']/
+    );
+    expect(adapterSource).not.toMatch(
+      /\bfrom\s*["']\.\.\/\.\.\/services\/user-connectors["']/
+    );
+  });
+
+  it("does not expose OAuth callback completion helpers from broad service barrels", () => {
+    const connectorIndexSource = source("services/connectors/index.ts");
+    const userConnectorIndexSource = source(
+      "services/user-connectors/index.ts"
+    );
+
+    expect(connectorIndexSource).not.toContain("completeLinearConnectorOAuth");
+    expect(connectorIndexSource).not.toContain("completeXConnectorOAuth");
+    expect(connectorIndexSource).toContain("startConnectorOAuth");
+    expect(connectorIndexSource).toContain("refreshConnectorTools");
+
+    expect(userConnectorIndexSource).not.toContain(
+      "completeGranolaUserConnectorOAuth"
+    );
+    expect(userConnectorIndexSource).not.toContain(
+      "startGranolaUserConnectorOAuth"
+    );
+    expect(userConnectorIndexSource).not.toContain(
+      "disconnectGranolaUserConnector"
+    );
+    expect(userConnectorIndexSource).toContain("listUserConnectorsForViewer");
+  });
+});

--- a/api/app/src/__tests__/connector-oauth-internal-adapter.test.ts
+++ b/api/app/src/__tests__/connector-oauth-internal-adapter.test.ts
@@ -7,12 +7,15 @@ vi.mock("@vendor/clerk/server", () => ({
   auth: authMock,
 }));
 
-vi.mock("../services/connectors", () => ({
+vi.mock("../services/connectors/linear-flow", () => ({
   completeLinearConnectorOAuth: vi.fn(),
+}));
+
+vi.mock("../services/connectors/x-flow", () => ({
   completeXConnectorOAuth: vi.fn(),
 }));
 
-vi.mock("../services/user-connectors", () => ({
+vi.mock("../services/user-connectors/granola-flow", () => ({
   completeGranolaUserConnectorOAuth: completeGranolaUserConnectorOAuthMock,
 }));
 

--- a/api/app/src/__tests__/user-connectors-flow.test.ts
+++ b/api/app/src/__tests__/user-connectors-flow.test.ts
@@ -141,9 +141,11 @@ vi.mock("../env", () => ({ env: envMock }));
 const {
   completeGranolaUserConnectorOAuth,
   disconnectGranolaUserConnector,
-  listUserConnectorsForViewer,
   startGranolaUserConnectorOAuth,
-} = await import("../services/user-connectors");
+} = await import("../services/user-connectors/granola-flow");
+const { listUserConnectorsForViewer } = await import(
+  "../services/user-connectors"
+);
 
 function userConnection(
   overrides: Partial<UserConnectorConnection> = {}

--- a/api/app/src/adapters/internal/connector-oauth.ts
+++ b/api/app/src/adapters/internal/connector-oauth.ts
@@ -1,11 +1,11 @@
 import { auth } from "@vendor/clerk/server";
 
+import { completeLinearConnectorOAuth } from "../../services/connectors/linear-flow";
 import {
-  completeLinearConnectorOAuth,
   completeXConnectorOAuth,
   type XConnectorOAuthRedirectPaths,
-} from "../../services/connectors";
-import { completeGranolaUserConnectorOAuth } from "../../services/user-connectors";
+} from "../../services/connectors/x-flow";
+import { completeGranolaUserConnectorOAuth } from "../../services/user-connectors/granola-flow";
 
 export type { XConnectorOAuthRedirectPaths };
 

--- a/api/app/src/services/connectors/index.ts
+++ b/api/app/src/services/connectors/index.ts
@@ -44,23 +44,6 @@ export {
   callChatProviderRoutine,
   findChatProviderRoutines,
 } from "./chat-routines";
-export {
-  completeLinearConnectorOAuth,
-  disconnectLinearConnector,
-  refreshLinearConnectorTools,
-  setLinearConnectorAgentEnabled,
-  setLinearConnectorAutomationEnabled,
-  startLinearConnectorOAuth,
-} from "./linear-flow";
-export {
-  completeXConnectorOAuth,
-  disconnectXConnector,
-  refreshXConnectorTools,
-  setXConnectorAgentEnabled,
-  setXConnectorAutomationEnabled,
-  startXConnectorOAuth,
-  type XConnectorOAuthRedirectPaths,
-} from "./x-flow";
 export { listConnectorsForOrg };
 
 function unsupportedProvider(provider: string): never {

--- a/api/app/src/services/user-connectors/index.ts
+++ b/api/app/src/services/user-connectors/index.ts
@@ -1,6 +1,1 @@
 export { listUserConnectorsForViewer } from "./catalog";
-export {
-  completeGranolaUserConnectorOAuth,
-  disconnectGranolaUserConnector,
-  startGranolaUserConnectorOAuth,
-} from "./granola-flow";


### PR DESCRIPTION
## Summary
- Import connector OAuth callback services from concrete provider flow files in the internal adapter.
- Stop exposing OAuth callback completion helpers from the broad connector service barrels.
- Add a source-boundary ratchet for connector OAuth adapter imports and service-barrel exports.

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/connector-oauth-boundary-source.test.ts src/__tests__/connector-oauth-internal-adapter.test.ts src/__tests__/connectors-flow.test.ts src/__tests__/user-connectors-flow.test.ts src/__tests__/connector-service-domain-errors-source.test.ts
- pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts
- pnpm --filter @api/app typecheck
- pnpm --filter @lightfast/app typecheck
- pnpm check
- pnpm turbo boundaries
- git diff --check
- SKIP_ENV_VALIDATION=true pnpm knip --include files (fails only on known unused-file backlog; touched connector files are not reported)