### PR TITLE
refactor(api): remove user connectors service barrel

### DIFF
--- a/api/app/src/__tests__/app-trpc-root-source.test.ts
+++ b/api/app/src/__tests__/app-trpc-root-source.test.ts
@@ -50,7 +50,6 @@ describe("api/app app-facing tRPC root", () => {
       "services/developer-sandbox-runs/index.ts",
       "services/user-connectors/catalog.ts",
       "services/user-connectors/granola-flow.ts",
-      "services/user-connectors/index.ts",
     ];
     for (const file of rawAuthFreeServiceFiles) {
       const fileSource = source(file);

--- a/api/app/src/__tests__/connector-oauth-boundary-source.test.ts
+++ b/api/app/src/__tests__/connector-oauth-boundary-source.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -27,8 +27,8 @@ describe("connector OAuth request boundary", () => {
 
   it("does not expose OAuth callback completion helpers from broad service barrels", () => {
     const connectorIndexSource = source("services/connectors/index.ts");
-    const userConnectorIndexSource = source(
-      "services/user-connectors/index.ts"
+    const userConnectorCatalogSource = source(
+      "services/user-connectors/catalog.ts"
     );
 
     expect(connectorIndexSource).not.toContain("completeLinearConnectorOAuth");
@@ -36,15 +36,18 @@ describe("connector OAuth request boundary", () => {
     expect(connectorIndexSource).toContain("startConnectorOAuth");
     expect(connectorIndexSource).toContain("refreshConnectorTools");
 
-    expect(userConnectorIndexSource).not.toContain(
+    expect(
+      existsSync(resolve(apiRoot, "services/user-connectors/index.ts"))
+    ).toBe(false);
+    expect(userConnectorCatalogSource).not.toContain(
       "completeGranolaUserConnectorOAuth"
     );
-    expect(userConnectorIndexSource).not.toContain(
+    expect(userConnectorCatalogSource).not.toContain(
       "startGranolaUserConnectorOAuth"
     );
-    expect(userConnectorIndexSource).not.toContain(
+    expect(userConnectorCatalogSource).not.toContain(
       "disconnectGranolaUserConnector"
     );
-    expect(userConnectorIndexSource).toContain("listUserConnectorsForViewer");
+    expect(userConnectorCatalogSource).toContain("listUserConnectorsForViewer");
   });
 });

--- a/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
+++ b/api/app/src/__tests__/connector-service-domain-errors-source.test.ts
@@ -21,12 +21,12 @@ describe("connector service domain errors", () => {
       expect(fileSource, file).not.toContain("TRPCError");
     }
 
-    const userConnectorIndexSource = source(
-      "services/user-connectors/index.ts"
+    const userConnectorCatalogSource = source(
+      "services/user-connectors/catalog.ts"
     );
-    expect(userConnectorIndexSource).not.toContain("../../domain/errors");
-    expect(userConnectorIndexSource).not.toContain("switch");
-    expect(userConnectorIndexSource).not.toContain("unsupportedProvider");
+    expect(userConnectorCatalogSource).not.toContain("../../domain/errors");
+    expect(userConnectorCatalogSource).not.toContain("switch");
+    expect(userConnectorCatalogSource).not.toContain("unsupportedProvider");
   });
 
   it("keeps connector provider flow errors framework-neutral", () => {

--- a/api/app/src/__tests__/connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/connectors-domain-commands.test.ts
@@ -34,7 +34,7 @@ vi.mock("../services/connectors", () => ({
   startConnectorOAuth: serviceMocks.startConnectorOAuth,
 }));
 
-vi.mock("../services/user-connectors", () => ({
+vi.mock("../services/user-connectors/catalog", () => ({
   listUserConnectorsForViewer: serviceMocks.listUserConnectorsForViewer,
 }));
 

--- a/api/app/src/__tests__/user-connectors-flow.test.ts
+++ b/api/app/src/__tests__/user-connectors-flow.test.ts
@@ -144,7 +144,7 @@ const {
   startGranolaUserConnectorOAuth,
 } = await import("../services/user-connectors/granola-flow");
 const { listUserConnectorsForViewer } = await import(
-  "../services/user-connectors"
+  "../services/user-connectors/catalog"
 );
 
 function userConnection(

--- a/api/app/src/__tests__/user-connectors-service-boundary-source.test.ts
+++ b/api/app/src/__tests__/user-connectors-service-boundary-source.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+function sourceFiles(dir = apiRoot): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absPath = resolve(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return sourceFiles(absPath);
+    }
+
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [absPath] : [];
+  });
+}
+
+function isThisTestFile(path: string) {
+  return path.endsWith(
+    "src/__tests__/user-connectors-service-boundary-source.test.ts"
+  );
+}
+
+describe("user connector service boundary", () => {
+  it("pins user connector catalog imports to the concrete service module", () => {
+    const connectorCommandsSource = source("domain/connectors/commands.ts");
+    const connectorCommandsTestSource = source(
+      "__tests__/connectors-domain-commands.test.ts"
+    );
+    const userConnectorsFlowTestSource = source(
+      "__tests__/user-connectors-flow.test.ts"
+    );
+
+    expect(connectorCommandsSource).toContain(
+      "../../services/user-connectors/catalog"
+    );
+    expect(connectorCommandsSource).not.toMatch(
+      /\bfrom\s*["']\.\.\/\.\.\/services\/user-connectors["']/
+    );
+    expect(connectorCommandsTestSource).toContain(
+      "../services/user-connectors/catalog"
+    );
+    expect(userConnectorsFlowTestSource).toContain(
+      "../services/user-connectors/catalog"
+    );
+  });
+
+  it("does not keep a broad user connector service barrel", () => {
+    expect(
+      existsSync(resolve(apiRoot, "services/user-connectors/index.ts"))
+    ).toBe(false);
+  });
+
+  it("does not import the broad user connector service path", () => {
+    const bareSpecifierPattern =
+      /(?:from|import|vi\.mock)\(\s*["'][^"']*services\/user-connectors["']\s*\)|\bfrom\s*["'][^"']*services\/user-connectors["']/;
+    const offenders = sourceFiles()
+      .filter((path) => !isThisTestFile(path))
+      .map((path) => ({
+        path: relative(apiRoot, path),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ source }) => bareSpecifierPattern.test(source))
+      .map(({ path }) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/api/app/src/domain/connectors/commands.ts
+++ b/api/app/src/domain/connectors/commands.ts
@@ -10,7 +10,7 @@ import {
   setConnectorAutomationEnabled,
   startConnectorOAuth,
 } from "../../services/connectors";
-import { listUserConnectorsForViewer } from "../../services/user-connectors";
+import { listUserConnectorsForViewer } from "../../services/user-connectors/catalog";
 import type { ExecutionContext } from "../actor";
 import { defineCommand } from "../command";
 import {

--- a/api/app/src/services/user-connectors/index.ts
+++ b/api/app/src/services/user-connectors/index.ts
@@ -1,1 +1,0 @@
-export { listUserConnectorsForViewer } from "./catalog";


### PR DESCRIPTION
## Summary
- remove the one-line `api/app/src/services/user-connectors` barrel
- import the user connector catalog directly from `services/user-connectors/catalog`
- add a source ratchet that scans API source/tests for bare `services/user-connectors` specifiers

## Test Plan
- [x] `pnpm --filter @api/app test -- src/__tests__/user-connectors-service-boundary-source.test.ts src/__tests__/connectors-domain-commands.test.ts src/__tests__/user-connectors-flow.test.ts src/__tests__/app-trpc-root-source.test.ts src/__tests__/connector-oauth-boundary-source.test.ts src/__tests__/connector-service-domain-errors-source.test.ts`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/connectors-routes.test.ts`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` (fails only on known unused-file backlog; touched/deleted user connector files do not appear)

## Review
- [x] subagent review found one ratchet-hardening concern; fixed by scanning API source files for bare user connector service specifiers
