### PR TITLE
Refactor GitHub setup command deps

### DIFF
--- a/api/app/src/__tests__/github-setup-domain-boundary-source.test.ts
+++ b/api/app/src/__tests__/github-setup-domain-boundary-source.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const apiRoot = resolve(repoRoot, "api/app");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("GitHub setup domain boundary", () => {
+  it("keeps GitHub runtime wiring outside the domain command module", () => {
+    const commandSource = source("src/domain/github-setup/commands.ts");
+    const tanstackAdapterSource = source(
+      "src/adapters/tanstack/github-setup.ts"
+    );
+
+    expect(commandSource).not.toContain("@lightfast/connector-github/node");
+    expect(commandSource).not.toContain("createDefaultGitHubSetupCommandDeps");
+    expect(tanstackAdapterSource).toContain(
+      "../../services/github/setup/command-deps"
+    );
+  });
+});

--- a/api/app/src/adapters/tanstack/github-setup.ts
+++ b/api/app/src/adapters/tanstack/github-setup.ts
@@ -7,11 +7,11 @@ import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultGitHubSetupCommandDeps,
   startGitHubOrgSetupCommand,
   syncGitHubBindingClaimCommand,
   verifyGitHubLightfastRepoCommand,
 } from "../../domain/github-setup";
+import { createDefaultGitHubSetupCommandDeps } from "../../services/github/setup/command-deps";
 
 export type StartGitHubOrgSetupInput = z.input<
   typeof startGitHubOrgSetupCommand.input

--- a/api/app/src/domain/github-setup/commands.ts
+++ b/api/app/src/domain/github-setup/commands.ts
@@ -1,21 +1,9 @@
 import type { Database } from "@db/app";
 import { githubBindStartOutputSchema } from "@lightfast/connector-github/contract";
-import { buildGitHubInstallationUrl } from "@lightfast/connector-github/node";
-import { orgSetupGateSchema } from "@repo/api-contract";
+import { type OrgSetupGate, orgSetupGateSchema } from "@repo/api-contract";
 import { clerkOrgSlugSchema } from "@repo/app-validation";
 import { z } from "zod";
 
