### PR TITLE
fix(www): align home metadata title format

### DIFF
--- a/apps/www/src/content/home/home.mdx
+++ b/apps/www/src/content/home/home.mdx
@@ -8,7 +8,7 @@ keywords:
   - "AI collaboration systems"
   - "AI evals"
   - "product engineering AI"
-ogTitle: "Lightfast - Collaboration between humans and machine"
+ogTitle: "Collaboration between humans and machine | Lightfast"
 ogDescription: "An applied AI lab developing models, interfaces, infrastructure, and evals for teams designing, building, and shipping with AI in real time."
 noindex: false
 nofollow: false

--- a/apps/www/src/lib/site/identity.ts
+++ b/apps/www/src/lib/site/identity.ts
@@ -2,7 +2,7 @@ import type { Thing, WithContext } from "@vendor/seo/json-ld";
 import type { Metadata, MetadataRoute, Viewport } from "next";
 
 const baseUrl = "https://lightfast.ai";
-const defaultTitle = "Lightfast - Collaboration between humans and machine";
+const defaultTitle = "Collaboration between humans and machine | Lightfast";
 const defaultDescription =
   "Lightfast is an applied AI lab building systems where product and engineering teams design, build, and ship with AI in real time.";
 const defaultOgDescription =


### PR DESCRIPTION
## Summary

- Aligns the site default title with the home metadata builder's `title | Lightfast` format.
- Updates the home page `ogTitle` to match the same structure, resolving CodeRabbit's blocker from #1101.

## Validation

- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm check`
- [x] `cd apps/www && pnpm with-env next typegen && tsc --noEmit`
- [x] `pnpm build:www`