### PR TITLE
Refactor app command deps ownership

### DIFF
--- a/api/app/src/__tests__/account-connector-domain-commands.test.ts
+++ b/api/app/src/__tests__/account-connector-domain-commands.test.ts
@@ -9,7 +9,6 @@ import {
   revokeAccountMcpConnectionCommand,
 } from "../domain/mcp-connections";
 import {
-  createDefaultUserConnectorCommandDeps,
   disconnectUserConnectorCommand,
   startUserConnectorCommand,
 } from "../domain/user-connectors";
@@ -93,12 +92,12 @@ function mcpDeps() {
 }
 
 function userConnectorDeps(referer?: string | null) {
-  return createDefaultUserConnectorCommandDeps({
+  return {
     db: {} as Database,
     disconnectGranolaUserConnector: disconnectGranolaUserConnectorMock,
     request: { referer },
     startGranolaUserConnectorOAuth: startGranolaUserConnectorOAuthMock,
-  });
+  };
 }
 
 beforeEach(() => {

--- a/api/app/src/__tests__/account-connector-domain-commands.test.ts
+++ b/api/app/src/__tests__/account-connector-domain-commands.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   disconnectUserConnectorCommand,
   startUserConnectorCommand,
+  type UserConnectorCommandDeps,
 } from "../domain/user-connectors";
 
 const listMcpOauthGrantConnectionsForUserMock = vi.fn();
@@ -97,7 +98,7 @@ function userConnectorDeps(referer?: string | null) {
     disconnectGranolaUserConnector: disconnectGranolaUserConnectorMock,
     request: { referer },
     startGranolaUserConnectorOAuth: startGranolaUserConnectorOAuthMock,
-  };
+  } satisfies UserConnectorCommandDeps;
 }
 
 beforeEach(() => {

--- a/api/app/src/__tests__/account-domain-commands.test.ts
+++ b/api/app/src/__tests__/account-domain-commands.test.ts
@@ -5,8 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
+  type AccountCommandDeps,
   createAccountUsernameCommand,
-  createDefaultAccountCommandDeps,
   getAccountProfileCommand,
   updateAccountNameCommand,
 } from "../domain/account";
@@ -88,7 +88,7 @@ function operation(
 }
 
 function deps() {
-  return createDefaultAccountCommandDeps({
+  return {
     clerk: {
       users: {
         getUser: getUserMock,
@@ -97,13 +97,17 @@ function deps() {
     },
     db: {} as Database,
     deletePreClerkNamespaceReservation: deletePreClerkNamespaceReservationMock,
+    disconnectGitHubUserAccount: vi.fn(),
     finalizeNamespaceOperation: finalizeNamespaceOperationMock,
+    getGitHubUserAccountStatus: vi.fn(),
     isClerkConflictError: isClerkConflictErrorMock,
     log: { error: logErrorMock },
     markNamespaceOperationClerkApplied: markNamespaceOperationClerkAppliedMock,
+    parseError: (error: unknown) => error,
     reserveNamespaceForOperation: reserveNamespaceForOperationMock,
+    startGitHubUserAccountBinding: vi.fn(),
     startNamespaceOperation: startNamespaceOperationMock,
-  });
+  } satisfies AccountCommandDeps;
 }
 
 beforeEach(() => {

--- a/api/app/src/__tests__/connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/connectors-domain-commands.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
-  createDefaultConnectorCommandDeps,
+  type ConnectorCommandDeps,
   disconnectConnectorCommand,
   listConnectorSectionsCommand,
   listConnectorsCommand,
@@ -62,7 +62,7 @@ function ctx(input: { admin?: boolean; identity?: AuthIdentity } = {}) {
 }
 
 function deps() {
-  return createDefaultConnectorCommandDeps({
+  return {
     db: {} as Database,
     disconnectConnector: serviceMocks.disconnectConnector,
     listConnectorsForOrg: serviceMocks.listConnectorsForOrg,
@@ -71,7 +71,7 @@ function deps() {
     setConnectorAgentEnabled: serviceMocks.setConnectorAgentEnabled,
     setConnectorAutomationEnabled: serviceMocks.setConnectorAutomationEnabled,
     startConnectorOAuth: serviceMocks.startConnectorOAuth,
-  });
+  } satisfies ConnectorCommandDeps;
 }
 
 describe("connector domain commands", () => {

--- a/api/app/src/__tests__/developer-connections-domain-commands.test.ts
+++ b/api/app/src/__tests__/developer-connections-domain-commands.test.ts
@@ -6,7 +6,7 @@ import { actorFromAuthIdentity } from "../domain";
 import {
   completeSentryDeveloperConnectionAuthCommand,
   connectDeveloperConnectionCommand,
-  createDefaultDeveloperConnectionCommandDeps,
+  type DeveloperConnectionCommandDeps,
   disconnectDeveloperConnectionCommand,
   listDeveloperConnectionsCommand,
   setDeveloperConnectionSandboxEnabledCommand,
@@ -54,7 +54,7 @@ function ctx(input: { admin?: boolean; identity?: AuthIdentity } = {}) {
 }
 
 function deps() {
-  return createDefaultDeveloperConnectionCommandDeps({
+  return {
     completeSentryDeveloperConnectionAuth:
       serviceMocks.completeSentryDeveloperConnectionAuth,
     connectDeveloperConnection: serviceMocks.connectDeveloperConnection,
@@ -65,7 +65,7 @@ function deps() {
       serviceMocks.setDeveloperConnectionSandboxEnabled,
     startSentryDeveloperConnectionAuth:
       serviceMocks.startSentryDeveloperConnectionAuth,
-  });
+  } satisfies DeveloperConnectionCommandDeps;
 }
 
 describe("developer connection domain commands", () => {

--- a/api/app/src/__tests__/domain-command-deps-boundary-source.test.ts
+++ b/api/app/src/__tests__/domain-command-deps-boundary-source.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const apiRoot = resolve(repoRoot, "api/app");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("domain command dependency boundaries", () => {
+  it("keeps app runtime wiring out of service-backed domain command modules", () => {
+    const modules = [
+      {
+        command: "src/domain/account/commands.ts",
+        factory: "createDefaultAccountCommandDeps",
+        runtimeImports: [
+          "../../services/github/user-account/flow",
+          "@vendor/clerk/server",
+        ],
+      },
+      {
+        command: "src/domain/connectors/commands.ts",
+        factory: "createDefaultConnectorCommandDeps",
+        runtimeImports: [
+          "../../services/connectors",
+          "../../services/user-connectors/catalog",
+        ],
+      },
+      {
+        command: "src/domain/developer-connections/commands.ts",
+        factory: "createDefaultDeveloperConnectionCommandDeps",
+        runtimeImports: ["../../services/developer-connections"],
+      },
+      {
+        command: "src/domain/org-identity/commands.ts",
+        factory: "createDefaultOrgIdentityCommandDeps",
+        runtimeImports: [
+          "../../services/identity/eligibility",
+          "../../services/identity/github",
+          "../../inngest/client",
+        ],
+      },
+      {
+        command: "src/domain/user-connectors/commands.ts",
+        factory: "createDefaultUserConnectorCommandDeps",
+        runtimeImports: ["../../services/user-connectors/granola-flow"],
+      },
+    ];
+
+    for (const module of modules) {
+      const commandSource = source(module.command);
+      expect(commandSource).not.toContain(module.factory);
+
+      for (const runtimeImport of module.runtimeImports) {
+        expect(commandSource).not.toContain(runtimeImport);
+      }
+    }
+  });
+
+  it("keeps concrete app wiring explicit in the TanStack adapter modules", () => {
+    const adapterExpectations = [
+      {
+        adapter: "src/adapters/tanstack/account.ts",
+        runtimeImports: ["../../services/github/user-account/flow"],
+      },
+      {
+        adapter: "src/adapters/tanstack/connectors.ts",
+        runtimeImports: [
+          "../../services/connectors",
+          "../../services/user-connectors/catalog",
+        ],
+      },
+      {
+        adapter: "src/adapters/tanstack/developer-connections.ts",
+        runtimeImports: ["../../services/developer-connections"],
+      },
+      {
+        adapter: "src/adapters/tanstack/org-identity.ts",
+        runtimeImports: [
+          "../../services/identity/eligibility",
+          "../../services/identity/github",
+          "../../inngest/client",
+        ],
+      },
+      {
+        adapter: "src/adapters/tanstack/user-connectors.ts",
+        runtimeImports: ["../../services/user-connectors/granola-flow"],
+      },
+    ];
+
+    for (const expectation of adapterExpectations) {
+      const adapterSource = source(expectation.adapter);
+
+      for (const runtimeImport of expectation.runtimeImports) {
+        expect(adapterSource).toContain(runtimeImport);
+      }
+    }
+  });
+});

--- a/api/app/src/__tests__/github-account-domain-commands.test.ts
+++ b/api/app/src/__tests__/github-account-domain-commands.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
-  createDefaultAccountCommandDeps,
+  type AccountCommandDeps,
   disconnectGitHubAccountCommand,
   getGitHubAccountStatusCommand,
   startGitHubAccountBindingCommand,
@@ -32,7 +32,7 @@ function ctx(identity: AuthIdentity = pendingIdentity) {
 }
 
 function deps() {
-  return createDefaultAccountCommandDeps({
+  return {
     clerk: {
       users: {
         getUser: vi.fn(),
@@ -40,10 +40,18 @@ function deps() {
       },
     },
     db: {} as Database,
+    deletePreClerkNamespaceReservation: vi.fn(),
     disconnectGitHubUserAccount: disconnectGitHubUserAccountMock,
+    finalizeNamespaceOperation: vi.fn(),
     getGitHubUserAccountStatus: getGitHubUserAccountStatusMock,
+    isClerkConflictError: vi.fn(),
+    log: { error: vi.fn() },
+    markNamespaceOperationClerkApplied: vi.fn(),
+    parseError: (error: unknown) => error,
+    reserveNamespaceForOperation: vi.fn(),
     startGitHubUserAccountBinding: startGitHubUserAccountBindingMock,
-  });
+    startNamespaceOperation: vi.fn(),
+  } satisfies AccountCommandDeps;
 }
 
 describe("GitHub account domain commands", () => {

--- a/api/app/src/__tests__/user-connectors-domain-boundary-source.test.ts
+++ b/api/app/src/__tests__/user-connectors-domain-boundary-source.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../../../..");
+const apiRoot = resolve(repoRoot, "api/app");
+
+function source(path: string) {
+  return readFileSync(resolve(apiRoot, path), "utf8");
+}
+
+describe("user connectors domain boundary", () => {
+  it("keeps Granola service wiring outside the domain command module", () => {
+    const commandSource = source("src/domain/user-connectors/commands.ts");
+    const tanstackAdapterSource = source(
+      "src/adapters/tanstack/user-connectors.ts"
+    );
+
+    expect(commandSource).not.toContain(
+      "../../services/user-connectors/granola-flow"
+    );
+    expect(commandSource).not.toContain(
+      "createDefaultUserConnectorCommandDeps"
+    );
+    expect(tanstackAdapterSource).toContain(
+      "../../services/user-connectors/granola-flow"
+    );
+  });
+});

--- a/api/app/src/__tests__/user-connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/user-connectors-domain-commands.test.ts
@@ -7,7 +7,6 @@ import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import { ValidationError } from "../domain/errors";
 import {
-  createDefaultUserConnectorCommandDeps,
   disconnectUserConnectorCommand,
   startUserConnectorCommand,
 } from "../domain/user-connectors";
@@ -30,12 +29,12 @@ function ctx() {
 }
 
 function deps() {
-  return createDefaultUserConnectorCommandDeps({
+  return {
     db: {} as Database,
     disconnectGranolaUserConnector: serviceMocks.disconnectGranolaUserConnector,
     request: {},
     startGranolaUserConnectorOAuth: serviceMocks.startGranolaUserConnectorOAuth,
-  });
+  };
 }
 
 describe("user connector domain commands", () => {

--- a/api/app/src/__tests__/user-connectors-domain-commands.test.ts
+++ b/api/app/src/__tests__/user-connectors-domain-commands.test.ts
@@ -9,6 +9,7 @@ import { ValidationError } from "../domain/errors";
 import {
   disconnectUserConnectorCommand,
   startUserConnectorCommand,
+  type UserConnectorCommandDeps,
 } from "../domain/user-connectors";
 
 const serviceMocks = vi.hoisted(() => ({
@@ -34,7 +35,7 @@ function deps() {
     disconnectGranolaUserConnector: serviceMocks.disconnectGranolaUserConnector,
     request: {},
     startGranolaUserConnectorOAuth: serviceMocks.startGranolaUserConnectorOAuth,
-  };
+  } satisfies UserConnectorCommandDeps;
 }
 
 describe("user connector domain commands", () => {

--- a/api/app/src/__tests__/user-connectors-service-boundary-source.test.ts
+++ b/api/app/src/__tests__/user-connectors-service-boundary-source.test.ts
@@ -27,8 +27,9 @@ function isThisTestFile(path: string) {
 }
 
 describe("user connector service boundary", () => {
-  it("pins user connector catalog imports to the concrete service module", () => {
+  it("pins user connector catalog imports to the concrete app adapter/service modules", () => {
     const connectorCommandsSource = source("domain/connectors/commands.ts");
+    const connectorAdapterSource = source("adapters/tanstack/connectors.ts");
     const connectorCommandsTestSource = source(
       "__tests__/connectors-domain-commands.test.ts"
     );
@@ -36,7 +37,10 @@ describe("user connector service boundary", () => {
       "__tests__/user-connectors-flow.test.ts"
     );
 
-    expect(connectorCommandsSource).toContain(
+    expect(connectorCommandsSource).not.toContain(
+      "../../services/user-connectors/catalog"
+    );
+    expect(connectorAdapterSource).toContain(
       "../../services/user-connectors/catalog"
     );
     expect(connectorCommandsSource).not.toMatch(

--- a/api/app/src/adapters/tanstack/account.ts
+++ b/api/app/src/adapters/tanstack/account.ts
@@ -1,18 +1,34 @@
+import {
+  deletePreClerkNamespaceReservation,
+  finalizeNamespaceOperation,
+  markNamespaceOperationClerkApplied,
+  reserveNamespaceForOperation,
+  startNamespaceOperation,
+} from "@db/app";
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { clerkClient } from "@vendor/clerk/server";
+import { parseError } from "@vendor/observability/error/next";
+import { log } from "@vendor/observability/log/next";
 
+import { isClerkConflictError } from "../../auth/clerk-errors";
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
+  type AccountCommandDeps,
   createAccountUsernameCommand,
-  createDefaultAccountCommandDeps,
   getAccountProfileCommand,
   getGitHubAccountStatusCommand,
   startGitHubAccountBindingCommand,
   syncGitHubAccountCommand,
   updateAccountNameCommand,
 } from "../../domain/account";
+import {
+  disconnectGitHubUserAccount,
+  getGitHubUserAccountStatus,
+  startGitHubUserAccountBinding,
+} from "../../services/github/user-account/flow";
 
 function requestId() {
   return crypto.randomUUID();
@@ -43,13 +59,32 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+async function deps(): Promise<AccountCommandDeps> {
+  const clerk = await clerkClient();
+  return {
+    clerk,
+    db,
+    deletePreClerkNamespaceReservation,
+    disconnectGitHubUserAccount,
+    finalizeNamespaceOperation,
+    getGitHubUserAccountStatus,
+    isClerkConflictError,
+    log,
+    markNamespaceOperationClerkApplied,
+    parseError,
+    reserveNamespaceForOperation,
+    startGitHubUserAccountBinding,
+    startNamespaceOperation,
+  };
+}
+
 export const getAccountProfile = createServerFn({ method: "GET" }).handler(
   async () => {
     noStore();
     try {
       return await getAccountProfileCommand.run({
         ctx: await createTanStackAccountContext(),
-        deps: await createDefaultAccountCommandDeps({ db }),
+        deps: await deps(),
         input: {},
       });
     } catch (error) {
@@ -65,7 +100,7 @@ export const updateAccountName = createServerFn({ method: "POST" })
     try {
       return await updateAccountNameCommand.run({
         ctx: await createTanStackAccountContext(),
-        deps: await createDefaultAccountCommandDeps({ db }),
+        deps: await deps(),
         input: data,
       });
     } catch (error) {
@@ -80,7 +115,7 @@ export const createAccountUsername = createServerFn({ method: "POST" })
     try {
       return await createAccountUsernameCommand.run({
         ctx: await createTanStackAccountContext(),
-        deps: await createDefaultAccountCommandDeps({ db }),
+        deps: await deps(),
         input: data,
       });
     } catch (error) {
@@ -94,7 +129,7 @@ export const getGitHubAccountStatus = createServerFn({ method: "GET" }).handler(
     try {
       return await getGitHubAccountStatusCommand.run({
         ctx: await createTanStackAccountContext(),
-        deps: await createDefaultAccountCommandDeps({ db }),
+        deps: await deps(),
         input: {},
       });
     } catch (error) {
@@ -110,7 +145,7 @@ export const startGitHubAccountBinding = createServerFn({ method: "POST" })
     try {
       return await startGitHubAccountBindingCommand.run({
         ctx: await createTanStackAccountContext(),
-        deps: await createDefaultAccountCommandDeps({ db }),
+        deps: await deps(),
         input: data,
       });
     } catch (error) {
@@ -124,7 +159,7 @@ export const syncGitHubAccount = createServerFn({ method: "POST" }).handler(
     try {
       return await syncGitHubAccountCommand.run({
         ctx: await createTanStackAccountContext(),
-        deps: await createDefaultAccountCommandDeps({ db }),
+        deps: await deps(),
         input: {},
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/connectors.ts
+++ b/api/app/src/adapters/tanstack/connectors.ts
@@ -7,7 +7,7 @@ import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultConnectorCommandDeps,
+  type ConnectorCommandDeps,
   disconnectConnectorCommand,
   listConnectorSectionsCommand,
   listConnectorsCommand,
@@ -16,6 +16,15 @@ import {
   setConnectorAutomationEnabledCommand,
   startConnectorOAuthCommand,
 } from "../../domain/connectors";
+import {
+  disconnectConnector as disconnectConnectorService,
+  listConnectorsForOrg,
+  refreshConnectorTools as refreshConnectorToolsService,
+  setConnectorAgentEnabled as setConnectorAgentEnabledService,
+  setConnectorAutomationEnabled as setConnectorAutomationEnabledService,
+  startConnectorOAuth as startConnectorOAuthService,
+} from "../../services/connectors";
+import { listUserConnectorsForViewer } from "../../services/user-connectors/catalog";
 
 export type StartConnectorInput = z.input<
   typeof startConnectorOAuthCommand.input
@@ -81,10 +90,17 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
-function deps() {
-  return createDefaultConnectorCommandDeps({
+function deps(): ConnectorCommandDeps {
+  return {
     db,
-  });
+    disconnectConnector: disconnectConnectorService,
+    listConnectorsForOrg,
+    listUserConnectorsForViewer,
+    refreshConnectorTools: refreshConnectorToolsService,
+    setConnectorAgentEnabled: setConnectorAgentEnabledService,
+    setConnectorAutomationEnabled: setConnectorAutomationEnabledService,
+    startConnectorOAuth: startConnectorOAuthService,
+  };
 }
 
 export const listConnectors = createServerFn({ method: "GET" }).handler(

--- a/api/app/src/adapters/tanstack/developer-connections.ts
+++ b/api/app/src/adapters/tanstack/developer-connections.ts
@@ -9,12 +9,20 @@ import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
   completeSentryDeveloperConnectionAuthCommand,
   connectDeveloperConnectionCommand,
-  createDefaultDeveloperConnectionCommandDeps,
+  type DeveloperConnectionCommandDeps,
   disconnectDeveloperConnectionCommand,
   listDeveloperConnectionsCommand,
   setDeveloperConnectionSandboxEnabledCommand,
   startSentryDeveloperConnectionAuthCommand,
 } from "../../domain/developer-connections";
+import {
+  completeSentryDeveloperConnectionAuth as completeSentryDeveloperConnectionAuthService,
+  connectDeveloperConnection as connectDeveloperConnectionService,
+  disconnectDeveloperConnection as disconnectDeveloperConnectionService,
+  listDeveloperConnectionsForOrg,
+  setDeveloperConnectionSandboxEnabled as setDeveloperConnectionSandboxEnabledService,
+  startSentryDeveloperConnectionAuth as startSentryDeveloperConnectionAuthService,
+} from "../../services/developer-connections";
 
 export type ConnectDeveloperConnectionInput = z.input<
   typeof connectDeveloperConnectionCommand.input
@@ -80,6 +88,21 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+function deps(): DeveloperConnectionCommandDeps {
+  return {
+    completeSentryDeveloperConnectionAuth:
+      completeSentryDeveloperConnectionAuthService,
+    connectDeveloperConnection: connectDeveloperConnectionService,
+    db,
+    disconnectDeveloperConnection: disconnectDeveloperConnectionService,
+    listDeveloperConnectionsForOrg,
+    setDeveloperConnectionSandboxEnabled:
+      setDeveloperConnectionSandboxEnabledService,
+    startSentryDeveloperConnectionAuth:
+      startSentryDeveloperConnectionAuthService,
+  };
+}
+
 export const listDeveloperConnections = createServerFn({
   method: "GET",
 }).handler(async () => {
@@ -88,9 +111,7 @@ export const listDeveloperConnections = createServerFn({
     const request = await createTanStackDeveloperConnectionRequest();
     return await listDeveloperConnectionsCommand.run({
       ctx: request.ctx,
-      deps: createDefaultDeveloperConnectionCommandDeps({
-        db,
-      }),
+      deps: deps(),
       input: {},
     });
   } catch (error) {
@@ -106,9 +127,7 @@ export const connectDeveloperConnection = createServerFn({ method: "POST" })
       const request = await createTanStackDeveloperConnectionRequest();
       return await connectDeveloperConnectionCommand.run({
         ctx: request.ctx,
-        deps: createDefaultDeveloperConnectionCommandDeps({
-          db,
-        }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -126,9 +145,7 @@ export const startSentryDeveloperConnectionAuth = createServerFn({
       const request = await createTanStackDeveloperConnectionRequest();
       return await startSentryDeveloperConnectionAuthCommand.run({
         ctx: request.ctx,
-        deps: createDefaultDeveloperConnectionCommandDeps({
-          db,
-        }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -146,9 +163,7 @@ export const completeSentryDeveloperConnectionAuth = createServerFn({
       const request = await createTanStackDeveloperConnectionRequest();
       return await completeSentryDeveloperConnectionAuthCommand.run({
         ctx: request.ctx,
-        deps: createDefaultDeveloperConnectionCommandDeps({
-          db,
-        }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -166,9 +181,7 @@ export const setDeveloperConnectionSandboxEnabled = createServerFn({
       const request = await createTanStackDeveloperConnectionRequest();
       return await setDeveloperConnectionSandboxEnabledCommand.run({
         ctx: request.ctx,
-        deps: createDefaultDeveloperConnectionCommandDeps({
-          db,
-        }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {
@@ -184,9 +197,7 @@ export const disconnectDeveloperConnection = createServerFn({ method: "POST" })
       const request = await createTanStackDeveloperConnectionRequest();
       return await disconnectDeveloperConnectionCommand.run({
         ctx: request.ctx,
-        deps: createDefaultDeveloperConnectionCommandDeps({
-          db,
-        }),
+        deps: deps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/org-identity.ts
+++ b/api/app/src/adapters/tanstack/org-identity.ts
@@ -1,3 +1,8 @@
+import {
+  getIdentityIndexStateBySourceControlRepositoryId,
+  listIdentityIndexFiles,
+  listIdentityIndexRefreshCandidates,
+} from "@db/app";
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
@@ -5,9 +10,13 @@ import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultOrgIdentityCommandDeps,
   getOrgIdentityCommand,
+  type OrgIdentityCommandDeps,
 } from "../../domain/org-identity";
+import { inngest } from "../../inngest/client";
+import { createIdentityRefreshDedupeKey } from "../../inngest/workflow/identity-refresh-event";
+import { isVerifiedLightfastIdentityRepository } from "../../services/identity/eligibility";
+import { readIdentityRepositoryMainRef } from "../../services/identity/github";
 
 function requestId() {
   return crypto.randomUUID();
@@ -38,13 +47,43 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+async function requestIdentityRefresh(sourceControlRepositoryId: number) {
+  try {
+    await inngest.send({
+      data: {
+        dedupeKey: createIdentityRefreshDedupeKey({
+          reason: "read",
+          sourceControlRepositoryId,
+        }),
+        reason: "read",
+        sourceControlRepositoryId,
+      },
+      name: "app/identity.index.refresh.requested",
+    });
+  } catch {
+    return;
+  }
+}
+
+function deps(): OrgIdentityCommandDeps {
+  return {
+    db,
+    getIdentityIndexStateBySourceControlRepositoryId,
+    isVerifiedLightfastIdentityRepository,
+    listIdentityIndexFiles,
+    listIdentityIndexRefreshCandidates,
+    readIdentityRepositoryMainRef,
+    requestIdentityRefresh,
+  };
+}
+
 export const getOrgIdentity = createServerFn({ method: "GET" }).handler(
   async () => {
     noStore();
     try {
       return await getOrgIdentityCommand.run({
         ctx: await createTanStackOrgIdentityContext(),
-        deps: createDefaultOrgIdentityCommandDeps({ db }),
+        deps: deps(),
         input: {},
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/org-identity.ts
+++ b/api/app/src/adapters/tanstack/org-identity.ts
@@ -6,6 +6,7 @@ import {
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { log } from "@vendor/observability/log/next";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
@@ -60,7 +61,11 @@ async function requestIdentityRefresh(sourceControlRepositoryId: number) {
       },
       name: "app/identity.index.refresh.requested",
     });
-  } catch {
+  } catch (error) {
+    log.error("[org-identity] refresh enqueue failed", {
+      error,
+      sourceControlRepositoryId,
+    });
     return;
   }
 }

--- a/api/app/src/adapters/tanstack/user-connectors.ts
+++ b/api/app/src/adapters/tanstack/user-connectors.ts
@@ -5,10 +5,14 @@ import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultUserConnectorCommandDeps,
   disconnectUserConnectorCommand,
   startUserConnectorCommand,
+  type UserConnectorCommandDeps,
 } from "../../domain/user-connectors";
+import {
+  disconnectGranolaUserConnector,
+  startGranolaUserConnectorOAuth,
+} from "../../services/user-connectors/granola-flow";
 
 function requestId() {
   return crypto.randomUUID();
@@ -38,6 +42,15 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+function deps(request: Request): UserConnectorCommandDeps {
+  return {
+    db,
+    disconnectGranolaUserConnector,
+    request: { referer: request.headers.get("referer") },
+    startGranolaUserConnectorOAuth,
+  };
+}
+
 export const startUserConnector = createServerFn({ method: "POST" })
   .inputValidator(startUserConnectorCommand.input)
   .handler(async ({ data }) => {
@@ -46,10 +59,7 @@ export const startUserConnector = createServerFn({ method: "POST" })
     try {
       return await startUserConnectorCommand.run({
         ctx: await createTanStackUserConnectorContext(request),
-        deps: createDefaultUserConnectorCommandDeps({
-          db,
-          request: { referer: request.headers.get("referer") },
-        }),
+        deps: deps(request),
         input: data,
       });
     } catch (error) {
@@ -65,10 +75,7 @@ export const disconnectUserConnector = createServerFn({ method: "POST" })
     try {
       return await disconnectUserConnectorCommand.run({
         ctx: await createTanStackUserConnectorContext(request),
-        deps: createDefaultUserConnectorCommandDeps({
-          db,
-          request: { referer: request.headers.get("referer") },
-        }),
+        deps: deps(request),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/user-connectors.ts
+++ b/api/app/src/adapters/tanstack/user-connectors.ts
@@ -42,11 +42,29 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+function sameOriginReferer(request: Request) {
+  const referer = request.headers.get("referer");
+  if (!referer) {
+    return null;
+  }
+
+  try {
+    const requestOrigin = new URL(request.url).origin;
+    const refererUrl = new URL(referer);
+    if (refererUrl.origin !== requestOrigin) {
+      return null;
+    }
+    return refererUrl.toString();
+  } catch {
+    return null;
+  }
+}
+
 function deps(request: Request): UserConnectorCommandDeps {
   return {
     db,
     disconnectGranolaUserConnector,
-    request: { referer: request.headers.get("referer") },
+    request: { referer: sameOriginReferer(request) },
     startGranolaUserConnectorOAuth,
   };
 }

--- a/api/app/src/domain/account/commands.ts
+++ b/api/app/src/domain/account/commands.ts
@@ -1,28 +1,19 @@
-import type { Database } from "@db/app";
-import {
+import type {
+  Database,
   deletePreClerkNamespaceReservation,
   finalizeNamespaceOperation,
   markNamespaceOperationClerkApplied,
-  NamespaceConflictError,
   reserveNamespaceForOperation,
   startNamespaceOperation,
 } from "@db/app";
+import { NamespaceConflictError } from "@db/app";
 import { githubUserAccountReturnToSchema } from "@lightfast/connector-github/contract";
 import {
   accountSettingsFormSchema,
   lightfastHandleSchema,
 } from "@repo/app-validation";
-import { clerkClient } from "@vendor/clerk/server";
-import { parseError } from "@vendor/observability/error/next";
-import { log } from "@vendor/observability/log/next";
 import { z } from "zod";
 
-import { isClerkConflictError } from "../../auth/clerk-errors";
-import {
-  disconnectGitHubUserAccount,
-  getGitHubUserAccountStatus,
-  startGitHubUserAccountBinding,
-} from "../../services/github/user-account/flow";
 import { defineCommand } from "../command";
 import {
   AuthzError,
@@ -33,95 +24,50 @@ import {
 import { requireClerkUserActor } from "../gates";
 import { type AccountProfileUser, toAccountProfile } from "./profile";
 
-type ClerkClient = Awaited<ReturnType<typeof clerkClient>>;
-type ClerkUserClient = Pick<ClerkClient["users"], "getUser" | "updateUser">;
+interface ClerkUserClient {
+  getUser(userId: string): Promise<AccountProfileUser>;
+  updateUser(
+    userId: string,
+    params: {
+      firstName?: string;
+      lastName?: string;
+      username?: string;
+    }
+  ): Promise<AccountProfileUser>;
+}
 
-interface AccountCommandDeps {
+interface GitHubAccountStatusResult {
+  account: null | {
+    accessTokenExpiresAt: Date;
+    connectedAt: Date;
+    provider: "github";
+    providerUserId: string;
+    refreshTokenExpiresAt: Date;
+    status: "active";
+  };
+}
+
+export interface AccountCommandDeps {
   clerk: { users: ClerkUserClient };
   db: Database;
   deletePreClerkNamespaceReservation: typeof deletePreClerkNamespaceReservation;
-  disconnectGitHubUserAccount: typeof disconnectGitHubUserAccount;
+  disconnectGitHubUserAccount(input: {
+    clerkUserId: string;
+  }): Promise<{ ok: true }>;
   finalizeNamespaceOperation: typeof finalizeNamespaceOperation;
-  getGitHubUserAccountStatus: typeof getGitHubUserAccountStatus;
-  isClerkConflictError: typeof isClerkConflictError;
-  log: Pick<typeof log, "error">;
+  getGitHubUserAccountStatus(input: {
+    clerkUserId: string;
+  }): Promise<GitHubAccountStatusResult>;
+  isClerkConflictError(error: unknown): boolean;
+  log: { error(message: string, context: Record<string, unknown>): void };
   markNamespaceOperationClerkApplied: typeof markNamespaceOperationClerkApplied;
+  parseError(error: unknown): unknown;
   reserveNamespaceForOperation: typeof reserveNamespaceForOperation;
-  startGitHubUserAccountBinding: typeof startGitHubUserAccountBinding;
+  startGitHubUserAccountBinding(input: {
+    lightfastUserId: string;
+    returnTo?: string;
+  }): Promise<{ authorizationUrl: string }>;
   startNamespaceOperation: typeof startNamespaceOperation;
-}
-
-export function createDefaultAccountCommandDeps(input: {
-  clerk: { users: ClerkUserClient };
-  db: Database;
-  deletePreClerkNamespaceReservation?: typeof deletePreClerkNamespaceReservation;
-  disconnectGitHubUserAccount?: typeof disconnectGitHubUserAccount;
-  finalizeNamespaceOperation?: typeof finalizeNamespaceOperation;
-  getGitHubUserAccountStatus?: typeof getGitHubUserAccountStatus;
-  isClerkConflictError?: typeof isClerkConflictError;
-  log?: Pick<typeof log, "error">;
-  markNamespaceOperationClerkApplied?: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation?: typeof reserveNamespaceForOperation;
-  startGitHubUserAccountBinding?: typeof startGitHubUserAccountBinding;
-  startNamespaceOperation?: typeof startNamespaceOperation;
-}): AccountCommandDeps;
-export function createDefaultAccountCommandDeps(input: {
-  clerk?: { users: ClerkUserClient };
-  db: Database;
-  deletePreClerkNamespaceReservation?: typeof deletePreClerkNamespaceReservation;
-  disconnectGitHubUserAccount?: typeof disconnectGitHubUserAccount;
-  finalizeNamespaceOperation?: typeof finalizeNamespaceOperation;
-  getGitHubUserAccountStatus?: typeof getGitHubUserAccountStatus;
-  isClerkConflictError?: typeof isClerkConflictError;
-  log?: Pick<typeof log, "error">;
-  markNamespaceOperationClerkApplied?: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation?: typeof reserveNamespaceForOperation;
-  startGitHubUserAccountBinding?: typeof startGitHubUserAccountBinding;
-  startNamespaceOperation?: typeof startNamespaceOperation;
-}): Promise<AccountCommandDeps>;
-export function createDefaultAccountCommandDeps(input: {
-  clerk?: { users: ClerkUserClient };
-  db: Database;
-  deletePreClerkNamespaceReservation?: typeof deletePreClerkNamespaceReservation;
-  disconnectGitHubUserAccount?: typeof disconnectGitHubUserAccount;
-  finalizeNamespaceOperation?: typeof finalizeNamespaceOperation;
-  getGitHubUserAccountStatus?: typeof getGitHubUserAccountStatus;
-  isClerkConflictError?: typeof isClerkConflictError;
-  log?: Pick<typeof log, "error">;
-  markNamespaceOperationClerkApplied?: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation?: typeof reserveNamespaceForOperation;
-  startGitHubUserAccountBinding?: typeof startGitHubUserAccountBinding;
-  startNamespaceOperation?: typeof startNamespaceOperation;
-}): AccountCommandDeps | Promise<AccountCommandDeps> {
-  const base = {
-    db: input.db,
-    deletePreClerkNamespaceReservation:
-      input.deletePreClerkNamespaceReservation ??
-      deletePreClerkNamespaceReservation,
-    disconnectGitHubUserAccount:
-      input.disconnectGitHubUserAccount ?? disconnectGitHubUserAccount,
-    finalizeNamespaceOperation:
-      input.finalizeNamespaceOperation ?? finalizeNamespaceOperation,
-    getGitHubUserAccountStatus:
-      input.getGitHubUserAccountStatus ?? getGitHubUserAccountStatus,
-    isClerkConflictError: input.isClerkConflictError ?? isClerkConflictError,
-    log: input.log ?? log,
-    markNamespaceOperationClerkApplied:
-      input.markNamespaceOperationClerkApplied ??
-      markNamespaceOperationClerkApplied,
-    reserveNamespaceForOperation:
-      input.reserveNamespaceForOperation ?? reserveNamespaceForOperation,
-    startGitHubUserAccountBinding:
-      input.startGitHubUserAccountBinding ?? startGitHubUserAccountBinding,
-    startNamespaceOperation:
-      input.startNamespaceOperation ?? startNamespaceOperation,
-  };
-
-  if (input.clerk) {
-    return { ...base, clerk: input.clerk };
-  }
-
-  return Promise.resolve(clerkClient()).then((clerk) => ({ ...base, clerk }));
 }
 
 const accountProfileInput = z.object({}).strict();
@@ -239,7 +185,7 @@ export const getAccountProfileCommand = defineCommand<
     } catch (error) {
       deps.log.error("[account] get profile failed", {
         userId: actor.userId,
-        error: parseError(error),
+        error: deps.parseError(error),
       });
 
       throw new InternalDomainError(
@@ -274,7 +220,7 @@ export const updateAccountNameCommand = defineCommand<
     } catch (error) {
       deps.log.error("[account] update display name failed", {
         userId: actor.userId,
-        error: parseError(error),
+        error: deps.parseError(error),
       });
 
       throw new InternalDomainError(
@@ -401,7 +347,7 @@ export const createAccountUsernameCommand = defineCommand<
       deps.log.error("[account] create username failed", {
         userId: actor.userId,
         username,
-        error: parseError(error),
+        error: deps.parseError(error),
       });
 
       throw new InternalDomainError(

--- a/api/app/src/domain/connectors/commands.ts
+++ b/api/app/src/domain/connectors/commands.ts
@@ -1,16 +1,11 @@
 import type { Database } from "@db/app";
-import { connectableConnectorProviderSchema } from "@repo/api-contract";
+import {
+  type ConnectableConnectorProvider,
+  type ConnectorProvider,
+  connectableConnectorProviderSchema,
+} from "@repo/api-contract";
 import { z } from "zod";
 
-import {
-  disconnectConnector,
-  listConnectorsForOrg,
-  refreshConnectorTools,
-  setConnectorAgentEnabled,
-  setConnectorAutomationEnabled,
-  startConnectorOAuth,
-} from "../../services/connectors";
-import { listUserConnectorsForViewer } from "../../services/user-connectors/catalog";
 import type { ExecutionContext } from "../actor";
 import { defineCommand } from "../command";
 import {
@@ -28,18 +23,86 @@ import {
   requireClerkOrgAdminActor,
 } from "../gates";
 
-type ListConnectorsResult = Awaited<ReturnType<typeof listConnectorsForOrg>>;
-type ListUserConnectorsResult = Awaited<
-  ReturnType<typeof listUserConnectorsForViewer>
->;
-type StartConnectorOAuthResult = Awaited<
-  ReturnType<typeof startConnectorOAuth>
->;
-type RefreshConnectorToolsResult = Awaited<
-  ReturnType<typeof refreshConnectorTools>
->;
+type ConnectAvailability =
+  | { status: "available" }
+  | {
+      missing?: string[];
+      reason: "coming_soon" | "missing_config" | "permission_required";
+      status: "unavailable";
+    };
 
-interface ConnectorMutationServiceContext {
+interface DisplayConnectorTool {
+  availableForAgents: boolean;
+  availableForAutomations: boolean;
+  description?: string;
+  name: string;
+}
+
+interface ConnectorCatalogRow {
+  availableForAgents: boolean;
+  availableForAutomations: boolean;
+  builder: "Lightfast";
+  canManage: boolean;
+  catalogStatus: "available" | "coming_soon";
+  category: string;
+  connectAvailability: ConnectAvailability;
+  connection: {
+    connectedAt: Date;
+    enabledForAgents: boolean;
+    enabledForAutomations: boolean;
+    lastToolRefreshAt: Date | null;
+    lastToolRefreshErrorAt: Date | null;
+    lastToolRefreshErrorCode: string | null;
+    missingScopes: string[];
+    providerActorName: string | null;
+    providerWorkspaceName: string | null;
+    scopeStatus: "complete" | "missing_requested_scopes";
+    status: "active" | "error" | "revoked";
+    tools: DisplayConnectorTool[];
+  } | null;
+  description: string;
+  displayName: string;
+  provider: ConnectorProvider;
+}
+
+interface UserConnectorCatalogRow {
+  builder: "Granola";
+  canManage: boolean;
+  catalogStatus: "available" | "coming_soon";
+  category: string;
+  connectAvailability: { status: "available" };
+  connection: {
+    availableForInteractiveChats: boolean;
+    connectedAt: Date;
+    lastToolRefreshAt: Date | null;
+    lastToolRefreshErrorAt: Date | null;
+    lastToolRefreshErrorCode: string | null;
+    providerAccountName: string | null;
+    status: "active" | "error" | "revoked";
+    tools: Array<{
+      availableForInteractiveChats: boolean;
+      description?: string;
+      name: string;
+    }>;
+  } | null;
+  description: string;
+  displayName: string;
+  ownerType: "user";
+  provider: "granola";
+}
+
+type ListConnectorsResult = ConnectorCatalogRow[];
+type ListUserConnectorsResult = UserConnectorCatalogRow[];
+interface StartConnectorOAuthResult {
+  authorizationUrl: string;
+  mode: string;
+}
+interface RefreshConnectorToolsResult {
+  refreshed: boolean;
+  status: string;
+}
+
+export interface ConnectorMutationServiceContext {
   actor: {
     userId: string;
   };
@@ -49,40 +112,37 @@ interface ConnectorMutationServiceContext {
   };
 }
 
-interface ConnectorCommandDeps {
+export interface ConnectorCommandDeps {
   db: Database;
-  disconnectConnector: typeof disconnectConnector;
-  listConnectorsForOrg: typeof listConnectorsForOrg;
-  listUserConnectorsForViewer: typeof listUserConnectorsForViewer;
-  refreshConnectorTools: typeof refreshConnectorTools;
-  setConnectorAgentEnabled: typeof setConnectorAgentEnabled;
-  setConnectorAutomationEnabled: typeof setConnectorAutomationEnabled;
-  startConnectorOAuth: typeof startConnectorOAuth;
-}
-
-export function createDefaultConnectorCommandDeps(input: {
-  db: Database;
-  disconnectConnector?: typeof disconnectConnector;
-  listConnectorsForOrg?: typeof listConnectorsForOrg;
-  listUserConnectorsForViewer?: typeof listUserConnectorsForViewer;
-  refreshConnectorTools?: typeof refreshConnectorTools;
-  setConnectorAgentEnabled?: typeof setConnectorAgentEnabled;
-  setConnectorAutomationEnabled?: typeof setConnectorAutomationEnabled;
-  startConnectorOAuth?: typeof startConnectorOAuth;
-}): ConnectorCommandDeps {
-  return {
-    db: input.db,
-    disconnectConnector: input.disconnectConnector ?? disconnectConnector,
-    listConnectorsForOrg: input.listConnectorsForOrg ?? listConnectorsForOrg,
-    listUserConnectorsForViewer:
-      input.listUserConnectorsForViewer ?? listUserConnectorsForViewer,
-    refreshConnectorTools: input.refreshConnectorTools ?? refreshConnectorTools,
-    setConnectorAgentEnabled:
-      input.setConnectorAgentEnabled ?? setConnectorAgentEnabled,
-    setConnectorAutomationEnabled:
-      input.setConnectorAutomationEnabled ?? setConnectorAutomationEnabled,
-    startConnectorOAuth: input.startConnectorOAuth ?? startConnectorOAuth,
-  };
+  disconnectConnector(
+    ctx: ConnectorMutationServiceContext,
+    input: { provider: ConnectableConnectorProvider }
+  ): Promise<{ disconnected: boolean }>;
+  listConnectorsForOrg(input: {
+    db: Database;
+    organization: { orgId: string };
+    viewer: { canManage: boolean };
+  }): Promise<ListConnectorsResult>;
+  listUserConnectorsForViewer(input: {
+    db: Database;
+    viewer: { userId: string };
+  }): Promise<ListUserConnectorsResult>;
+  refreshConnectorTools(
+    ctx: ConnectorMutationServiceContext,
+    input: { provider: ConnectableConnectorProvider }
+  ): Promise<RefreshConnectorToolsResult>;
+  setConnectorAgentEnabled(
+    ctx: ConnectorMutationServiceContext,
+    input: { enabled: boolean; provider: ConnectableConnectorProvider }
+  ): Promise<{ enabled: boolean }>;
+  setConnectorAutomationEnabled(
+    ctx: ConnectorMutationServiceContext,
+    input: { enabled: boolean; provider: ConnectableConnectorProvider }
+  ): Promise<{ enabled: boolean }>;
+  startConnectorOAuth(
+    ctx: ConnectorMutationServiceContext,
+    input: { provider: ConnectableConnectorProvider }
+  ): Promise<StartConnectorOAuthResult>;
 }
 
 const emptyInput = z.object({}).strict();

--- a/api/app/src/domain/developer-connections/commands.ts
+++ b/api/app/src/domain/developer-connections/commands.ts
@@ -1,5 +1,12 @@
 import type { Database } from "@db/app";
 import {
+  type DeveloperConnectionCatalogStatus,
+  type DeveloperConnectionCompleteAuthInput,
+  type DeveloperConnectionConnectInput,
+  type DeveloperConnectionProvider,
+  type DeveloperConnectionSetSandboxEnabledInput,
+  type DeveloperConnectionStartAuthInput,
+  type DeveloperConnectionStatus,
   developerConnectionCompleteAuthInputSchema,
   developerConnectionConnectInputSchema,
   developerConnectionProviderInputSchema,
@@ -10,14 +17,6 @@ import {
 } from "@repo/api-contract";
 import { z } from "zod";
 
-import {
-  completeSentryDeveloperConnectionAuth,
-  connectDeveloperConnection,
-  disconnectDeveloperConnection,
-  listDeveloperConnectionsForOrg,
-  setDeveloperConnectionSandboxEnabled,
-  startSentryDeveloperConnectionAuth,
-} from "../../services/developer-connections";
 import type { ExecutionContext } from "../actor";
 import { defineCommand } from "../command";
 import {
@@ -33,11 +32,37 @@ import {
   requireClerkOrgAdminActor,
 } from "../gates";
 
-type ListDeveloperConnectionsResult = Awaited<
-  ReturnType<typeof listDeveloperConnectionsForOrg>
->;
+type ConnectAvailability =
+  | { status: "available" }
+  | { reason: "coming_soon" | "permission_required"; status: "unavailable" };
 
-interface DeveloperConnectionMutationServiceContext {
+interface DeveloperConnectionCatalogRow {
+  builder: "Lightfast";
+  canManage: boolean;
+  catalogStatus: DeveloperConnectionCatalogStatus;
+  category: string;
+  connectAvailability: ConnectAvailability;
+  connection: {
+    connectedAt: Date;
+    enabledForSandboxes: boolean;
+    lastUsedAt: Date | null;
+    lastUsedByUserId: string | null;
+    lastVerifiedAt: Date | null;
+    providerAccountName: string;
+    status: DeveloperConnectionStatus;
+  } | null;
+  description: string;
+  displayName: string;
+  provider: DeveloperConnectionProvider;
+}
+
+type ListDeveloperConnectionsResult = DeveloperConnectionCatalogRow[];
+interface DeveloperConnectionMutationResult {
+  provider: DeveloperConnectionProvider;
+  status: DeveloperConnectionStatus;
+}
+
+export interface DeveloperConnectionMutationServiceContext {
   actor: {
     userId: string;
   };
@@ -47,43 +72,38 @@ interface DeveloperConnectionMutationServiceContext {
   };
 }
 
-interface DeveloperConnectionCommandDeps {
-  completeSentryDeveloperConnectionAuth: typeof completeSentryDeveloperConnectionAuth;
-  connectDeveloperConnection: typeof connectDeveloperConnection;
+export interface DeveloperConnectionCommandDeps {
+  completeSentryDeveloperConnectionAuth(
+    ctx: DeveloperConnectionMutationServiceContext,
+    input: DeveloperConnectionCompleteAuthInput
+  ): Promise<DeveloperConnectionMutationResult>;
+  connectDeveloperConnection(
+    ctx: DeveloperConnectionMutationServiceContext,
+    input: DeveloperConnectionConnectInput
+  ): Promise<DeveloperConnectionMutationResult>;
   db: Database;
-  disconnectDeveloperConnection: typeof disconnectDeveloperConnection;
-  listDeveloperConnectionsForOrg: typeof listDeveloperConnectionsForOrg;
-  setDeveloperConnectionSandboxEnabled: typeof setDeveloperConnectionSandboxEnabled;
-  startSentryDeveloperConnectionAuth: typeof startSentryDeveloperConnectionAuth;
-}
-
-export function createDefaultDeveloperConnectionCommandDeps(input: {
-  completeSentryDeveloperConnectionAuth?: typeof completeSentryDeveloperConnectionAuth;
-  connectDeveloperConnection?: typeof connectDeveloperConnection;
-  db: Database;
-  disconnectDeveloperConnection?: typeof disconnectDeveloperConnection;
-  listDeveloperConnectionsForOrg?: typeof listDeveloperConnectionsForOrg;
-  setDeveloperConnectionSandboxEnabled?: typeof setDeveloperConnectionSandboxEnabled;
-  startSentryDeveloperConnectionAuth?: typeof startSentryDeveloperConnectionAuth;
-}): DeveloperConnectionCommandDeps {
-  return {
-    completeSentryDeveloperConnectionAuth:
-      input.completeSentryDeveloperConnectionAuth ??
-      completeSentryDeveloperConnectionAuth,
-    connectDeveloperConnection:
-      input.connectDeveloperConnection ?? connectDeveloperConnection,
-    db: input.db,
-    disconnectDeveloperConnection:
-      input.disconnectDeveloperConnection ?? disconnectDeveloperConnection,
-    listDeveloperConnectionsForOrg:
-      input.listDeveloperConnectionsForOrg ?? listDeveloperConnectionsForOrg,
-    setDeveloperConnectionSandboxEnabled:
-      input.setDeveloperConnectionSandboxEnabled ??
-      setDeveloperConnectionSandboxEnabled,
-    startSentryDeveloperConnectionAuth:
-      input.startSentryDeveloperConnectionAuth ??
-      startSentryDeveloperConnectionAuth,
-  };
+  disconnectDeveloperConnection(
+    ctx: DeveloperConnectionMutationServiceContext,
+    input: { provider: DeveloperConnectionProvider }
+  ): Promise<{ disconnected: boolean }>;
+  listDeveloperConnectionsForOrg(input: {
+    db: Database;
+    organization: { orgId: string };
+    viewer: { canManage: boolean };
+  }): Promise<ListDeveloperConnectionsResult>;
+  setDeveloperConnectionSandboxEnabled(
+    ctx: DeveloperConnectionMutationServiceContext,
+    input: DeveloperConnectionSetSandboxEnabledInput
+  ): Promise<{ enabled: boolean }>;
+  startSentryDeveloperConnectionAuth(
+    ctx: DeveloperConnectionMutationServiceContext,
+    input: DeveloperConnectionStartAuthInput
+  ): Promise<{
+    attemptId: string;
+    expiresAt: Date;
+    userCode: string;
+    verificationUri: string;
+  }>;
 }
 
 const listDeveloperConnectionsInput = z.object({}).strict();

--- a/api/app/src/domain/org-identity/commands.ts
+++ b/api/app/src/domain/org-identity/commands.ts
@@ -1,19 +1,14 @@
 import type {
   Database,
+  getIdentityIndexStateBySourceControlRepositoryId,
   IdentityIndexFile,
   IdentityIndexState,
-  SourceControlRepository,
-} from "@db/app";
-import {
-  getIdentityIndexStateBySourceControlRepositoryId,
   listIdentityIndexFiles,
   listIdentityIndexRefreshCandidates,
+  SourceControlRepository,
 } from "@db/app";
 import { z } from "zod";
 
-import { createIdentityRefreshDedupeKey } from "../../inngest/workflow/identity-refresh-event";
-import { isVerifiedLightfastIdentityRepository } from "../../services/identity/eligibility";
-import { readIdentityRepositoryMainRef } from "../../services/identity/github";
 import { defineCommand } from "../command";
 import { requireBoundClerkOrgActor } from "../gates";
 
@@ -36,43 +31,20 @@ interface IdentityRefreshCandidate {
   state?: IdentityIndexState | null;
 }
 
-interface OrgIdentityCommandDeps {
+export interface OrgIdentityCommandDeps {
   db: Database;
   getIdentityIndexStateBySourceControlRepositoryId: typeof getIdentityIndexStateBySourceControlRepositoryId;
-  isVerifiedLightfastIdentityRepository: typeof isVerifiedLightfastIdentityRepository;
+  isVerifiedLightfastIdentityRepository(input: {
+    binding: IdentityRefreshCandidate["binding"];
+    repository: SourceControlRepository;
+  }): boolean;
   listIdentityIndexFiles: typeof listIdentityIndexFiles;
   listIdentityIndexRefreshCandidates: typeof listIdentityIndexRefreshCandidates;
-  readIdentityRepositoryMainRef: typeof readIdentityRepositoryMainRef;
+  readIdentityRepositoryMainRef(input: {
+    fullName: string;
+    installationId: string;
+  }): Promise<{ defaultBranch?: string | null; status: string }>;
   requestIdentityRefresh: (sourceControlRepositoryId: number) => Promise<void>;
-}
-
-export function createDefaultOrgIdentityCommandDeps(input: {
-  db: Database;
-  getIdentityIndexStateBySourceControlRepositoryId?: typeof getIdentityIndexStateBySourceControlRepositoryId;
-  isVerifiedLightfastIdentityRepository?: typeof isVerifiedLightfastIdentityRepository;
-  listIdentityIndexFiles?: typeof listIdentityIndexFiles;
-  listIdentityIndexRefreshCandidates?: typeof listIdentityIndexRefreshCandidates;
-  readIdentityRepositoryMainRef?: typeof readIdentityRepositoryMainRef;
-  requestIdentityRefresh?: (sourceControlRepositoryId: number) => Promise<void>;
-}): OrgIdentityCommandDeps {
-  return {
-    db: input.db,
-    getIdentityIndexStateBySourceControlRepositoryId:
-      input.getIdentityIndexStateBySourceControlRepositoryId ??
-      getIdentityIndexStateBySourceControlRepositoryId,
-    isVerifiedLightfastIdentityRepository:
-      input.isVerifiedLightfastIdentityRepository ??
-      isVerifiedLightfastIdentityRepository,
-    listIdentityIndexFiles:
-      input.listIdentityIndexFiles ?? listIdentityIndexFiles,
-    listIdentityIndexRefreshCandidates:
-      input.listIdentityIndexRefreshCandidates ??
-      listIdentityIndexRefreshCandidates,
-    readIdentityRepositoryMainRef:
-      input.readIdentityRepositoryMainRef ?? readIdentityRepositoryMainRef,
-    requestIdentityRefresh:
-      input.requestIdentityRefresh ?? requestIdentityRefresh,
-  };
 }
 
 const orgIdentityInput = z.object({}).strict();
@@ -189,25 +161,6 @@ function shouldEnqueueRefresh(state: IdentityIndexState | null): boolean {
     state.lastRefreshStatus === "never" ||
     state.lastRefreshStatus === "stale"
   );
-}
-
-async function requestIdentityRefresh(sourceControlRepositoryId: number) {
-  try {
-    const { inngest } = await import("../../inngest/client");
-    await inngest.send({
-      data: {
-        dedupeKey: createIdentityRefreshDedupeKey({
-          reason: "read",
-          sourceControlRepositoryId,
-        }),
-        reason: "read",
-        sourceControlRepositoryId,
-      },
-      name: "app/identity.index.refresh.requested",
-    });
-  } catch {
-    return;
-  }
 }
 
 export const getOrgIdentityCommand = defineCommand<

--- a/api/app/src/domain/user-connectors/commands.ts
+++ b/api/app/src/domain/user-connectors/commands.ts
@@ -1,10 +1,6 @@
 import type { Database } from "@db/app";
 import { z } from "zod";
 
-import {
-  disconnectGranolaUserConnector,
-  startGranolaUserConnectorOAuth,
-} from "../../services/user-connectors/granola-flow";
 import type { Actor } from "../actor";
 import { defineCommand } from "../command";
 import {
@@ -25,27 +21,15 @@ interface UserConnectorServiceContext {
   viewer: { userId: string };
 }
 
-interface UserConnectorCommandDeps {
+export interface UserConnectorCommandDeps {
   db: Database;
-  disconnectGranolaUserConnector: typeof disconnectGranolaUserConnector;
+  disconnectGranolaUserConnector: (
+    ctx: UserConnectorServiceContext
+  ) => Promise<{ disconnected: boolean }>;
   request: UserConnectorRequestContext;
-  startGranolaUserConnectorOAuth: typeof startGranolaUserConnectorOAuth;
-}
-
-export function createDefaultUserConnectorCommandDeps(input: {
-  db: Database;
-  disconnectGranolaUserConnector?: typeof disconnectGranolaUserConnector;
-  request: UserConnectorRequestContext;
-  startGranolaUserConnectorOAuth?: typeof startGranolaUserConnectorOAuth;
-}): UserConnectorCommandDeps {
-  return {
-    db: input.db,
-    disconnectGranolaUserConnector:
-      input.disconnectGranolaUserConnector ?? disconnectGranolaUserConnector,
-    request: input.request,
-    startGranolaUserConnectorOAuth:
-      input.startGranolaUserConnectorOAuth ?? startGranolaUserConnectorOAuth,
-  };
+  startGranolaUserConnectorOAuth: (
+    ctx: UserConnectorServiceContext
+  ) => Promise<{ authorizationUrl: string; mode: "connect" | "reconnect" }>;
 }
 
 const startUserConnectorOutput = z.object({


### PR DESCRIPTION
## Summary
- moves concrete app runtime wiring for account, connectors, developer connections, org identity, and user connectors out of domain command modules
- keeps domain command modules on structural dependency interfaces while TanStack adapters explicitly own Clerk/service/Inngest wiring
- adds source ratchets for service-backed command dependency ownership and updates command tests to pass explicit deps

## Verification
- pnpm --filter @api/app test -- src/__tests__/domain-command-deps-boundary-source.test.ts src/__tests__/user-connectors-domain-boundary-source.test.ts src/__tests__/user-connectors-service-boundary-source.test.ts src/__tests__/account-domain-commands.test.ts src/__tests__/github-account-domain-commands.test.ts src/__tests__/connectors-domain-commands.test.ts src/__tests__/developer-connections-domain-commands.test.ts src/__tests__/user-connectors-domain-commands.test.ts src/__tests__/account-connector-domain-commands.test.ts src/__tests__/account-tanstack-adapter-source.test.ts
- pnpm --filter @api/app typecheck
- pnpm check
- pnpm turbo boundaries
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known unused-file backlog only; touched files not listed)
- pnpm typecheck
- agent-browser smoke: aggregate route rendered, /api/v1/signals returned 401 auth_required, OPTIONS returned 204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dependency injection patterns across multiple modules by removing factory functions and implementing explicit dependency interfaces. Adapters now directly wire service dependencies, while domain modules define clear dependency contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->