-import {
-  getOrgAccessBySlug,
-  isOrgAccessError,
-} from "../../auth/organization-access";
-import { getGitHubAppConfig } from "../../services/github/config";
-import { issueGitHubInstallAttempt } from "../../services/github/setup/attempts";
-import { syncGitHubBindingClaim } from "../../services/github/setup/flow";
-import {
-  GitHubLightfastRepositorySetupError,
-  verifyGitHubLightfastRepositorySetup,
-} from "../../services/github/setup/lightfast-repository";
 import { defineCommand } from "../command";
 import {
   AuthzError,
@@ -34,35 +22,47 @@ type GitHubLightfastRepositorySetupErrorCode =
   | "lightfast_repo_inaccessible"
   | "lightfast_repo_missing";
 
-interface GitHubSetupCommandDeps {
-  buildGitHubInstallationUrl: typeof buildGitHubInstallationUrl;
-  db: Database;
-  getGitHubAppConfig: typeof getGitHubAppConfig;
-  getOrgAccessBySlug: typeof getOrgAccessBySlug;
-  isOrgAccessError: (error: unknown) => boolean;
-  issueGitHubInstallAttempt: typeof issueGitHubInstallAttempt;
-  syncGitHubBindingClaim: typeof syncGitHubBindingClaim;
-  verifyGitHubLightfastRepositorySetup: typeof verifyGitHubLightfastRepositorySetup;
+interface GitHubSetupOrgAccess {
+  org: {
+    id: string;
+    slug: string;
+  };
+  role: string;
 }
 
-export function createDefaultGitHubSetupCommandDeps(
-  input: { db: Database } & Partial<GitHubSetupCommandDeps>
-): GitHubSetupCommandDeps {
-  return {
-    buildGitHubInstallationUrl:
-      input.buildGitHubInstallationUrl ?? buildGitHubInstallationUrl,
-    db: input.db,
-    getGitHubAppConfig: input.getGitHubAppConfig ?? getGitHubAppConfig,
-    getOrgAccessBySlug: input.getOrgAccessBySlug ?? getOrgAccessBySlug,
-    isOrgAccessError: input.isOrgAccessError ?? isOrgAccessError,
-    issueGitHubInstallAttempt:
-      input.issueGitHubInstallAttempt ?? issueGitHubInstallAttempt,
-    syncGitHubBindingClaim:
-      input.syncGitHubBindingClaim ?? syncGitHubBindingClaim,
-    verifyGitHubLightfastRepositorySetup:
-      input.verifyGitHubLightfastRepositorySetup ??
-      verifyGitHubLightfastRepositorySetup,
+interface GitHubSetupAppConfig {
+  appSlug: string;
+  endpoints: {
+    webBaseUrl: string;
   };
+}
+
+export interface GitHubSetupCommandDeps {
+  buildGitHubInstallationUrl: (input: {
+    appSlug: string;
+    state: string;
+    webBaseUrl?: string;
+  }) => string;
+  db: Database;
+  getGitHubAppConfig: () => GitHubSetupAppConfig;
+  getOrgAccessBySlug: (input: {
+    db: Database;
+    slug: string;
+    userId: string;
+  }) => Promise<GitHubSetupOrgAccess>;
+  isOrgAccessError: (error: unknown) => boolean;
+  issueGitHubInstallAttempt: (input: {
+    clerkOrgId: string;
+    lightfastUserId: string;
+    orgSlug: string;
+  }) => Promise<{ state: string }>;
+  syncGitHubBindingClaim: (input: {
+    clerkOrgId: string;
+  }) => Promise<OrgSetupGate>;
+  verifyGitHubLightfastRepositorySetup: (input: {
+    clerkOrgId: string;
+    db: Database;
+  }) => Promise<OrgSetupGate>;
 }
 
 const startGitHubOrgSetupInput = z.object({
@@ -74,10 +74,6 @@ function isGitHubLightfastRepositorySetupError(error: unknown): error is {
   code: GitHubLightfastRepositorySetupErrorCode;
   message: string;
 } {
-  if (error instanceof GitHubLightfastRepositorySetupError) {
-    return true;
-  }
-
   return (
     typeof error === "object" &&
     error !== null &&

--- a/api/app/src/services/github/setup/command-deps.ts
+++ b/api/app/src/services/github/setup/command-deps.ts
@@ -1,0 +1,36 @@
+import type { Database } from "@db/app";
+import { buildGitHubInstallationUrl } from "@lightfast/connector-github/node";
+
+import {
+  getOrgAccessBySlug,
+  isOrgAccessError,
+} from "../../../auth/organization-access";
+import type { GitHubSetupCommandDeps } from "../../../domain/github-setup";
+import { getGitHubAppConfig } from "../config";
+import { issueGitHubInstallAttempt } from "./attempts";
+import { syncGitHubBindingClaim } from "./flow";
+import { verifyGitHubLightfastRepositorySetup } from "./lightfast-repository";
+
+type GitHubSetupCommandDepOverrides = Partial<
+  Omit<GitHubSetupCommandDeps, "db">
+>;
+
+export function createDefaultGitHubSetupCommandDeps(
+  input: { db: Database } & GitHubSetupCommandDepOverrides
+): GitHubSetupCommandDeps {
+  return {
+    buildGitHubInstallationUrl:
+      input.buildGitHubInstallationUrl ?? buildGitHubInstallationUrl,
+    db: input.db,
+    getGitHubAppConfig: input.getGitHubAppConfig ?? getGitHubAppConfig,
+    getOrgAccessBySlug: input.getOrgAccessBySlug ?? getOrgAccessBySlug,
+    isOrgAccessError: input.isOrgAccessError ?? isOrgAccessError,
+    issueGitHubInstallAttempt:
+      input.issueGitHubInstallAttempt ?? issueGitHubInstallAttempt,
+    syncGitHubBindingClaim:
+      input.syncGitHubBindingClaim ?? syncGitHubBindingClaim,
+    verifyGitHubLightfastRepositorySetup:
+      input.verifyGitHubLightfastRepositorySetup ??
+      verifyGitHubLightfastRepositorySetup,
+  };
+}


### PR DESCRIPTION
## Summary
- move GitHub setup runtime wiring out of the domain command module into a service-owned command-deps factory
- make GitHub setup domain commands consume explicit dependency function contracts
- add a source boundary ratchet for the GitHub setup domain command module

## Verification
- pnpm --filter @api/app test -- src/__tests__/github-setup-domain-boundary-source.test.ts src/__tests__/github-setup-domain-commands.test.ts src/__tests__/github-setup-tanstack-adapter-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog only; no touched files listed)
- agent-browser smoke: https://auth-architecture-next-slice-42.lightfast.localhost loaded
- curl /api/v1/signals returned 401 auth_required
- OPTIONS /api/v1/signals returned 204