### PR TITLE
Move API key actor mapping into auth layer

### DIFF
--- a/api/app/src/__tests__/api-key-actors.test.ts
+++ b/api/app/src/__tests__/api-key-actors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { actorFromApiKeyAuth } from "../auth/actors";
+import type { ApiKeyAuthResult } from "../auth/api-key";
+import type { AuthIdentity } from "../auth/identity";
+
+const boundIdentity: Extract<AuthIdentity, { type: "active" }> = {
+  type: "active",
+  userId: "user_test",
+  orgId: "org_test",
+  orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+};
+
+describe("actorFromApiKeyAuth", () => {
+  it("creates an org-scoped API-key actor with creator attribution", () => {
+    const auth: ApiKeyAuthResult = {
+      apiKeyId: "key_test",
+      identity: boundIdentity,
+      scopes: ["api.signals.read"],
+    };
+
+    expect(actorFromApiKeyAuth(auth)).toEqual({
+      createdByUserId: "user_test",
+      keyId: "key_test",
+      kind: "apiKey",
+      orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
+      orgId: "org_test",
+      scopes: ["api.signals.read"],
+    });
+  });
+});

--- a/api/app/src/__tests__/domain-core.test.ts
+++ b/api/app/src/__tests__/domain-core.test.ts
@@ -1,9 +1,9 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import type { ApiKeyAuthResult } from "../auth/api-key";
 import type { AuthIdentity } from "../auth/identity";
 import {
-  actorFromApiKeyAuth,
   actorFromAuthIdentity,
   DomainError,
   defineCommand,
@@ -11,6 +11,12 @@ import {
   dispatchCommand,
   requireBoundClerkOrgActor,
 } from "../domain";
+
+const apiSrcRoot = resolve(import.meta.dirname, "..");
+
+function apiSource(path: string) {
+  return readFileSync(resolve(apiSrcRoot, path), "utf8");
+}
 
 const boundIdentity: Extract<AuthIdentity, { type: "active" }> = {
   type: "active",
@@ -37,25 +43,6 @@ describe("actorFromAuthIdentity", () => {
       kind: "clerkUser",
       source: "web",
       userId: "user_test",
-    });
-  });
-});
-
-describe("actorFromApiKeyAuth", () => {
-  it("creates an org-scoped API-key actor with creator attribution", () => {
-    const auth: ApiKeyAuthResult = {
-      apiKeyId: "key_test",
-      identity: boundIdentity,
-      scopes: ["api.signals.read"],
-    };
-
-    expect(actorFromApiKeyAuth(auth)).toEqual({
-      createdByUserId: "user_test",
-      keyId: "key_test",
-      kind: "apiKey",
-      orgGate: { bindingStatus: "bound", nextSetupRequirement: null },
-      orgId: "org_test",
-      scopes: ["api.signals.read"],
     });
   });
 });
@@ -145,5 +132,17 @@ describe("dispatchCommand", () => {
     );
     expect(error.kind).toBe("validation");
     expect(error.code).toBe("INVALID_INPUT");
+  });
+});
+
+describe("domain actor boundary", () => {
+  it("stays independent of API-key auth result shapes and request transport types", () => {
+    const actorSource = apiSource("domain/actor.ts");
+
+    expect(actorSource).not.toContain("../auth/api-key");
+    expect(actorSource).not.toContain("ApiKeyAuthResult");
+    expect(actorSource).not.toContain("Headers");
+    expect(actorSource).not.toContain("Request");
+    expect(actorSource).not.toContain("Response");
   });
 });

--- a/api/app/src/adapters/public/signals.ts
+++ b/api/app/src/adapters/public/signals.ts
@@ -12,12 +12,13 @@ import {
 } from "@repo/api-contract";
 import { z } from "zod";
 
+import { actorFromApiKeyAuth } from "../../auth/actors";
 import {
   type ApiKeyAuthResult,
   isApiKeyAuthError,
   resolveApiKeyAuth,
 } from "../../auth/api-key";
