### PR TITLE
Refactor org Clerk command deps ownership

### DIFF
--- a/api/app/src/__tests__/domain-command-deps-boundary-source.test.ts
+++ b/api/app/src/__tests__/domain-command-deps-boundary-source.test.ts
@@ -47,6 +47,25 @@ describe("domain command dependency boundaries", () => {
         factory: "createDefaultUserConnectorCommandDeps",
         runtimeImports: ["../../services/user-connectors/granola-flow"],
       },
+      {
+        command: "src/domain/org-members/commands.ts",
+        factory: "createDefaultOrgMembersCommandDeps",
+        runtimeImports: ["@vendor/clerk/server"],
+      },
+      {
+        command: "src/domain/org-billing/commands.ts",
+        factory: "createDefaultOrgBillingCommandDeps",
+        runtimeImports: ["@vendor/clerk/server"],
+      },
+      {
+        command: "src/domain/organizations/commands.ts",
+        factory: "createDefaultOrganizationCommandDeps",
+        runtimeImports: [
+          "@vendor/clerk/server",
+          "@vendor/observability/error/next",
+          "@vendor/observability/log/next",
+        ],
+      },
     ];
 
     for (const module of modules) {
@@ -87,6 +106,22 @@ describe("domain command dependency boundaries", () => {
       {
         adapter: "src/adapters/tanstack/user-connectors.ts",
         runtimeImports: ["../../services/user-connectors/granola-flow"],
+      },
+      {
+        adapter: "src/adapters/tanstack/org-members.ts",
+        runtimeImports: ["@vendor/clerk/server"],
+      },
+      {
+        adapter: "src/adapters/tanstack/org-billing.ts",
+        runtimeImports: ["@vendor/clerk/server"],
+      },
+      {
+        adapter: "src/adapters/tanstack/organizations.ts",
+        runtimeImports: [
+          "@vendor/clerk/server",
+          "@vendor/observability/error/next",
+          "@vendor/observability/log/next",
+        ],
       },
     ];
 

--- a/api/app/src/__tests__/org-billing-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-billing-domain-commands.test.ts
@@ -4,6 +4,7 @@ import type { ExecutionContext } from "../domain";
 import {
   cancelOrgBillingSubscriptionItemCommand,
   getOrgBillingOverviewCommand,
+  type OrgBillingCommandDeps,
 } from "../domain/org-billing";
 
 const cancelSubscriptionItemMock = vi.fn();
@@ -145,16 +146,14 @@ function subscriptionFixture(
 
 function createDeps() {
   return {
-    clerkClient: vi.fn().mockResolvedValue({
-      billing: {
-        cancelSubscriptionItem: cancelSubscriptionItemMock,
-        getPlanList: getPlanListMock,
-        getOrganizationBillingSubscription:
-          getOrganizationBillingSubscriptionMock,
-      },
-    }),
+    billing: {
+      cancelSubscriptionItem: cancelSubscriptionItemMock,
+      getPlanList: getPlanListMock,
+      getOrganizationBillingSubscription:
+        getOrganizationBillingSubscriptionMock,
+    },
     toPlainClerkResource,
-  };
+  } satisfies OrgBillingCommandDeps;
 }
 
 let deps: ReturnType<typeof createDeps>;

--- a/api/app/src/__tests__/org-members-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-members-domain-commands.test.ts
@@ -4,6 +4,7 @@ import type { ExecutionContext } from "../domain";
 import {
   inviteOrgMemberCommand,
   listOrgMembersCommand,
+  type OrgMembersCommandDeps,
   removeOrgMemberCommand,
   revokeOrgInvitationCommand,
   updateOrgMemberRoleCommand,
@@ -48,18 +49,16 @@ const pendingCtx: ExecutionContext = {
 
 function createDeps() {
   return {
-    clerkClient: vi.fn().mockResolvedValue({
-      organizations: {
-        createOrganizationInvitation: createOrganizationInvitationMock,
-        deleteOrganizationMembership: deleteOrganizationMembershipMock,
-        getOrganizationInvitationList: getOrganizationInvitationListMock,
-        getOrganizationMembershipList: getOrganizationMembershipListMock,
-        revokeOrganizationInvitation: revokeOrganizationInvitationMock,
-        updateOrganizationMembership: updateOrganizationMembershipMock,
-      },
-    }),
     isClerkConflictError: isClerkConflictErrorMock,
-  };
+    organizations: {
+      createOrganizationInvitation: createOrganizationInvitationMock,
+      deleteOrganizationMembership: deleteOrganizationMembershipMock,
+      getOrganizationInvitationList: getOrganizationInvitationListMock,
+      getOrganizationMembershipList: getOrganizationMembershipListMock,
+      revokeOrganizationInvitation: revokeOrganizationInvitationMock,
+      updateOrganizationMembership: updateOrganizationMembershipMock,
+    },
+  } satisfies OrgMembersCommandDeps;
 }
 
 let deps: ReturnType<typeof createDeps>;

--- a/api/app/src/__tests__/organizations-domain-commands.test.ts
+++ b/api/app/src/__tests__/organizations-domain-commands.test.ts
@@ -4,11 +4,11 @@ import type { AuthIdentity } from "../auth/identity";
 import { OrgAccessError } from "../auth/organization-access";
 import { actorFromAuthIdentity } from "../domain";
 import {
-  createDefaultOrganizationCommandDeps,
   createOrganizationCommand,
   getOrganizationBySlugCommand,
   listOrganizationDomainsCommand,
   listUserOrganizationsCommand,
+  type OrganizationCommandDeps,
   updateOrganizationDomainsCommand,
   updateOrganizationNameCommand,
 } from "../domain/organizations";
@@ -29,26 +29,10 @@ const updateOrganizationMock = vi.fn();
 const updateOrganizationDomainMock = vi.fn();
 const isClerkConflictErrorMock = vi.fn();
 const isClerkOrganizationDomainsNotEnabledMock = vi.fn();
+const parseErrorMock = vi.fn((error: unknown) => error);
 const logInfoMock = vi.fn();
 const logErrorMock = vi.fn();
 const logWarnMock = vi.fn();
-
-const { MockNamespaceConflictError } = vi.hoisted(() => ({
-  MockNamespaceConflictError: class MockNamespaceConflictError extends Error {
-    readonly code: string;
-
-    constructor(code: string, message: string) {
-      super(message);
-      this.name = "NamespaceConflictError";
-      this.code = code;
-    }
-  },
-}));
-
-vi.mock("@db/app", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@db/app")>()),
-  NamespaceConflictError: MockNamespaceConflictError,
-}));
 
 const pendingIdentity: AuthIdentity = {
   type: "pending",
@@ -118,7 +102,7 @@ function organizationDomain(overrides: Record<string, unknown> = {}) {
 }
 
 function deps() {
-  return createDefaultOrganizationCommandDeps({
+  return {
     clerk: {
       organizations: {
         createOrganization: createOrganizationMock,
@@ -137,12 +121,17 @@ function deps() {
     isClerkConflictError: isClerkConflictErrorMock,
     isClerkOrganizationDomainsNotEnabled:
       isClerkOrganizationDomainsNotEnabledMock,
+    isNamespaceConflictError(_error): _error is never {
+      return false;
+    },
+    isOrgAccessError: (error) => error instanceof OrgAccessError,
     listUserOrganizationMemberships: listUserOrganizationMembershipsMock,
     log: { error: logErrorMock, info: logInfoMock, warn: logWarnMock },
     markNamespaceOperationClerkApplied: markNamespaceOperationClerkAppliedMock,
+    parseError: parseErrorMock,
     reserveNamespaceForOperation: reserveNamespaceForOperationMock,
     startNamespaceOperation: startNamespaceOperationMock,
-  });
+  } satisfies OrganizationCommandDeps;
 }
 
 beforeEach(() => {
@@ -198,6 +187,7 @@ beforeEach(() => {
   isClerkConflictErrorMock.mockReturnValue(false);
   isClerkOrganizationDomainsNotEnabledMock.mockReset();
   isClerkOrganizationDomainsNotEnabledMock.mockReturnValue(false);
+  parseErrorMock.mockClear();
   logInfoMock.mockReset();
   logErrorMock.mockReset();
   logWarnMock.mockReset();

--- a/api/app/src/adapters/tanstack/org-billing.ts
+++ b/api/app/src/adapters/tanstack/org-billing.ts
@@ -1,14 +1,15 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { clerkClient, toPlainClerkResource } from "@vendor/clerk/server";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
   cancelOrgBillingSubscriptionItemCommand,
-  createDefaultOrgBillingCommandDeps,
   getOrgBillingOverviewCommand,
+  type OrgBillingCommandDeps,
 } from "../../domain/org-billing";
 
 function requestId() {
@@ -61,6 +62,21 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+async function commandDeps(): Promise<OrgBillingCommandDeps> {
+  const clerk = await clerkClient();
+
+  return {
+    billing: {
+      cancelSubscriptionItem: (subscriptionItemId, input) =>
+        clerk.billing.cancelSubscriptionItem(subscriptionItemId, input),
+      getOrganizationBillingSubscription: (orgId) =>
+        clerk.billing.getOrganizationBillingSubscription(orgId),
+      getPlanList: (input) => clerk.billing.getPlanList(input),
+    },
+    toPlainClerkResource,
+  };
+}
+
 export const getOrgBillingOverview = createServerFn({
   method: "GET",
 }).handler(async () => {
@@ -68,7 +84,7 @@ export const getOrgBillingOverview = createServerFn({
   try {
     return await getOrgBillingOverviewCommand.run({
       ctx: await createTanStackOrgBillingContext(),
-      deps: createDefaultOrgBillingCommandDeps(),
+      deps: await commandDeps(),
       input: {},
     });
   } catch (error) {
@@ -85,7 +101,7 @@ export const cancelOrgBillingSubscriptionItem = createServerFn({
     try {
       return await cancelOrgBillingSubscriptionItemCommand.run({
         ctx: await createTanStackOrgBillingContext(),
-        deps: createDefaultOrgBillingCommandDeps(),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/org-members.ts
+++ b/api/app/src/adapters/tanstack/org-members.ts
@@ -1,14 +1,16 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { clerkClient } from "@vendor/clerk/server";
 
+import { isClerkConflictError } from "../../auth/clerk-errors";
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultOrgMembersCommandDeps,
   inviteOrgMemberCommand,
   listOrgMembersCommand,
+  type OrgMembersCommandDeps,
   removeOrgMemberCommand,
   revokeOrgInvitationCommand,
   updateOrgMemberRoleCommand,
@@ -64,13 +66,35 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+async function commandDeps(): Promise<OrgMembersCommandDeps> {
+  const clerk = await clerkClient();
+
+  return {
+    isClerkConflictError,
+    organizations: {
+      createOrganizationInvitation: (input) =>
+        clerk.organizations.createOrganizationInvitation(input),
+      deleteOrganizationMembership: (input) =>
+        clerk.organizations.deleteOrganizationMembership(input),
+      getOrganizationInvitationList: (input) =>
+        clerk.organizations.getOrganizationInvitationList(input),
+      getOrganizationMembershipList: (input) =>
+        clerk.organizations.getOrganizationMembershipList(input),
+      revokeOrganizationInvitation: (input) =>
+        clerk.organizations.revokeOrganizationInvitation(input),
+      updateOrganizationMembership: (input) =>
+        clerk.organizations.updateOrganizationMembership(input),
+    },
+  };
+}
+
 export const listOrgMembers = createServerFn({ method: "GET" }).handler(
   async () => {
     noStore();
     try {
       return await listOrgMembersCommand.run({
         ctx: await createTanStackOrgMembersContext(),
-        deps: createDefaultOrgMembersCommandDeps(),
+        deps: await commandDeps(),
         input: {},
       });
     } catch (error) {
@@ -86,7 +110,7 @@ export const inviteOrgMember = createServerFn({ method: "POST" })
     try {
       return await inviteOrgMemberCommand.run({
         ctx: await createTanStackOrgMembersContext(),
-        deps: createDefaultOrgMembersCommandDeps(),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -101,7 +125,7 @@ export const updateOrgMemberRole = createServerFn({ method: "POST" })
     try {
       return await updateOrgMemberRoleCommand.run({
         ctx: await createTanStackOrgMembersContext(),
-        deps: createDefaultOrgMembersCommandDeps(),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -116,7 +140,7 @@ export const removeOrgMember = createServerFn({ method: "POST" })
     try {
       return await removeOrgMemberCommand.run({
         ctx: await createTanStackOrgMembersContext(),
-        deps: createDefaultOrgMembersCommandDeps(),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -131,7 +155,7 @@ export const revokeOrgInvitation = createServerFn({ method: "POST" })
     try {
       return await revokeOrgInvitationCommand.run({
         ctx: await createTanStackOrgMembersContext(),
-        deps: createDefaultOrgMembersCommandDeps(),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/organizations.ts
+++ b/api/app/src/adapters/tanstack/organizations.ts
@@ -1,16 +1,36 @@
+import {
+  deletePreClerkNamespaceReservation,
+  finalizeNamespaceOperation,
+  markNamespaceOperationClerkApplied,
+  NamespaceConflictError,
+  reserveNamespaceForOperation,
+  startNamespaceOperation,
+} from "@db/app";
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { clerkClient } from "@vendor/clerk/server";
+import { parseError } from "@vendor/observability/error/next";
+import { log } from "@vendor/observability/log/next";
 
+import {
+  isClerkConflictError,
+  isClerkOrganizationDomainsNotEnabled,
+} from "../../auth/clerk-errors";
+import { listUserOrganizationMemberships } from "../../auth/clerk-org-membership";
 import { resolveAuthContextFromClerk } from "../../auth/identity";
+import {
+  getOrgAccessBySlug,
+  isOrgAccessError,
+} from "../../auth/organization-access";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultOrganizationCommandDeps,
   createOrganizationCommand,
   getOrganizationBySlugCommand,
   listOrganizationDomainsCommand,
   listUserOrganizationsCommand,
+  type OrganizationCommandDeps,
   updateOrganizationDomainsCommand,
   updateOrganizationNameCommand,
 } from "../../domain/organizations";
@@ -63,6 +83,45 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+async function commandDeps(): Promise<OrganizationCommandDeps> {
+  const clerk = await clerkClient();
+
+  return {
+    clerk: {
+      organizations: {
+        createOrganization: (input) =>
+          clerk.organizations.createOrganization(input),
+        createOrganizationDomain: (input) =>
+          clerk.organizations.createOrganizationDomain(input),
+        deleteOrganizationDomain: (input) =>
+          clerk.organizations.deleteOrganizationDomain(input),
+        getOrganization: (input) => clerk.organizations.getOrganization(input),
+        getOrganizationDomainList: (input) =>
+          clerk.organizations.getOrganizationDomainList(input),
+        updateOrganization: (organizationId, input) =>
+          clerk.organizations.updateOrganization(organizationId, input),
+        updateOrganizationDomain: (input) =>
+          clerk.organizations.updateOrganizationDomain(input),
+      },
+    },
+    db,
+    deletePreClerkNamespaceReservation,
+    finalizeNamespaceOperation,
+    getOrgAccessBySlug,
+    isClerkConflictError,
+    isClerkOrganizationDomainsNotEnabled,
+    isNamespaceConflictError: (error): error is NamespaceConflictError =>
+      error instanceof NamespaceConflictError,
+    isOrgAccessError,
+    listUserOrganizationMemberships,
+    log,
+    markNamespaceOperationClerkApplied,
+    parseError,
+    reserveNamespaceForOperation,
+    startNamespaceOperation,
+  };
+}
+
 export const listUserOrganizations = createServerFn({
   method: "GET",
 }).handler(async () => {
@@ -70,7 +129,7 @@ export const listUserOrganizations = createServerFn({
   try {
     return await listUserOrganizationsCommand.run({
       ctx: await createTanStackOrganizationContext(),
-      deps: await createDefaultOrganizationCommandDeps({ db }),
+      deps: await commandDeps(),
       input: {},
     });
   } catch (error) {
@@ -85,7 +144,7 @@ export const getOrganizationBySlug = createServerFn({ method: "GET" })
     try {
       return await getOrganizationBySlugCommand.run({
         ctx: await createTanStackOrganizationContext(),
-        deps: await createDefaultOrganizationCommandDeps({ db }),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -100,7 +159,7 @@ export const createOrganization = createServerFn({ method: "POST" })
     try {
       return await createOrganizationCommand.run({
         ctx: await createTanStackOrganizationContext(),
-        deps: await createDefaultOrganizationCommandDeps({ db }),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -115,7 +174,7 @@ export const listOrganizationDomains = createServerFn({ method: "GET" })
     try {
       return await listOrganizationDomainsCommand.run({
         ctx: await createTanStackOrganizationContext(),
-        deps: await createDefaultOrganizationCommandDeps({ db }),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -130,7 +189,7 @@ export const updateOrganizationName = createServerFn({ method: "POST" })
     try {
       return await updateOrganizationNameCommand.run({
         ctx: await createTanStackOrganizationContext(),
-        deps: await createDefaultOrganizationCommandDeps({ db }),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -145,7 +204,7 @@ export const updateOrganizationDomains = createServerFn({ method: "POST" })
     try {
       return await updateOrganizationDomainsCommand.run({
         ctx: await createTanStackOrganizationContext(),
-        deps: await createDefaultOrganizationCommandDeps({ db }),
+        deps: await commandDeps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/domain/org-billing/commands.ts
+++ b/api/app/src/domain/org-billing/commands.ts
@@ -1,4 +1,3 @@
-import { clerkClient, toPlainClerkResource } from "@vendor/clerk/server";
 import { z } from "zod";
 
 import { defineCommand } from "../command";
@@ -7,20 +6,6 @@ import {
   requireActiveClerkOrgActor,
   requireClerkOrgAdminActor,
 } from "../gates";
-
-type ClerkClient = Awaited<ReturnType<typeof clerkClient>>;
-type MaybePromise<T> = Promise<T> | T;
-type ClerkBillingClient = Pick<
-  ClerkClient["billing"],
-  | "cancelSubscriptionItem"
-  | "getOrganizationBillingSubscription"
-  | "getPlanList"
->;
-
-interface OrgBillingCommandDeps {
-  clerkClient: () => MaybePromise<{ billing: ClerkBillingClient }>;
-  toPlainClerkResource: <T>(resource: T) => T;
-}
 
 export interface OrgBillingMoneyAmount {
   amount: number;
@@ -85,13 +70,30 @@ export interface OrgBillingSubscription {
   updatedAt?: Date | number | null;
 }
 
-export function createDefaultOrgBillingCommandDeps(
-  input: Partial<OrgBillingCommandDeps> = {}
-): OrgBillingCommandDeps {
-  return {
-    clerkClient: input.clerkClient ?? clerkClient,
-    toPlainClerkResource: input.toPlainClerkResource ?? toPlainClerkResource,
-  };
+interface ClerkBillingSubscription {
+  subscriptionItems: Array<{
+    id: string;
+    plan?: { slug?: string | null } | null;
+  }>;
+}
+
+interface ClerkBillingClient {
+  cancelSubscriptionItem(
+    subscriptionItemId: string,
+    input: { endNow: boolean }
+  ): Promise<unknown>;
+  getOrganizationBillingSubscription(
+    orgId: string
+  ): Promise<ClerkBillingSubscription>;
+  getPlanList(input: {
+    limit: number;
+    payerType: "org";
+  }): Promise<{ data: unknown[] }>;
+}
+
+export interface OrgBillingCommandDeps {
+  billing: ClerkBillingClient;
+  toPlainClerkResource: <T>(resource: T) => T;
 }
 
 const billingPlanOutput = z.custom<OrgBillingPlan>(
@@ -131,10 +133,9 @@ export const getOrgBillingOverviewCommand = defineCommand<
   output: getOrgBillingOverviewOutput,
   run: async ({ ctx, deps }) => {
     const actor = requireActiveClerkOrgActor(ctx);
-    const clerk = await deps.clerkClient();
     const [plans, subscription] = await Promise.all([
-      clerk.billing.getPlanList({ limit: 100, payerType: "org" }),
-      clerk.billing.getOrganizationBillingSubscription(actor.orgId),
+      deps.billing.getPlanList({ limit: 100, payerType: "org" }),
+      deps.billing.getOrganizationBillingSubscription(actor.orgId),
     ]);
 
     return {
@@ -157,8 +158,7 @@ export const cancelOrgBillingSubscriptionItemCommand = defineCommand<
   output: billingSubscriptionItemOutput,
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkOrgAdminActor(ctx);
-    const clerk = await deps.clerkClient();
-    const subscription = await clerk.billing.getOrganizationBillingSubscription(
+    const subscription = await deps.billing.getOrganizationBillingSubscription(
       actor.orgId
     );
     const item = subscription.subscriptionItems.find(
@@ -179,7 +179,7 @@ export const cancelOrgBillingSubscriptionItemCommand = defineCommand<
       );
     }
 
-    const canceledItem = await clerk.billing.cancelSubscriptionItem(
+    const canceledItem = await deps.billing.cancelSubscriptionItem(
       input.subscriptionItemId,
       {
         endNow: false,

--- a/api/app/src/domain/org-members/commands.ts
+++ b/api/app/src/domain/org-members/commands.ts
@@ -4,14 +4,8 @@ import {
   revokeOrgInvitationSchema,
   updateOrgMemberRoleSchema,
 } from "@repo/app-validation/schemas";
-import {
-  clerkClient,
-  type OrganizationInvitation,
-  type OrganizationMembership,
-} from "@vendor/clerk/server";
 import { z } from "zod";
 
-import { isClerkConflictError } from "../../auth/clerk-errors";
 import { defineCommand } from "../command";
 import { ConflictError, ValidationError } from "../errors";
 import {
@@ -19,30 +13,72 @@ import {
   requireClerkOrgAdminActor,
 } from "../gates";
 
-type ClerkClient = Awaited<ReturnType<typeof clerkClient>>;
-type MaybePromise<T> = Promise<T> | T;
-type ClerkOrganizationsClient = Pick<
-  ClerkClient["organizations"],
-  | "createOrganizationInvitation"
-  | "deleteOrganizationMembership"
-  | "getOrganizationInvitationList"
-  | "getOrganizationMembershipList"
-  | "revokeOrganizationInvitation"
-  | "updateOrganizationMembership"
->;
-
-interface OrgMembersCommandDeps {
-  clerkClient: () => MaybePromise<{ organizations: ClerkOrganizationsClient }>;
-  isClerkConflictError: typeof isClerkConflictError;
+interface OrganizationMembership {
+  createdAt: number;
+  id: string;
+  publicUserData?: {
+    firstName?: string | null;
+    identifier?: string | null;
+    imageUrl?: string | null;
+    lastName?: string | null;
+    userId?: string | null;
+  } | null;
+  role: string;
+  updatedAt: number;
 }
 
-export function createDefaultOrgMembersCommandDeps(
-  input: Partial<OrgMembersCommandDeps> = {}
-): OrgMembersCommandDeps {
-  return {
-    clerkClient: input.clerkClient ?? clerkClient,
-    isClerkConflictError: input.isClerkConflictError ?? isClerkConflictError,
-  };
+interface OrganizationInvitation {
+  createdAt: number;
+  emailAddress: string;
+  expiresAt?: number | null;
+  id: string;
+  role: string;
+  roleName?: string | null;
+  status?: string | null;
+  updatedAt: number;
+}
+
+interface ClerkPage<T> {
+  data: T[];
+}
+
+interface ClerkOrganizationsClient {
+  createOrganizationInvitation(input: {
+    emailAddress: string;
+    inviterUserId: string;
+    organizationId: string;
+    role: string;
+  }): Promise<OrganizationInvitation>;
+  deleteOrganizationMembership(input: {
+    organizationId: string;
+    userId: string;
+  }): Promise<unknown>;
+  getOrganizationInvitationList(input: {
+    limit: number;
+    offset: number;
+    organizationId: string;
+    status: ["pending"];
+  }): Promise<ClerkPage<OrganizationInvitation>>;
+  getOrganizationMembershipList(input: {
+    limit: number;
+    offset: number;
+    organizationId: string;
+  }): Promise<ClerkPage<OrganizationMembership>>;
+  revokeOrganizationInvitation(input: {
+    invitationId: string;
+    organizationId: string;
+    requestingUserId: string;
+  }): Promise<unknown>;
+  updateOrganizationMembership(input: {
+    organizationId: string;
+    role: string;
+    userId: string;
+  }): Promise<unknown>;
+}
+
+export interface OrgMembersCommandDeps {
+  isClerkConflictError(error: unknown): boolean;
+  organizations: ClerkOrganizationsClient;
 }
 
 const orgMemberOutput = z.object({
@@ -150,17 +186,16 @@ export const listOrgMembersCommand = defineCommand<
   output: listOrgMembersOutput,
   run: async ({ ctx, deps }) => {
     const actor = requireActiveClerkOrgActor(ctx);
-    const clerk = await deps.clerkClient();
     const [memberships, invitations] = await Promise.all([
       collectAllPages((offset) =>
-        clerk.organizations.getOrganizationMembershipList({
+        deps.organizations.getOrganizationMembershipList({
           limit: ORG_MEMBERS_PAGE_SIZE,
           offset,
           organizationId: actor.orgId,
         })
       ),
       collectAllPages((offset) =>
-        clerk.organizations.getOrganizationInvitationList({
+        deps.organizations.getOrganizationInvitationList({
           limit: ORG_MEMBERS_PAGE_SIZE,
           offset,
           organizationId: actor.orgId,
@@ -187,16 +222,13 @@ export const inviteOrgMemberCommand = defineCommand<
   output: orgInvitationOutput,
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkOrgAdminActor(ctx);
-    const clerk = await deps.clerkClient();
     try {
-      const invitation = await clerk.organizations.createOrganizationInvitation(
-        {
-          emailAddress: input.emailAddress,
-          inviterUserId: actor.userId,
-          organizationId: actor.orgId,
-          role: input.role,
-        }
-      );
+      const invitation = await deps.organizations.createOrganizationInvitation({
+        emailAddress: input.emailAddress,
+        inviterUserId: actor.userId,
+        organizationId: actor.orgId,
+        role: input.role,
+      });
       return toInvitationDto(invitation);
     } catch (error) {
       if (deps.isClerkConflictError(error)) {
@@ -223,8 +255,7 @@ export const updateOrgMemberRoleCommand = defineCommand<
   output: successOutput,
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkOrgAdminActor(ctx);
-    const clerk = await deps.clerkClient();
-    await clerk.organizations.updateOrganizationMembership({
+    await deps.organizations.updateOrganizationMembership({
       organizationId: actor.orgId,
       role: input.role,
       userId: input.userId,
@@ -251,8 +282,7 @@ export const removeOrgMemberCommand = defineCommand<
       );
     }
 
-    const clerk = await deps.clerkClient();
-    await clerk.organizations.deleteOrganizationMembership({
+    await deps.organizations.deleteOrganizationMembership({
       organizationId: actor.orgId,
       userId: input.userId,
     });
@@ -271,8 +301,7 @@ export const revokeOrgInvitationCommand = defineCommand<
   output: successOutput,
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkOrgAdminActor(ctx);
-    const clerk = await deps.clerkClient();
-    await clerk.organizations.revokeOrganizationInvitation({
+    await deps.organizations.revokeOrganizationInvitation({
       invitationId: input.invitationId,
       organizationId: actor.orgId,
       requestingUserId: actor.userId,

--- a/api/app/src/domain/organizations/commands.ts
+++ b/api/app/src/domain/organizations/commands.ts
@@ -1,28 +1,8 @@
 import type { Database } from "@db/app";
-import {
-  deletePreClerkNamespaceReservation,
-  finalizeNamespaceOperation,
-  markNamespaceOperationClerkApplied,
-  NamespaceConflictError,
-  reserveNamespaceForOperation,
-  startNamespaceOperation,
-} from "@db/app";
+import type { OrgSetupGate } from "@repo/api-contract";
 import { clerkOrgSlugSchema } from "@repo/app-validation";
-import { clerkClient } from "@vendor/clerk/server";
-import { parseError } from "@vendor/observability/error/next";
-import { log } from "@vendor/observability/log/next";
 import { z } from "zod";
 
-import {
-  isClerkConflictError,
-  isClerkOrganizationDomainsNotEnabled,
-} from "../../auth/clerk-errors";
-import { listUserOrganizationMemberships } from "../../auth/clerk-org-membership";
-import {
-  getOrgAccessBySlug,
-  isOrgAccessError,
-  orgInitials,
-} from "../../auth/organization-access";
 import { defineCommand } from "../command";
 import { ConflictError, InternalDomainError, NotFoundError } from "../errors";
 import {
@@ -31,116 +11,151 @@ import {
   requireClerkUserActor,
 } from "../gates";
 
-type ClerkClient = Awaited<ReturnType<typeof clerkClient>>;
-type OrganizationMembership = Awaited<
-  ReturnType<typeof listUserOrganizationMemberships>
->[number];
-
 const AUTO_JOIN_DOMAIN_ENROLLMENT_MODE = "automatic_invitation" as const;
 const MAX_ORGANIZATION_DOMAINS = 10;
 const DOMAIN_PATTERN =
   /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
-type ClerkOrganizationClient = Pick<
-  ClerkClient["organizations"],
-  | "createOrganization"
-  | "createOrganizationDomain"
-  | "deleteOrganizationDomain"
-  | "getOrganization"
-  | "getOrganizationDomainList"
-  | "updateOrganization"
-  | "updateOrganizationDomain"
->;
-type ClerkOrganizationDomain = Awaited<
-  ReturnType<ClerkOrganizationClient["getOrganizationDomainList"]>
->["data"][number];
-
-interface OrganizationCommandDeps {
-  clerk: { organizations: ClerkOrganizationClient };
-  db: Database;
-  deletePreClerkNamespaceReservation: typeof deletePreClerkNamespaceReservation;
-  finalizeNamespaceOperation: typeof finalizeNamespaceOperation;
-  getOrgAccessBySlug: typeof getOrgAccessBySlug;
-  isClerkConflictError: typeof isClerkConflictError;
-  isClerkOrganizationDomainsNotEnabled: typeof isClerkOrganizationDomainsNotEnabled;
-  listUserOrganizationMemberships: typeof listUserOrganizationMemberships;
-  log: Pick<typeof log, "error" | "info" | "warn">;
-  markNamespaceOperationClerkApplied: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation: typeof reserveNamespaceForOperation;
-  startNamespaceOperation: typeof startNamespaceOperation;
+interface OrganizationMembership {
+  organization: {
+    id: string;
+    imageUrl: string;
+    name: string;
+    slug: string | null;
+  };
+  role: string;
 }
 
-export function createDefaultOrganizationCommandDeps(input: {
+export type OrganizationAccess = OrgSetupGate & {
+  org: {
+    id: string;
+    imageUrl: string;
+    initials: string;
+    name: string;
+    slug: string;
+  };
+  role: string;
+};
+
+interface ClerkOrganizationDomain {
+  enrollmentMode?: string | null;
+  id: string;
+  name: string;
+  verification?: { status?: string | null } | null;
+}
+
+interface ClerkOrganizationClient {
+  createOrganization(input: {
+    createdBy: string;
+    name: string;
+    slug: string;
+  }): Promise<{ id: string; slug?: string | null }>;
+  createOrganizationDomain(input: {
+    enrollmentMode: typeof AUTO_JOIN_DOMAIN_ENROLLMENT_MODE;
+    name: string;
+    organizationId: string;
+    verified: true;
+  }): Promise<unknown>;
+  deleteOrganizationDomain(input: {
+    domainId: string;
+    organizationId: string;
+  }): Promise<unknown>;
+  getOrganization(input: { slug: string }): Promise<{ id: string }>;
+  getOrganizationDomainList(input: {
+    limit: number;
+    organizationId: string;
+  }): Promise<{ data: ClerkOrganizationDomain[] }>;
+  updateOrganization(
+    organizationId: string,
+    input: { name: string; slug: string }
+  ): Promise<unknown>;
+  updateOrganizationDomain(input: {
+    domainId: string;
+    enrollmentMode: typeof AUTO_JOIN_DOMAIN_ENROLLMENT_MODE;
+    organizationId: string;
+    verified: true;
+  }): Promise<unknown>;
+}
+
+type NamespaceConflictCode =
+  | "HANDLE_ALREADY_CLAIMED"
+  | "IDEMPOTENCY_KEY_REUSED"
+  | "OWNER_ALREADY_CLAIMED"
+  | "OWNER_NAMESPACE_IN_PROGRESS"
+  | "OWNER_MISMATCH";
+
+interface NamespaceOperation {
+  clerkOrgId: string | null;
+  clerkUserId: string | null;
+  errorMessage?: string | null;
+  id: number;
+  operationType: string;
+  ownerKind: string;
+  status:
+    | "clerk_applied"
+    | "compensating"
+    | "failed"
+    | "finalized"
+    | "namespace_reserved"
+    | "started";
+  toHandle: string;
+}
+
+interface NamespaceConflictLike {
+  code: NamespaceConflictCode;
+}
+
+interface OrganizationLog {
+  error(message: string, metadata?: Record<string, unknown>): void;
+  info(message: string, metadata?: Record<string, unknown>): void;
+  warn(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export interface OrganizationCommandDeps {
   clerk: { organizations: ClerkOrganizationClient };
   db: Database;
-  deletePreClerkNamespaceReservation?: typeof deletePreClerkNamespaceReservation;
-  finalizeNamespaceOperation?: typeof finalizeNamespaceOperation;
-  getOrgAccessBySlug?: typeof getOrgAccessBySlug;
-  isClerkConflictError?: typeof isClerkConflictError;
-  isClerkOrganizationDomainsNotEnabled?: typeof isClerkOrganizationDomainsNotEnabled;
-  listUserOrganizationMemberships?: typeof listUserOrganizationMemberships;
-  log?: Pick<typeof log, "error" | "info" | "warn">;
-  markNamespaceOperationClerkApplied?: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation?: typeof reserveNamespaceForOperation;
-  startNamespaceOperation?: typeof startNamespaceOperation;
-}): OrganizationCommandDeps;
-export function createDefaultOrganizationCommandDeps(input: {
-  clerk?: { organizations: ClerkOrganizationClient };
-  db: Database;
-  deletePreClerkNamespaceReservation?: typeof deletePreClerkNamespaceReservation;
-  finalizeNamespaceOperation?: typeof finalizeNamespaceOperation;
-  getOrgAccessBySlug?: typeof getOrgAccessBySlug;
-  isClerkConflictError?: typeof isClerkConflictError;
-  isClerkOrganizationDomainsNotEnabled?: typeof isClerkOrganizationDomainsNotEnabled;
-  listUserOrganizationMemberships?: typeof listUserOrganizationMemberships;
-  log?: Pick<typeof log, "error" | "info" | "warn">;
-  markNamespaceOperationClerkApplied?: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation?: typeof reserveNamespaceForOperation;
-  startNamespaceOperation?: typeof startNamespaceOperation;
-}): Promise<OrganizationCommandDeps>;
-export function createDefaultOrganizationCommandDeps(input: {
-  clerk?: { organizations: ClerkOrganizationClient };
-  db: Database;
-  deletePreClerkNamespaceReservation?: typeof deletePreClerkNamespaceReservation;
-  finalizeNamespaceOperation?: typeof finalizeNamespaceOperation;
-  getOrgAccessBySlug?: typeof getOrgAccessBySlug;
-  isClerkConflictError?: typeof isClerkConflictError;
-  isClerkOrganizationDomainsNotEnabled?: typeof isClerkOrganizationDomainsNotEnabled;
-  listUserOrganizationMemberships?: typeof listUserOrganizationMemberships;
-  log?: Pick<typeof log, "error" | "info" | "warn">;
-  markNamespaceOperationClerkApplied?: typeof markNamespaceOperationClerkApplied;
-  reserveNamespaceForOperation?: typeof reserveNamespaceForOperation;
-  startNamespaceOperation?: typeof startNamespaceOperation;
-}): OrganizationCommandDeps | Promise<OrganizationCommandDeps> {
-  const base = {
-    db: input.db,
-    deletePreClerkNamespaceReservation:
-      input.deletePreClerkNamespaceReservation ??
-      deletePreClerkNamespaceReservation,
-    finalizeNamespaceOperation:
-      input.finalizeNamespaceOperation ?? finalizeNamespaceOperation,
-    getOrgAccessBySlug: input.getOrgAccessBySlug ?? getOrgAccessBySlug,
-    isClerkConflictError: input.isClerkConflictError ?? isClerkConflictError,
-    isClerkOrganizationDomainsNotEnabled:
-      input.isClerkOrganizationDomainsNotEnabled ??
-      isClerkOrganizationDomainsNotEnabled,
-    listUserOrganizationMemberships:
-      input.listUserOrganizationMemberships ?? listUserOrganizationMemberships,
-    log: input.log ?? log,
-    markNamespaceOperationClerkApplied:
-      input.markNamespaceOperationClerkApplied ??
-      markNamespaceOperationClerkApplied,
-    reserveNamespaceForOperation:
-      input.reserveNamespaceForOperation ?? reserveNamespaceForOperation,
-    startNamespaceOperation:
-      input.startNamespaceOperation ?? startNamespaceOperation,
-  };
-
-  if (input.clerk) {
-    return { ...base, clerk: input.clerk };
-  }
-
-  return Promise.resolve(clerkClient()).then((clerk) => ({ ...base, clerk }));
+  deletePreClerkNamespaceReservation(
+    db: Database,
+    operation: NamespaceOperation,
+    input: { errorCode: string; errorMessage: string }
+  ): Promise<NamespaceOperation>;
+  finalizeNamespaceOperation(
+    db: Database,
+    operation: NamespaceOperation
+  ): Promise<NamespaceOperation>;
+  getOrgAccessBySlug(input: {
+    db: Database;
+    slug: string;
+    userId: string;
+  }): Promise<OrganizationAccess>;
+  isClerkConflictError(error: unknown): boolean;
+  isClerkOrganizationDomainsNotEnabled(error: unknown): boolean;
+  isNamespaceConflictError(error: unknown): error is NamespaceConflictLike;
+  isOrgAccessError(error: unknown): boolean;
+  listUserOrganizationMemberships(input: {
+    userId: string;
+  }): Promise<OrganizationMembership[]>;
+  log: OrganizationLog;
+  markNamespaceOperationClerkApplied(
+    db: Database,
+    operation: NamespaceOperation,
+    input: { clerkOrgId: string }
+  ): Promise<NamespaceOperation>;
+  parseError(error: unknown): unknown;
+  reserveNamespaceForOperation(
+    db: Database,
+    operation: NamespaceOperation
+  ): Promise<NamespaceOperation>;
+  startNamespaceOperation(
+    db: Database,
+    input: {
+      clerkUserId: string;
+      idempotencyKey: string;
+      operationType: "create_org_slug";
+      ownerKind: "org";
+      toHandle: string;
+    }
+  ): Promise<NamespaceOperation>;
 }
 
 const listUserOrganizationsInput = z.object({}).strict();
@@ -158,9 +173,9 @@ const listUserOrganizationsOutput = z.custom<
 const getOrganizationBySlugInput = z.object({
   slug: clerkOrgSlugSchema,
 });
-const getOrganizationBySlugOutput = z.custom<Awaited<
-  ReturnType<typeof getOrgAccessBySlug>
-> | null>((value) => typeof value === "object" && value !== null);
+const getOrganizationBySlugOutput = z.custom<OrganizationAccess | null>(
+  (value) => typeof value === "object" && value !== null
+);
 
 const createOrganizationInput = z.object({
   idempotencyKey: z.string().min(1).max(128),
@@ -248,6 +263,16 @@ function mapMembership(membership: OrganizationMembership) {
   };
 }
 
+function orgInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
 function domainVerificationStatus(domain: ClerkOrganizationDomain) {
   return domain.verification?.status ?? "unverified";
 }
@@ -299,7 +324,7 @@ async function listOrganizationDomainsWithAvailability(
     if (deps.isClerkOrganizationDomainsNotEnabled(error)) {
       deps.log.warn("[organization] domains unavailable", {
         organizationId,
-        error: parseError(error),
+        error: deps.parseError(error),
       });
       return { domains: [], enabled: false };
     }
@@ -319,7 +344,7 @@ async function getOrganizationAccessBySlugOrThrow(input: {
       userId: input.userId,
     });
   } catch (error) {
-    if (isOrgAccessError(error)) {
+    if (input.deps.isOrgAccessError(error)) {
       throw new NotFoundError("ORG_NOT_FOUND", "Organization not found.", {
         slug: input.slug,
       });
@@ -338,7 +363,7 @@ function organizationConflict(handle: string, cause?: unknown) {
 }
 
 function namespaceConflictToDomainError(
-  error: NamespaceConflictError,
+  error: NamespaceConflictLike,
   handle: string
 ) {
   switch (error.code) {
@@ -401,7 +426,7 @@ export const getOrganizationBySlugCommand = defineCommand<
         userId: actor.userId,
       });
     } catch (error) {
-      if (isOrgAccessError(error)) {
+      if (deps.isOrgAccessError(error)) {
         throw new NotFoundError("ORG_NOT_FOUND", "Organization not found.", {
           slug: input.slug,
         });
@@ -638,14 +663,14 @@ export const createOrganizationCommand = defineCommand<
         throw error;
       }
 
-      if (error instanceof NamespaceConflictError) {
+      if (deps.isNamespaceConflictError(error)) {
         throw namespaceConflictToDomainError(error, slug);
       }
 
       deps.log.error("[organization] create failed", {
         slug,
         userId: actor.userId,
-        error: parseError(error),
+        error: deps.parseError(error),
         errorDetails: error,
       });
 
@@ -712,7 +737,7 @@ export const updateOrganizationNameCommand = defineCommand<
       deps.log.error("[organization] updateName failed", {
         slug: input.slug,
         userId: actor.userId,
-        error: parseError(error),
+        error: deps.parseError(error),
       });
 
       if (deps.isClerkConflictError(error)) {


### PR DESCRIPTION
## Summary
- Move org members, org billing, and organizations concrete Clerk/runtime dependency wiring out of domain commands and into explicit TanStack adapters
- Replace domain default deps factories with structural command dependency interfaces
- Extend the command dependency boundary ratchet to cover these org-facing Clerk surfaces

## Test Plan
- pnpm --filter @api/app test -- src/__tests__/domain-command-deps-boundary-source.test.ts src/__tests__/org-members-domain-commands.test.ts src/__tests__/org-billing-domain-commands.test.ts src/__tests__/organizations-domain-commands.test.ts src/__tests__/org-members-tanstack-adapter-source.test.ts src/__tests__/org-billing-tanstack-adapter-source.test.ts src/__tests__/organizations-tanstack-adapter-source.test.ts
- pnpm check
- pnpm typecheck
- pnpm turbo boundaries
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known existing unused-file backlog; no touched files listed)