### PR TITLE
refactor(api): remove team members service barrel

### DIFF
--- a/api/app/src/__tests__/team-member-reconciler-workflow.test.ts
+++ b/api/app/src/__tests__/team-member-reconciler-workflow.test.ts
@@ -34,7 +34,7 @@ vi.mock("@vendor/observability/log/next", () => ({
   },
 }));
 
-vi.mock("../services/team-members", () => ({
+vi.mock("../services/team-members/people-sync", () => ({
   syncTeamMembersForOrg: syncTeamMembersForOrgMock,
 }));
 

--- a/api/app/src/__tests__/team-members-service-boundary-source.test.ts
+++ b/api/app/src/__tests__/team-members-service-boundary-source.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const apiRoot = resolve(import.meta.dirname, "..");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+function sourceFiles(dir = apiRoot): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absPath = resolve(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return sourceFiles(absPath);
+    }
+
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [absPath] : [];
+  });
+}
+
+function isThisTestFile(path: string) {
+  return path.endsWith(
+    "src/__tests__/team-members-service-boundary-source.test.ts"
+  );
+}
+
+describe("team member service boundary", () => {
+  it("pins team member sync imports to the concrete people-sync module", () => {
+    const workflowSource = source("inngest/workflow/team-member-reconciler.ts");
+    const workflowTestSource = source(
+      "__tests__/team-member-reconciler-workflow.test.ts"
+    );
+
+    expect(workflowSource).toContain("../../services/team-members/people-sync");
+    expect(workflowTestSource).toContain(
+      "../services/team-members/people-sync"
+    );
+  });
+
+  it("does not keep a broad team member service barrel", () => {
+    expect(existsSync(resolve(apiRoot, "services/team-members/index.ts"))).toBe(
+      false
+    );
+  });
+
+  it("does not import the broad team member service path", () => {
+    const bareSpecifierPattern =
+      /(?:from|import|vi\.mock)\(\s*["'][^"']*services\/team-members["']\s*\)|\bfrom\s*["'][^"']*services\/team-members["']/;
+    const offenders = sourceFiles()
+      .filter((path) => !isThisTestFile(path))
+      .map((path) => ({
+        path: relative(apiRoot, path),
+        source: readFileSync(path, "utf8"),
+      }))
+      .filter(({ source }) => bareSpecifierPattern.test(source))
+      .map(({ path }) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/api/app/src/inngest/workflow/team-member-reconciler.ts
+++ b/api/app/src/inngest/workflow/team-member-reconciler.ts
@@ -3,7 +3,7 @@ import { db } from "@db/app/client";
 import { clerkClient } from "@vendor/clerk/server";
 import { log } from "@vendor/observability/log/next";
 
-import { syncTeamMembersForOrg } from "../../services/team-members";
+import { syncTeamMembersForOrg } from "../../services/team-members/people-sync";
 import { inngest } from "../client";
 import { appEvents } from "../schemas/app";
 

--- a/api/app/src/services/team-members/index.ts
+++ b/api/app/src/services/team-members/index.ts
@@ -1,7 +1,0 @@
-export {
-  type ClerkOrganizationMembership,
-  type ClerkOrganizationMembershipListClient,
-  listAcceptedOrgMemberships,
-  type SyncTeamMembersForOrgResult,
-  syncTeamMembersForOrg,
-} from "./people-sync";


### PR DESCRIPTION
## Summary
- remove the broad `api/app/src/services/team-members` barrel
- import team member sync directly from `services/team-members/people-sync`
- add a source ratchet that scans API source/tests for bare `services/team-members` specifiers

## Test Plan
- [x] `pnpm --filter @api/app test -- src/__tests__/team-members-service-boundary-source.test.ts src/__tests__/team-member-reconciler-workflow.test.ts src/__tests__/team-member-people-sync.test.ts`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` (fails only on known unused-file backlog; touched/deleted team-member files do not appear)
