### PR TITLE
Extend auth architecture route ratchets

### DIFF
--- a/api/app/src/adapters/cli-api.ts
+++ b/api/app/src/adapters/cli-api.ts
@@ -11,6 +11,7 @@ import {
 } from "@repo/native-auth-contract";
 import {
   createProviderRoutineCommandDeps,
+  type ProviderRoutineCommandDeps,
   providerRoutineCallCommand,
   providerRoutineFindCommand,
 } from "../domain/provider-routines";
@@ -42,12 +43,22 @@ export function handleCliNativeRpcRequest(request: Request) {
   });
 }
 
-async function createCliProviderRoutineCommandContext(req: Request) {
+async function createCliProviderRoutineContext(req: Request) {
   const { db } = await import("@db/app/client");
   const { resolveAuthContextFromClerk } = await import("../auth/identity");
   const { loadAgentConnectorRuntimeTools } = await import(
     "../services/connectors/runtime"
   );
+  const adapters: Pick<
+    ProviderRoutineCommandDeps,
+    "loadConnectorRuntimeTools"
+  > = {
+    loadConnectorRuntimeTools: async (input) =>
+      await loadAgentConnectorRuntimeTools({
+        ...input,
+        sourceSurface: "native_cli",
+      }),
+  };
   const headers = new Headers(req.headers);
   headers.set(NATIVE_AUTH_HEADERS.client, "cli");
   const auth = await resolveAuthContextFromClerk({
@@ -86,7 +97,7 @@ async function createCliProviderRoutineCommandContext(req: Request) {
     },
     deps: createProviderRoutineCommandDeps({
       db,
-      loadConnectorRuntimeTools: loadAgentConnectorRuntimeTools,
+      ...adapters,
       log,
       now: () => new Date(),
     }),
@@ -102,8 +113,7 @@ async function handleCliProviderRoutineCallCommand({
 }) {
   try {
     const input = parseProviderRoutineCallInput(commandInput);
-    const commandContext =
-      await createCliProviderRoutineCommandContext(request);
+    const commandContext = await createCliProviderRoutineContext(request);
     const result = await providerRoutineCallCommand.run({
       ...commandContext,
       input: { input },
@@ -123,8 +133,7 @@ async function handleCliProviderRoutineFindCommand({
 }) {
   try {
     const input = parseProviderRoutineFindInput(commandInput);
-    const commandContext =
-      await createCliProviderRoutineCommandContext(request);
+    const commandContext = await createCliProviderRoutineContext(request);
     const result = await providerRoutineFindCommand.run({
       ...commandContext,
       input: { input },

--- a/api/app/src/adapters/internal/mcp-proxy.ts
+++ b/api/app/src/adapters/internal/mcp-proxy.ts
@@ -10,6 +10,7 @@ import {
 import { verifyServiceJWT } from "@repo/service-jwt";
 import {
   createProviderRoutineCommandDeps,
+  type ProviderRoutineCommandDeps,
   providerRoutineCallCommand,
   providerRoutineFindCommand,
 } from "../../domain/provider-routines";
@@ -178,14 +179,24 @@ function providerRoutineContext(
 }
 
 function providerRoutineDeps() {
-  return createProviderRoutineCommandDeps({
-    db,
+  const adapters: Pick<
+    ProviderRoutineCommandDeps,
+    "loadConnectorRuntimeTools"
+  > = {
     loadConnectorRuntimeTools: async (input) => {
       const { loadAgentConnectorRuntimeTools } = await import(
         "../../services/connectors/runtime"
       );
-      return await loadAgentConnectorRuntimeTools(input);
+      return await loadAgentConnectorRuntimeTools({
+        ...input,
+        sourceSurface: "hosted_mcp",
+      });
     },
+  };
+
+  return createProviderRoutineCommandDeps({
+    db,
+    ...adapters,
     log: noopProviderRoutineLog,
     now: () => new Date(),
   });

--- a/db/app/src/__tests__/schema-conventions.test.ts
+++ b/db/app/src/__tests__/schema-conventions.test.ts
@@ -23,6 +23,7 @@ const SKIPPED_DIRECTORIES = new Set([
   ".cache",
   ".git",
   ".next",
+  ".output",
   ".turbo",
   ".vercel",
   "coverage",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "db:studio": "pnpm --filter @db/app db:studio",
     "db:baseline": "pnpm --filter @db/app db:baseline",
     "entity-graph:simulated": "pnpm --filter @db/app entity-graph:simulated",
-    "knip": "knip"
+    "knip": "SKIP_ENV_VALIDATION=true knip"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.12",

--- a/packages/app-reserved-names/data/organization-names.json
+++ b/packages/app-reserved-names/data/organization-names.json
@@ -53,6 +53,7 @@
   "about",
   "abuse",
   "account",
+  "accounts",
   "accept-invitation",
   "admin",
   "agent",

--- a/packages/app-reserved-names/src/__tests__/route-coverage.test.ts
+++ b/packages/app-reserved-names/src/__tests__/route-coverage.test.ts
@@ -22,6 +22,10 @@ const repoRoot = path.resolve(
 );
 
 function findRouteArtifacts(root: string): string[] {
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+
   const artifacts: string[] = [];
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     const entryPath = path.join(root, entry.name);
@@ -41,7 +45,7 @@ function isRouteGroup(segment: string): boolean {
 }
 
 function isDynamicSegment(segment: string): boolean {
-  return segment.startsWith("[");
+  return segment.startsWith("[") || segment.startsWith("$");
 }
 
 function isPrivateSegment(segment: string): boolean {
@@ -88,6 +92,73 @@ function collectAppRouteSegments(appRoot: string): Set<string> {
   return segments;
 }
 
+function normalizeTanStackRouteSegment(segment: string): string | null {
+  const normalized = segment.replaceAll("[.]", ".").replace(/_$/, "");
+  if (
+    !normalized ||
+    normalized === "__root" ||
+    normalized === "index" ||
+    isRouteGroup(normalized) ||
+    isPrivateSegment(normalized)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function splitTanStackRoutePart(segment: string): string[] {
+  const escapedDot = "\0tanstack-dot\0";
+  return segment
+    .replaceAll("[.]", escapedDot)
+    .split(".")
+    .map((part) => part.replaceAll(escapedDot, "[.]"));
+}
+
+function collectTanStackTopLevelRouteSegments(routesRoot: string): Set<string> {
+  const segments = new Set<string>();
+  if (!fs.existsSync(routesRoot)) {
+    return segments;
+  }
+
+  const visit = (directory: string) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+        continue;
+      }
+
+      if (!/\.(?:ts|tsx)$/.test(entry.name)) {
+        continue;
+      }
+
+      const routePath = path
+        .relative(routesRoot, entryPath)
+        .replace(/\.(?:ts|tsx)$/, "");
+      const routeSegments = routePath
+        .split(path.sep)
+        .flatMap((segment) => splitTanStackRoutePart(segment));
+
+      for (const routeSegment of routeSegments) {
+        const normalized = normalizeTanStackRouteSegment(routeSegment);
+        if (!normalized) {
+          continue;
+        }
+        if (isDynamicSegment(normalized)) {
+          break;
+        }
+
+        segments.add(normalized);
+        break;
+      }
+    }
+  };
+
+  visit(routesRoot);
+  return segments;
+}
+
 function normalizeMicrofrontendSegment(segment: string): string | null {
   if (segment.startsWith(":")) {
     return null;
@@ -125,6 +196,9 @@ function collectCurrentStaticRouteSegments(): string[] {
   return [
     ...new Set([
       ...collectAppRouteSegments(path.join(repoRoot, "apps/app/src/app")),
+      ...collectTanStackTopLevelRouteSegments(
+        path.join(repoRoot, "apps/app/src/routes")
+      ),
       ...collectAppRouteSegments(path.join(repoRoot, "apps/www/src/app")),
       ...collectMicrofrontendRouteSegments(),
     ]),


### PR DESCRIPTION
## Summary
- extend reserved-name route coverage to TanStack file routes and reserve the new `/accounts` top-level route segment
- keep provider routine connector-runtime provenance explicit at CLI and hosted-MCP adapter boundaries
- make architecture ratchets ignore generated `.output` artifacts and let Knip load without app env validation

## Test Plan
- `pnpm --filter @lightfast/app test -- src/__tests__/internal-mcp-routes-source.test.ts src/__tests__/native-rpc-routes-source.test.ts`
- `pnpm --filter @db/app test -- src/__tests__/schema-conventions.test.ts`
- `pnpm --filter @api/app test -- src/__tests__/native-rpc-adapter.test.ts src/__tests__/provider-routines-domain-commands.test.ts`
- `pnpm --filter @repo/app-reserved-names test`
- `pnpm --filter @repo/app-reserved-names typecheck`
- `pnpm test`
- `pnpm typecheck`
- `pnpm check`
- `pnpm turbo boundaries`
- `git diff --check`
- agent-browser smoke: `/api/v1/system/health` returns public API `auth_required` JSON without an API key
- agent-browser smoke: signed-out `/chat` redirects to `/sign-in?redirect_url=%2Fchat` through the worktree MFE URL
