### PR TITLE
Inline skills query key

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -700,7 +700,6 @@ describe("app authenticated route migration", () => {
     );
     const skillsClientSource = source("src/skills/skills-client.tsx");
     const skillsSearchSource = source("src/skills/skills-search-params.ts");
-    const skillsQuerySource = source("src/skills/skills-queries.ts");
     const connectorsRouteSource = source(
       "src/routes/_authenticated/$slug/connectors.tsx"
     );
@@ -760,13 +759,17 @@ describe("app authenticated route migration", () => {
     expect(skillsSearchSource).toContain("validateSkillsSearch");
     expect(skillsClientSource).toContain('@api/app/tanstack/skills"');
     expect(skillsClientSource).toContain("listSkills");
-    expect(skillsClientSource).toContain("skillsListQueryKey");
+    expect(skillsClientSource).toContain(
+      'queryKey: ["skills", "list"] as const'
+    );
+    expect(skillsClientSource).not.toContain("skillsListQueryKey");
+    expect(skillsClientSource).not.toContain("skills-queries");
     expect(skillsClientSource).toContain(
       'enabled: typeof window !== "undefined"'
     );
-    expect(skillsQuerySource).toContain("skillsListQueryKey");
-    expect(skillsQuerySource).not.toContain("skillsListQueryOptions");
-    expect(skillsQuerySource).not.toContain("@api/app/tanstack/skills");
+    expect(existsSync(resolve(appRoot, "src/skills/skills-queries.ts"))).toBe(
+      false
+    );
     expect(skillsClientSource).not.toContain("useSkillsListQuery");
 
     expect(connectorsRouteSource).toContain("validateConnectorsSearch");

--- a/apps/app/src/__tests__/skills-no-trpc-source.test.ts
+++ b/apps/app/src/__tests__/skills-no-trpc-source.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -12,7 +12,7 @@ describe("migrated skills data access", () => {
   it("uses TanStack server functions instead of tRPC", () => {
     const skillsAdapterImport = /from\s+["']@api\/app\/tanstack\/skills["']/;
     const clientSource = source("src/skills/skills-client.tsx");
-    const querySource = source("src/skills/skills-queries.ts");
+    const queryPath = resolve(appRoot, "src/skills/skills-queries.ts");
     const controllerSource = source(
       "src/skills/use-skill-index-refresh-controller.ts"
     );
@@ -20,15 +20,17 @@ describe("migrated skills data access", () => {
 
     expect(clientSource).toMatch(skillsAdapterImport);
     expect(clientSource).toContain("listSkills");
-    expect(clientSource).toContain("skillsListQueryKey");
+    expect(clientSource).toContain('queryKey: ["skills", "list"] as const');
+    expect(clientSource).not.toContain("skillsListQueryKey");
+    expect(clientSource).not.toContain("skills-queries");
     expect(clientSource).not.toContain("skillsListQueryOptions");
     expect(clientSource).not.toContain("useTRPC");
     expect(clientSource).not.toContain("trpc.org.workspace.skills");
-    expect(querySource).toContain("skillsListQueryKey");
-    expect(querySource).not.toMatch(skillsAdapterImport);
-    expect(querySource).not.toContain("useTRPC");
-    expect(querySource).not.toContain("trpc.org.workspace.skills");
+    expect(existsSync(queryPath)).toBe(false);
     expect(controllerSource).toMatch(skillsAdapterImport);
+    expect(controllerSource).toContain('queryKey: ["skills"] as const');
+    expect(controllerSource).not.toContain("skillsListQueryKey");
+    expect(controllerSource).not.toContain("skills-queries");
     expect(controllerSource).not.toContain("useTRPC");
     expect(controllerSource).not.toContain("trpc.org.workspace.skills");
     expect(typesSource).toMatch(skillsAdapterImport);

--- a/apps/app/src/__tests__/skills-queries-source.test.ts
+++ b/apps/app/src/__tests__/skills-queries-source.test.ts
@@ -9,14 +9,10 @@ function source(path: string) {
 }
 
 describe("skills app data access", () => {
-  it("keeps only the shared skills list query key in the query module", () => {
-    const querySource = source("src/skills/skills-queries.ts");
+  it("removes the skills query module instead of hiding one query key", () => {
+    const queryPath = resolve(appRoot, "src/skills/skills-queries.ts");
 
-    expect(querySource).toContain("skillsListQueryKey");
-    expect(querySource).not.toContain("skillsListQueryOptions");
-    expect(querySource).not.toContain("@api/app/tanstack/skills");
-    expect(querySource).not.toContain("queryOptions");
-    expect(querySource).not.toContain("useTRPC");
+    expect(existsSync(queryPath)).toBe(false);
   });
 
   it("inlines the shared skills list hook into its consumers", () => {
@@ -38,11 +34,15 @@ describe("skills app data access", () => {
     expect(clientSource).toContain("useQuery");
     expect(clientSource).toContain('@api/app/tanstack/skills"');
     expect(clientSource).toContain("listSkills");
-    expect(clientSource).toContain("skillsListQueryKey");
+    expect(clientSource).toContain('queryKey: ["skills", "list"] as const');
+    expect(clientSource).not.toContain("skillsListQueryKey");
+    expect(clientSource).not.toContain("skills-queries");
     expect(clientSource).not.toContain("skillsListQueryOptions");
     expect(clientSource).toContain("<SkillsActions");
     expect(clientSource).not.toContain("useSkillsListQuery");
     expect(clientSource).not.toContain("./use-skills-list-query");
-    expect(controllerSource).toContain('from "./skills-queries"');
+    expect(controllerSource).toContain('queryKey: ["skills"] as const');
+    expect(controllerSource).not.toContain("skillsListQueryKey");
+    expect(controllerSource).not.toContain("skills-queries");
   });
 });

--- a/apps/app/src/__tests__/skills-refresh-controller-source.test.ts
+++ b/apps/app/src/__tests__/skills-refresh-controller-source.test.ts
@@ -21,7 +21,9 @@ describe("skills refresh controller source", () => {
     );
     expect(controllerSource).toContain("requestSkillRefresh");
     expect(controllerSource).toContain("Skill index refresh was not enqueued");
-    expect(controllerSource).toContain("skillsListQueryKey");
+    expect(controllerSource).toContain('queryKey: ["skills"] as const');
+    expect(controllerSource).not.toContain("skillsListQueryKey");
+    expect(controllerSource).not.toContain("skills-queries");
     expect(controllerSource).toContain(
       'new EventSource("/api/skills/index/events")'
     );

--- a/apps/app/src/skills/skills-client.tsx
+++ b/apps/app/src/skills/skills-client.tsx
@@ -19,7 +19,6 @@ import { SkillGrid } from "./skill-grid";
 import { SkillsActions } from "./skills-actions";
 import { SkillsLoading } from "./skills-loading";
 import { getVisibleSkills, type SkillFilter } from "./skills-model";
-import { skillsListQueryKey } from "./skills-queries";
 import type { NormalizedSkillsSearch } from "./skills-search-params";
 import type { SkillsListResult } from "./skills-types";
 import { useSkillIndexRefreshController } from "./use-skill-index-refresh-controller";
@@ -35,7 +34,7 @@ export function SkillsClient({
     enabled: typeof window !== "undefined",
     queryFn: async (): Promise<SkillsListResult> =>
       (await listSkills()) as SkillsListResult,
-    queryKey: skillsListQueryKey,
+    queryKey: ["skills", "list"] as const,
     staleTime: 0,
   });
   const [query, setQuery] = useState("");

--- a/apps/app/src/skills/skills-queries.ts
+++ b/apps/app/src/skills/skills-queries.ts
@@ -1,1 +1,0 @@
-export const skillsListQueryKey = ["skills", "list"] as const;

--- a/apps/app/src/skills/use-skill-index-refresh-controller.ts
+++ b/apps/app/src/skills/use-skill-index-refresh-controller.ts
@@ -1,7 +1,6 @@
 import { requestSkillRefresh } from "@api/app/tanstack/skills";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import { skillsListQueryKey } from "./skills-queries";
 import type { SkillsListResult } from "./skills-types";
 
 const REFRESHABLE_STATUSES = new Set(["stale", "unavailable"]);
@@ -26,7 +25,7 @@ export function useSkillIndexRefreshController(snapshot: SkillsListResult) {
       return result;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: skillsListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: ["skills"] as const });
     },
   });
 
@@ -88,7 +87,7 @@ export function useSkillIndexRefreshController(snapshot: SkillsListResult) {
 
     const source = new EventSource("/api/skills/index/events");
     const onSkillIndex = () => {
-      void queryClient.invalidateQueries({ queryKey: skillsListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: ["skills"] as const });
     };
 
     source.addEventListener("skill-index", onSkillIndex);
@@ -107,7 +106,7 @@ export function useSkillIndexRefreshController(snapshot: SkillsListResult) {
     }
 
     const interval = setInterval(() => {
-      void queryClient.invalidateQueries({ queryKey: skillsListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: ["skills"] as const });
     }, REFRESH_POLL_INTERVAL_MS);
 
     return () => {


### PR DESCRIPTION
## Summary
- Delete the one-line `skills-queries.ts` wrapper.
- Inline the skills list query key in `SkillsClient`.
- Invalidate the explicit `['skills']` query family from the refresh controller and ratchet the source tests.

## Verification
- `pnpm --filter @lightfast/app test -- src/__tests__/skills-queries-source.test.ts src/__tests__/skills-no-trpc-source.test.ts src/__tests__/skills-refresh-controller-source.test.ts`
- `pnpm --filter @lightfast/app test -- src/__tests__/authenticated-routes-source.test.ts`
- `rg -n "skillsListQueryKey|skills-queries" apps/app/src --glob '*.ts' --glob '*.tsx'` only returns ratchet test references
- `pnpm --filter @lightfast/app typecheck`
- `pnpm check`
- `pnpm turbo boundaries`
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits 1 on the known unused-file backlog; touched files are not listed
- `agent-browser open https://auth-architecture-next-slice-36.lightfast.localhost && agent-browser wait --load networkidle && agent-browser snapshot -i -c`
- `curl -sk -i https://auth-architecture-next-slice-36.lightfast.localhost/api/v1/signals` returns `401 auth_required`
- `curl -sk -i -X OPTIONS https://auth-architecture-next-slice-36.lightfast.localhost/api/v1/signals -H 'Origin: https://auth-architecture-next-slice-36.lightfast.localhost' -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization,content-type'` returns `204`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal skills query architecture to improve data fetching efficiency and cache management.
  * Updated query key handling throughout the skills module for consistency and performance optimization.
  * Refined cache invalidation mechanisms in skills refresh operations for enhanced system reliability.
  * Updated test suite to validate new query management implementation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->