### PR TITLE
refactor(app): keep signal cache keys-only

### DIFF
--- a/apps/app/src/__tests__/signals-queries-source.test.ts
+++ b/apps/app/src/__tests__/signals-queries-source.test.ts
@@ -6,19 +6,21 @@ const appRoot = resolve(import.meta.dirname, "../..");
 const repoRoot = resolve(appRoot, "../..");
 
 describe("signals query helpers", () => {
-  it("keeps signal keys and result types without a query-options abstraction", () => {
+  it("keeps the signal cache module keys-only without a query-options abstraction", () => {
     const queriesPath = resolve(appRoot, "src/signals/signals-queries.ts");
     const cacheSource = readFileSync(
       resolve(appRoot, "src/signals/signals-cache.ts"),
       "utf8"
     );
+    const modelSource = readFileSync(
+      resolve(appRoot, "src/signals/signals-model.ts"),
+      "utf8"
+    );
 
     expect(existsSync(queriesPath)).toBe(false);
-    expect(cacheSource).toContain('@api/app/tanstack/signals"');
     expect(cacheSource).toContain("signalQueryKeys");
-    expect(cacheSource).toContain("ProcessingSignalsResult");
-    expect(cacheSource).toContain("WorkingSetSignalsResult");
-    expect(cacheSource).toContain("SignalDetailQueryResult");
+    expect(cacheSource).not.toMatch(/@api\/app\/tanstack\/signals/);
+    expect(cacheSource).not.toContain("export type");
     expect(cacheSource).not.toContain("queryOptions");
     expect(cacheSource).not.toContain("signalDetailQueryOptions");
     expect(cacheSource).not.toContain("workingSetSignalsQueryOptions");
@@ -29,6 +31,8 @@ describe("signals query helpers", () => {
     expect(cacheSource).not.toContain("createSignalMutationOptions");
     expect(cacheSource).not.toContain("createSignal,");
     expect(cacheSource).not.toContain("useTRPC");
+    expect(modelSource).toContain('@api/app/tanstack/signals"');
+    expect(modelSource).not.toContain('from "./signals-cache"');
   });
 
   it("keeps detail reads inline at the query call sites", () => {

--- a/apps/app/src/signals/signals-cache.ts
+++ b/apps/app/src/signals/signals-cache.ts
@@ -1,16 +1,7 @@
-import type {
-  ListProcessingSignalsResult,
-  ListWorkingSetSignalsResult,
-  SignalDetailResult,
-} from "@api/app/tanstack/signals";
 import {
   PROCESSING_SIGNALS_LIMIT,
   signalProcessingStatuses,
 } from "./signals-model";
-
-export type ProcessingSignalsResult = ListProcessingSignalsResult;
-export type WorkingSetSignalsResult = ListWorkingSetSignalsResult;
-export type SignalDetailQueryResult = SignalDetailResult;
 
 export const signalQueryKeys = {
   all: ["signals"] as const,

--- a/apps/app/src/signals/signals-model.ts
+++ b/apps/app/src/signals/signals-model.ts
@@ -1,19 +1,19 @@
 import type {
-  ProcessingSignalsResult,
-  SignalDetailQueryResult,
-  WorkingSetSignalsResult,
-} from "./signals-cache";
+  ListProcessingSignalsResult,
+  ListWorkingSetSignalsResult,
+  SignalDetailResult,
+} from "@api/app/tanstack/signals";
 
 /** Full row from the cursor `list` query (processing path) — carries body fields. */
-export type SignalList = ProcessingSignalsResult;
+export type SignalList = ListProcessingSignalsResult;
 export type SignalRow = SignalList["items"][number];
 
 /** Projected working-set row (classified, no body). */
-export type WorkspaceSignals = WorkingSetSignalsResult;
+export type WorkspaceSignals = ListWorkingSetSignalsResult;
 export type WorkspaceSignalRow = WorkspaceSignals["items"][number];
 
 /** Full row from `get` — used for the detail body. */
-export type SignalDetailRow = SignalDetailQueryResult;
+export type SignalDetailRow = SignalDetailResult;
 
 /**
  * Canonical view-row type for list/grouping. It is the projected


### PR DESCRIPTION
## Summary
- keep `signals-cache.ts` focused on shared query keys only
- move signal result type derivation into `signals-model.ts`
- tighten the signal source ratchet so cache cannot import TanStack adapter result types

## Test Plan
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/signals-queries-source.test.ts` red first, failed on the existing `@api/app/tanstack/signals` import in `signals-cache.ts`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/signals-queries-source.test.ts src/__tests__/signals-no-trpc-source.test.ts src/__tests__/signals-signals-model.test.ts`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` failed only on known unused-file backlog; touched signal files were not reported
- [x] worktree dev stack opened with agent-browser at `https://auth-architecture-next-slice-31.lightfast.localhost`
- [x] public `/api/v1/system/health` returned API-key auth-required response without oRPC/tRPC catch-all
- [x] hosted MCP `/mcp` returned `invalid_token` without app env leakage symptoms
