### PR TITLE
Add Linear connector contract entrypoint

### DIFF
--- a/api/app/src/__tests__/connector-workspace-source.test.ts
+++ b/api/app/src/__tests__/connector-workspace-source.test.ts
@@ -300,8 +300,13 @@ describe("connector workspace boundary", () => {
       name?: string;
       private?: boolean;
     }>("connectors/linear/package.json");
+    const linearContractSource = source("connectors/linear/src/contract.ts");
+    const linearOAuthSource = source("connectors/linear/src/oauth.ts");
 
     expect(existsSync(resolve(repoRoot, oldLinearPath))).toBe(false);
+    expect(
+      existsSync(resolve(repoRoot, "connectors/linear/src/contract.ts"))
+    ).toBe(true);
     expect(linearPackage.name).toBe("@lightfast/connector-linear");
     expect(linearPackage.private).toBe(true);
     expect(linearPackage.dependencies?.["@lightfast/connector-core"]).toBe(
@@ -310,10 +315,14 @@ describe("connector workspace boundary", () => {
     expect(linearPackage.dependencies?.["@vendor/mcp"]).toBe("workspace:*");
     expect(linearPackage.dependencies?.zod).toBe("catalog:");
     expect(Object.keys(linearPackage.exports ?? {}).sort()).toEqual([
+      "./contract",
       "./mcp",
       "./node",
       "./oauth",
     ]);
+    expect(linearContractSource).toContain("LINEAR_OAUTH_SCOPES");
+    expect(linearContractSource).toContain("LINEAR_OAUTH_SCOPE");
+    expect(linearOAuthSource).toContain('from "./contract"');
   });
 
   it("removes the old Linear app node package name from source and manifests", () => {

--- a/connectors/linear/package.json
+++ b/connectors/linear/package.json
@@ -6,6 +6,10 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
+    "./contract": {
+      "types": "./src/contract.ts",
+      "default": "./src/contract.ts"
+    },
     "./mcp": {
       "types": "./src/mcp.ts",
       "default": "./src/mcp.ts"

--- a/connectors/linear/src/__tests__/contract.test.ts
+++ b/connectors/linear/src/__tests__/contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { LINEAR_OAUTH_SCOPE, LINEAR_OAUTH_SCOPES } from "../contract";
+import { LINEAR_OAUTH_SCOPE as runtimeLinearOAuthScope } from "../oauth";
+
+describe("Linear connector contract", () => {
+  it("owns the public OAuth scope contract separately from OAuth runtime code", () => {
+    expect(LINEAR_OAUTH_SCOPES).toEqual(["read", "write"]);
+    expect(LINEAR_OAUTH_SCOPE).toBe(LINEAR_OAUTH_SCOPES.join(","));
+    expect(runtimeLinearOAuthScope).toBe(LINEAR_OAUTH_SCOPE);
+  });
+});

--- a/connectors/linear/src/__tests__/oauth.test.ts
+++ b/connectors/linear/src/__tests__/oauth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { LINEAR_OAUTH_SCOPE } from "../contract";
 import {
   buildLinearOAuthAuthorizeUrl,
   exchangeLinearOAuthCode,
@@ -25,7 +26,7 @@ describe("buildLinearOAuthAuthorizeUrl", () => {
     );
     expect(url.searchParams.get("actor")).toBe("app");
     expect(url.searchParams.get("response_type")).toBe("code");
-    expect(url.searchParams.get("scope")).toBe("read,write");
+    expect(url.searchParams.get("scope")).toBe(LINEAR_OAUTH_SCOPE);
     expect(url.searchParams.get("state")).toBe("state_123");
     expect(url.searchParams.get("code_challenge")).toBe("challenge_123");
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");

--- a/connectors/linear/src/contract.ts
+++ b/connectors/linear/src/contract.ts
@@ -1,0 +1,5 @@
+export const LINEAR_OAUTH_SCOPES = ["read", "write"] as const;
+
+export const LINEAR_OAUTH_SCOPE = LINEAR_OAUTH_SCOPES.join(",");
+
+export type LinearOAuthScope = (typeof LINEAR_OAUTH_SCOPES)[number];

--- a/connectors/linear/src/oauth.ts
+++ b/connectors/linear/src/oauth.ts
@@ -6,7 +6,14 @@ import {
   assertLinearEndpointAllowed,
   DEFAULT_LINEAR_ENDPOINTS,
 } from "./config";
+import { LINEAR_OAUTH_SCOPE } from "./contract";
 import { LinearAppNodeError } from "./errors";
+
+export {
+  LINEAR_OAUTH_SCOPE,
+  LINEAR_OAUTH_SCOPES,
+  type LinearOAuthScope,
+} from "./contract";
 
 const DEFAULT_LINEAR_OAUTH_TIMEOUT_MS = 10_000;
 
@@ -77,7 +84,7 @@ export function buildLinearOAuthAuthorizeUrl(input: {
   url.searchParams.set("response_type", "code");
   url.searchParams.set("client_id", input.clientId);
   url.searchParams.set("redirect_uri", input.callbackUrl);
-  url.searchParams.set("scope", "read,write");
+  url.searchParams.set("scope", LINEAR_OAUTH_SCOPE);
   url.searchParams.set("state", input.state);
   url.searchParams.set("code_challenge", input.codeChallenge);
   url.searchParams.set("code_challenge_method", "S256");


### PR DESCRIPTION
## Summary
- add `@lightfast/connector-linear/contract` as the client-safe Linear OAuth scope entrypoint
- have Linear OAuth runtime import/re-export the scope contract instead of hardcoding the authorize scope string
- extend connector workspace source ratchets so Linear matches the explicit provider entrypoint shape

## Test Plan
- [x] Red: `pnpm --filter @lightfast/connector-linear test -- src/__tests__/contract.test.ts src/__tests__/oauth.test.ts` failed before implementation because `../contract` did not exist
- [x] Red: `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts` failed before implementation because `connectors/linear/src/contract.ts` did not exist
- [x] `pnpm --filter @lightfast/connector-linear test -- src/__tests__/contract.test.ts src/__tests__/oauth.test.ts`
- [x] `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts`
- [x] `pnpm --filter @lightfast/connector-linear typecheck && pnpm --filter @api/app typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits on known unused-file backlog; touched files are not listed
- [x] Agent-browser smoke: `https://auth-architecture-next-slice-39.lightfast.localhost` rendered the marketing shell
- [x] Public API smoke: unauthenticated `GET /api/v1/signals` returned `401 auth_required`; `OPTIONS /api/v1/signals` returned `204`