### PR TITLE
feat(www): align canonical founder entity

### DIFF
--- a/apps/www/src/__tests__/public-identity.test.ts
+++ b/apps/www/src/__tests__/public-identity.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { getLlmsFooter } from "../lib/site/discovery";
 import {
@@ -25,6 +27,37 @@ describe("public founder identity", () => {
   it("uses the official personal domain in discovery output", () => {
     expect(getLlmsFooter()).toContain(
       "- Founder: Jeevan Pillay - jp@lightfast.ai - https://www.jeevanpillay.com/"
+    );
+  });
+
+  it("links the existing founder sentence to the official personal domain", () => {
+    const brand = readFileSync(
+      resolve(import.meta.dirname, "../content/brand/brand.mdx"),
+      "utf8"
+    );
+    const founderSentence = brand
+      .split("\n")
+      .find((line) => line.includes("is the founder of Lightfast."));
+
+    expect(founderSentence).toBe(
+      "Lightfast studies how people, machines, and artificial intelligence can work together to develop consequential physical technologies. " +
+        "[Jeevan Pillay](https://www.jeevanpillay.com/) is the founder of Lightfast."
+    );
+    expect(founderSentence).not.toMatch(
+      /scientist|personal fabrication|funding|customers|traction|founded in/i
+    );
+  });
+
+  it("does not modify the homepage thesis", () => {
+    const home = readFileSync(
+      resolve(import.meta.dirname, "../content/home/home.mdx"),
+      "utf8"
+    );
+    expect(home).toContain(
+      "How should people and machines work together as scientific and engineering teams develop physical systems?"
+    );
+    expect(home).toContain(
+      "Lightfast is an applied artificial intelligence research and product lab."
     );
   });
 });

--- a/apps/www/src/__tests__/public-identity.test.ts
+++ b/apps/www/src/__tests__/public-identity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getLlmsFooter } from "../lib/site/discovery";
+import {
+  buildOrganizationEntity,
+  SITE_IDENTITY,
+} from "../lib/site/identity";
+
+describe("public founder identity", () => {
+  it("uses the canonical personal Person reference", () => {
+    expect(SITE_IDENTITY.contact.founder).toEqual({
+      name: "Jeevan Pillay",
+      email: "jp@lightfast.ai",
+      id: "https://www.jeevanpillay.com/#person",
+      url: "https://www.jeevanpillay.com/",
+    });
+
+    expect(buildOrganizationEntity().founder).toEqual({
+      "@type": "Person",
+      "@id": "https://www.jeevanpillay.com/#person",
+      name: "Jeevan Pillay",
+      url: "https://www.jeevanpillay.com/",
+    });
+  });
+
+  it("uses the official personal domain in discovery output", () => {
+    expect(getLlmsFooter()).toContain(
+      "- Founder: Jeevan Pillay - jp@lightfast.ai - https://www.jeevanpillay.com/"
+    );
+  });
+});

--- a/apps/www/src/__tests__/public-identity.test.ts
+++ b/apps/www/src/__tests__/public-identity.test.ts
@@ -2,10 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { getLlmsFooter } from "../lib/site/discovery";
-import {
-  buildOrganizationEntity,
-  SITE_IDENTITY,
-} from "../lib/site/identity";
+import { buildOrganizationEntity, SITE_IDENTITY } from "../lib/site/identity";
 
 describe("public founder identity", () => {
   it("uses the canonical personal Person reference", () => {

--- a/apps/www/src/content/brand/brand.mdx
+++ b/apps/www/src/content/brand/brand.mdx
@@ -183,7 +183,7 @@ Don't place partner lockups over busy imagery or low-contrast backgrounds.
 
 When mentioning Lightfast in press materials, use a concise and factual company description.
 
-Lightfast studies how people, machines, and artificial intelligence can work together to develop consequential physical technologies. Jeevan Pillay is the founder of Lightfast.
+Lightfast studies how people, machines, and artificial intelligence can work together to develop consequential physical technologies. [Jeevan Pillay](https://www.jeevanpillay.com/) is the founder of Lightfast.
 
 For announcements, blogs, or communications that go beyond these guidelines, contact [hello@lightfast.ai](mailto:hello@lightfast.ai).
 

--- a/apps/www/src/lib/site/identity.ts
+++ b/apps/www/src/lib/site/identity.ts
@@ -6,6 +6,8 @@ const defaultTitle = "People and Machines, Working Together | Lightfast";
 const defaultDescription =
   "Lightfast studies how people, machines, and artificial intelligence can work together to develop consequential physical technologies.";
 const founderName = "Jeevan Pillay";
+const founderUrl = "https://www.jeevanpillay.com/";
+const founderId = "https://www.jeevanpillay.com/#person";
 
 export const SITE_IDENTITY = {
   name: "Lightfast",
@@ -42,7 +44,8 @@ export const SITE_IDENTITY = {
     founder: {
       name: founderName,
       email: "jp@lightfast.ai",
-      url: "https://twitter.com/jeevanpillay",
+      id: founderId,
+      url: founderUrl,
     },
   },
   socialLinks: [
@@ -96,7 +99,9 @@ export function buildOrganizationEntity(): OrganizationEntity {
     url: SITE_IDENTITY.baseUrl,
     founder: {
       "@type": "Person",
+      "@id": SITE_IDENTITY.contact.founder.id,
       name: SITE_IDENTITY.contact.founder.name,
+      url: SITE_IDENTITY.contact.founder.url,
     },
     logo: {
       "@type": "ImageObject",


### PR DESCRIPTION
## Summary

- centralize Jeevan Pillay's canonical Person `@id` and personal URL in the Lightfast site identity
- project that reference into Organization JSON-LD and the existing discovery footer
- link the existing factual founder sentence to the official personal domain
- add focused identity, discovery, visible-link, prohibited-claim, and homepage non-regression tests

## Scope

This PR changes only:

- `apps/www/src/lib/site/identity.ts`
- `apps/www/src/content/brand/brand.mdx`
- `apps/www/src/__tests__/public-identity.test.ts`

The planning document, homepage, metadata, company sheet, discovery implementation, Organization social `sameAs`, and unrelated saved-checkout changes are excluded.

## Validation

- `pnpm --filter @lightfast/www test -- public-identity.test.ts` — 4/4 passed
- `pnpm check` — passed (1,761 files)
- `pnpm typecheck` — passed (66/66 tasks)
- independent post-rebase scope/content review — passed with no findings
- stable patch and file blobs match the previously reviewed local implementation

Local `pnpm build:www` reaches environment validation and stops because `INNGEST_APP_NAME` is not linked in this worktree. No validation bypass is included; protected CI/preview must establish build readiness.

## Merge and production gate

Do not merge or trigger production until the personal-site owner verifies that the approved Person entity is live at `https://www.jeevanpillay.com/#person` with canonical URL `https://www.jeevanpillay.com/`.

After that verification, merge only through repository protections, verify the Lightfast production Organization founder linkage and unchanged homepage thesis, and use supported indexing controls only after clean production verification. No profile edits or unrelated AEO work are part of this PR.