### PR TITLE
fix: fail Linear MCP tool error results

### DIFF
--- a/api/app/src/__tests__/provider-routines-policy.test.ts
+++ b/api/app/src/__tests__/provider-routines-policy.test.ts
@@ -39,6 +39,7 @@ describe("provider routine policy", () => {
   it("classifies known Linear routines and defaults unknown names to write", () => {
     expect(classifyLinearRoutine("list_issues")).toBe("read");
     expect(classifyLinearRoutine("create_issue")).toBe("write");
+    expect(classifyLinearRoutine("save_initiative")).toBe("write");
     expect(classifyLinearRoutine("some_future_tool")).toBe(
       "unknown_write_default"
     );

--- a/api/app/src/services/provider-routines/policy.ts
+++ b/api/app/src/services/provider-routines/policy.ts
@@ -126,7 +126,7 @@ export function classifyLinearRoutine(
     return "read";
   }
   if (
-    /^(archive|assign|create|delete|move|remove|set|update)(_|$)/.test(
+    /^(archive|assign|create|delete|move|remove|save|set|update)(_|$)/.test(
       providerToolName
     )
   ) {

--- a/connectors/linear/src/__tests__/mcp.test.ts
+++ b/connectors/linear/src/__tests__/mcp.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mcpState = vi.hoisted(() => ({
-  callTool: vi.fn(async () => ({
+  callTool: vi.fn(async (): Promise<unknown> => ({
     content: [{ text: "created", type: "text" }],
   })),
   close: vi.fn(async () => undefined),
@@ -203,6 +203,38 @@ describe("callLinearMcpTool", () => {
       })
     ).rejects.toMatchObject({
       cause: { name: "Error" },
+      code: "LINEAR_MCP_FAILED",
+      message: "Linear MCP tool call failed.",
+      name: "LinearAppNodeError",
+    });
+    expect(mcpState.close).toHaveBeenCalledOnce();
+  });
+
+  it("treats MCP tool-level error results as failures", async () => {
+    mcpState.callTool.mockResolvedValueOnce({
+      content: [
+        {
+          text: JSON.stringify({
+            error: "invalid_request",
+            message: "Invalid request.",
+            requestId: "req_123",
+            status: 400,
+          }),
+          type: "text",
+        },
+      ],
+      isError: true,
+    });
+
+    await expect(
+      callLinearMcpTool({
+        accessToken: "lin_access",
+        endpoint: "https://mcp.linear.test/mcp",
+        input: { query: "Roadmap" },
+        name: "list_initiatives",
+      })
+    ).rejects.toMatchObject({
+      cause: { name: "object" },
       code: "LINEAR_MCP_FAILED",
       message: "Linear MCP tool call failed.",
       name: "LinearAppNodeError",

--- a/connectors/linear/src/__tests__/mcp.test.ts
+++ b/connectors/linear/src/__tests__/mcp.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mcpState = vi.hoisted(() => ({
-  callTool: vi.fn(async (): Promise<unknown> => ({
-    content: [{ text: "created", type: "text" }],
-  })),
+  callTool: vi.fn(
+    async (): Promise<unknown> => ({
+      content: [{ text: "created", type: "text" }],
+    })
+  ),
   close: vi.fn(async () => undefined),
   connect: vi.fn(async () => undefined),
   listTools: vi.fn(async () => ({

--- a/connectors/linear/src/mcp.ts
+++ b/connectors/linear/src/mcp.ts
@@ -100,13 +100,21 @@ export async function callLinearMcpTool(input: {
 
   try {
     await withAbort(client.connect(transport), abortController.signal);
-    return await withAbort(
+    const result = await withAbort(
       client.callTool({
         arguments: input.input,
         name: input.name,
       }),
       abortController.signal
     );
+    if (isMcpToolErrorResult(result)) {
+      throw new LinearAppNodeError(
+        "LINEAR_MCP_FAILED",
+        "Linear MCP tool call failed.",
+        result
+      );
+    }
+    return result;
   } catch (error) {
     if (error instanceof LinearAppNodeError) {
       throw error;
@@ -153,6 +161,17 @@ function delay(timeoutMs: number): Promise<void> {
 
 function abortError() {
   return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function isMcpToolErrorResult(
+  result: unknown
+): result is { isError: true } {
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    "isError" in result &&
+    (result as { isError?: unknown }).isError === true
+  );
 }
 
 function toManifestItem(tool: Tool) {

--- a/connectors/linear/src/mcp.ts
+++ b/connectors/linear/src/mcp.ts
@@ -163,9 +163,7 @@ function abortError() {
   return new DOMException("The operation was aborted.", "AbortError");
 }
 
-function isMcpToolErrorResult(
-  result: unknown
-): result is { isError: true } {
+function isMcpToolErrorResult(result: unknown): result is { isError: true } {
   return (
     result !== null &&
     typeof result === "object" &&


### PR DESCRIPTION
## Summary
- Treat Linear MCP `CallToolResult.isError === true` responses as `LINEAR_MCP_FAILED` instead of successful provider routine results.
- Classify Linear `save_*` provider routines as writes so `save_initiative` is surfaced with an explicit write classification.
- Add regression coverage for provider-returned MCP tool errors and `save_initiative` classification.

## Root Cause
Linear MCP can resolve `tools/call` with a tool-level error payload, for example initiative routines returning `isError: true` with `400 invalid_request`. Lightfast previously treated any resolved MCP result as success, so these provider failures were recorded as succeeded decisions.

## Validation
- `pnpm --filter @lightfast/connector-linear test`
- `pnpm --filter @lightfast/connector-linear typecheck`
- `pnpm --filter @api/app test -- provider-routines-policy.test.ts`
- `pnpm --filter @api/app typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Linear MCP tool failures so MCP “tool-level” error responses now raise a clear, consistent failure instead of returning an unexpected success-shaped result.
* **Tests**
  * Added a new case ensuring `save_initiative` is classified correctly by routine policy.
  * Strengthened MCP test coverage to verify error wrapping behavior and that the MCP client is properly closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->