### PR TITLE
Add X connector contract entrypoint

### DIFF
--- a/api/app/src/__tests__/connector-workspace-source.test.ts
+++ b/api/app/src/__tests__/connector-workspace-source.test.ts
@@ -339,8 +339,14 @@ describe("connector workspace boundary", () => {
       name?: string;
       private?: boolean;
     }>("connectors/x/package.json");
+    const xContractSource = source("connectors/x/src/contract.ts");
+    const xOAuthSource = source("connectors/x/src/oauth.ts");
+    const catalogSource = source("api/app/src/services/connectors/catalog.ts");
 
     expect(existsSync(resolve(repoRoot, oldXPath))).toBe(false);
+    expect(existsSync(resolve(repoRoot, "connectors/x/src/contract.ts"))).toBe(
+      true
+    );
     expect(xPackage.name).toBe("@lightfast/connector-x");
     expect(xPackage.private).toBe(true);
     expect(xPackage.dependencies?.["@lightfast/connector-core"]).toBe(
@@ -349,12 +355,18 @@ describe("connector workspace boundary", () => {
     expect(xPackage.dependencies?.["@vendor/mcp"]).toBe("workspace:*");
     expect(xPackage.dependencies?.zod).toBe("catalog:");
     expect(Object.keys(xPackage.exports ?? {}).sort()).toEqual([
+      "./contract",
       "./mcp",
       "./node",
       "./oauth",
       "./operations",
       "./tools",
     ]);
+    expect(xContractSource).toContain("X_OAUTH_SCOPES");
+    expect(xContractSource).toContain("X_OAUTH_SCOPE");
+    expect(xOAuthSource).toContain('from "./contract"');
+    expect(catalogSource).toContain('@lightfast/connector-x/contract"');
+    expect(catalogSource).not.toContain('@lightfast/connector-x/oauth"');
   });
 
   it("removes the old X app node package name from source and manifests", () => {

--- a/api/app/src/services/connectors/catalog.ts
+++ b/api/app/src/services/connectors/catalog.ts
@@ -4,7 +4,7 @@ import {
   type OrgConnectorConnection,
 } from "@db/app";
 import { connectorRuntimeToolName } from "@lightfast/connector-core";
-import { X_OAUTH_SCOPES } from "@lightfast/connector-x/oauth";
+import { X_OAUTH_SCOPES } from "@lightfast/connector-x/contract";
 import {
   CONNECTABLE_CONNECTOR_PROVIDERS,
   type ConnectableConnectorProvider,

--- a/connectors/x/package.json
+++ b/connectors/x/package.json
@@ -6,6 +6,10 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
+    "./contract": {
+      "types": "./src/contract.ts",
+      "default": "./src/contract.ts"
+    },
     "./mcp": {
       "types": "./src/mcp.ts",
       "default": "./src/mcp.ts"

--- a/connectors/x/src/__tests__/contract.test.ts
+++ b/connectors/x/src/__tests__/contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { X_OAUTH_SCOPE, X_OAUTH_SCOPES } from "../contract";
+import { X_OAUTH_SCOPE as runtimeXOAuthScope } from "../oauth";
+
+describe("X connector contract", () => {
+  it("owns the public OAuth scope contract separately from OAuth runtime code", () => {
+    expect(X_OAUTH_SCOPES).toEqual([
+      "tweet.read",
+      "users.read",
+      "offline.access",
+      "tweet.write",
+      "tweet.moderate.write",
+      "follows.read",
+      "follows.write",
+      "mute.read",
+      "mute.write",
+      "like.read",
+      "like.write",
+      "list.read",
+      "list.write",
+      "block.read",
+      "block.write",
+      "bookmark.read",
+      "bookmark.write",
+      "dm.read",
+      "dm.write",
+      "media.write",
+    ]);
+    expect(X_OAUTH_SCOPE).toBe(X_OAUTH_SCOPES.join(" "));
+    expect(runtimeXOAuthScope).toBe(X_OAUTH_SCOPE);
+  });
+});

--- a/connectors/x/src/__tests__/operations.test.ts
+++ b/connectors/x/src/__tests__/operations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { X_OAUTH_SCOPES } from "../oauth";
+import { X_OAUTH_SCOPES } from "../contract";
 import {
   getXOperationDefinition,
   getXOperationDefinitions,

--- a/connectors/x/src/contract.ts
+++ b/connectors/x/src/contract.ts
@@ -1,0 +1,26 @@
+export const X_OAUTH_SCOPES = [
+  "tweet.read",
+  "users.read",
+  "offline.access",
+  "tweet.write",
+  "tweet.moderate.write",
+  "follows.read",
+  "follows.write",
+  "mute.read",
+  "mute.write",
+  "like.read",
+  "like.write",
+  "list.read",
+  "list.write",
+  "block.read",
+  "block.write",
+  "bookmark.read",
+  "bookmark.write",
+  "dm.read",
+  "dm.write",
+  "media.write",
+] as const;
+
+export const X_OAUTH_SCOPE = X_OAUTH_SCOPES.join(" ");
+
+export type XOAuthScope = (typeof X_OAUTH_SCOPES)[number];

--- a/connectors/x/src/oauth.ts
+++ b/connectors/x/src/oauth.ts
@@ -3,34 +3,13 @@ import { createHash, randomBytes } from "node:crypto";
 import { z } from "zod";
 
 import { assertXEndpointAllowed, DEFAULT_X_ENDPOINTS } from "./config";
+import { X_OAUTH_SCOPE } from "./contract";
+
+export { X_OAUTH_SCOPE, X_OAUTH_SCOPES, type XOAuthScope } from "./contract";
+
 import { XAppNodeError } from "./errors";
 
 const DEFAULT_X_OAUTH_TIMEOUT_MS = 10_000;
-
-export const X_OAUTH_SCOPES = [
-  "tweet.read",
-  "users.read",
-  "offline.access",
-  "tweet.write",
-  "tweet.moderate.write",
-  "follows.read",
-  "follows.write",
-  "mute.read",
-  "mute.write",
-  "like.read",
-  "like.write",
-  "list.read",
-  "list.write",
-  "block.read",
-  "block.write",
-  "bookmark.read",
-  "bookmark.write",
-  "dm.read",
-  "dm.write",
-  "media.write",
-] as const;
-
-export const X_OAUTH_SCOPE = X_OAUTH_SCOPES.join(" ");
 
 const xOAuthTokenResponseSchema = z.object({
   access_token: z.string().min(1),


### PR DESCRIPTION
## Summary
- Add `@lightfast/connector-x/contract` as the client-safe X connector contract entrypoint.
- Move `X_OAUTH_SCOPES`/`X_OAUTH_SCOPE` ownership out of the OAuth runtime module into `connectors/x/src/contract.ts`.
- Update the app connector catalog to import X scopes from the contract entrypoint instead of the OAuth runtime.

## Verification
- Red test first: `pnpm --filter @lightfast/connector-x test -- src/__tests__/contract.test.ts src/__tests__/operations.test.ts` failed because `../contract` did not exist
- Red boundary first: `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts` failed because `connectors/x/src/contract.ts` did not exist
- `pnpm --filter @lightfast/connector-x test -- src/__tests__/contract.test.ts src/__tests__/operations.test.ts`
- `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts`
- `pnpm --filter @lightfast/connector-x typecheck && pnpm --filter @api/app typecheck`
- `pnpm check`
- `pnpm turbo boundaries`
- `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits 1 on the known unused-file backlog; touched connector/API files are not listed
- `agent-browser open https://auth-architecture-next-slice-38.lightfast.localhost && agent-browser wait --load networkidle && agent-browser snapshot -i -c`
- `curl -sk -i https://auth-architecture-next-slice-38.lightfast.localhost/api/v1/signals` returns `401 auth_required`
- `curl -sk -i -X OPTIONS https://auth-architecture-next-slice-38.lightfast.localhost/api/v1/signals -H 'Origin: https://auth-architecture-next-slice-38.lightfast.localhost' -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization,content-type'` returns `204`
