### PR TITLE
fix(app): prevent pending auth redirect loop

### DIFF
--- a/apps/app/src/__tests__/authenticated-routes-source.test.ts
+++ b/apps/app/src/__tests__/authenticated-routes-source.test.ts
@@ -273,6 +273,13 @@ describe("app authenticated route migration", () => {
     );
 
     expect(shellSource).toContain('createFileRoute("/_authenticated")');
+    expect(shellSource).toContain(
+      'import { useUser } from "@clerk/tanstack-react-start"'
+    );
+    expect(shellSource).toContain("const { isLoaded, isSignedIn } = useUser()");
+    expect(shellSource).not.toContain(
+      "const { isLoaded, isSignedIn } = useAuth()"
+    );
     expect(shellSource).toContain('to: "/sign-in"');
     expect(shellSource).toContain("redirect_url: location.href");
     expect(shellSource).toContain("AUTH_ROUTE_PATHS");

--- a/apps/app/src/routes/_authenticated.tsx
+++ b/apps/app/src/routes/_authenticated.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@clerk/tanstack-react-start";
+import { useUser } from "@clerk/tanstack-react-start";
 import {
   createFileRoute,
   Outlet,
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/_authenticated")({
 });
 
 function AuthenticatedLayout() {
-  const { isLoaded, isSignedIn } = useAuth();
+  const { isLoaded, isSignedIn } = useUser();
   const location = useLocation();
   const navigate = useNavigate();
   const pathname = location.pathname;


### PR DESCRIPTION
## Summary
- Use Clerk `useUser()` in the TanStack authenticated layout so pending new-account sessions are treated as authenticated account sessions.
- Add a source regression assertion to keep the layout from drifting back to `useAuth().isSignedIn` semantics.

## Root Cause
New Clerk sign-ups can create a pending session with a user but no active organization. The app-level route guard used `useAuth().isSignedIn`, which sent that pending session to `/sign-in`; the sign-in page used `useUser().isSignedIn`, which immediately redirected back to the protected route. That disagreement caused the production redirect loop.

## Verification
- `pnpm --filter @lightfast/app test src/__tests__/authenticated-routes-source.test.ts`
- `pnpm --filter @lightfast/app typecheck`
- `SKIP_ENV_VALIDATION=true pnpm build:app`

Note: plain `pnpm build:app` is blocked in this local worktree by missing DB env (`DATABASE_HOST`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authenticated route handling to use the latest user state checks, improving sign-in redirects and loading behavior.
  * Kept account and organization routes protected while preserving the existing shell layout and skeleton loading states.
* **Tests**
  * Adjusted route coverage to verify the updated authentication logic and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->