### PR TITLE
refactor: invert connector core provider primitive ownership

### DIFF
--- a/api/app/src/__tests__/connector-workspace-source.test.ts
+++ b/api/app/src/__tests__/connector-workspace-source.test.ts
@@ -78,9 +78,9 @@ describe("connector workspace boundary", () => {
     expect(existsSync(resolve(repoRoot, oldConnectorPath))).toBe(false);
     expect(connectorCorePackage.name).toBe("@lightfast/connector-core");
     expect(connectorCorePackage.private).toBe(true);
-    expect(connectorCorePackage.dependencies?.["@repo/api-contract"]).toBe(
-      "workspace:*"
-    );
+    expect(
+      connectorCorePackage.dependencies?.["@repo/api-contract"]
+    ).toBeUndefined();
     expect(connectorCorePackage.dependencies?.zod).toBe("catalog:");
     expect(Object.keys(connectorCorePackage.exports ?? {}).sort()).toEqual([
       ".",
@@ -133,14 +133,20 @@ describe("connector workspace boundary", () => {
     expect(
       existsSync(resolve(repoRoot, "connectors/core/src/provider-routines.ts"))
     ).toBe(false);
-    expect(
-      apiContractPackage.dependencies?.["@lightfast/connector-core"]
-    ).toBeUndefined();
-    expect(connectorCorePackage.dependencies?.["@repo/api-contract"]).toBe(
+    expect(apiContractPackage.dependencies?.["@lightfast/connector-core"]).toBe(
       "workspace:*"
     );
+    expect(
+      connectorCorePackage.dependencies?.["@repo/api-contract"]
+    ).toBeUndefined();
 
     const connectorCoreSource = source("connectors/core/src/index.ts");
+    const apiContractConnectorsSource = source(
+      "packages/api-contract/src/connectors.ts"
+    );
+
+    expect(connectorCoreSource).not.toContain("@repo/api-contract");
+    expect(apiContractConnectorsSource).toContain("@lightfast/connector-core");
     expect(connectorCoreSource).not.toContain("CONNECTOR_CATALOG");
     expect(connectorCoreSource).not.toContain("USER_CONNECTOR_CATALOG");
     expect(connectorCoreSource).not.toContain(
@@ -272,6 +278,19 @@ describe("connector workspace boundary", () => {
     const repoCiWorkflow = source(".github/workflows/ci.yml");
 
     expect(repoCiWorkflow.match(/'connectors\/\*\*'/g) ?? []).toHaveLength(2);
+  });
+
+  it("bundles connector core with public packages that inline api-contract", () => {
+    for (const path of [
+      "core/cli/tsup.config.ts",
+      "core/lightfast/tsup.config.ts",
+      "core/mcp/tsup.config.ts",
+    ]) {
+      const tsupSource = source(path);
+
+      expect(tsupSource).toContain('"@repo/api-contract"');
+      expect(tsupSource).toContain('"@lightfast/connector-core"');
+    }
   });
 
   it("hosts Linear provider runtime code behind explicit connector entrypoints", () => {

--- a/connectors/core/package.json
+++ b/connectors/core/package.json
@@ -17,7 +17,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@repo/api-contract": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/connectors/core/src/index.ts
+++ b/connectors/core/src/index.ts
@@ -1,20 +1,20 @@
-export {
-  CONNECTABLE_CONNECTOR_PROVIDERS,
-  CONNECTOR_PROVIDERS,
-  type ConnectableConnectorProvider,
-  type ConnectorProvider,
-  connectableConnectorProviderSchema,
-  connectorProviderSchema,
-  USER_CONNECTOR_PROVIDERS,
-  type UserConnectorProvider,
-  userConnectorProviderSchema,
-} from "@repo/api-contract";
-
-import {
-  type ConnectableConnectorProvider,
-  connectableConnectorProviderSchema,
-} from "@repo/api-contract";
 import { z } from "zod";
+
+export const CONNECTOR_PROVIDERS = ["linear", "x"] as const;
+export const connectorProviderSchema = z.enum(CONNECTOR_PROVIDERS);
+export type ConnectorProvider = z.infer<typeof connectorProviderSchema>;
+
+export const CONNECTABLE_CONNECTOR_PROVIDERS = ["linear", "x"] as const;
+export const connectableConnectorProviderSchema = z.enum(
+  CONNECTABLE_CONNECTOR_PROVIDERS
+);
+export type ConnectableConnectorProvider = z.infer<
+  typeof connectableConnectorProviderSchema
+>;
+
+export const USER_CONNECTOR_PROVIDERS = ["granola"] as const;
+export const userConnectorProviderSchema = z.enum(USER_CONNECTOR_PROVIDERS);
+export type UserConnectorProvider = z.infer<typeof userConnectorProviderSchema>;
 
 export const connectorToolNameSchema = z
   .string()

--- a/core/cli/tsup.config.ts
+++ b/core/cli/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   target: "node22",
   bundle: true,
   noExternal: [
+    "@lightfast/connector-core",
     "@repo/api-contract",
     "@repo/native-auth-contract",
     "@repo/native-auth-node",

--- a/core/lightfast/tsup.config.ts
+++ b/core/lightfast/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: [],
-  noExternal: ["@repo/api-contract"],
+  noExternal: ["@lightfast/connector-core", "@repo/api-contract"],
   target: "node18",
   bundle: true,
   silent: false,

--- a/core/mcp/tsup.config.ts
+++ b/core/mcp/tsup.config.ts
@@ -10,7 +10,12 @@ export default defineConfig({
   target: "node18",
   bundle: true,
   external: ["@modelcontextprotocol/sdk"],
-  noExternal: ["lightfast", "@repo/api-contract", "@repo/mcp-tools"],
+  noExternal: [
+    "@lightfast/connector-core",
+    "lightfast",
+    "@repo/api-contract",
+    "@repo/mcp-tools",
+  ],
   outExtension: () => ({ js: ".mjs" }),
   banner: {
     js: "#!/usr/bin/env node",

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@lightfast/connector-core": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/api-contract/src/connectors.ts
+++ b/packages/api-contract/src/connectors.ts
@@ -1,20 +1,16 @@
+export {
+  CONNECTABLE_CONNECTOR_PROVIDERS,
+  CONNECTOR_PROVIDERS,
+  type ConnectableConnectorProvider,
+  type ConnectorProvider,
+  connectableConnectorProviderSchema,
+  connectorProviderSchema,
+  USER_CONNECTOR_PROVIDERS,
+  type UserConnectorProvider,
+  userConnectorProviderSchema,
+} from "@lightfast/connector-core";
+
 import { z } from "zod";
-
-export const CONNECTOR_PROVIDERS = ["linear", "x"] as const;
-export const connectorProviderSchema = z.enum(CONNECTOR_PROVIDERS);
-export type ConnectorProvider = z.infer<typeof connectorProviderSchema>;
-
-export const CONNECTABLE_CONNECTOR_PROVIDERS = ["linear", "x"] as const;
-export const connectableConnectorProviderSchema = z.enum(
-  CONNECTABLE_CONNECTOR_PROVIDERS
-);
-export type ConnectableConnectorProvider = z.infer<
-  typeof connectableConnectorProviderSchema
->;
-
-export const USER_CONNECTOR_PROVIDERS = ["granola"] as const;
-export const userConnectorProviderSchema = z.enum(USER_CONNECTOR_PROVIDERS);
-export type UserConnectorProvider = z.infer<typeof userConnectorProviderSchema>;
 
 export const connectorConnectionStatusSchema = z.enum([
   "active",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1375,9 +1375,6 @@ importers:
 
   connectors/core:
     dependencies:
-      '@repo/api-contract':
-        specifier: workspace:*
-        version: link:../../packages/api-contract
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1903,6 +1900,9 @@ importers:
 
   packages/api-contract:
     dependencies:
+      '@lightfast/connector-core':
+        specifier: workspace:*
+        version: link:../../connectors/core
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
## Summary
- Move connector provider primitive ownership into `@lightfast/connector-core` instead of re-exporting from `@repo/api-contract`.
- Make `@repo/api-contract` import/re-export connector provider primitives from connector-core while keeping product connection statuses in api-contract.
- Add source ratchets for the corrected dependency direction and update pnpm lockfile importer metadata.

## Test Plan
- [x] `pnpm --filter @lightfast/connector-core test`
- [x] `pnpm --filter @repo/api-contract test`
- [x] `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts`
- [x] `pnpm --filter @lightfast/connector-core typecheck`
- [x] `pnpm --filter @repo/api-contract typecheck`
- [x] `pnpm --filter @api/app typecheck`
- [x] `pnpm --filter @lightfast/app typecheck`
- [x] `pnpm --filter @lightfast/mcp typecheck`
- [x] `pnpm --filter @lightfast/connector-linear typecheck`
- [x] `pnpm --filter @lightfast/connector-x typecheck`
- [x] `pnpm --filter @lightfast/connector-granola typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] Agent-browser smoke opened `https://auth-architecture-next-slice-33.lightfast.localhost`
- [x] `curl --cacert ~/.portless/ca.pem -i https://auth-architecture-next-slice-33.lightfast.localhost/api/v1/signals` returned `401 auth_required`
- [x] `curl --cacert ~/.portless/ca.pem -i -X OPTIONS https://auth-architecture-next-slice-33.lightfast.localhost/api/v1/signals` returned `204` with CORS headers

## Notes
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` still fails on the known repository unused-file backlog; it does not report the touched connector/api-contract files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized connector provider definitions and dependency ownership across modules for improved code structure and maintainability.

* **Tests**
  * Updated connector workspace-boundary tests to reflect revised dependency structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->