### PR TITLE
Fix hosted MCP tools/list schema serialization

### DIFF
--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -1,10 +1,11 @@
+import { Client, InMemoryTransport, McpServer } from "@vendor/mcp";
 import { afterEach, describe, expect, it, vi } from "vitest";
-
 import type { HostedMcpContext } from "../context";
 import {
   type ExecuteHostedMcpToolDependencies,
   executeHostedMcpTool,
   listHostedMcpTools,
+  registerHostedMcpTools,
 } from "../tools/execute";
 
 const signalId = "signal_123e4567-e89b-12d3-a456-426614174000";
@@ -157,6 +158,48 @@ describe("hosted MCP tools", () => {
         requiredScope: "mcp:provider_routines:read",
       }),
     ]);
+  });
+
+  it("serializes every hosted tool schema through MCP tools/list", async () => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    registerHostedMcpTools(server);
+
+    const mcpClient = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await Promise.all([
+      server.connect(serverTransport),
+      mcpClient.connect(clientTransport),
+    ]);
+
+    try {
+      const { tools } = await mcpClient.listTools();
+
+      expect(tools.map((tool) => tool.name)).toEqual([
+        "lightfast_signals_create",
+        "lightfast_signals_get",
+        "lightfast_system_health",
+        "decisions_find",
+        "decisions_get",
+        "proxy_call",
+        "proxy_find",
+      ]);
+      expect(
+        tools.find((tool) => tool.name === "decisions_find")?.inputSchema
+      ).toMatchObject({
+        properties: {
+          since: expect.objectContaining({
+            format: "date-time",
+            type: "string",
+          }),
+        },
+        type: "object",
+      });
+    } finally {
+      await mcpClient.close();
+      await server.close();
+    }
   });
 
   it("creates a signal with MCP actor attribution", async () => {

--- a/apps/mcp/src/tools/execute.ts
+++ b/apps/mcp/src/tools/execute.ts
@@ -1,14 +1,17 @@
 import {
   apiContract,
   type CreateSignalInput,
+  connectableConnectorProviderSchema,
   type DecisionDetail,
   type DecisionFindInput,
   type DecisionFindOutput,
   type DecisionGetInput,
+  decisionCalledByKindSchema,
   decisionFindInputSchema,
   decisionFindOutputSchema,
   decisionGetInputSchema,
   decisionGetOutputSchema,
+  decisionStatusSchema,
   type GetSignalInput,
   type GetSignalOutput,
   lightfastMcpToolPolicy,
@@ -22,7 +25,9 @@ import {
   type ProviderRoutineFindOutput,
   type ProviderRoutineSourceSurface,
   providerRoutineCallInputSchema,
+  providerRoutineClassificationSchema,
   providerRoutineFindInputSchema,
+  providerRoutineSourceSurfaceSchema,
 } from "@repo/api-contract";
 import {
   createLightfastMcpToolDefinitions,
@@ -224,6 +229,81 @@ const DECISION_TOOLS = [
   },
 ] satisfies LightfastMcpToolDefinition[];
 
+const mcpDecisionDateTimeSchema = z.string().datetime();
+
+const mcpDecisionCursorSchema = z
+  .object({
+    createdAt: mcpDecisionDateTimeSchema,
+    id: z.number().int().positive(),
+  })
+  .strict();
+
+const mcpDecisionFindInputSchema = z
+  .object({
+    cursor: mcpDecisionCursorSchema.nullish(),
+    limit: z.number().int().min(1).max(100).optional(),
+    providers: z.array(connectableConnectorProviderSchema).max(8).optional(),
+    query: z.string().trim().max(200).optional(),
+    since: mcpDecisionDateTimeSchema.optional(),
+    sourceSurfaces: z
+      .array(providerRoutineSourceSurfaceSchema)
+      .max(8)
+      .optional(),
+    statuses: z.array(decisionStatusSchema).max(3).optional(),
+    until: mcpDecisionDateTimeSchema.optional(),
+  })
+  .strict();
+
+const mcpDecisionRedactedPayloadSchema = z
+  .record(z.string(), z.unknown())
+  .nullable();
+
+const mcpDecisionBaseSchema = z
+  .object({
+    calledById: z.string().min(1),
+    calledByKind: decisionCalledByKindSchema,
+    calledByUserId: z.string().nullable(),
+    classification: providerRoutineClassificationSchema,
+    createdAt: mcpDecisionDateTimeSchema,
+    errorCode: z.string().nullable(),
+    errorMessage: z.string().nullable(),
+    finishedAt: mcpDecisionDateTimeSchema.nullable(),
+    id: z.string().min(1),
+    provider: connectableConnectorProviderSchema,
+    providerToolName: z.string().min(1),
+    routineId: z.string().min(1),
+    snippet: z.string(),
+    sourceSurface: providerRoutineSourceSurfaceSchema,
+    startedAt: mcpDecisionDateTimeSchema,
+    status: decisionStatusSchema,
+    title: z.string().min(1),
+  })
+  .strict();
+
+const mcpDecisionSummarySchema = mcpDecisionBaseSchema;
+
+const mcpDecisionDetailSchema = mcpDecisionBaseSchema.extend({
+  inputRedacted: mcpDecisionRedactedPayloadSchema,
+  outputRedacted: mcpDecisionRedactedPayloadSchema,
+  providerActorId: z.string().nullable(),
+  providerAttempted: z.boolean(),
+  providerConnectionId: z.number().int().positive(),
+  providerRoutineCallId: z.string().min(1),
+  providerWorkspaceId: z.string().nullable(),
+  sourceClientId: z.string().nullable(),
+  sourceRef: z.string().nullable(),
+  updatedAt: mcpDecisionDateTimeSchema,
+});
+
+const mcpDecisionFindOutputSchema = z
+  .object({
+    items: z.array(mcpDecisionSummarySchema),
+    nextCursor: mcpDecisionCursorSchema.nullable(),
+  })
+  .strict();
+
+const mcpDecisionGetOutputSchema = mcpDecisionDetailSchema;
+
 const PROXY_TOOLS = [
   {
     auditEventName: "mcp.proxy.call",
@@ -258,14 +338,15 @@ const PROXY_TOOLS = [
 export function registerHostedMcpTools(server: unknown): void {
   const target = server as HostedMcpServerAdapter;
   for (const tool of listHostedMcpTools()) {
+    const registrationSchemas = registrationSchemasForTool(tool);
     const config: Record<string, unknown> = {
       description: tool.description,
     };
-    if (tool.inputSchema) {
-      config.inputSchema = tool.inputSchema;
+    if (registrationSchemas.inputSchema) {
+      config.inputSchema = registrationSchemas.inputSchema;
     }
-    if (tool.outputSchema) {
-      config.outputSchema = tool.outputSchema;
+    if (registrationSchemas.outputSchema) {
+      config.outputSchema = registrationSchemas.outputSchema;
     }
 
     target.registerTool(tool.name, config, async (...args: unknown[]) => {
@@ -287,6 +368,31 @@ export function registerHostedMcpTools(server: unknown): void {
         return formatMcpError(error);
       }
     });
+  }
+}
+
+function registrationSchemasForTool(tool: LightfastMcpToolDefinition): {
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+} {
+  switch (tool.contractPath) {
+    case "decisions.find":
+      return {
+        inputSchema: mcpDecisionFindInputSchema,
+        outputSchema: mcpDecisionFindOutputSchema,
+      };
+
+    case "decisions.get":
+      return {
+        inputSchema: decisionGetInputSchema,
+        outputSchema: mcpDecisionGetOutputSchema,
+      };
+
+    default:
+      return {
+        inputSchema: tool.inputSchema,
+        outputSchema: tool.outputSchema,
+      };
   }
 }
 

--- a/packages/mcp-tools/src/__tests__/results.test.ts
+++ b/packages/mcp-tools/src/__tests__/results.test.ts
@@ -40,6 +40,23 @@ describe("MCP result formatting", () => {
     });
   });
 
+  it("degrades safely when result JSON serialization throws", () => {
+    expect(formatMcpSuccess({ count: 1n })).toEqual({
+      content: [{ text: "[object Object]", type: "text" }],
+      structuredContent: { result: null },
+    });
+  });
+
+  it("degrades safely for circular result objects", () => {
+    const result: { self?: unknown } = {};
+    result.self = result;
+
+    expect(formatMcpSuccess(result)).toEqual({
+      content: [{ text: "[object Object]", type: "text" }],
+      structuredContent: { result: null },
+    });
+  });
+
   it("formats errors without leaking stack traces", () => {
     const result = formatMcpError(new Error("Nope"));
     expect(result).toEqual({

--- a/packages/mcp-tools/src/__tests__/results.test.ts
+++ b/packages/mcp-tools/src/__tests__/results.test.ts
@@ -22,6 +22,24 @@ describe("MCP result formatting", () => {
     });
   });
 
+  it("returns JSON-compatible structured content", () => {
+    expect(
+      formatMcpSuccess({
+        createdAt: new Date("2026-06-25T03:26:25.180Z"),
+      })
+    ).toEqual({
+      content: [
+        {
+          text: '{\n  "createdAt": "2026-06-25T03:26:25.180Z"\n}',
+          type: "text",
+        },
+      ],
+      structuredContent: {
+        createdAt: "2026-06-25T03:26:25.180Z",
+      },
+    });
+  });
+
   it("formats errors without leaking stack traces", () => {
     const result = formatMcpError(new Error("Nope"));
     expect(result).toEqual({

--- a/packages/mcp-tools/src/results.ts
+++ b/packages/mcp-tools/src/results.ts
@@ -16,15 +16,28 @@ export interface LightfastMcpErrorResult {
 }
 
 function toStructuredContent(result: unknown): Record<string, unknown> {
-  if (result && typeof result === "object" && !Array.isArray(result)) {
-    return result as Record<string, unknown>;
+  const jsonResult = toJsonCompatible(result);
+  if (
+    jsonResult &&
+    typeof jsonResult === "object" &&
+    !Array.isArray(jsonResult)
+  ) {
+    return jsonResult as Record<string, unknown>;
   }
-  return { result };
+  return { result: jsonResult ?? null };
 }
 
 function stringifyResult(result: unknown): string {
   const json = JSON.stringify(result, null, 2);
   return json ?? String(result);
+}
+
+function toJsonCompatible(result: unknown): unknown {
+  const json = JSON.stringify(result);
+  if (json === undefined) {
+    return;
+  }
+  return JSON.parse(json) as unknown;
 }
 
 export function formatMcpSuccess(result: unknown): LightfastMcpSuccessResult {

--- a/packages/mcp-tools/src/results.ts
+++ b/packages/mcp-tools/src/results.ts
@@ -28,16 +28,32 @@ function toStructuredContent(result: unknown): Record<string, unknown> {
 }
 
 function stringifyResult(result: unknown): string {
-  const json = JSON.stringify(result, null, 2);
-  return json ?? String(result);
+  const json = safeStringify(result, 2);
+  return json ?? safeToString(result);
 }
 
 function toJsonCompatible(result: unknown): unknown {
-  const json = JSON.stringify(result);
+  const json = safeStringify(result);
   if (json === undefined) {
     return;
   }
   return JSON.parse(json) as unknown;
+}
+
+function safeStringify(result: unknown, space?: number): string | undefined {
+  try {
+    return JSON.stringify(result, null, space);
+  } catch {
+    return;
+  }
+}
+
+function safeToString(result: unknown): string {
+  try {
+    return String(result);
+  } catch {
+    return "[Unserializable MCP result]";
+  }
 }
 
 export function formatMcpSuccess(result: unknown): LightfastMcpSuccessResult {


### PR DESCRIPTION
## Summary\n- Register hosted decision MCP tools with JSON-wire schemas so tools/list can serialize date fields\n- Keep internal execution schemas unchanged so decision filters still parse into Date for DB queries\n- Normalize MCP structuredContent through JSON so Date results validate against wire schemas\n- Add an in-memory MCP Client tools/list regression test for the hosted registration path\n\n## Verification\n- pnpm --filter @lightfast/mcp test\n- pnpm --filter @repo/mcp-tools test\n- pnpm --filter @lightfast/mcp typecheck\n- pnpm --filter @repo/mcp-tools typecheck\n- pnpm --filter @lightfast/mcp build\n- pnpm turbo //#check --summarize\n\n## Root Cause\nMCP SDK serializes every registered tool schema during tools/list. The hosted decision tools registered shared Zod schemas containing z.date(), and Zod cannot represent Date in JSON Schema. Direct initialize/tools/call for system health could still work, but tool discovery failed before clients could expose any tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted MCP tools now provide richer, strongly-typed decision tool schemas, including time-based `since` filters and expanded classification fields.
* **Bug Fixes**
  * Improved MCP result formatting for JSON compatibility: date values are emitted as ISO strings.
  * Added safer fallbacks when results can’t be serialized (e.g., circular structures or non-JSON types).
* **Tests**
  * Added integration coverage for hosted tool registration and tool input schema expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->