### PR TITLE
Refactor source-control command deps

### DIFF
--- a/api/app/src/__tests__/org-source-control-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-source-control-domain-commands.test.ts
@@ -95,6 +95,25 @@ function liveRepository(overrides: Record<string, unknown> = {}) {
 
 function createDeps() {
   return {
+    buildGitHubNewRepositoryUrl: vi.fn(
+      (input: { accountLogin: string; name: string; webBaseUrl?: string }) => {
+        const baseUrl =
+          input.webBaseUrl ?? "https://github.lightfast.localhost";
+        const url = new URL(
+          `/organizations/${input.accountLogin}/repositories/new`,
+          baseUrl
+        );
+        url.searchParams.set("name", input.name);
+        return url.toString();
+      }
+    ),
+    buildGitHubRepositoryUrl: vi.fn(
+      (input: { fullName: string; webBaseUrl?: string }) => {
+        const baseUrl =
+          input.webBaseUrl ?? "https://github.lightfast.localhost";
+        return new URL(`/${input.fullName}`, baseUrl).toString();
+      }
+    ),
     createGitHubAppJwt: vi.fn().mockResolvedValue("app.jwt"),
     createGitHubInstallationToken: vi.fn().mockResolvedValue({
       expiresAt: "2026-05-29T02:02:03.000Z",

--- a/api/app/src/__tests__/source-control-domain-boundary-source.test.ts
+++ b/api/app/src/__tests__/source-control-domain-boundary-source.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+
+function source(path: string) {
+  return readFileSync(resolve(repoRoot, "api/app", path), "utf8");
+}
+
+describe("source-control domain boundary", () => {
+  it("keeps GitHub runtime wiring outside the domain command module", () => {
+    const commandSource = source("src/domain/source-control/commands.ts");
+    const tanstackAdapterSource = source(
+      "src/adapters/tanstack/source-control.ts"
+    );
+
+    expect(commandSource).not.toContain("@lightfast/connector-github/node");
+    expect(commandSource).not.toContain(
+      "createDefaultSourceControlCommandDeps"
+    );
+    expect(tanstackAdapterSource).toContain(
+      "../../services/github/source-control/command-deps"
+    );
+  });
+});

--- a/api/app/src/adapters/tanstack/source-control.ts
+++ b/api/app/src/adapters/tanstack/source-control.ts
@@ -6,11 +6,11 @@ import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultSourceControlCommandDeps,
   getSourceControlConnectionCommand,
   importSourceControlRepositoryCommand,
   listSourceControlRepositoriesCommand,
 } from "../../domain/source-control";
+import { createDefaultSourceControlCommandDeps } from "../../services/github/source-control/command-deps";
 
 function requestId() {
   return crypto.randomUUID();

--- a/api/app/src/domain/source-control/commands.ts
+++ b/api/app/src/domain/source-control/commands.ts
@@ -1,28 +1,17 @@
-import type { Database, OrgSourceControlBinding } from "@db/app";
-import {
-  getActiveOrgBinding,
-  insertWatchedSourceControlRepository,
-  listWatchedSourceControlRepositories,
+import type {
+  Database,
+  OrgSourceControlBinding,
+  SourceControlRepository,
+  UpsertWatchedSourceControlRepositoryInput,
 } from "@db/app";
 import {
-  buildGitHubNewRepositoryUrl,
-  createGitHubAppJwt,
-  createGitHubInstallationToken,
-  getGitHubAppInstallation,
-} from "@lightfast/connector-github/node";
-import { LIGHTFAST_REPOSITORY_NAME } from "@repo/api-contract";
+  githubLightfastRepositoryProofSchema,
+  LIGHTFAST_REPOSITORY_NAME,
+} from "@repo/api-contract";
 import { sourceControlRepositorySyncStatusSchema } from "@repo/source-control-contract";
 import { z } from "zod";
 
 import { getMatchingGitHubLightfastRepository } from "../../auth/org-setup-gate";
-import { getGitHubAppConfig } from "../../services/github/config";
-import {
-  buildSourceControlRepositoryResponse,
-  countNormalImportedRepositories,
-  lightfastRepositoryIdFromBinding,
-  listAllGitHubInstallationRepositories,
-  type SourceControlRepositoryRow,
-} from "../../services/github/source-control/repositories";
 import { defineCommand } from "../command";
 import { ConflictError } from "../errors";
 import {
@@ -36,51 +25,93 @@ type ActiveGitHubBinding = OrgSourceControlBinding & {
   providerInstallationId: string;
 };
 
-type GitHubAppConfig = ReturnType<typeof getGitHubAppConfig>;
-type GitHubInstallation = Awaited<ReturnType<typeof getGitHubAppInstallation>>;
-
-interface SourceControlCommandDeps {
-  createGitHubAppJwt: typeof createGitHubAppJwt;
-  createGitHubInstallationToken: typeof createGitHubInstallationToken;
-  db: Database;
-  getActiveOrgBinding: typeof getActiveOrgBinding;
-  getGitHubAppConfig: typeof getGitHubAppConfig;
-  getGitHubAppInstallation: typeof getGitHubAppInstallation;
-  insertWatchedSourceControlRepository: typeof insertWatchedSourceControlRepository;
-  listAllGitHubInstallationRepositories: typeof listAllGitHubInstallationRepositories;
-  listWatchedSourceControlRepositories: typeof listWatchedSourceControlRepositories;
+interface GitHubAppConfig {
+  apiVersion: string;
+  appId: string;
+  endpoints: {
+    apiBaseUrl: string;
+    webBaseUrl: string;
+  };
+  privateKey: string;
 }
 
-export function createDefaultSourceControlCommandDeps(input: {
-  createGitHubAppJwt?: typeof createGitHubAppJwt;
-  createGitHubInstallationToken?: typeof createGitHubInstallationToken;
-  db: Database;
-  getActiveOrgBinding?: typeof getActiveOrgBinding;
-  getGitHubAppConfig?: typeof getGitHubAppConfig;
-  getGitHubAppInstallation?: typeof getGitHubAppInstallation;
-  insertWatchedSourceControlRepository?: typeof insertWatchedSourceControlRepository;
-  listAllGitHubInstallationRepositories?: typeof listAllGitHubInstallationRepositories;
-  listWatchedSourceControlRepositories?: typeof listWatchedSourceControlRepositories;
-}): SourceControlCommandDeps {
-  return {
-    createGitHubAppJwt: input.createGitHubAppJwt ?? createGitHubAppJwt,
-    createGitHubInstallationToken:
-      input.createGitHubInstallationToken ?? createGitHubInstallationToken,
-    db: input.db,
-    getActiveOrgBinding: input.getActiveOrgBinding ?? getActiveOrgBinding,
-    getGitHubAppConfig: input.getGitHubAppConfig ?? getGitHubAppConfig,
-    getGitHubAppInstallation:
-      input.getGitHubAppInstallation ?? getGitHubAppInstallation,
-    insertWatchedSourceControlRepository:
-      input.insertWatchedSourceControlRepository ??
-      insertWatchedSourceControlRepository,
-    listAllGitHubInstallationRepositories:
-      input.listAllGitHubInstallationRepositories ??
-      listAllGitHubInstallationRepositories,
-    listWatchedSourceControlRepositories:
-      input.listWatchedSourceControlRepositories ??
-      listWatchedSourceControlRepositories,
+interface GitHubInstallation {
+  account: {
+    id: string;
+    login: string;
   };
+  htmlUrl: string;
+}
+
+interface SourceControlLiveRepository {
+  fullName: string;
+  id: string;
+  name: string;
+  ownerId: string;
+  ownerLogin: string;
+  private: boolean;
+}
+
+export interface SourceControlRepositoryRow {
+  fullName: string;
+  id: string;
+  imported: boolean;
+  name: string;
+  owner: {
+    id: string;
+    login: string;
+  };
+  private: boolean;
+  syncStatus: SourceControlRepository["syncStatus"];
+  watchedPathGlobs: string[] | null;
+  webUrl: string;
+}
+
+export interface SourceControlCommandDeps {
+  buildGitHubNewRepositoryUrl: (input: {
+    accountLogin: string;
+    name: string;
+    webBaseUrl?: string;
+  }) => string;
+  buildGitHubRepositoryUrl: (input: {
+    fullName: string;
+    webBaseUrl?: string;
+  }) => string;
+  createGitHubAppJwt: (input: {
+    appId: string;
+    privateKey: string;
+  }) => Promise<string>;
+  createGitHubInstallationToken: (input: {
+    apiBaseUrl?: string;
+    apiVersion?: string;
+    appJwt: string;
+    installationId: string;
+  }) => Promise<{ token: string }>;
+  db: Database;
+  getActiveOrgBinding: (
+    db: Database,
+    clerkOrgId: string
+  ) => Promise<OrgSourceControlBinding | undefined>;
+  getGitHubAppConfig: () => GitHubAppConfig;
+  getGitHubAppInstallation: (input: {
+    apiBaseUrl?: string;
+    apiVersion?: string;
+    appJwt: string;
+    installationId: string;
+  }) => Promise<GitHubInstallation>;
+  insertWatchedSourceControlRepository: (
+    db: Database,
+    input: UpsertWatchedSourceControlRepositoryInput
+  ) => Promise<unknown>;
+  listAllGitHubInstallationRepositories: (input: {
+    apiBaseUrl?: string;
+    apiVersion?: string;
+    installationToken: string;
+  }) => Promise<SourceControlLiveRepository[]>;
+  listWatchedSourceControlRepositories: (
+    db: Database,
+    input: { orgSourceControlBindingId: number }
+  ) => Promise<SourceControlRepository[]>;
 }
 
 export interface SourceControlBindingSummary {
@@ -253,7 +284,7 @@ function providerLabel(provider: string) {
 }
 
 function assertActiveGitHubBinding(
-  binding: Awaited<ReturnType<typeof getActiveOrgBinding>>
+  binding: OrgSourceControlBinding | undefined
 ): ActiveGitHubBinding | null {
   if (
     !binding ||
@@ -269,6 +300,7 @@ function assertActiveGitHubBinding(
 
 function bindingResponse(input: {
   binding: ActiveGitHubBinding;
+  deps: Pick<SourceControlCommandDeps, "buildGitHubNewRepositoryUrl">;
   githubWebBaseUrl: string;
   importedRepositoryCount: number;
 }): SourceControlBindingSummary {
@@ -280,7 +312,7 @@ function bindingResponse(input: {
     connectedAt: input.binding.connectedAt,
     importedRepositoryCount: input.importedRepositoryCount,
     lightfastRepository: getMatchingGitHubLightfastRepository(input.binding),
-    newLightfastRepositoryUrl: buildGitHubNewRepositoryUrl({
+    newLightfastRepositoryUrl: input.deps.buildGitHubNewRepositoryUrl({
       accountLogin,
       name: LIGHTFAST_REPOSITORY_NAME,
       webBaseUrl: input.githubWebBaseUrl,
@@ -317,6 +349,87 @@ function importPreconditionFailed(code: string, message: string) {
   return new ConflictError(code, message);
 }
 
+function lightfastRepositoryIdFromBinding(input: {
+  metadata: Record<string, unknown>;
+  providerInstallationId?: string | null;
+}): string | null {
+  const parsed = githubLightfastRepositoryProofSchema.safeParse(
+    input.metadata.lightfastRepository
+  );
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  if (
+    input.providerInstallationId &&
+    parsed.data.installationId !== input.providerInstallationId
+  ) {
+    return null;
+  }
+
+  return parsed.data.id;
+}
+
+function countNormalImportedRepositories(input: {
+  binding: {
+    metadata: Record<string, unknown>;
+  };
+  watchedRepositories: SourceControlRepository[];
+}): number {
+  const lightfastRepositoryId = lightfastRepositoryIdFromBinding(input.binding);
+  return input.watchedRepositories.filter(
+    (repository) => repository.providerRepositoryId !== lightfastRepositoryId
+  ).length;
+}
+
+function buildSourceControlRepositoryResponse(input: {
+  binding: {
+    id: number;
+    metadata: Record<string, unknown>;
+    providerAccountId: string | null;
+  };
+  buildGitHubRepositoryUrl: SourceControlCommandDeps["buildGitHubRepositoryUrl"];
+  liveRepositories: SourceControlLiveRepository[];
+  watchedRepositories: SourceControlRepository[];
+  webBaseUrl: string;
+}): SourceControlRepositoryRow[] {
+  const lightfastRepositoryId = lightfastRepositoryIdFromBinding(input.binding);
+  const watchedByProviderId = new Map(
+    input.watchedRepositories.map((repository) => [
+      repository.providerRepositoryId,
+      repository,
+    ])
+  );
+
+  return input.liveRepositories
+    .filter(
+      (repository) => repository.ownerId === input.binding.providerAccountId
+    )
+    .filter((repository) => repository.id !== lightfastRepositoryId)
+    .filter((repository) => repository.name !== LIGHTFAST_REPOSITORY_NAME)
+    .map((repository) => {
+      const watched = watchedByProviderId.get(repository.id);
+      return {
+        fullName: repository.fullName,
+        id: repository.id,
+        imported: Boolean(watched),
+        name: repository.name,
+        owner: {
+          id: repository.ownerId,
+          login: repository.ownerLogin,
+        },
+        private: repository.private,
+        syncStatus: watched?.syncStatus ?? "disabled",
+        watchedPathGlobs: watched?.watchedPathGlobs ?? null,
+        webUrl: input.buildGitHubRepositoryUrl({
+          fullName: repository.fullName,
+          webBaseUrl: input.webBaseUrl,
+        }),
+      };
+    });
+}
+
 async function getActiveBindingForOrg(input: {
   deps: SourceControlCommandDeps;
   orgId: string;
@@ -338,6 +451,7 @@ async function createBindingSummary(input: {
 
   return bindingResponse({
     binding: input.binding,
+    deps: input.deps,
     githubWebBaseUrl: input.config.endpoints.webBaseUrl,
     importedRepositoryCount: countNormalImportedRepositories({
       binding: input.binding,
@@ -414,6 +528,7 @@ export const listSourceControlRepositoriesCommand = defineCommand<
     );
     const bindingSummary = bindingResponse({
       binding,
+      deps,
       githubWebBaseUrl: config.endpoints.webBaseUrl,
       importedRepositoryCount: countNormalImportedRepositories({
         binding,
@@ -479,6 +594,7 @@ export const listSourceControlRepositoriesCommand = defineCommand<
         organization: organizationResponse(installation),
         repositories: buildSourceControlRepositoryResponse({
           binding,
+          buildGitHubRepositoryUrl: deps.buildGitHubRepositoryUrl,
           liveRepositories,
           watchedRepositories,
           webBaseUrl: config.endpoints.webBaseUrl,
@@ -605,6 +721,7 @@ export const importSourceControlRepositoryCommand = defineCommand<
     );
     const bindingSummary = bindingResponse({
       binding,
+      deps,
       githubWebBaseUrl: config.endpoints.webBaseUrl,
       importedRepositoryCount: countNormalImportedRepositories({
         binding,
@@ -618,6 +735,7 @@ export const importSourceControlRepositoryCommand = defineCommand<
       organization: organizationResponse(installation),
       repositories: buildSourceControlRepositoryResponse({
         binding,
+        buildGitHubRepositoryUrl: deps.buildGitHubRepositoryUrl,
         liveRepositories,
         watchedRepositories,
         webBaseUrl: config.endpoints.webBaseUrl,

--- a/api/app/src/services/github/source-control/command-deps.ts
+++ b/api/app/src/services/github/source-control/command-deps.ts
@@ -1,0 +1,49 @@
+import type { Database } from "@db/app";
+import {
+  getActiveOrgBinding,
+  insertWatchedSourceControlRepository,
+  listWatchedSourceControlRepositories,
+} from "@db/app";
+import {
+  buildGitHubNewRepositoryUrl,
+  buildGitHubRepositoryUrl,
+  createGitHubAppJwt,
+  createGitHubInstallationToken,
+  getGitHubAppInstallation,
+} from "@lightfast/connector-github/node";
+
+import type { SourceControlCommandDeps } from "../../../domain/source-control";
+import { getGitHubAppConfig } from "../config";
+import { listAllGitHubInstallationRepositories } from "./repositories";
+
+type SourceControlCommandDepOverrides = Partial<
+  Omit<SourceControlCommandDeps, "db">
+>;
+
+export function createDefaultSourceControlCommandDeps(
+  input: { db: Database } & SourceControlCommandDepOverrides
+): SourceControlCommandDeps {
+  return {
+    buildGitHubNewRepositoryUrl:
+      input.buildGitHubNewRepositoryUrl ?? buildGitHubNewRepositoryUrl,
+    buildGitHubRepositoryUrl:
+      input.buildGitHubRepositoryUrl ?? buildGitHubRepositoryUrl,
+    createGitHubAppJwt: input.createGitHubAppJwt ?? createGitHubAppJwt,
+    createGitHubInstallationToken:
+      input.createGitHubInstallationToken ?? createGitHubInstallationToken,
+    db: input.db,
+    getActiveOrgBinding: input.getActiveOrgBinding ?? getActiveOrgBinding,
+    getGitHubAppConfig: input.getGitHubAppConfig ?? getGitHubAppConfig,
+    getGitHubAppInstallation:
+      input.getGitHubAppInstallation ?? getGitHubAppInstallation,
+    insertWatchedSourceControlRepository:
+      input.insertWatchedSourceControlRepository ??
+      insertWatchedSourceControlRepository,
+    listAllGitHubInstallationRepositories:
+      input.listAllGitHubInstallationRepositories ??
+      listAllGitHubInstallationRepositories,
+    listWatchedSourceControlRepositories:
+      input.listWatchedSourceControlRepositories ??
+      listWatchedSourceControlRepositories,
+  };
+}


### PR DESCRIPTION
## Summary
- move source-control runtime GitHub wiring out of the domain command module into a service-owned command-deps factory
- make source-control domain commands consume explicit dependency function contracts
- add a source boundary ratchet for the source-control domain command module

## Verification
- pnpm --filter @api/app test -- src/__tests__/source-control-domain-boundary-source.test.ts src/__tests__/org-source-control-domain-commands.test.ts src/__tests__/org-source-control-tanstack-adapter-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog only; no touched files listed)
- agent-browser smoke: https://auth-architecture-next-slice-41.lightfast.localhost loaded
- curl /api/v1/signals returned 401 auth_required
- OPTIONS /api/v1/signals returned 204