### PR TITLE
Add signals list to SDK

### DIFF
--- a/core/lightfast/src/__tests__/client.test.ts
+++ b/core/lightfast/src/__tests__/client.test.ts
@@ -129,6 +129,62 @@ describe("createLightfast", () => {
     });
   });
 
+  it("lists signals with optional filters on the contract route", async () => {
+    let lastRequest: { method: string; url: string } | undefined;
+    const fetchMock = vi.fn(async (input: Request) => {
+      lastRequest = {
+        method: input.method,
+        url: input.url,
+      };
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              classification: null,
+              createdAt: "2026-05-21T00:00:00.000Z",
+              id: "signal_123e4567-e89b-12d3-a456-426614174000",
+              input: "Classify this",
+              status: "queued",
+              updatedAt: "2026-05-21T00:01:00.000Z",
+              visibilityScope: "team",
+            },
+          ],
+          nextCursor: "next_cursor",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const lf = createLightfast("lf_test", {
+      baseUrl: "https://example.test",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await lf.signals.list({
+      cursor: "cursor_1",
+      limit: 25,
+      statuses: ["queued", "classified"],
+    });
+
+    expect(result).toEqual({
+      items: [
+        {
+          classification: null,
+          createdAt: "2026-05-21T00:00:00.000Z",
+          id: "signal_123e4567-e89b-12d3-a456-426614174000",
+          input: "Classify this",
+          status: "queued",
+          updatedAt: "2026-05-21T00:01:00.000Z",
+          visibilityScope: "team",
+        },
+      ],
+      nextCursor: "next_cursor",
+    });
+    expect(lastRequest).toEqual({
+      method: "GET",
+      url: "https://example.test/api/v1/signals?cursor=cursor_1&limit=25&statuses=queued%2Cclassified",
+    });
+  });
+
   it("interpolates signal ids into contract paths", async () => {
     let lastRequest: { method: string; url: string } | undefined;
     const fetchMock = vi.fn(async (input: Request) => {

--- a/core/lightfast/src/index.ts
+++ b/core/lightfast/src/index.ts
@@ -3,6 +3,8 @@ import type {
   CreateSignalOutput,
   GetSignalInput,
   GetSignalOutput,
+  ListSignalsInput,
+  ListSignalsOutput,
   SystemHealthOutput,
 } from "@repo/api-contract";
 
@@ -19,6 +21,7 @@ export interface LightfastClient {
   signals: {
     create(input: CreateSignalInput): Promise<CreateSignalOutput>;
     get(input: GetSignalInput): Promise<GetSignalOutput>;
+    list(input?: ListSignalsInput): Promise<ListSignalsOutput>;
   };
   system: {
     health(): Promise<SystemHealthOutput>;
@@ -43,6 +46,22 @@ function normalizeBaseUrl(baseUrl: string): string {
 
 function apiUrl(baseUrl: string, path: string): string {
   return `${baseUrl}/api/v1${path}`;
+}
+
+function signalListQuery(input: ListSignalsInput): string {
+  const params = new URLSearchParams();
+  if (input.cursor) {
+    params.set("cursor", input.cursor);
+  }
+  if (input.limit !== undefined) {
+    params.set("limit", String(input.limit));
+  }
+  if (input.statuses?.length) {
+    params.set("statuses", input.statuses.join(","));
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
 }
 
 async function responseBody(response: Response): Promise<unknown> {
@@ -123,6 +142,14 @@ export function createLightfast(
             normalizedBase,
             `/signals/${encodeURIComponent(input.id)}`
           ),
+        });
+      },
+      list(input = { limit: 50 }) {
+        return requestJson({
+          apiKey,
+          fetch: fetchImpl,
+          method: "GET",
+          url: apiUrl(normalizedBase, `/signals${signalListQuery(input)}`),
         });
       },
     },


### PR DESCRIPTION
## Summary
- Add `lf.signals.list()` to the public `lightfast` SDK.
- Serialize optional `cursor`, `limit`, and `statuses` filters onto the existing `/api/v1/signals` GET route.
- Add a client test covering the SDK route, method, query serialization, and list response shape.

## Verification
- Red test first: `pnpm --filter lightfast test -- src/__tests__/client.test.ts` failed with `TypeError: lf.signals.list is not a function`
- `pnpm --filter lightfast test -- src/__tests__/client.test.ts`
- `pnpm --filter lightfast test`
- `pnpm --filter lightfast typecheck`
- `pnpm --filter lightfast build`
- `pnpm check`
- `pnpm turbo boundaries`
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits 1 on the known unused-file backlog; touched SDK files are not listed
- `agent-browser open https://auth-architecture-next-slice-37.lightfast.localhost && agent-browser wait --load networkidle && agent-browser snapshot -i -c`
- `curl -sk -i 'https://auth-architecture-next-slice-37.lightfast.localhost/api/v1/signals?cursor=cursor_1&limit=25&statuses=queued%2Cclassified'` returns `401 auth_required`
- `curl -sk -i -X OPTIONS https://auth-architecture-next-slice-37.lightfast.localhost/api/v1/signals -H 'Origin: https://auth-architecture-next-slice-37.lightfast.localhost' -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization,content-type'` returns `204`

## Local Note
- `pnpm dev` served the aggregate app/API smoke successfully, but the QStash task exited because port `4325` was already held by an unrelated local `astro preview` process. I left that process untouched.
