### PR TITLE
Add Granola connector contract entrypoint

### DIFF
--- a/api/app/src/__tests__/connector-workspace-source.test.ts
+++ b/api/app/src/__tests__/connector-workspace-source.test.ts
@@ -436,8 +436,13 @@ describe("connector workspace boundary", () => {
       name?: string;
       private?: boolean;
     }>("connectors/granola/package.json");
+    const granolaContractSource = source("connectors/granola/src/contract.ts");
+    const granolaConfigSource = source("connectors/granola/src/config.ts");
 
     expect(existsSync(resolve(repoRoot, oldGranolaPath))).toBe(false);
+    expect(
+      existsSync(resolve(repoRoot, "connectors/granola/src/contract.ts"))
+    ).toBe(true);
     expect(granolaPackage.name).toBe("@lightfast/connector-granola");
     expect(granolaPackage.private).toBe(true);
     expect(granolaPackage.dependencies?.["@lightfast/connector-core"]).toBe(
@@ -446,10 +451,14 @@ describe("connector workspace boundary", () => {
     expect(granolaPackage.dependencies?.["@vendor/mcp"]).toBe("workspace:*");
     expect(granolaPackage.dependencies?.zod).toBe("catalog:");
     expect(Object.keys(granolaPackage.exports ?? {}).sort()).toEqual([
+      "./contract",
       "./mcp",
       "./node",
       "./oauth",
     ]);
+    expect(granolaContractSource).toContain("DEFAULT_GRANOLA_MCP_ENDPOINT");
+    expect(granolaContractSource).toContain("granolaClientMetadata");
+    expect(granolaConfigSource).toContain('from "./contract"');
   });
 
   it("removes the old Granola app node package name from source and manifests", () => {

--- a/connectors/granola/package.json
+++ b/connectors/granola/package.json
@@ -6,6 +6,10 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
+    "./contract": {
+      "types": "./src/contract.ts",
+      "default": "./src/contract.ts"
+    },
     "./mcp": {
       "types": "./src/mcp.ts",
       "default": "./src/mcp.ts"

--- a/connectors/granola/src/__tests__/contract.test.ts
+++ b/connectors/granola/src/__tests__/contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  granolaClientMetadata as runtimeGranolaClientMetadata,
+  DEFAULT_GRANOLA_MCP_ENDPOINT as runtimeGranolaMcpEndpoint,
+} from "../config";
+import {
+  DEFAULT_GRANOLA_MCP_ENDPOINT,
+  granolaClientMetadata,
+} from "../contract";
+
+describe("Granola connector contract", () => {
+  it("owns client-safe MCP endpoint and OAuth metadata separately from runtime code", () => {
+    const redirectUrl =
+      "https://app.lightfast.ai/api/connectors/granola/oauth/callback";
+
+    expect(DEFAULT_GRANOLA_MCP_ENDPOINT).toBe("https://mcp.granola.ai/mcp");
+    expect(granolaClientMetadata({ redirectUrl })).toEqual({
+      client_name: "Lightfast",
+      grant_types: ["authorization_code", "refresh_token"],
+      redirect_uris: [redirectUrl],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+    expect(runtimeGranolaMcpEndpoint).toBe(DEFAULT_GRANOLA_MCP_ENDPOINT);
+    expect(runtimeGranolaClientMetadata({ redirectUrl })).toEqual(
+      granolaClientMetadata({ redirectUrl })
+    );
+  });
+});

--- a/connectors/granola/src/__tests__/oauth-provider.test.ts
+++ b/connectors/granola/src/__tests__/oauth-provider.test.ts
@@ -5,7 +5,10 @@ import type {
 } from "@vendor/mcp";
 import { describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_GRANOLA_MCP_ENDPOINT, granolaClientMetadata } from "../config";
+import {
+  DEFAULT_GRANOLA_MCP_ENDPOINT,
+  granolaClientMetadata,
+} from "../contract";
 import { GranolaOAuthClientProvider } from "../oauth";
 
 describe("Granola OAuth client provider", () => {

--- a/connectors/granola/src/config.ts
+++ b/connectors/granola/src/config.ts
@@ -1,15 +1,5 @@
-import type { OAuthClientMetadata } from "@vendor/mcp";
-
-export const DEFAULT_GRANOLA_MCP_ENDPOINT = "https://mcp.granola.ai/mcp";
-
-export function granolaClientMetadata(input: {
-  redirectUrl: string | URL;
-}): OAuthClientMetadata {
-  return {
-    client_name: "Lightfast",
-    grant_types: ["authorization_code", "refresh_token"],
-    redirect_uris: [input.redirectUrl.toString()],
-    response_types: ["code"],
-    token_endpoint_auth_method: "none",
-  };
-}
+export {
+  DEFAULT_GRANOLA_MCP_ENDPOINT,
+  type GranolaOAuthClientMetadata,
+  granolaClientMetadata,
+} from "./contract";

--- a/connectors/granola/src/contract.ts
+++ b/connectors/granola/src/contract.ts
@@ -1,0 +1,21 @@
+export interface GranolaOAuthClientMetadata {
+  client_name: string;
+  grant_types: ["authorization_code", "refresh_token"];
+  redirect_uris: string[];
+  response_types: ["code"];
+  token_endpoint_auth_method: "none";
+}
+
+export const DEFAULT_GRANOLA_MCP_ENDPOINT = "https://mcp.granola.ai/mcp";
+
+export function granolaClientMetadata(input: {
+  redirectUrl: string | URL;
+}): GranolaOAuthClientMetadata {
+  return {
+    client_name: "Lightfast",
+    grant_types: ["authorization_code", "refresh_token"],
+    redirect_uris: [input.redirectUrl.toString()],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  };
+}


### PR DESCRIPTION
## Summary
- add `@lightfast/connector-granola/contract` for client-safe Granola MCP endpoint and OAuth client metadata
- keep `config.ts` as a compatibility re-export while runtime provider code stays in OAuth/MCP/node entrypoints
- extend connector workspace source ratchets so Granola matches the explicit provider entrypoint shape

## Test Plan
- [x] Red: `pnpm --filter @lightfast/connector-granola test -- src/__tests__/contract.test.ts src/__tests__/oauth-provider.test.ts` failed before implementation because `../contract` did not exist
- [x] Red: `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts` failed before implementation because `connectors/granola/src/contract.ts` did not exist
- [x] `pnpm --filter @lightfast/connector-granola test -- src/__tests__/contract.test.ts src/__tests__/oauth-provider.test.ts`
- [x] `pnpm --filter @api/app test -- src/__tests__/connector-workspace-source.test.ts`
- [x] `pnpm --filter @lightfast/connector-granola typecheck && pnpm --filter @api/app typecheck`
- [x] `pnpm check`
- [x] `pnpm turbo boundaries`
- [x] `SKIP_ENV_VALIDATION=true pnpm knip --include files` exits on known unused-file backlog; touched files are not listed
- [x] Agent-browser smoke: `https://auth-architecture-next-slice-40.lightfast.localhost` rendered the marketing shell
- [x] Public API smoke: unauthenticated `GET /api/v1/signals` returned `401 auth_required`; `OPTIONS /api/v1/signals` returned `204`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Granola connector now exports a dedicated contract module containing OAuth and MCP endpoint configuration via the `./contract` subpath.

* **Tests**
  * Updated test suite to verify contract module exports and consistency of configuration across the connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->