-import { actorFromApiKeyAuth, isDomainError } from "../../domain";
+import { isDomainError } from "../../domain";
 import {
   createSignalCommand,
   createSignalCommandDeps,

--- a/api/app/src/auth/actors.ts
+++ b/api/app/src/auth/actors.ts
@@ -1,0 +1,13 @@
+import type { Actor } from "../domain/actor";
+import type { ApiKeyAuthResult } from "./api-key";
+
+export function actorFromApiKeyAuth(auth: ApiKeyAuthResult): Actor {
+  return {
+    createdByUserId: auth.identity.userId,
+    keyId: auth.apiKeyId,
+    kind: "apiKey",
+    orgGate: auth.identity.orgGate,
+    orgId: auth.identity.orgId,
+    scopes: auth.scopes,
+  };
+}

--- a/api/app/src/domain/actor.ts
+++ b/api/app/src/domain/actor.ts
@@ -1,4 +1,3 @@
-import type { ApiKeyAuthResult } from "../auth/api-key";
 import type { AuthIdentity, OrgGate } from "../auth/identity";
 import { AuthzError } from "./errors";
 
@@ -83,16 +82,5 @@ export function actorFromAuthIdentity(
     orgId: identity.orgId,
     source,
     userId: identity.userId,
-  };
-}
-
-export function actorFromApiKeyAuth(auth: ApiKeyAuthResult): Actor {
-  return {
-    createdByUserId: auth.identity.userId,
-    keyId: auth.apiKeyId,
-    kind: "apiKey",
-    orgGate: auth.identity.orgGate,
-    orgId: auth.identity.orgId,
-    scopes: auth.scopes,
   };
 }

--- a/apps/app/src/__tests__/public-api-routes-source.test.ts
+++ b/apps/app/src/__tests__/public-api-routes-source.test.ts
@@ -67,6 +67,7 @@ describe("public API route boundaries", () => {
 
     expect(packageJson.exports).toHaveProperty("./public-api/signals");
     expect(adapter).toContain("resolveApiKeyAuth");
+    expect(adapter).toContain('from "../../auth/actors"');
     expect(adapter).toContain("actorFromApiKeyAuth");
     expect(adapter).toContain("createSignalCommand");
     expect(adapter).toContain("getSignalCommand");
@@ -78,6 +79,7 @@ describe("public API route boundaries", () => {
     expect(adapter).not.toContain("ORPCError");
     expect(adapter).not.toContain("@orpc/");
     expect(adapter).not.toContain("OpenAPIHandler");
+    expect(adapter).not.toContain("actorFromApiKeyAuth, isDomainError");
   });
 
   it("keeps public system health behavior in an explicit api/app adapter", () => {


### PR DESCRIPTION
## Summary
- Move `actorFromApiKeyAuth` out of the domain actor module and into auth-owned API-key actor composition.
- Keep the public signals adapter as the adapter boundary that resolves API-key auth and maps it into a domain actor.
- Add source ratchets so `domain/actor.ts` stays independent of API-key auth result shapes and public routes use the auth-owned mapper.

## Test Plan
- [x] `pnpm --filter @api/app test -- src/__tests__/domain-core.test.ts src/__tests__/api-key-actors.test.ts`
- [x] `pnpm --filter @lightfast/app test -- src/__tests__/public-api-routes-source.test.ts`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] Agent-browser smoke opened `https://auth-architecture-next-slice-32.lightfast.localhost` and `/api/v1/signals`
- [x] `curl --cacert ~/.portless/ca.pem -i https://auth-architecture-next-slice-32.lightfast.localhost/api/v1/signals` returned `401 auth_required`
- [x] `curl --cacert ~/.portless/ca.pem -i -X OPTIONS https://auth-architecture-next-slice-32.lightfast.localhost/api/v1/signals` returned `204` with CORS headers

## Notes
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` still fails on the known repository unused-file backlog, but it does not report the new auth mapper or test file.