### PR TITLE
Refactor auth command runtime ownership

### DIFF
--- a/api/app/src/__tests__/account-connector-domain-commands.test.ts
+++ b/api/app/src/__tests__/account-connector-domain-commands.test.ts
@@ -1,11 +1,12 @@
-import type { Database, McpOauthGrant } from "@db/app";
+import type { Database } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
-  createDefaultMcpConnectionCommandDeps,
   listAccountMcpConnectionsCommand,
+  type McpConnectionCommandDeps,
+  type McpConnectionGrant,
   revokeAccountMcpConnectionCommand,
 } from "../domain/mcp-connections";
 import {
@@ -34,27 +35,25 @@ const activeIdentity: AuthIdentity = {
 
 const now = new Date("2026-06-01T00:00:00.000Z");
 
-function grant(overrides: Partial<McpOauthGrant> = {}): McpOauthGrant {
+function grant(
+  overrides: Partial<McpConnectionGrant> = {}
+): McpConnectionGrant {
   return {
-    id: 1,
     clientPublicId: "mcp_client_test",
     clerkOrgId: "org_acme",
     clerkUserId: "user_current",
     createdAt: now,
     lastUsedAt: null,
-    metadata: null,
     publicId: "mcp_grant_test",
     resource: "https://mcp.lightfast.localhost/mcp",
-    resourceHash: "resource_hash",
     revokedAt: null,
     scopes: ["mcp:signals:read"],
     status: "active",
-    updatedAt: now,
     ...overrides,
   };
 }
 
-function connection(overrides: Partial<McpOauthGrant> = {}) {
+function connection(overrides: Partial<McpConnectionGrant> = {}) {
   return {
     client: {
       clientName: "Lightfield",
@@ -83,13 +82,12 @@ function ctx(identity: AuthIdentity = pendingIdentity) {
 }
 
 function mcpDeps() {
-  return createDefaultMcpConnectionCommandDeps({
-    db: {} as Database,
-    getMcpOauthGrantByPublicId: getMcpOauthGrantByPublicIdMock,
-    listMcpOauthGrantConnectionsForUser:
-      listMcpOauthGrantConnectionsForUserMock,
-    revokeMcpOauthGrant: revokeMcpOauthGrantMock,
-  });
+  return {
+    getGrantByPublicId: getMcpOauthGrantByPublicIdMock,
+    listGrantConnectionsForOrg: vi.fn(),
+    listGrantConnectionsForUser: listMcpOauthGrantConnectionsForUserMock,
+    revokeGrant: revokeMcpOauthGrantMock,
+  } satisfies McpConnectionCommandDeps;
 }
 
 function userConnectorDeps(referer?: string | null) {
@@ -138,10 +136,9 @@ describe("account MCP connection domain commands", () => {
       }),
     ]);
 
-    expect(listMcpOauthGrantConnectionsForUserMock).toHaveBeenCalledWith(
-      expect.anything(),
-      { clerkUserId: "user_current" }
-    );
+    expect(listMcpOauthGrantConnectionsForUserMock).toHaveBeenCalledWith({
+      clerkUserId: "user_current",
+    });
   });
 
   it("revokes only the signed-in user's MCP grant", async () => {
@@ -153,11 +150,10 @@ describe("account MCP connection domain commands", () => {
       })
     ).resolves.toEqual({ success: true });
 
-    expect(getMcpOauthGrantByPublicIdMock).toHaveBeenCalledWith(
-      expect.anything(),
-      { publicId: "mcp_grant_test" }
-    );
-    expect(revokeMcpOauthGrantMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(getMcpOauthGrantByPublicIdMock).toHaveBeenCalledWith({
+      publicId: "mcp_grant_test",
+    });
+    expect(revokeMcpOauthGrantMock).toHaveBeenCalledWith({
       publicId: "mcp_grant_test",
     });
   });

--- a/api/app/src/__tests__/account-domain-commands.test.ts
+++ b/api/app/src/__tests__/account-domain-commands.test.ts
@@ -1,11 +1,10 @@
-import type { Database } from "@db/app";
-import type { NamespaceOperation } from "@db/app/schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
   type AccountCommandDeps,
+  type AccountUsernameNamespaceOperation,
   createAccountUsernameCommand,
   getAccountProfileCommand,
   updateAccountNameCommand,
@@ -20,23 +19,7 @@ const markNamespaceOperationClerkAppliedMock = vi.fn();
 const finalizeNamespaceOperationMock = vi.fn();
 const deletePreClerkNamespaceReservationMock = vi.fn();
 const logErrorMock = vi.fn();
-
-const { MockNamespaceConflictError } = vi.hoisted(() => ({
-  MockNamespaceConflictError: class MockNamespaceConflictError extends Error {
-    readonly code: string;
-
-    constructor(code: string, message: string) {
-      super(message);
-      this.name = "NamespaceConflictError";
-      this.code = code;
-    }
-  },
-}));
-
-vi.mock("@db/app", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@db/app")>()),
-  NamespaceConflictError: MockNamespaceConflictError,
-}));
+const isNamespaceConflictErrorMock = vi.fn();
 
 const pendingIdentity: AuthIdentity = {
   type: "pending",
@@ -64,8 +47,8 @@ function clerkUser(overrides: Record<string, unknown> = {}) {
 }
 
 function operation(
-  overrides: Partial<NamespaceOperation> = {}
-): NamespaceOperation {
+  overrides: Partial<AccountUsernameNamespaceOperation> = {}
+): AccountUsernameNamespaceOperation {
   return {
     id: 1,
     clerkOrgId: null,
@@ -89,24 +72,24 @@ function operation(
 
 function deps() {
   return {
-    clerk: {
-      users: {
-        getUser: getUserMock,
-        updateUser: updateUserMock,
-      },
-    },
-    db: {} as Database,
-    deletePreClerkNamespaceReservation: deletePreClerkNamespaceReservationMock,
     disconnectGitHubUserAccount: vi.fn(),
-    finalizeNamespaceOperation: finalizeNamespaceOperationMock,
     getGitHubUserAccountStatus: vi.fn(),
-    isClerkConflictError: isClerkConflictErrorMock,
     log: { error: logErrorMock },
-    markNamespaceOperationClerkApplied: markNamespaceOperationClerkAppliedMock,
     parseError: (error: unknown) => error,
-    reserveNamespaceForOperation: reserveNamespaceForOperationMock,
     startGitHubUserAccountBinding: vi.fn(),
-    startNamespaceOperation: startNamespaceOperationMock,
+    usernameNamespace: {
+      deletePreClerkReservation: deletePreClerkNamespaceReservationMock,
+      finalize: finalizeNamespaceOperationMock,
+      isConflict: isNamespaceConflictErrorMock,
+      markClerkApplied: markNamespaceOperationClerkAppliedMock,
+      reserve: reserveNamespaceForOperationMock,
+      start: startNamespaceOperationMock,
+    },
+    users: {
+      getUser: getUserMock,
+      isUsernameConflictError: isClerkConflictErrorMock,
+      updateUser: updateUserMock,
+    },
   } satisfies AccountCommandDeps;
 }
 
@@ -120,6 +103,7 @@ beforeEach(() => {
   finalizeNamespaceOperationMock.mockReset();
   deletePreClerkNamespaceReservationMock.mockReset();
   logErrorMock.mockReset();
+  isNamespaceConflictErrorMock.mockReset();
 
   getUserMock.mockResolvedValue(clerkUser());
   updateUserMock.mockImplementation(
@@ -136,6 +120,12 @@ beforeEach(() => {
   );
   finalizeNamespaceOperationMock.mockResolvedValue(
     operation({ status: "finalized" })
+  );
+  isNamespaceConflictErrorMock.mockImplementation(
+    (error: unknown): error is { code: "HANDLE_ALREADY_CLAIMED" } =>
+      error instanceof Error &&
+      error.name === "NamespaceConflictError" &&
+      "code" in error
   );
 });
 
@@ -193,21 +183,17 @@ describe("account domain commands", () => {
       username: "ada-dev",
     });
 
-    expect(startNamespaceOperationMock).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        clerkUserId: "user_test",
-        idempotencyKey: "idem_1",
-        operationType: "create_user_username",
-        ownerKind: "user",
-        toHandle: "ada-dev",
-      }
-    );
+    expect(startNamespaceOperationMock).toHaveBeenCalledWith({
+      clerkUserId: "user_test",
+      idempotencyKey: "idem_1",
+      operationType: "create_user_username",
+      ownerKind: "user",
+      toHandle: "ada-dev",
+    });
     expect(updateUserMock).toHaveBeenCalledWith("user_test", {
       username: "ada-dev",
     });
     expect(finalizeNamespaceOperationMock).toHaveBeenCalledWith(
-      expect.anything(),
       operation({ status: "clerk_applied" })
     );
   });
@@ -271,7 +257,6 @@ describe("account domain commands", () => {
     );
 
     expect(deletePreClerkNamespaceReservationMock).toHaveBeenCalledWith(
-      expect.anything(),
       operation({ status: "namespace_reserved" }),
       {
         errorCode: "CLERK_USERNAME_CONFLICT",

--- a/api/app/src/__tests__/domain-command-deps-boundary-source.test.ts
+++ b/api/app/src/__tests__/domain-command-deps-boundary-source.test.ts
@@ -16,8 +16,28 @@ describe("domain command dependency boundaries", () => {
         command: "src/domain/account/commands.ts",
         factory: "createDefaultAccountCommandDeps",
         runtimeImports: [
+          "@db/app",
+          "@db/app/schema",
           "../../services/github/user-account/flow",
           "@vendor/clerk/server",
+        ],
+      },
+      {
+        command: "src/domain/org-api-keys/commands.ts",
+        factory: "createDefaultOrgApiKeyCommandDeps",
+        runtimeImports: [
+          "@vendor/observability/log/next",
+          "@vendor/unkey/server",
+        ],
+      },
+      {
+        command: "src/domain/mcp-connections/commands.ts",
+        factory: "createDefaultMcpConnectionCommandDeps",
+        runtimeImports: [
+          "getMcpOauthGrantByPublicId",
+          "listMcpOauthGrantConnectionsForOrg",
+          "listMcpOauthGrantConnectionsForUser",
+          "revokeMcpOauthGrant",
         ],
       },
       {
@@ -76,13 +96,37 @@ describe("domain command dependency boundaries", () => {
         expect(commandSource).not.toContain(runtimeImport);
       }
     }
+
+    expect(source("src/domain/account/profile.ts")).not.toContain(
+      "@vendor/clerk/server"
+    );
   });
 
   it("keeps concrete app wiring explicit in the TanStack adapter modules", () => {
     const adapterExpectations = [
       {
         adapter: "src/adapters/tanstack/account.ts",
-        runtimeImports: ["../../services/github/user-account/flow"],
+        runtimeImports: [
+          "@db/app",
+          "../../services/github/user-account/flow",
+          "NamespaceConflictError",
+        ],
+      },
+      {
+        adapter: "src/adapters/tanstack/org-api-keys.ts",
+        runtimeImports: [
+          "@vendor/observability/log/next",
+          "@vendor/unkey/server",
+        ],
+      },
+      {
+        adapter: "src/adapters/tanstack/mcp-connections.ts",
+        runtimeImports: [
+          "getMcpOauthGrantByPublicId",
+          "listMcpOauthGrantConnectionsForOrg",
+          "listMcpOauthGrantConnectionsForUser",
+          "revokeMcpOauthGrant",
+        ],
       },
       {
         adapter: "src/adapters/tanstack/connectors.ts",

--- a/api/app/src/__tests__/github-account-domain-commands.test.ts
+++ b/api/app/src/__tests__/github-account-domain-commands.test.ts
@@ -1,4 +1,3 @@
-import type { Database } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthIdentity } from "../auth/identity";
@@ -33,24 +32,24 @@ function ctx(identity: AuthIdentity = pendingIdentity) {
 
 function deps() {
   return {
-    clerk: {
-      users: {
-        getUser: vi.fn(),
-        updateUser: vi.fn(),
-      },
-    },
-    db: {} as Database,
-    deletePreClerkNamespaceReservation: vi.fn(),
     disconnectGitHubUserAccount: disconnectGitHubUserAccountMock,
-    finalizeNamespaceOperation: vi.fn(),
     getGitHubUserAccountStatus: getGitHubUserAccountStatusMock,
-    isClerkConflictError: vi.fn(),
     log: { error: vi.fn() },
-    markNamespaceOperationClerkApplied: vi.fn(),
     parseError: (error: unknown) => error,
-    reserveNamespaceForOperation: vi.fn(),
     startGitHubUserAccountBinding: startGitHubUserAccountBindingMock,
-    startNamespaceOperation: vi.fn(),
+    usernameNamespace: {
+      deletePreClerkReservation: vi.fn(),
+      finalize: vi.fn(),
+      isConflict: vi.fn(),
+      markClerkApplied: vi.fn(),
+      reserve: vi.fn(),
+      start: vi.fn(),
+    },
+    users: {
+      getUser: vi.fn(),
+      isUsernameConflictError: vi.fn(),
+      updateUser: vi.fn(),
+    },
   } satisfies AccountCommandDeps;
 }
 

--- a/api/app/src/__tests__/org-api-keys-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-api-keys-domain-commands.test.ts
@@ -1,45 +1,24 @@
-import type { KeyResponseData } from "@vendor/unkey";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
-  createDefaultOrgApiKeyCommandDeps,
   createOrgApiKeyCommand,
   deleteOrgApiKeyCommand,
   listOrgApiKeysCommand,
+  type OrgApiKeyCommandDeps,
+  type OrgApiKeyListItem,
   revokeOrgApiKeyCommand,
   rotateOrgApiKeyCommand,
 } from "../domain/org-api-keys";
 
-const mocks = vi.hoisted(() => ({
-  apisListKeysMock: vi.fn(),
-  identitiesCreateIdentityMock: vi.fn(),
-  keysCreateKeyMock: vi.fn(),
-  keysDeleteKeyMock: vi.fn(),
-  keysGetKeyMock: vi.fn(),
-  keysRerollKeyMock: vi.fn(),
-  keysUpdateKeyMock: vi.fn(),
-  logInfoMock: vi.fn(),
-}));
-
-vi.mock("@vendor/unkey/server", () => ({
-  unkeyEnv: { UNKEY_API_ID: "api_test" },
-  getUnkeyClient: () => ({
-    apis: { listKeys: mocks.apisListKeysMock },
-    identities: { createIdentity: mocks.identitiesCreateIdentityMock },
-    keys: {
-      createKey: mocks.keysCreateKeyMock,
-      deleteKey: mocks.keysDeleteKeyMock,
-      getKey: mocks.keysGetKeyMock,
-      rerollKey: mocks.keysRerollKeyMock,
-      updateKey: mocks.keysUpdateKeyMock,
-    },
-  }),
-}));
-
-vi.mock("@vendor/observability/log/next", () => ({
-  log: { info: mocks.logInfoMock },
-}));
+const apisListKeysMock = vi.fn();
+const identitiesCreateIdentityMock = vi.fn();
+const keysCreateKeyMock = vi.fn();
+const keysDeleteKeyMock = vi.fn();
+const keysGetKeyMock = vi.fn();
+const keysRerollKeyMock = vi.fn();
+const keysUpdateKeyMock = vi.fn();
+const logInfoMock = vi.fn();
 
 const identity: Extract<AuthIdentity, { type: "active" }> = {
   type: "active",
@@ -48,7 +27,7 @@ const identity: Extract<AuthIdentity, { type: "active" }> = {
   orgGate: { bindingStatus: "unbound", nextSetupRequirement: "github_org" },
 };
 
-const key: KeyResponseData = {
+const key: OrgApiKeyListItem = {
   createdAt: 1_700_000_000_000,
   enabled: true,
   identity: { externalId: "org_test", id: "identity_test" },
@@ -70,12 +49,37 @@ function ctx({ admin = false }: { admin?: boolean } = {}) {
 }
 
 function deps() {
-  return createDefaultOrgApiKeyCommandDeps({ now: () => 1_700_000_000_000 });
+  return {
+    apiId: "api_test",
+    isProviderConflictError: (error) =>
+      typeof error === "object" &&
+      error !== null &&
+      "statusCode" in error &&
+      error.statusCode === 409,
+    isProviderNotFoundError: (error) =>
+      typeof error === "object" &&
+      error !== null &&
+      "statusCode" in error &&
+      error.statusCode === 404,
+    log: { info: logInfoMock },
+    now: () => 1_700_000_000_000,
+    provider: {
+      apis: { listKeys: apisListKeysMock },
+      identities: { createIdentity: identitiesCreateIdentityMock },
+      keys: {
+        createKey: keysCreateKeyMock,
+        deleteKey: keysDeleteKeyMock,
+        getKey: keysGetKeyMock,
+        rerollKey: keysRerollKeyMock,
+        updateKey: keysUpdateKeyMock,
+      },
+    },
+  } satisfies OrgApiKeyCommandDeps;
 }
 
 beforeEach(() => {
-  mocks.apisListKeysMock.mockReset();
-  mocks.apisListKeysMock
+  apisListKeysMock.mockReset();
+  apisListKeysMock
     .mockResolvedValueOnce({
       data: [key],
       pagination: { cursor: "cursor_2", hasMore: true },
@@ -84,27 +88,27 @@ beforeEach(() => {
       data: [{ ...key, keyId: "key_second", start: "lf_second" }],
       pagination: { hasMore: false },
     });
-  mocks.identitiesCreateIdentityMock.mockReset();
-  mocks.identitiesCreateIdentityMock.mockResolvedValue({
+  identitiesCreateIdentityMock.mockReset();
+  identitiesCreateIdentityMock.mockResolvedValue({
     data: { externalId: "org_test", id: "identity_test" },
   });
-  mocks.keysCreateKeyMock.mockReset();
-  mocks.keysCreateKeyMock.mockResolvedValue({
+  keysCreateKeyMock.mockReset();
+  keysCreateKeyMock.mockResolvedValue({
     data: { key: "lf_secret_value", keyId: "key_test" },
   });
-  mocks.keysDeleteKeyMock.mockReset();
-  mocks.keysDeleteKeyMock.mockResolvedValue({ data: {} });
-  mocks.keysGetKeyMock.mockReset();
-  mocks.keysGetKeyMock.mockResolvedValue({ data: key });
-  mocks.keysRerollKeyMock.mockReset();
-  mocks.keysRerollKeyMock.mockResolvedValue({
+  keysDeleteKeyMock.mockReset();
+  keysDeleteKeyMock.mockResolvedValue({ data: {} });
+  keysGetKeyMock.mockReset();
+  keysGetKeyMock.mockResolvedValue({ data: key });
+  keysRerollKeyMock.mockReset();
+  keysRerollKeyMock.mockResolvedValue({
     data: { key: "lf_rotated_secret", keyId: "key_test" },
   });
-  mocks.keysUpdateKeyMock.mockReset();
-  mocks.keysUpdateKeyMock.mockResolvedValue({
+  keysUpdateKeyMock.mockReset();
+  keysUpdateKeyMock.mockResolvedValue({
     data: { ...key, enabled: false },
   });
-  mocks.logInfoMock.mockReset();
+  logInfoMock.mockReset();
 });
 
 describe("org API key domain commands", () => {
@@ -116,14 +120,14 @@ describe("org API key domain commands", () => {
       { ...key, keyId: "key_second", start: "lf_second" },
     ]);
 
-    expect(mocks.apisListKeysMock).toHaveBeenNthCalledWith(1, {
+    expect(apisListKeysMock).toHaveBeenNthCalledWith(1, {
       apiId: "api_test",
       cursor: undefined,
       decrypt: false,
       externalId: "org_test",
       limit: 100,
     });
-    expect(mocks.apisListKeysMock).toHaveBeenNthCalledWith(2, {
+    expect(apisListKeysMock).toHaveBeenNthCalledWith(2, {
       apiId: "api_test",
       cursor: "cursor_2",
       decrypt: false,
@@ -141,11 +145,11 @@ describe("org API key domain commands", () => {
       })
     ).resolves.toEqual({ key: "lf_secret_value", keyId: "key_test" });
 
-    expect(mocks.identitiesCreateIdentityMock).toHaveBeenCalledWith({
+    expect(identitiesCreateIdentityMock).toHaveBeenCalledWith({
       externalId: "org_test",
       meta: { clerkOrgId: "org_test" },
     });
-    expect(mocks.keysCreateKeyMock).toHaveBeenCalledWith({
+    expect(keysCreateKeyMock).toHaveBeenCalledWith({
       apiId: "api_test",
       expires: 1_700_000_060_000,
       externalId: "org_test",
@@ -161,7 +165,7 @@ describe("org API key domain commands", () => {
     const conflict = Object.assign(new Error("already exists"), {
       statusCode: 409,
     });
-    mocks.identitiesCreateIdentityMock.mockRejectedValueOnce(conflict);
+    identitiesCreateIdentityMock.mockRejectedValueOnce(conflict);
 
     await expect(
       createOrgApiKeyCommand.run({
@@ -195,22 +199,22 @@ describe("org API key domain commands", () => {
       })
     ).resolves.toEqual({ key: "lf_rotated_secret", keyId: "key_test" });
 
-    expect(mocks.keysUpdateKeyMock).toHaveBeenCalledWith({
+    expect(keysUpdateKeyMock).toHaveBeenCalledWith({
       enabled: false,
       keyId: "key_test",
     });
-    expect(mocks.keysDeleteKeyMock).toHaveBeenCalledWith({
+    expect(keysDeleteKeyMock).toHaveBeenCalledWith({
       keyId: "key_test",
       permanent: false,
     });
-    expect(mocks.keysRerollKeyMock).toHaveBeenCalledWith({
+    expect(keysRerollKeyMock).toHaveBeenCalledWith({
       expiration: 0,
       keyId: "key_test",
     });
   });
 
   it("hides another organization's key as not found", async () => {
-    mocks.keysGetKeyMock.mockResolvedValueOnce({
+    keysGetKeyMock.mockResolvedValueOnce({
       data: {
         ...key,
         identity: { externalId: "org_other", id: "identity_other" },
@@ -229,7 +233,7 @@ describe("org API key domain commands", () => {
         kind: "not_found",
       })
     );
-    expect(mocks.keysRerollKeyMock).not.toHaveBeenCalled();
+    expect(keysRerollKeyMock).not.toHaveBeenCalled();
   });
 
   it("requires a matching admin actor for writes", async () => {
@@ -245,6 +249,6 @@ describe("org API key domain commands", () => {
         kind: "authz",
       })
     );
-    expect(mocks.keysCreateKeyMock).not.toHaveBeenCalled();
+    expect(keysCreateKeyMock).not.toHaveBeenCalled();
   });
 });

--- a/api/app/src/__tests__/org-mcp-connections-domain-commands.test.ts
+++ b/api/app/src/__tests__/org-mcp-connections-domain-commands.test.ts
@@ -1,11 +1,11 @@
-import type { Database, McpOauthGrant } from "@db/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthIdentity } from "../auth/identity";
 import { actorFromAuthIdentity } from "../domain";
 import {
-  createDefaultMcpConnectionCommandDeps,
   listOrgMcpConnectionsCommand,
+  type McpConnectionCommandDeps,
+  type McpConnectionGrant,
   revokeOrgMcpConnectionCommand,
 } from "../domain/mcp-connections";
 
@@ -27,27 +27,25 @@ const pendingIdentity: AuthIdentity = {
 
 const now = new Date("2026-06-01T00:00:00.000Z");
 
-function grant(overrides: Partial<McpOauthGrant> = {}): McpOauthGrant {
+function grant(
+  overrides: Partial<McpConnectionGrant> = {}
+): McpConnectionGrant {
   return {
-    id: 1,
     clientPublicId: "mcp_client_test",
     clerkOrgId: "org_acme",
     clerkUserId: "user_current",
     createdAt: now,
     lastUsedAt: null,
-    metadata: null,
     publicId: "mcp_grant_test",
     resource: "https://mcp.lightfast.localhost/mcp",
-    resourceHash: "resource_hash",
     revokedAt: null,
     scopes: ["mcp:signals:read"],
     status: "active",
-    updatedAt: now,
     ...overrides,
   };
 }
 
-function connection(overrides: Partial<McpOauthGrant> = {}) {
+function connection(overrides: Partial<McpConnectionGrant> = {}) {
   return {
     client: {
       clientName: "Lightfield",
@@ -83,12 +81,12 @@ function memberCtx(identity: AuthIdentity = activeIdentity) {
 }
 
 function deps() {
-  return createDefaultMcpConnectionCommandDeps({
-    db: {} as Database,
-    getMcpOauthGrantByPublicId: getMcpOauthGrantByPublicIdMock,
-    listMcpOauthGrantConnectionsForOrg: listMcpOauthGrantConnectionsForOrgMock,
-    revokeMcpOauthGrant: revokeMcpOauthGrantMock,
-  });
+  return {
+    getGrantByPublicId: getMcpOauthGrantByPublicIdMock,
+    listGrantConnectionsForOrg: listMcpOauthGrantConnectionsForOrgMock,
+    listGrantConnectionsForUser: vi.fn(),
+    revokeGrant: revokeMcpOauthGrantMock,
+  } satisfies McpConnectionCommandDeps;
 }
 
 beforeEach(() => {
@@ -121,10 +119,9 @@ describe("org MCP connection domain commands", () => {
       }),
     ]);
 
-    expect(listMcpOauthGrantConnectionsForOrgMock).toHaveBeenCalledWith(
-      expect.anything(),
-      { clerkOrgId: "org_acme" }
-    );
+    expect(listMcpOauthGrantConnectionsForOrgMock).toHaveBeenCalledWith({
+      clerkOrgId: "org_acme",
+    });
   });
 
   it("blocks non-admin members before listing org MCP grants", async () => {
@@ -153,11 +150,10 @@ describe("org MCP connection domain commands", () => {
       })
     ).resolves.toEqual({ success: true });
 
-    expect(getMcpOauthGrantByPublicIdMock).toHaveBeenCalledWith(
-      expect.anything(),
-      { publicId: "mcp_grant_test" }
-    );
-    expect(revokeMcpOauthGrantMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(getMcpOauthGrantByPublicIdMock).toHaveBeenCalledWith({
+      publicId: "mcp_grant_test",
+    });
+    expect(revokeMcpOauthGrantMock).toHaveBeenCalledWith({
       publicId: "mcp_grant_test",
     });
   });

--- a/api/app/src/adapters/tanstack/account.ts
+++ b/api/app/src/adapters/tanstack/account.ts
@@ -2,6 +2,7 @@ import {
   deletePreClerkNamespaceReservation,
   finalizeNamespaceOperation,
   markNamespaceOperationClerkApplied,
+  NamespaceConflictError,
   reserveNamespaceForOperation,
   startNamespaceOperation,
 } from "@db/app";
@@ -62,19 +63,27 @@ function noStore() {
 async function deps(): Promise<AccountCommandDeps> {
   const clerk = await clerkClient();
   return {
-    clerk,
-    db,
-    deletePreClerkNamespaceReservation,
     disconnectGitHubUserAccount,
-    finalizeNamespaceOperation,
     getGitHubUserAccountStatus,
-    isClerkConflictError,
     log,
-    markNamespaceOperationClerkApplied,
     parseError,
-    reserveNamespaceForOperation,
     startGitHubUserAccountBinding,
-    startNamespaceOperation,
+    usernameNamespace: {
+      deletePreClerkReservation: (operation, input) =>
+        deletePreClerkNamespaceReservation(db, operation, input),
+      finalize: (operation) => finalizeNamespaceOperation(db, operation),
+      isConflict: (error): error is NamespaceConflictError =>
+        error instanceof NamespaceConflictError,
+      markClerkApplied: (operation) =>
+        markNamespaceOperationClerkApplied(db, operation),
+      reserve: (operation) => reserveNamespaceForOperation(db, operation),
+      start: (input) => startNamespaceOperation(db, input),
+    },
+    users: {
+      getUser: (userId) => clerk.users.getUser(userId),
+      isUsernameConflictError: isClerkConflictError,
+      updateUser: (userId, params) => clerk.users.updateUser(userId, params),
+    },
   };
 }
 

--- a/api/app/src/adapters/tanstack/mcp-connections.ts
+++ b/api/app/src/adapters/tanstack/mcp-connections.ts
@@ -1,3 +1,9 @@
+import {
+  getMcpOauthGrantByPublicId,
+  listMcpOauthGrantConnectionsForOrg,
+  listMcpOauthGrantConnectionsForUser,
+  revokeMcpOauthGrant,
+} from "@db/app";
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
@@ -6,9 +12,9 @@ import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultMcpConnectionCommandDeps,
   listAccountMcpConnectionsCommand,
   listOrgMcpConnectionsCommand,
+  type McpConnectionCommandDeps,
   revokeAccountMcpConnectionCommand,
   revokeOrgMcpConnectionCommand,
 } from "../../domain/mcp-connections";
@@ -61,6 +67,18 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+function commandDeps(): McpConnectionCommandDeps {
+  return {
+    getGrantByPublicId: async (input) =>
+      (await getMcpOauthGrantByPublicId(db, input)) ?? null,
+    listGrantConnectionsForOrg: (input) =>
+      listMcpOauthGrantConnectionsForOrg(db, input),
+    listGrantConnectionsForUser: (input) =>
+      listMcpOauthGrantConnectionsForUser(db, input),
+    revokeGrant: (input) => revokeMcpOauthGrant(db, input),
+  };
+}
+
 export const listAccountMcpConnections = createServerFn({
   method: "GET",
 }).handler(async () => {
@@ -68,7 +86,7 @@ export const listAccountMcpConnections = createServerFn({
   try {
     return await listAccountMcpConnectionsCommand.run({
       ctx: await createTanStackMcpConnectionContext(),
-      deps: createDefaultMcpConnectionCommandDeps({ db }),
+      deps: commandDeps(),
       input: {},
     });
   } catch (error) {
@@ -83,7 +101,7 @@ export const revokeAccountMcpConnection = createServerFn({ method: "POST" })
     try {
       return await revokeAccountMcpConnectionCommand.run({
         ctx: await createTanStackMcpConnectionContext(),
-        deps: createDefaultMcpConnectionCommandDeps({ db }),
+        deps: commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -98,7 +116,7 @@ export const listOrgMcpConnections = createServerFn({
   try {
     return await listOrgMcpConnectionsCommand.run({
       ctx: await createTanStackMcpConnectionContext(),
-      deps: createDefaultMcpConnectionCommandDeps({ db }),
+      deps: commandDeps(),
       input: {},
     });
   } catch (error) {
@@ -113,7 +131,7 @@ export const revokeOrgMcpConnection = createServerFn({ method: "POST" })
     try {
       return await revokeOrgMcpConnectionCommand.run({
         ctx: await createTanStackMcpConnectionContext(),
-        deps: createDefaultMcpConnectionCommandDeps({ db }),
+        deps: commandDeps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/adapters/tanstack/org-api-keys.ts
+++ b/api/app/src/adapters/tanstack/org-api-keys.ts
@@ -1,15 +1,17 @@
 import { db } from "@db/app/client";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+import { log } from "@vendor/observability/log/next";
+import { getUnkeyClient, unkeyEnv } from "@vendor/unkey/server";
 
 import { resolveAuthContextFromClerk } from "../../auth/identity";
 import type { Actor } from "../../domain";
 import { actorFromAuthIdentity, isDomainError } from "../../domain";
 import {
-  createDefaultOrgApiKeyCommandDeps,
   createOrgApiKeyCommand,
   deleteOrgApiKeyCommand,
   listOrgApiKeysCommand,
+  type OrgApiKeyCommandDeps,
   revokeOrgApiKeyCommand,
   rotateOrgApiKeyCommand,
 } from "../../domain/org-api-keys";
@@ -62,13 +64,33 @@ function noStore() {
   setResponseHeader("vary", "Cookie, Authorization");
 }
 
+function isUnkeyStatus(error: unknown, statusCode: number) {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    (error as { statusCode?: unknown }).statusCode === statusCode
+  );
+}
+
+function commandDeps(): OrgApiKeyCommandDeps {
+  return {
+    apiId: unkeyEnv.UNKEY_API_ID,
+    isProviderConflictError: (error) => isUnkeyStatus(error, 409),
+    isProviderNotFoundError: (error) => isUnkeyStatus(error, 404),
+    log,
+    now: Date.now,
+    provider: getUnkeyClient(),
+  };
+}
+
 export const listOrgApiKeys = createServerFn({ method: "GET" }).handler(
   async () => {
     noStore();
     try {
       return await listOrgApiKeysCommand.run({
         ctx: await createTanStackOrgApiKeyContext(),
-        deps: createDefaultOrgApiKeyCommandDeps(),
+        deps: commandDeps(),
         input: {},
       });
     } catch (error) {
@@ -84,7 +106,7 @@ export const createOrgApiKey = createServerFn({ method: "POST" })
     try {
       return await createOrgApiKeyCommand.run({
         ctx: await createTanStackOrgApiKeyContext(),
-        deps: createDefaultOrgApiKeyCommandDeps(),
+        deps: commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -99,7 +121,7 @@ export const revokeOrgApiKey = createServerFn({ method: "POST" })
     try {
       return await revokeOrgApiKeyCommand.run({
         ctx: await createTanStackOrgApiKeyContext(),
-        deps: createDefaultOrgApiKeyCommandDeps(),
+        deps: commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -114,7 +136,7 @@ export const deleteOrgApiKey = createServerFn({ method: "POST" })
     try {
       return await deleteOrgApiKeyCommand.run({
         ctx: await createTanStackOrgApiKeyContext(),
-        deps: createDefaultOrgApiKeyCommandDeps(),
+        deps: commandDeps(),
         input: data,
       });
     } catch (error) {
@@ -129,7 +151,7 @@ export const rotateOrgApiKey = createServerFn({ method: "POST" })
     try {
       return await rotateOrgApiKeyCommand.run({
         ctx: await createTanStackOrgApiKeyContext(),
-        deps: createDefaultOrgApiKeyCommandDeps(),
+        deps: commandDeps(),
         input: data,
       });
     } catch (error) {

--- a/api/app/src/domain/account/commands.ts
+++ b/api/app/src/domain/account/commands.ts
@@ -1,12 +1,3 @@
-import type {
-  Database,
-  deletePreClerkNamespaceReservation,
-  finalizeNamespaceOperation,
-  markNamespaceOperationClerkApplied,
-  reserveNamespaceForOperation,
-  startNamespaceOperation,
-} from "@db/app";
-import { NamespaceConflictError } from "@db/app";
 import { githubUserAccountReturnToSchema } from "@lightfast/connector-github/contract";
 import {
   accountSettingsFormSchema,
@@ -24,8 +15,9 @@ import {
 import { requireClerkUserActor } from "../gates";
 import { type AccountProfileUser, toAccountProfile } from "./profile";
 
-interface ClerkUserClient {
+interface AccountUserClient {
   getUser(userId: string): Promise<AccountProfileUser>;
+  isUsernameConflictError(error: unknown): boolean;
   updateUser(
     userId: string,
     params: {
@@ -47,27 +39,90 @@ interface GitHubAccountStatusResult {
   };
 }
 
+type NamespaceConflictCode =
+  | "HANDLE_ALREADY_CLAIMED"
+  | "IDEMPOTENCY_KEY_REUSED"
+  | "OWNER_ALREADY_CLAIMED"
+  | "OWNER_NAMESPACE_IN_PROGRESS"
+  | "OWNER_MISMATCH";
+
+interface NamespaceConflictLike {
+  code: NamespaceConflictCode;
+}
+
+type AccountUsernameNamespaceOperationType =
+  | "backfill_existing_handle"
+  | "create_org_slug"
+  | "create_user_username";
+
+type AccountUsernameNamespaceOwnerKind = "org" | "user";
+
+type AccountUsernameNamespaceOperationStatus =
+  | "clerk_applied"
+  | "compensating"
+  | "failed"
+  | "finalized"
+  | "namespace_reserved"
+  | "started";
+
+export interface AccountUsernameNamespaceOperation {
+  clerkOrgId: string | null;
+  clerkUserId: string | null;
+  createdAt: Date;
+  errorCode: string | null;
+  errorMessage: string | null;
+  expiresAt: Date | null;
+  fromHandle: string | null;
+  id: number;
+  idempotencyClerkOrgId: string | null;
+  idempotencyClerkUserId: string | null;
+  idempotencyKey: string;
+  operationType: AccountUsernameNamespaceOperationType;
+  ownerKind: AccountUsernameNamespaceOwnerKind;
+  status: AccountUsernameNamespaceOperationStatus;
+  toHandle: string;
+  updatedAt: Date;
+}
+
+interface AccountUsernameNamespace {
+  deletePreClerkReservation(
+    operation: AccountUsernameNamespaceOperation,
+    input: { errorCode: string; errorMessage: string }
+  ): Promise<AccountUsernameNamespaceOperation>;
+  finalize(
+    operation: AccountUsernameNamespaceOperation
+  ): Promise<AccountUsernameNamespaceOperation>;
+  isConflict(error: unknown): boolean;
+  markClerkApplied(
+    operation: AccountUsernameNamespaceOperation
+  ): Promise<AccountUsernameNamespaceOperation>;
+  reserve(
+    operation: AccountUsernameNamespaceOperation
+  ): Promise<AccountUsernameNamespaceOperation>;
+  start(input: {
+    clerkUserId: string;
+    idempotencyKey: string;
+    operationType: "create_user_username";
+    ownerKind: "user";
+    toHandle: string;
+  }): Promise<AccountUsernameNamespaceOperation>;
+}
+
 export interface AccountCommandDeps {
-  clerk: { users: ClerkUserClient };
-  db: Database;
-  deletePreClerkNamespaceReservation: typeof deletePreClerkNamespaceReservation;
   disconnectGitHubUserAccount(input: {
     clerkUserId: string;
   }): Promise<{ ok: true }>;
-  finalizeNamespaceOperation: typeof finalizeNamespaceOperation;
   getGitHubUserAccountStatus(input: {
     clerkUserId: string;
   }): Promise<GitHubAccountStatusResult>;
-  isClerkConflictError(error: unknown): boolean;
   log: { error(message: string, context: Record<string, unknown>): void };
-  markNamespaceOperationClerkApplied: typeof markNamespaceOperationClerkApplied;
   parseError(error: unknown): unknown;
-  reserveNamespaceForOperation: typeof reserveNamespaceForOperation;
   startGitHubUserAccountBinding(input: {
     lightfastUserId: string;
     returnTo?: string;
   }): Promise<{ authorizationUrl: string }>;
-  startNamespaceOperation: typeof startNamespaceOperation;
+  usernameNamespace: AccountUsernameNamespace;
+  users: AccountUserClient;
 }
 
 const accountProfileInput = z.object({}).strict();
@@ -123,7 +178,7 @@ function usernameConflict(username: string, cause?: unknown) {
 }
 
 function namespaceConflictToDomainError(
-  error: NamespaceConflictError,
+  error: NamespaceConflictLike,
   username: string
 ) {
   switch (error.code) {
@@ -180,7 +235,7 @@ export const getAccountProfileCommand = defineCommand<
     const actor = requireClerkUserActor(ctx);
 
     try {
-      const user = await deps.clerk.users.getUser(actor.userId);
+      const user = await deps.users.getUser(actor.userId);
       return toAccountProfile(user);
     } catch (error) {
       deps.log.error("[account] get profile failed", {
@@ -211,7 +266,7 @@ export const updateAccountNameCommand = defineCommand<
     const actor = requireClerkUserActor(ctx);
 
     try {
-      const user = await deps.clerk.users.updateUser(actor.userId, {
+      const user = await deps.users.updateUser(actor.userId, {
         firstName: input.displayName,
         lastName: "",
       });
@@ -247,7 +302,7 @@ export const createAccountUsernameCommand = defineCommand<
     const username = input.username.trim().toLowerCase();
 
     try {
-      const currentUser = await deps.clerk.users.getUser(actor.userId);
+      const currentUser = await deps.users.getUser(actor.userId);
       if (currentUser.username) {
         if (currentUser.username === username) {
           return toAccountProfile(currentUser);
@@ -260,7 +315,7 @@ export const createAccountUsernameCommand = defineCommand<
         );
       }
 
-      let operation = await deps.startNamespaceOperation(deps.db, {
+      let operation = await deps.usernameNamespace.start({
         clerkUserId: actor.userId,
         idempotencyKey: input.idempotencyKey,
         operationType: "create_user_username",
@@ -268,7 +323,7 @@ export const createAccountUsernameCommand = defineCommand<
         toHandle: username,
       });
 
-      operation = await deps.reserveNamespaceForOperation(deps.db, operation);
+      operation = await deps.usernameNamespace.reserve(operation);
 
       if (operation.status === "failed") {
         throw new ConflictError(
@@ -279,12 +334,12 @@ export const createAccountUsernameCommand = defineCommand<
       }
 
       if (operation.status === "finalized") {
-        return toAccountProfile(await deps.clerk.users.getUser(actor.userId));
+        return toAccountProfile(await deps.users.getUser(actor.userId));
       }
 
       if (operation.status === "clerk_applied") {
-        await deps.finalizeNamespaceOperation(deps.db, operation);
-        return toAccountProfile(await deps.clerk.users.getUser(actor.userId));
+        await deps.usernameNamespace.finalize(operation);
+        return toAccountProfile(await deps.users.getUser(actor.userId));
       }
 
       if (operation.status !== "namespace_reserved") {
@@ -297,12 +352,12 @@ export const createAccountUsernameCommand = defineCommand<
 
       let updatedUser: AccountProfileUser;
       try {
-        updatedUser = await deps.clerk.users.updateUser(actor.userId, {
+        updatedUser = await deps.users.updateUser(actor.userId, {
           username,
         });
       } catch (error) {
-        if (deps.isClerkConflictError(error)) {
-          await deps.deletePreClerkNamespaceReservation(deps.db, operation, {
+        if (deps.users.isUsernameConflictError(error)) {
+          await deps.usernameNamespace.deletePreClerkReservation(operation, {
             errorCode: "CLERK_USERNAME_CONFLICT",
             errorMessage: `Clerk rejected username ${username} as already claimed`,
           });
@@ -310,7 +365,7 @@ export const createAccountUsernameCommand = defineCommand<
           throw usernameConflict(username, error);
         }
 
-        await deps.deletePreClerkNamespaceReservation(deps.db, operation, {
+        await deps.usernameNamespace.deletePreClerkReservation(operation, {
           errorCode: "CLERK_USERNAME_UPDATE_FAILED",
           errorMessage: `Clerk failed to set username ${username}`,
         });
@@ -323,11 +378,8 @@ export const createAccountUsernameCommand = defineCommand<
         );
       }
 
-      operation = await deps.markNamespaceOperationClerkApplied(
-        deps.db,
-        operation
-      );
-      await deps.finalizeNamespaceOperation(deps.db, operation);
+      operation = await deps.usernameNamespace.markClerkApplied(operation);
+      await deps.usernameNamespace.finalize(operation);
 
       return toAccountProfile(updatedUser);
     } catch (error) {
@@ -340,8 +392,11 @@ export const createAccountUsernameCommand = defineCommand<
         throw error;
       }
 
-      if (error instanceof NamespaceConflictError) {
-        throw namespaceConflictToDomainError(error, username);
+      if (deps.usernameNamespace.isConflict(error)) {
+        throw namespaceConflictToDomainError(
+          error as NamespaceConflictLike,
+          username
+        );
       }
 
       deps.log.error("[account] create username failed", {

--- a/api/app/src/domain/account/profile.ts
+++ b/api/app/src/domain/account/profile.ts
@@ -1,5 +1,3 @@
-import type { User } from "@vendor/clerk/server";
-
 function deriveInitials(input: {
   firstName: string | null;
   fullName: string | null;
@@ -31,16 +29,15 @@ function deriveInitials(input: {
   return "LF";
 }
 
-export type AccountProfileUser = Pick<
-  User,
-  | "createdAt"
-  | "firstName"
-  | "id"
-  | "imageUrl"
-  | "lastName"
-  | "primaryEmailAddress"
-  | "username"
->;
+export interface AccountProfileUser {
+  createdAt: Date | number | string;
+  firstName: string | null;
+  id: string;
+  imageUrl: string;
+  lastName: string | null;
+  primaryEmailAddress: { emailAddress: string } | null;
+  username: string | null;
+}
 
 export function toAccountProfile(user: AccountProfileUser) {
   const fullName =

--- a/api/app/src/domain/mcp-connections/commands.ts
+++ b/api/app/src/domain/mcp-connections/commands.ts
@@ -1,17 +1,43 @@
-import {
-  type Database,
-  getMcpOauthGrantByPublicId,
-  listMcpOauthGrantConnectionsForOrg,
-  listMcpOauthGrantConnectionsForUser,
-  type McpOauthGrant,
-  type McpOauthGrantConnection,
-  revokeMcpOauthGrant,
-} from "@db/app";
 import { z } from "zod";
 
 import { defineCommand } from "../command";
 import { NotFoundError } from "../errors";
 import { requireClerkOrgAdminActor, requireClerkUserActor } from "../gates";
+
+type McpConnectionStatus = "active" | "revoked";
+
+export interface McpConnectionGrant {
+  clerkOrgId: string;
+  clerkUserId: string;
+  clientPublicId: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  publicId: string;
+  resource: string;
+  revokedAt: Date | null;
+  scopes: string[];
+  status: McpConnectionStatus;
+}
+
+export interface McpConnectionClient {
+  clientName: string;
+  clientUri: string | null;
+  logoUri: string | null;
+  metadata: Record<string, unknown> | null;
+  status: string;
+}
+
+export interface McpConnectionRecord {
+  client: McpConnectionClient | null;
+  grant: McpConnectionGrant;
+  redirectUris: string[];
+  refreshTokenStatusSummary: {
+    active: number;
+    reuseDetected: number;
+    revoked: number;
+    rotated: number;
+  };
+}
 
 interface McpConnectionDto {
   clientId: string;
@@ -25,40 +51,24 @@ interface McpConnectionDto {
   lastUsedAt: string | null;
   logoUri: string | null;
   redirectUris: string[];
-  refreshTokenStatusSummary: McpOauthGrantConnection["refreshTokenStatusSummary"];
+  refreshTokenStatusSummary: McpConnectionRecord["refreshTokenStatusSummary"];
   resource: string;
   revokedAt: string | null;
   scopes: string[];
-  status: McpOauthGrant["status"];
+  status: McpConnectionStatus;
 }
 
-interface McpConnectionCommandDeps {
-  db: Database;
-  getMcpOauthGrantByPublicId: typeof getMcpOauthGrantByPublicId;
-  listMcpOauthGrantConnectionsForOrg: typeof listMcpOauthGrantConnectionsForOrg;
-  listMcpOauthGrantConnectionsForUser: typeof listMcpOauthGrantConnectionsForUser;
-  revokeMcpOauthGrant: typeof revokeMcpOauthGrant;
-}
-
-export function createDefaultMcpConnectionCommandDeps(input: {
-  db: Database;
-  getMcpOauthGrantByPublicId?: typeof getMcpOauthGrantByPublicId;
-  listMcpOauthGrantConnectionsForOrg?: typeof listMcpOauthGrantConnectionsForOrg;
-  listMcpOauthGrantConnectionsForUser?: typeof listMcpOauthGrantConnectionsForUser;
-  revokeMcpOauthGrant?: typeof revokeMcpOauthGrant;
-}): McpConnectionCommandDeps {
-  return {
-    db: input.db,
-    getMcpOauthGrantByPublicId:
-      input.getMcpOauthGrantByPublicId ?? getMcpOauthGrantByPublicId,
-    listMcpOauthGrantConnectionsForOrg:
-      input.listMcpOauthGrantConnectionsForOrg ??
-      listMcpOauthGrantConnectionsForOrg,
-    listMcpOauthGrantConnectionsForUser:
-      input.listMcpOauthGrantConnectionsForUser ??
-      listMcpOauthGrantConnectionsForUser,
-    revokeMcpOauthGrant: input.revokeMcpOauthGrant ?? revokeMcpOauthGrant,
-  };
+export interface McpConnectionCommandDeps {
+  getGrantByPublicId(input: {
+    publicId: string;
+  }): Promise<McpConnectionGrant | null>;
+  listGrantConnectionsForOrg(input: {
+    clerkOrgId: string;
+  }): Promise<McpConnectionRecord[]>;
+  listGrantConnectionsForUser(input: {
+    clerkUserId: string;
+  }): Promise<McpConnectionRecord[]>;
+  revokeGrant(input: { publicId: string }): Promise<unknown>;
 }
 
 const mcpConnectionInput = z.object({}).strict();
@@ -104,10 +114,9 @@ export const listAccountMcpConnectionsCommand = defineCommand<
   output: z.array(mcpConnectionDtoOutput),
   run: async ({ ctx, deps }) => {
     const actor = requireClerkUserActor(ctx);
-    const connections = await deps.listMcpOauthGrantConnectionsForUser(
-      deps.db,
-      { clerkUserId: actor.userId }
-    );
+    const connections = await deps.listGrantConnectionsForUser({
+      clerkUserId: actor.userId,
+    });
     return connections.map(toMcpConnectionDto);
   },
 });
@@ -123,7 +132,7 @@ export const revokeAccountMcpConnectionCommand = defineCommand<
   output: successOutput,
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkUserActor(ctx);
-    const grant = await deps.getMcpOauthGrantByPublicId(deps.db, {
+    const grant = await deps.getGrantByPublicId({
       publicId: input.grantId,
     });
 
@@ -135,7 +144,7 @@ export const revokeAccountMcpConnectionCommand = defineCommand<
     }
 
     if (grant.status === "active") {
-      await deps.revokeMcpOauthGrant(deps.db, { publicId: input.grantId });
+      await deps.revokeGrant({ publicId: input.grantId });
     }
 
     return { success: true };
@@ -153,7 +162,7 @@ export const listOrgMcpConnectionsCommand = defineCommand<
   output: z.array(mcpConnectionDtoOutput),
   run: async ({ ctx, deps }) => {
     const actor = requireClerkOrgAdminActor(ctx);
-    const connections = await deps.listMcpOauthGrantConnectionsForOrg(deps.db, {
+    const connections = await deps.listGrantConnectionsForOrg({
       clerkOrgId: actor.orgId,
     });
     return connections.map(toMcpConnectionDto);
@@ -171,7 +180,7 @@ export const revokeOrgMcpConnectionCommand = defineCommand<
   output: successOutput,
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkOrgAdminActor(ctx);
-    const grant = await deps.getMcpOauthGrantByPublicId(deps.db, {
+    const grant = await deps.getGrantByPublicId({
       publicId: input.grantId,
     });
 
@@ -183,16 +192,14 @@ export const revokeOrgMcpConnectionCommand = defineCommand<
     }
 
     if (grant.status === "active") {
-      await deps.revokeMcpOauthGrant(deps.db, { publicId: input.grantId });
+      await deps.revokeGrant({ publicId: input.grantId });
     }
 
     return { success: true };
   },
 });
 
-function toMcpConnectionDto(
-  connection: McpOauthGrantConnection
-): McpConnectionDto {
+function toMcpConnectionDto(connection: McpConnectionRecord): McpConnectionDto {
   const client = connection.client;
   return {
     clientId: connection.grant.clientPublicId,

--- a/api/app/src/domain/org-api-keys/commands.ts
+++ b/api/app/src/domain/org-api-keys/commands.ts
@@ -4,9 +4,6 @@ import {
   revokeOrgApiKeySchema,
   rotateOrgApiKeySchema,
 } from "@repo/app-validation/schemas";
-import { log } from "@vendor/observability/log/next";
-import type { KeyResponseData, UnkeyClient } from "@vendor/unkey";
-import { getUnkeyClient, unkeyEnv } from "@vendor/unkey/server";
 import { z } from "zod";
 
 import { PUBLIC_API_KEY_SCOPES } from "../../auth/api-key";
@@ -18,36 +15,86 @@ import {
   requireClerkOrgAdminActor,
 } from "../gates";
 
-type UnkeyListKeysResult = Awaited<ReturnType<UnkeyClient["apis"]["listKeys"]>>;
-type UnkeyCreateKeyResult = Awaited<
-  ReturnType<UnkeyClient["keys"]["createKey"]>
->["data"];
-type UnkeyRerollKeyResult = Awaited<
-  ReturnType<UnkeyClient["keys"]["rerollKey"]>
->["data"];
+type OrgApiKeyMetadataValue =
+  | boolean
+  | null
+  | number
+  | string
+  | OrgApiKeyMetadataValue[]
+  | { [key: string]: OrgApiKeyMetadataValue };
 
-type ListOrgApiKeysResult = KeyResponseData[];
-type CreateOrgApiKeyResult = UnkeyCreateKeyResult;
-type RotateOrgApiKeyResult = UnkeyRerollKeyResult;
-
-interface OrgApiKeyCommandDeps {
-  apiId: string;
-  log: Pick<typeof log, "info">;
-  now: () => number;
-  unkey: UnkeyClient;
+export interface OrgApiKeyListItem {
+  createdAt: number;
+  enabled: boolean;
+  expires?: number | null;
+  identity?: { externalId?: string | null; id?: string } | null;
+  keyId: string;
+  lastUsedAt?: number | null;
+  meta?: Record<string, OrgApiKeyMetadataValue> | null;
+  name?: string | null;
+  start: string;
+  updatedAt?: number;
 }
 
-export function createDefaultOrgApiKeyCommandDeps(
-  input: Partial<Omit<OrgApiKeyCommandDeps, "log">> & {
-    log?: Pick<typeof log, "info">;
-  } = {}
-): OrgApiKeyCommandDeps {
-  return {
-    apiId: input.apiId ?? unkeyEnv.UNKEY_API_ID,
-    log: input.log ?? log,
-    now: input.now ?? Date.now,
-    unkey: input.unkey ?? getUnkeyClient(),
+export interface OrgApiKeySecretResult {
+  key?: string;
+  keyId: string;
+}
+
+type ListOrgApiKeysResult = OrgApiKeyListItem[];
+type CreateOrgApiKeyResult = OrgApiKeySecretResult;
+type RotateOrgApiKeyResult = OrgApiKeySecretResult;
+
+interface OrgApiKeyProviderClient {
+  apis: {
+    listKeys(input: {
+      apiId: string;
+      cursor?: string;
+      decrypt: false;
+      externalId: string;
+      limit: number;
+    }): Promise<{
+      data: OrgApiKeyListItem[];
+      pagination?: { cursor?: string; hasMore?: boolean };
+    }>;
   };
+  identities: {
+    createIdentity(input: {
+      externalId: string;
+      meta: { clerkOrgId: string };
+    }): Promise<unknown>;
+  };
+  keys: {
+    createKey(input: {
+      apiId: string;
+      expires?: number;
+      externalId: string;
+      meta: { createdByUserId: string; source: "dashboard" };
+      name: string;
+      permissions: string[];
+      prefix: string;
+      recoverable: false;
+    }): Promise<{ data: CreateOrgApiKeyResult }>;
+    deleteKey(input: { keyId: string; permanent: false }): Promise<unknown>;
+    getKey(input: {
+      decrypt: false;
+      keyId: string;
+    }): Promise<{ data: { identity?: { externalId?: string | null } | null } }>;
+    rerollKey(input: {
+      expiration: number;
+      keyId: string;
+    }): Promise<{ data: RotateOrgApiKeyResult }>;
+    updateKey(input: { enabled: false; keyId: string }): Promise<unknown>;
+  };
+}
+
+export interface OrgApiKeyCommandDeps {
+  apiId: string;
+  isProviderConflictError(error: unknown): boolean;
+  isProviderNotFoundError(error: unknown): boolean;
+  log: { info(message: string, context: Record<string, unknown>): void };
+  now: () => number;
+  provider: OrgApiKeyProviderClient;
 }
 
 const listOrgApiKeysInput = z.object({}).strict();
@@ -60,26 +107,17 @@ const rotateOrgApiKeyOutput = z.custom<RotateOrgApiKeyResult>(
 );
 const successOutput = z.object({ success: z.literal(true) });
 
-function isUnkeyStatus(error: unknown, statusCode: number) {
-  return (
-    error !== null &&
-    typeof error === "object" &&
-    "statusCode" in error &&
-    (error as { statusCode?: unknown }).statusCode === statusCode
-  );
-}
-
-async function ensureUnkeyOrgIdentity(input: {
+async function ensureProviderOrgIdentity(input: {
   deps: OrgApiKeyCommandDeps;
   orgId: string;
 }) {
   try {
-    await input.deps.unkey.identities.createIdentity({
+    await input.deps.provider.identities.createIdentity({
       externalId: input.orgId,
       meta: { clerkOrgId: input.orgId },
     });
   } catch (error) {
-    if (isUnkeyStatus(error, 409)) {
+    if (input.deps.isProviderConflictError(error)) {
       return;
     }
     throw error;
@@ -91,14 +129,14 @@ async function getOrgApiKeyForOrg(input: {
   keyId: string;
   orgId: string;
 }) {
-  let response: Awaited<ReturnType<UnkeyClient["keys"]["getKey"]>>;
+  let response: Awaited<ReturnType<OrgApiKeyProviderClient["keys"]["getKey"]>>;
   try {
-    response = await input.deps.unkey.keys.getKey({
+    response = await input.deps.provider.keys.getKey({
       decrypt: false,
       keyId: input.keyId,
     });
   } catch (error) {
-    if (isUnkeyStatus(error, 404)) {
+    if (input.deps.isProviderNotFoundError(error)) {
       throw new NotFoundError("ORG_API_KEY_NOT_FOUND", "API key not found.");
     }
     throw error;
@@ -122,11 +160,11 @@ export const listOrgApiKeysCommand = defineCommand<
   output: listOrgApiKeysOutput,
   run: async ({ ctx, deps }) => {
     const actor = requireActiveClerkOrgActor(ctx);
-    const keys: KeyResponseData[] = [];
+    const keys: OrgApiKeyListItem[] = [];
     let cursor: string | undefined;
 
     do {
-      const response: UnkeyListKeysResult = await deps.unkey.apis.listKeys({
+      const response = await deps.provider.apis.listKeys({
         apiId: deps.apiId,
         cursor,
         decrypt: false,
@@ -156,12 +194,12 @@ export const createOrgApiKeyCommand = defineCommand<
   run: async ({ ctx, deps, input }) => {
     const actor = requireClerkOrgAdminActor(ctx);
 
-    await ensureUnkeyOrgIdentity({ deps, orgId: actor.orgId });
+    await ensureProviderOrgIdentity({ deps, orgId: actor.orgId });
 
     const expires = input.secondsUntilExpiration
       ? deps.now() + input.secondsUntilExpiration * 1000
       : undefined;
-    const response = await deps.unkey.keys.createKey({
+    const response = await deps.provider.keys.createKey({
       apiId: deps.apiId,
       externalId: actor.orgId,
       ...(expires ? { expires } : {}),
@@ -202,7 +240,7 @@ export const revokeOrgApiKeyCommand = defineCommand<
       keyId: input.keyId,
       orgId: actor.orgId,
     });
-    await deps.unkey.keys.updateKey({
+    await deps.provider.keys.updateKey({
       enabled: false,
       keyId: input.keyId,
     });
@@ -233,7 +271,7 @@ export const deleteOrgApiKeyCommand = defineCommand<
       keyId: input.keyId,
       orgId: actor.orgId,
     });
-    await deps.unkey.keys.deleteKey({
+    await deps.provider.keys.deleteKey({
       keyId: input.keyId,
       permanent: false,
     });
@@ -264,7 +302,7 @@ export const rotateOrgApiKeyCommand = defineCommand<
       keyId: input.keyId,
       orgId: actor.orgId,
     });
-    const response = await deps.unkey.keys.rerollKey({
+    const response = await deps.provider.keys.rerollKey({
       expiration: input.revokeOldAfterMs ?? 0,
       keyId: input.keyId,
     });


### PR DESCRIPTION
## Summary
- Move account username/profile runtime wiring out of account domain commands into the TanStack account adapter.
- Move org API-key provider/env/log wiring out of org API-key commands into the TanStack adapter.
- Move MCP grant DB-helper wiring out of MCP connection commands into the TanStack adapter and strengthen boundary source tests.

## Test Plan
- pnpm check
- pnpm --filter @api/app typecheck
- pnpm --filter @api/app test -- src/__tests__/domain-command-deps-boundary-source.test.ts src/__tests__/account-domain-commands.test.ts src/__tests__/github-account-domain-commands.test.ts src/__tests__/org-api-keys-domain-commands.test.ts src/__tests__/account-connector-domain-commands.test.ts src/__tests__/org-mcp-connections-domain-commands.test.ts
- pnpm typecheck
- pnpm turbo boundaries
- SKIP_ENV_VALIDATION=true pnpm knip --include files (known existing unused-file backlog; no touched files reported)
- agent-browser smoke: opened https://auth-architecture-next-slice-45.lightfast.localhost and confirmed rendered marketing surface
- curl smoke: GET /api/v1/signals returned 401 auth_required; OPTIONS /api/v1/signals returned 204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Reorganized internal dependency structures for account management, API key operations, and MCP connections to improve code maintainability and testability.
- Updated test suite across multiple domain command modules to reflect revised dependency contracts and data shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->