### PR TITLE
[codex] Preload brand page image

### DIFF
--- a/apps/www/src/app/(site)/(marketing)/brand/page.tsx
+++ b/apps/www/src/app/(site)/(marketing)/brand/page.tsx
@@ -49,6 +49,7 @@ export default function BrandPage() {
               alt="Lightfast wordmark"
               className="object-cover"
               fill
+              preload
               quality={40}
               sizes="(max-width: 640px) calc(100vw - 3rem), (max-width: 1024px) calc(100vw - 5rem), 48rem"
               src="/images/marketing/wordmark-panel.webp"


### PR DESCRIPTION
## Summary
- add preload to the brand page wordmark panel image
- keep the existing optimized Next Image path with quality 40
- keep the dark fallback background because it matches the wordmark panel

## Verification
- pnpm check
- pnpm --filter @lightfast/www build
- confirmed built /brand HTML emits a preload for wordmark-panel.webp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading of the brand wordmark image so it appears more quickly on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->