### PR TITLE
fix(app): trace React deps for Vercel bundle

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -56,7 +56,9 @@ export function createSentryBuildOptions(
 export default defineConfig(({ command }) => ({
   plugins: [
     ...tanstackStart(),
-    nitro(),
+    nitro({
+      traceDeps: ["react", "react-dom", "use-sync-external-store"],
+    }),
     react(),
     ...sentryTanstackStart(createSentryBuildOptions(command)),
   ],


### PR DESCRIPTION
## Summary

- Adds Nitro `traceDeps` for `react`, `react-dom`, and `use-sync-external-store` in `apps/app`.
- Ensures Vercel's generated server function bundle includes the CommonJS runtime deps required by Base UI/use-sync-external-store SSR chunks.

## Root Cause

The production failure was not that React was missing from `apps/app` dependencies. The Vercel/Nitro traced function package omitted React even though generated SSR chunks contained top-level `require("react")` calls. PR #957 changed the SSR chunk graph so a `usePositioner` chunk with that bare require became reachable on app-owned routes like `/.well-known/oauth-authorization-server`, `/.well-known/openid-configuration`, and `/api/inngest`, causing Lambda runtime `MODULE_NOT_FOUND` failures.

## Validation

- `pnpm --filter @lightfast/app typecheck`
- `pnpm build:app`
- Vercel-preset local build with `NITRO_PRESET=vercel`
- Isolated function bundle import check: bad bundle fails with `Cannot find module 'react'`; fixed bundle imports the `usePositioner` chunk successfully.
- Manual preview check: branch preview loaded successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app build configuration to better track key React-related dependencies during bundling.
  * This should improve reliability of development and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->